### PR TITLE
Block layout-based convolution in DNN

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -151,7 +151,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     const int& operator [](size_t idx) const;
     int& operator [](size_t idx);
     Size operator()() const; // for compatibility with MatSize
-    
+
     CV_WRAP int channels() const; // returns the number of channels
 
     CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -151,15 +151,16 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     const int& operator [](size_t idx) const;
     int& operator [](size_t idx);
     Size operator()() const; // for compatibility with MatSize
+    
+    CV_WRAP int channels() const; // returns the number of channels
 
     CV_WRAP bool hasSymbols() const; // negative elements in the shape may denote 'symbols' instead of actual values.
 
     // compute shape of the result with possible broadcasting
     CV_WRAP MatShape expand(const MatShape& another) const;
 
-    // convert shape to/from block layout
-    CV_WRAP MatShape toBlock(int C0) const;
-    CV_WRAP MatShape fromBlock(DataLayout newLayout) const;
+    // convert shape between layouts
+    CV_WRAP MatShape toLayout(DataLayout newLayout, int C0=0, int ngroups=1) const;
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -160,7 +160,7 @@ struct CV_EXPORTS_W_SIMPLE MatShape
     CV_WRAP MatShape expand(const MatShape& another) const;
 
     // convert shape between layouts
-    CV_WRAP MatShape toLayout(DataLayout newLayout, int C0=0, int ngroups=1) const;
+    CV_WRAP MatShape toLayout(DataLayout newLayout, int C0=0) const;
 
     size_t total() const; // returns the total number of elements in the tensor (including padding elements, i.e. the method ignores 'C' in the case of block layout). Returns 1 for scalar tensors. Returns 0 for empty shapes.
 

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -13,7 +13,7 @@ std::string layoutToString(DataLayout layout)
         layout == DATA_LAYOUT_ND ? "ND" :
         layout == DATA_LAYOUT_NCHW ? "NCHW" :
         layout == DATA_LAYOUT_NHWC ? "NHWC" :
-        layout == DATA_LAYOUT_BLOCK ? "NC1HWC0" :
+        layout == DATA_LAYOUT_BLOCK ? "BLOCK" :
         layout == DATA_LAYOUT_NCDHW ? "NCDHW" :
         layout == DATA_LAYOUT_NDHWC ? "NDHWC" :
         layout == DATA_LAYOUT_PLANAR ? "PLANAR" :
@@ -943,6 +943,8 @@ void Mat::fit(const std::vector<int>& _shape, int _type)
 void Mat::fit(const MatShape& _shape, int _type)
 {
     fit(_shape.dims, _shape.p, _type);
+    size.layout = _shape.layout;
+    size.C = _shape.C;
 }
 
 void Mat::fit(std::initializer_list<int> _shape, int _type)
@@ -1129,6 +1131,8 @@ void Mat::create(const MatShape& _shape, int _type)
         return;
     }
     create(_shape.dims, _shape.p, _type);
+    size.layout = _shape.layout;
+    size.C = _shape.C;
 }
 
 void Mat::create(std::initializer_list<int> _shape, int _type)

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -427,7 +427,7 @@ MatShape MatShape::expand(const MatShape& another) const
         int sz2 = i2 < 0 ? 1 : another.p[i2];
         CV_Assert(sz1 == sz2 || sz1 == 1 || sz2 == 1);
         // [TODO] handle symbolic shapes
-        result.p[i] = std::max(sz1, sz2);
+        result.p[i] = sz1 != 1 ? sz1 : sz2;
     }
     return result;
 }

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -345,22 +345,22 @@ MatShape MatShape::toLayout(DataLayout newLayout, int C0) const
 {
     CV_Assert(layout == DATA_LAYOUT_BLOCK || layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
     CV_Assert(newLayout == DATA_LAYOUT_BLOCK || newLayout == DATA_LAYOUT_NCHW || newLayout == DATA_LAYOUT_NHWC);
-    
+
     MatShape newsize = *this;
     newsize.layout = newLayout;
-    
+
     if (newLayout == DATA_LAYOUT_BLOCK) {
         // any => BLOCK
         CV_Assert_N(C0 > 1, (C0 & (C0-1)) == 0);
         int Corig = channels();
         newsize.C = Corig;
-        
+
         if (layout == DATA_LAYOUT_NHWC) {
             for (int i = 2; i < dims; i++) {
                 newsize.p[i] = p[i-1];
             }
         }
-        
+
         newsize.dims += layout != DATA_LAYOUT_BLOCK;
         newsize.p[1] = (Corig + C0 - 1)/C0;
         newsize.p[newsize.dims-1] = C0;
@@ -376,10 +376,10 @@ MatShape MatShape::toLayout(DataLayout newLayout, int C0) const
         newsize.dims--;
     } else {
         CV_Assert_N(C0 <= 1);
-        
+
         if (newLayout == layout)
             return newsize;
-        
+
         // NHWC => NCHW
         if (newLayout == DATA_LAYOUT_NCHW) {
             for (int i = 2; i < dims; i++)

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -341,7 +341,7 @@ int MatShape::channels() const
     return layout == DATA_LAYOUT_BLOCK ? C : p[layout == DATA_LAYOUT_NCHW ? 1 : dims-1];
 }
 
-MatShape MatShape::toLayout(DataLayout newLayout, int C0, int ngroups) const
+MatShape MatShape::toLayout(DataLayout newLayout, int C0) const
 {
     CV_Assert(layout == DATA_LAYOUT_BLOCK || layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
     CV_Assert(newLayout == DATA_LAYOUT_BLOCK || newLayout == DATA_LAYOUT_NCHW || newLayout == DATA_LAYOUT_NHWC);
@@ -353,7 +353,6 @@ MatShape MatShape::toLayout(DataLayout newLayout, int C0, int ngroups) const
         // any => BLOCK
         CV_Assert_N(C0 > 1, (C0 & (C0-1)) == 0);
         int Corig = channels();
-        CV_Assert_N(ngroups > 0, Corig % ngroups == 0);
         newsize.C = Corig;
         
         if (layout == DATA_LAYOUT_NHWC) {
@@ -363,11 +362,10 @@ MatShape MatShape::toLayout(DataLayout newLayout, int C0, int ngroups) const
         }
         
         newsize.dims += layout != DATA_LAYOUT_BLOCK;
-        newsize.p[1] = ((Corig/ngroups + C0 - 1)/C0)*ngroups;
+        newsize.p[1] = (Corig + C0 - 1)/C0;
         newsize.p[newsize.dims-1] = C0;
     } else if (layout == DATA_LAYOUT_BLOCK) {
         // BLOCK => any (except for BLOCK, which is handled above)
-        CV_Assert(ngroups == 1);
         newsize.C = 0;
         if (newLayout == DATA_LAYOUT_NHWC) {
             for (int i = 2; i < dims; i++) {
@@ -377,7 +375,7 @@ MatShape MatShape::toLayout(DataLayout newLayout, int C0, int ngroups) const
         newsize.p[newLayout == DATA_LAYOUT_NCHW ? 1 : dims-2] = C;
         newsize.dims--;
     } else {
-        CV_Assert_N(C0 <= 1, ngroups == 1);
+        CV_Assert_N(C0 <= 1);
         
         if (newLayout == layout)
             return newsize;

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -335,39 +335,65 @@ bool MatShape::hasSymbols() const
     return false;
 }
 
-MatShape MatShape::toBlock(int C0) const
+int MatShape::channels() const
 {
-    CV_Assert(dims >= 3);
-    // C0 should be > 1 and be a power-of-2: 2, 4, 8, ...
-    CV_Assert(C0 > 1 && (C0 & (C0-1)) == 0);
-    CV_Assert(layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
-    int c_idx = layout == DATA_LAYOUT_NCHW ? 1 : dims-1;
-
-    MatShape newsize = *this;
-    newsize.layout = DATA_LAYOUT_BLOCK;
-    newsize.C = p[c_idx];
-    newsize.p[newsize.dims++] = C0;
-    newsize.p[c_idx] = (p[c_idx] + C0 - 1)/C0;
-
-    return newsize;
+    CV_Assert(layout == DATA_LAYOUT_BLOCK || layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
+    return layout == DATA_LAYOUT_BLOCK ? C : p[layout == DATA_LAYOUT_NCHW ? 1 : dims-1];
 }
 
-MatShape MatShape::fromBlock(DataLayout newLayout) const
+MatShape MatShape::toLayout(DataLayout newLayout, int C0, int ngroups) const
 {
-    CV_Assert(dims >= 4);
-    CV_Assert(layout == DATA_LAYOUT_BLOCK);
-    // C0 should be > 1 and be a power-of-2: 2, 4, 8, ...
-    int C0 = p[dims-1];
-    CV_Assert(C0 > 1 && (C0 & (C0-1)) == 0);
-    CV_Assert(p[1] == (C + C0-1)/C0);
-    CV_Assert(newLayout == DATA_LAYOUT_NCHW || newLayout == DATA_LAYOUT_NHWC);
-    int c_idx = newLayout == DATA_LAYOUT_NCHW ? 1 : dims-2;
-
+    CV_Assert(layout == DATA_LAYOUT_BLOCK || layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
+    CV_Assert(newLayout == DATA_LAYOUT_BLOCK || newLayout == DATA_LAYOUT_NCHW || newLayout == DATA_LAYOUT_NHWC);
+    
     MatShape newsize = *this;
     newsize.layout = newLayout;
-    newsize.C = 0;
-    newsize.p[c_idx] = C;
-    newsize.dims--;
+    
+    if (newLayout == DATA_LAYOUT_BLOCK) {
+        // any => BLOCK
+        CV_Assert_N(C0 > 1, (C0 & (C0-1)) == 0);
+        int Corig = channels();
+        CV_Assert_N(ngroups > 0, Corig % ngroups == 0);
+        newsize.C = Corig;
+        
+        if (layout == DATA_LAYOUT_NHWC) {
+            for (int i = 2; i < dims; i++) {
+                newsize.p[i] = p[i-1];
+            }
+        }
+        
+        newsize.dims += layout != DATA_LAYOUT_BLOCK;
+        newsize.p[1] = ((Corig/ngroups + C0 - 1)/C0)*ngroups;
+        newsize.p[newsize.dims-1] = C0;
+    } else if (layout == DATA_LAYOUT_BLOCK) {
+        // BLOCK => any (except for BLOCK, which is handled above)
+        CV_Assert(ngroups == 1);
+        newsize.C = 0;
+        if (newLayout == DATA_LAYOUT_NHWC) {
+            for (int i = 2; i < dims; i++) {
+                newsize.p[i-1] = p[i];
+            }
+        }
+        newsize.p[newLayout == DATA_LAYOUT_NCHW ? 1 : dims-2] = C;
+        newsize.dims--;
+    } else {
+        CV_Assert_N(C0 <= 1, ngroups == 1);
+        
+        if (newLayout == layout)
+            return newsize;
+        
+        // NHWC => NCHW
+        if (newLayout == DATA_LAYOUT_NCHW) {
+            for (int i = 2; i < dims; i++)
+                newsize.p[i] = p[i-1];
+            newsize.p[1] = p[dims-1];
+        } else {
+            // NCHW => NHWC
+            for (int i = 2; i < dims; i++)
+                newsize.p[i-1] = p[i];
+            newsize.p[dims-1] = p[1];
+        }
+    }
 
     return newsize;
 }

--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -709,12 +709,52 @@ bool _InputArray::empty(int i) const
 
 MatShape _InputArray::shape(int i) const
 {
-    int sizes[CV_MAX_DIM];
-    int dims = sizend(sizes, i);
+    _InputArray::KindFlag k = kind();
+    MatShape shape;
 
-    if (dims == 0 && empty(i))
-        return MatShape();
-    return MatShape(dims, sizes);
+    if( k == NONE )
+        ;
+    else if( k == MAT )
+    {
+        CV_Assert( i < 0 );
+        const Mat& m = *(const Mat*)obj;
+        shape = m.size;
+    }
+    else if( k == UMAT )
+    {
+        CV_Assert( i < 0 );
+        const UMat& m = *(const UMat*)obj;
+        shape = m.size;
+    }
+    else if( k == STD_VECTOR_MAT && i >= 0 )
+    {
+        const std::vector<Mat>& vv = *(const std::vector<Mat>*)obj;
+        CV_Assert( (size_t)i < vv.size() );
+        const Mat& m = vv[i];
+        shape = m.size;
+    }
+    else if( k == STD_ARRAY_MAT && i >= 0 )
+    {
+        const Mat* vv = (const Mat*)obj;
+        CV_Assert( i < sz.height );
+        const Mat& m = vv[i];
+        shape = m.size;
+    }
+    else if( k == STD_VECTOR_UMAT && i >= 0 )
+    {
+        const std::vector<UMat>& vv = *(const std::vector<UMat>*)obj;
+        CV_Assert( (size_t)i < vv.size() );
+        const UMat& m = vv[i];
+        shape = m.size;
+    }
+    else
+    {
+        int sizes[CV_MAX_DIM];
+        int dims = sizend(sizes, i);
+        shape = MatShape(dims, sizes);
+    }
+
+    return shape;
 }
 
 bool _InputArray::sameSize(const _InputArray& arr) const

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -681,6 +681,8 @@ void UMat::create(const MatShape& _shape, int _type, UMatUsageFlags _usageFlags)
         release();
     } else {
         create(_shape.dims, _shape.p, _type, _usageFlags);
+        size.layout = _shape.layout;
+        size.C = _shape.C;
     }
 }
 
@@ -715,6 +717,8 @@ void UMat::fit(const std::vector<int>& _shape, int _type, UMatUsageFlags _usageF
 void UMat::fit(const MatShape& _shape, int _type, UMatUsageFlags _usageFlags)
 {
     fit(_shape.dims, _shape.p, _type, _usageFlags);
+    size.layout = _shape.layout;
+    size.C = _shape.C;
 }
 
 void UMat::fit(int _rows, int _cols, int _type, UMatUsageFlags _usageFlags)

--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -10,6 +10,8 @@ ocv_add_dispatched_file_force_all("layers/cpu_kernels/conv_block" AVX AVX2 NEON 
 ocv_add_dispatched_file_force_all("layers/cpu_kernels/conv_depthwise" AVX AVX2 RVV LASX)
 ocv_add_dispatched_file("layers/cpu_kernels/conv_winograd_f63" AVX AVX2 NEON NEON_FP16)
 ocv_add_dispatched_file_force_all("layers/cpu_kernels/fast_gemm_kernels" AVX AVX2 NEON LASX)
+ocv_add_dispatched_file("layers/cpu_kernels/conv2_depthwise" AVX AVX2 NEON NEON_FP16)
+ocv_add_dispatched_file("layers/cpu_kernels/conv2_kernels" AVX AVX2 NEON NEON_FP16)
 
 ocv_add_module(dnn opencv_core opencv_imgproc WRAP python java objc js)
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1229,6 +1229,9 @@ CV__DNN_INLINE_NS_BEGIN
             ADD,
             DIV,
             WHERE,
+            BITWISE_AND,
+            BITWISE_OR,
+            BITWISE_XOR
         };
         OPERATION op;
         

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -885,7 +885,7 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS ActivationLayer : public Layer
     {
     public:
-        virtual void getLayouts(const std::vector<DataLayout>& actualInputs,
+        virtual int getLayouts(const std::vector<DataLayout>& actualInputs,
                                 std::vector<DataLayout>& desiredInputs,
                                 const int requiredOutputs,
                                 std::vector<DataLayout>& outputs) const CV_OVERRIDE;

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -373,7 +373,7 @@ CV__DNN_INLINE_NS_BEGIN
                                 int C0, int accuracy) = 0;
         virtual bool fuseAddBias(InputArray bias) = 0;
         virtual bool fuseBatchNorm(const Ptr<Layer>& bn) = 0;
-        //virtual bool fuseActivation(const Ptr<Layer>& activ) = 0;
+        virtual bool fuseActivation(const Ptr<Layer>& activ) = 0;
         //virtual bool fuseAddResidual(const Ptr<Layer>& addres) = 0;
 
         std::vector<int> strides, dilations, pads;

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -374,13 +374,12 @@ CV__DNN_INLINE_NS_BEGIN
         virtual bool fuseAddBias(InputArray bias) = 0;
         virtual bool fuseBatchNorm(const Ptr<Layer>& bn) = 0;
         virtual bool fuseActivation(const Ptr<Layer>& activ) = 0;
-        //virtual bool fuseAddResidual(const Ptr<Layer>& addres) = 0;
+        virtual bool fuseAddResidual(Arg residual) = 0;
 
         std::vector<int> strides, dilations, pads;
         int ngroups;
         AutoPadding auto_pad;
         bool ceil_mode;
-        bool add_residual;
     };
 
     class CV_EXPORTS LRNLayer : public Layer
@@ -1207,6 +1206,32 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS NaryEltwiseLayer : public Layer
     {
     public:
+        enum class OPERATION
+        {
+            AND = 0,
+            EQUAL,
+            GREATER,
+            GREATER_EQUAL,
+            LESS,
+            LESS_EQUAL,
+            OR,
+            POW,
+            XOR,
+            BITSHIFT,
+            MAX,
+            MEAN,
+            MIN,
+            MOD,  // Integer Mod. Reminder's sign = Divisor's sign.
+            FMOD, // Floating-point Mod. Reminder's sign = Dividend's sign.
+            PROD,
+            SUB,
+            SUM,
+            ADD,
+            DIV,
+            WHERE,
+        };
+        OPERATION op;
+        
         static Ptr<NaryEltwiseLayer> create(const LayerParams &params);
     };
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -888,12 +888,12 @@ CV__DNN_INLINE_NS_BEGIN
                                 std::vector<DataLayout>& desiredInputs,
                                 const int requiredOutputs,
                                 std::vector<DataLayout>& outputs) const CV_OVERRIDE;
-        virtual void forwardSlice(const float* src, float* dst, int len,
-                                  size_t outPlaneSize, int cn0, int cn1) const {}
-        virtual void forwardSlice(const int* src, const int* lut, int* dst, int len,
-                                  size_t outPlaneSize, int cn0, int cn1) const {}
-        virtual void forwardSlice(const int8_t* src, const int8_t* lut, int8_t* dst, int len,
-                                  size_t outPlaneSize, int cn0, int cn1) const {}
+        virtual void forwardSlice(const float* /*src*/, float* /*dst*/, int /*len*/,
+                                  size_t /*outPlaneSize*/, int /*cn0*/, int /*cn1*/) const {}
+        virtual void forwardSlice(const int* /*src*/, const int* /*lut*/, int* /*dst*/, int /*len*/,
+                                  size_t /*outPlaneSize*/, int /*cn0*/, int /*cn1*/) const {}
+        virtual void forwardSlice(const int8_t* /*src*/, const int8_t* /*lut*/, int8_t* /*dst*/, int /*len*/,
+                                  size_t /*outPlaneSize*/, int /*cn0*/, int /*cn1*/) const {}
     };
 
     class CV_EXPORTS ReLULayer : public ActivationLayer

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -356,7 +356,7 @@ CV__DNN_INLINE_NS_BEGIN
     public:
         static Ptr<BaseConvolutionLayer> create(const LayerParams& params);
     };
-    
+
     enum AutoPadding
     {
         AUTO_PAD_NONE = 0,
@@ -468,7 +468,7 @@ CV__DNN_INLINE_NS_BEGIN
         float input_sc, output_sc;
         static Ptr<PoolingLayerInt8> create(const LayerParams& params);
     };
-    
+
     class CV_EXPORTS AveragePoolLayer : public Layer
     {
     public:
@@ -1234,7 +1234,7 @@ CV__DNN_INLINE_NS_BEGIN
             BITWISE_XOR
         };
         OPERATION op;
-        
+
         static Ptr<NaryEltwiseLayer> create(const LayerParams &params);
     };
 
@@ -1254,7 +1254,7 @@ CV__DNN_INLINE_NS_BEGIN
         int input_zp, output_zp;
         static Ptr<BatchNormLayerInt8> create(const LayerParams &params);
     };
-    
+
     class CV_EXPORTS BatchNorm2Layer : public Layer
     {
     public:
@@ -1556,7 +1556,7 @@ CV__DNN_INLINE_NS_BEGIN
     public:
         static Ptr<Tile2Layer> create(const LayerParams& params);
     };
-    
+
     class CV_EXPORTS TransformLayoutLayer : public Layer
     {
     public:

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -356,6 +356,32 @@ CV__DNN_INLINE_NS_BEGIN
     public:
         static Ptr<BaseConvolutionLayer> create(const LayerParams& params);
     };
+    
+    enum AutoPadding
+    {
+        AUTO_PAD_NONE = 0,
+        AUTO_PAD_SAME_UPPER = 1,
+        AUTO_PAD_SAME_LOWER = 2,
+        AUTO_PAD_VALID = 3
+    };
+
+    class CV_EXPORTS Conv2Layer : public Layer
+    {
+    public:
+        static Ptr<Conv2Layer> create(const LayerParams& params);
+        virtual void setWeights(InputArray weights, InputArray bias,
+                                int C0, int accuracy) = 0;
+        virtual bool fuseAddBias(InputArray bias) = 0;
+        virtual bool fuseBatchNorm(const Ptr<Layer>& bn) = 0;
+        //virtual bool fuseActivation(const Ptr<Layer>& activ) = 0;
+        //virtual bool fuseAddResidual(const Ptr<Layer>& addres) = 0;
+
+        std::vector<int> strides, dilations, pads;
+        int ngroups;
+        AutoPadding auto_pad;
+        bool ceil_mode;
+        bool add_residual;
+    };
 
     class CV_EXPORTS LRNLayer : public Layer
     {
@@ -442,6 +468,34 @@ CV__DNN_INLINE_NS_BEGIN
         int input_zp, output_zp;
         float input_sc, output_sc;
         static Ptr<PoolingLayerInt8> create(const LayerParams& params);
+    };
+    
+    class CV_EXPORTS AveragePoolLayer : public Layer
+    {
+    public:
+        std::vector<int> kernel_shape, strides, dilations, pads;
+        AutoPadding auto_pad;
+        bool ceil_mode;
+        bool count_include_pad;
+
+        static Ptr<AveragePoolLayer> create(const LayerParams& params);
+    };
+
+    class CV_EXPORTS MaxPoolLayer : public Layer
+    {
+    public:
+        std::vector<int> kernel_shape, strides, dilations, pads;
+        AutoPadding auto_pad;
+        bool ceil_mode;
+        int storage_order;
+
+        static Ptr<MaxPoolLayer> create(const LayerParams& params);
+    };
+
+    class CV_EXPORTS GlobalAveragePoolLayer : public Layer
+    {
+    public:
+        static Ptr<GlobalAveragePoolLayer> create(const LayerParams& params);
     };
 
     class CV_EXPORTS ReduceLayer : public Layer
@@ -831,12 +885,16 @@ CV__DNN_INLINE_NS_BEGIN
     class CV_EXPORTS ActivationLayer : public Layer
     {
     public:
-        virtual void forwardSlice(const float*, float*, int,
-                                  size_t, int, int) const {}
-        virtual void forwardSlice(const int*, const int*, int*, int,
-                                  size_t, int, int) const {}
-        virtual void forwardSlice(const int8_t*, const int8_t*, int8_t*, int,
-                                  size_t, int, int) const {}
+        virtual void getLayouts(const std::vector<DataLayout>& actualInputs,
+                                std::vector<DataLayout>& desiredInputs,
+                                const int requiredOutputs,
+                                std::vector<DataLayout>& outputs) const CV_OVERRIDE;
+        virtual void forwardSlice(const float* src, float* dst, int len,
+                                  size_t outPlaneSize, int cn0, int cn1) const {}
+        virtual void forwardSlice(const int* src, const int* lut, int* dst, int len,
+                                  size_t outPlaneSize, int cn0, int cn1) const {}
+        virtual void forwardSlice(const int8_t* src, const int8_t* lut, int8_t* dst, int len,
+                                  size_t outPlaneSize, int cn0, int cn1) const {}
     };
 
     class CV_EXPORTS ReLULayer : public ActivationLayer
@@ -1177,6 +1235,18 @@ CV__DNN_INLINE_NS_BEGIN
         int input_zp, output_zp;
         static Ptr<BatchNormLayerInt8> create(const LayerParams &params);
     };
+    
+    class CV_EXPORTS BatchNorm2Layer : public Layer
+    {
+    public:
+        float epsilon;
+        virtual bool freezeScaleBias() = 0;
+        virtual void getScaleBias(OutputArray scale, OutputArray bias) const = 0;
+        static void getScaleBias(InputArray scale, InputArray bias,
+                                 InputArray mean, InputArray variance, float eps,
+                                 OutputArray outscale, OutputArray outbias);
+        static Ptr<BatchNorm2Layer> create(const LayerParams &params);
+    };
 
     class CV_EXPORTS MaxUnpoolLayer : public Layer
     {
@@ -1466,6 +1536,14 @@ CV__DNN_INLINE_NS_BEGIN
     {
     public:
         static Ptr<Tile2Layer> create(const LayerParams& params);
+    };
+    
+    class CV_EXPORTS TransformLayoutLayer : public Layer
+    {
+    public:
+        DataLayout layout;
+        int C0;
+        static Ptr<TransformLayoutLayer> create(const LayerParams& params);
     };
 
     class CV_EXPORTS UniqueLayer : public Layer

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1247,15 +1247,6 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<BatchNormLayer> create(const LayerParams &params);
     };
 
-    class CV_EXPORTS BatchNorm2Layer : public Layer
-    {
-    public:
-        float epsilon;
-        bool useGlobalStats, hasWeights, hasBias;
-
-        static Ptr<BatchNorm2Layer> create(const LayerParams& params);
-    };
-
     class CV_EXPORTS BatchNormLayerInt8 : public BatchNormLayer
     {
     public:

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -472,7 +472,7 @@ CV__DNN_INLINE_NS_BEGIN
         // Some layers could override this default behaviour:
         // a) if they _can_ process block-layout data, like element-wise operations, or
         // b) if they _need_ block-layout data, like convolution
-        virtual void getLayouts(const std::vector<DataLayout>& actualInputs,
+        virtual int getLayouts(const std::vector<DataLayout>& actualInputs,
                                 std::vector<DataLayout>& desiredInputs,
                                 const int requiredOutputs,
                                 std::vector<DataLayout>& outputs) const;

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -459,6 +459,23 @@ CV__DNN_INLINE_NS_BEGIN
                               const int requiredInternals,
                               std::vector<MatType>&outputs,
                               std::vector<MatType>&internals) const;
+                              
+        // this is the method for Layer to express its attitude to the block layout
+        // or any other special form of layout. It takes
+        // layouts of the inputs and should return the desired layouts of
+        // inputs, as well as layouts of the outputs.
+        // By default, no mater what the actual inputs' layouts are,
+        // the desired inputs as well as outputs will get 'Unknown' layout values.
+        // It means that the layer can only handle non-block layout
+        // (depending on the model format, e.g. NCHW for ONNX or NHWC for TFLite)
+        // and will return tensors with non-block layout as well.
+        // Some layers could override this default behaviour:
+        // a) if they _can_ process block-layout data, like element-wise operations, or
+        // b) if they _need_ block-layout data, like convolution
+        virtual void getLayouts(const std::vector<DataLayout>& actualInputs,
+                                std::vector<DataLayout>& desiredInputs,
+                                const int requiredOutputs,
+                                std::vector<DataLayout>& outputs) const;
 
         virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                                const std::vector<MatShape> &outputs) const;

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -232,7 +232,7 @@ CV__DNN_INLINE_NS_BEGIN
         Arg();
         explicit Arg(int idx_);
         bool empty() const;
-        operator bool() const;
+        operator int() const;
         // idx > 0: the Arg is input or output argument of some operation inside inference graph
         // idx < 0: the Arg is input or output argument of a pattern
         // idx == 0: no/empty argument; used in operations where some of the inputs/outputs are optional.

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -459,7 +459,7 @@ CV__DNN_INLINE_NS_BEGIN
                               const int requiredInternals,
                               std::vector<MatType>&outputs,
                               std::vector<MatType>&internals) const;
-                              
+
         // this is the method for Layer to express its attitude to the block layout
         // or any other special form of layout. It takes
         // layouts of the inputs and should return the desired layouts of

--- a/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.inl.hpp
@@ -436,7 +436,7 @@ inline Arg::Arg(int idx_) : idx(idx_) {}
 
 inline bool Arg::empty() const { return idx == 0; }
 
-inline Arg::operator bool() const { return idx != 0; }
+inline Arg::operator int() const { return idx; }
 
 inline bool operator == (const Arg& a, const Arg& b) { return a.idx == b.idx; }
 

--- a/modules/dnn/src/graph_block_layout.cpp
+++ b/modules/dnn/src/graph_block_layout.cpp
@@ -128,7 +128,7 @@ struct BlockLayoutTransformer
             std::string op_name = layer->type;
             std::string name = layer->name;
             vector<PGraph>* subgraphs = layer->subgraphs();
-            std::cout << "name: " << name << ", op_name: " << op_name << ", inp0 layout: " << layoutToString(layouts[inputs[0].idx]) << "\n";
+            //std::cout << "name: " << name << ", op_name: " << op_name << ", inp0 layout: " << layoutToString(layouts[inputs[0].idx]) << "\n";
 
             if (subgraphs) {
                 for (PGraph& subgraph: *subgraphs) {

--- a/modules/dnn/src/graph_block_layout.cpp
+++ b/modules/dnn/src/graph_block_layout.cpp
@@ -1,0 +1,180 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+using std::vector;
+using std::string;
+
+using PLayer = Ptr<Layer>;
+
+/* Inserts layout conversion operations (if needed) into the model graph and subgraphs.
+
+ Some of the operations
+ (let's call them 'operations of category B' or B-operations, 'B' stands for 'Block'),
+ most notably Convolution (including depthwise convolution), ConvTranspose, MaxPool and AveragePool,
+ can be computed more efficiently if data is represented in so-called block layout,
+ i.e. when 4D tensor NxCxHxW is represented in memory as 5D tensor NxC1xHxWxC0,
+ where all C channels of the original tensor are split into C1 groups of C0 channels each.
+ For each spatial location (y=y0, x=x0) each group of C0 channels is stored sequentially.
+ C1 is thus computed as following: C1 = (C + C0-1)/C0, where division is performed with truncation.
+
+ Some other operations (let's call them A-operations, 'A' stands for 'Any'),
+ most notably unary element-wise operations or special cases of binary
+ element-wise operations can be efficiently computed in any layout, including block layout.
+
+ Finally, all other operations (denoted as C-operations, 'C' for 'Casual' or 'Channels')
+ do not support block layout at all. The inputs should come in the original model format
+ (e.g. NCHW in the case of Onnx).
+
+ We want to transform the graph so that:
+ 1. B-operations always take the inputs in block layout. If not, the inputs must be converted to
+    block layout prior to B-operation. Note that only the first input should be converted
+    in the case of Convolution, convolution weights (if constant) are pre-processed separately.
+ 2. C-operations always take the inputs in non-block layout, e.g. NCHW. If some of the inputs are
+    stored in block layout, they must be converted from block layout prior to C-operation.
+ 3. the number of layout transformation operations is minimal,
+    i.e. we don't do transformations unless it's necessary.
+
+ Note that this graph transformation is applied after fusion, since inside a fused operation
+ (e.g. 'Convolution + Batch Norm + Activation + Adding Skip connection') we don't need to
+ transform layout. That is, we have to deal with less operations at this stage.
+*/
+
+struct BlockLayoutTransformer
+{
+    BlockLayoutTransformer(Net::Impl* netimpl_) : netimpl(netimpl_) {}
+
+    Net::Impl* netimpl;
+    vector<DataLayout> layouts; // layouts for each argument
+    vector<Arg> blockCache; // if an Arg needs to be converted to block layout and
+                            // if it's used by several operations,
+                            // then we reuse once transformed arg,
+                            // don't transform it several times
+    vector<Arg> nonblockCache; // another cache of non-block args
+    DataLayout defaultLayout;
+
+    std::pair<Arg, PLayer> getProperArg(const Arg& arg, bool block, int64_t defaultC0)
+    {
+        if (arg.empty() || (layouts[arg.idx] == DATA_LAYOUT_BLOCK) == block)
+            return {arg, PLayer()};
+        std::vector<Arg> *cache, *another_cache;
+        if (block) {
+            cache = &blockCache;
+            another_cache = &nonblockCache;
+        } else {
+            cache = &nonblockCache;
+            another_cache = &blockCache;
+        }
+        Arg cached = cache->at(arg.idx);
+        if (!cached.empty())
+            return {cached, PLayer()};
+        const ArgData& adata = net->argData(arg);
+        cached = net->newArg(adata.name + (block ? ".block" : ".nonblock"), DNN_ARG_TEMP);
+        cache->at(arg.idx) = cached;
+        CV_Assert(cached.idx == (int)layouts.size());
+        Op tr_op;
+        if (block)
+            tr_op = TransformLayoutOp::create(DATA_LAYOUT_BLOCK, defaultC0);
+        else
+            tr_op = TransformLayoutOp::create(defaultLayout, 0);
+
+        std::vector<Arg> inputs = {arg}, outputs = {cached};
+        Node tr_node = NodeData::create(adata.name + (block ? ".to_block" : ".from_block"), tr_op, inputs, outputs);
+
+        layouts.push_back(block ? DATA_LAYOUT_BLOCK : defaultLayout);
+        cache->push_back(Arg());
+        another_cache->push_back(Arg());
+
+        return {cached, tr_node};
+    }
+
+    void transformGraph(Graph& g)
+    {
+        const vector<Node>& curr_prog = g->prog();
+        // [TODO] maybe we need to infer type and pass it to preferredBlockSize(), so that block size is dynamic
+        int defaultType = CV_32F;
+        int64_t defaultC0 = 8;//net->getBackend(0)->preferredBlockSize(defaultType);
+        vector<Node> new_prog;
+        std::vector<Arg> new_inputs;
+        size_t nchanges = 0;
+
+        for (const Node& node: curr_prog) {
+            const Op& op = node->op();
+            const vector<Arg>& inputs = node->inputs();
+            const vector<Arg>& outputs = node->outputs();
+            size_t ninputs = inputs.size(), noutputs = outputs.size();
+            new_inputs.clear();
+            int op_blockiness = 0;
+            DataLayout layout0 = defaultLayout;
+            std::string op_name = op->name();
+            std::string name = node->name();
+            //std::cout << "name: " << name << ", op_name: " << op_name << ", inp0 layout: " << layoutToString(layouts[inputs[0].idx]) << "\n";
+
+            for (const Graph& subgraph: node->subgraphs()) {
+                transformGraph(const_cast<Graph&>(subgraph));
+                nchanges++;
+            }
+
+            for (size_t i = 0; i < ninputs; i++) {
+                int blockiness = op->supportBlockLayout((int)i);
+                if (blockiness > 0) {
+                    CV_Assert(op_blockiness >= 0);
+                    op_blockiness = 1;
+                } else if (blockiness < 0 && op_blockiness <= 0) {
+                    op_blockiness = -1;
+                }
+
+                Arg inp = inputs[i], new_inp = inp;
+                if (i == 0)
+                    layout0 = layouts[inp.idx];
+                if (blockiness != 0) {
+                    auto new_inp_node = getProperArg(inp, blockiness > 0, defaultC0);
+                    new_inp = new_inp_node.first;
+                    if (new_inp_node.second) {
+                        new_prog.push_back(new_inp_node.second);
+                    }
+                    nchanges += !(new_inp == inp);
+                }
+                new_inputs.push_back(new_inp);
+            }
+
+            DataLayout layout1 = op_blockiness > 0 ? DATA_LAYOUT_BLOCK : op_blockiness < 0 ? defaultLayout : layout0;
+            for (size_t i = 0; i < noutputs; i++) {
+                Arg out = outputs[i];
+                layouts[out.idx] = layout1;
+            }
+            Node new_node = NodeData::create(node->name(), op, new_inputs, outputs, node->subgraphs());
+            new_prog.push_back(new_node);
+        }
+
+        if (nchanges > 0)
+            g->setProg(new_prog);
+    }
+
+    void transform()
+    {
+        size_t nargs = netimpl->args.size();
+        defaultLayout = netimpl->defaultLayout;
+
+        layouts.assign(nargs, defaultLayout);
+        blockCache.assign(nargs, Arg());
+        nonblockCache.assign(nargs, Arg());
+
+        transformGraph(netimpl->mainGraph);
+    }
+};
+
+void Net::Impl::useBlockLayout()
+{
+    BlockLayoutTransformer use_block_layout(this);
+    use_block_layout.transform();
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/graph_const_args.cpp
+++ b/modules/dnn/src/graph_const_args.cpp
@@ -1,0 +1,127 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+#if 0
+using std::vector;
+using std::string;
+
+typedef std::pair<int, int> int_pair;
+typedef std::pair<int, Arg> int_arg_pair;
+
+struct ConstArgs
+{
+    ConstArgs(Net* net_) : net(net_), netimpl(net_->getImpl()) {}
+
+    void process()
+    {
+        size_t nargs = netimpl->args.size();
+        netimpl->tensors.resize(nargs);
+        netimpl->useCounts(usecounts);
+        C0 = 8; // [TODO] netimpl->backends(0)
+        processGraph(netimpl->mainGraph);
+    }
+
+    void unuse(Arg inp)
+    {
+        CV_Assert(usecounts[inp.idx] > 0);
+        if (--usecounts[inp.idx] == 0 && net->isConstArg(inp)) {
+            netimpl->tensors[inp.idx] = Mat(); // deallocate unused tensor
+        }
+    }
+
+    bool processGraph(Ptr<Graph>& graph)
+    {
+        bool modified = false;
+        const std::vector<Ptr<Layer> >& prog = graph->prog();
+        size_t i, nops = prog.size();
+        std::vector<Node> newprog;
+        std::vector<Buffer> temp;
+        std::vector<Arg> removed_args;
+        std::vector<Tensor> t_inputs;
+
+        for (i = 0; i < nops; i++) {
+            const Node& node = prog[i];
+            std::vector<Graph>& subgraphs = const_cast<std::vector<Graph>&>(node->subgraphs());
+            for (Graph& g: subgraphs) {
+                if (processGraph(g))
+                    modified = true;
+            }
+            const std::vector<Arg>& inputs = node->inputs();
+            const std::vector<Arg>& outputs = node->outputs();
+            const Op& op = node->op();
+            size_t j, ninputs = inputs.size(), noutputs = outputs.size();
+            bool tail_const = true, unuse_tail = false;
+            t_inputs.assign(ninputs, Tensor());
+            for (j = 1; j < ninputs; j++) {
+                Arg inp = inputs[j];
+                bool const_arg = net->isConstArg(inp);
+                if (!const_arg)
+                    tail_const = false;
+                if (tail_const)
+                    t_inputs[j] = netimpl->tensors.at(inp.idx);
+            }
+
+            ConvOp* conv_op = getOp<ConvOp>(&node);
+            BatchNormOp* bn_op = getOp<BatchNormOp>(&node);
+            ElemwiseOp* elemwise_op = getOp<ElemwiseOp>(&node);
+
+            if (tail_const) {
+                if (conv_op) {
+                    // convolution with constant weights and bias
+                    conv_op->setWeights(t_inputs[1], ninputs > 2 ? t_inputs[2] : Tensor(), C0);
+                    modified = unuse_tail = true;
+                } else if (bn_op) {
+                    // batch norm with constant parameters
+                    bn_op->computeScaleBias(t_inputs[1], t_inputs[2], t_inputs[3], t_inputs[4]);
+                    modified = unuse_tail = true;
+                } else if (elemwise_op && elemwise_op->opcode == ELWISE_CLIP && ninputs == 3) {
+                    elemwise_op->setParams({t_inputs[1], t_inputs[2]});
+                    modified = unuse_tail = true;
+                }
+            }
+
+            if (unuse_tail) {
+                //printf("simplified %s: %s\n", op->name().data(), node->name().data());
+                std::vector<Arg> newinputs = {inputs[0]};
+                Node newnode = NodeData::create(node->name(), op, newinputs, outputs);
+                newprog.push_back(newnode);
+            } else {
+                newprog.push_back(node);
+            }
+
+            if (unuse_tail) {
+                for (size_t i = 1; i < ninputs; i++)
+                    unuse(inputs[i]);
+            }
+        }
+
+        if (modified) {
+            graph->setProg(newprog);
+        }
+
+        return modified;
+    }
+
+    Net* net;
+    Net::Impl* netimpl;
+    std::vector<int> usecounts;
+    int64_t C0;
+};
+
+void Net::Impl::constArgs()
+{
+    ConstArgs constargs(net);
+    constargs.process();
+}
+#endif
+
+CV__DNN_INLINE_NS_END
+}}
+

--- a/modules/dnn/src/graph_const_args.cpp
+++ b/modules/dnn/src/graph_const_args.cpp
@@ -51,7 +51,6 @@ struct ConstArgs
                 }
             }
             const std::vector<Arg>& inputs = layer->inputs;
-            const std::vector<Arg>& outputs = layer->outputs;
             size_t j, ninputs = inputs.size();
             if (ninputs == 1) {
                 continue;

--- a/modules/dnn/src/graph_const_args.cpp
+++ b/modules/dnn/src/graph_const_args.cpp
@@ -106,4 +106,3 @@ void Net::Impl::constArgs()
 
 CV__DNN_INLINE_NS_END
 }}
-

--- a/modules/dnn/src/graph_fusion_basic.cpp
+++ b/modules/dnn/src/graph_fusion_basic.cpp
@@ -65,7 +65,7 @@ struct ModelFusionBasic
             for(;;) {
                 BatchNorm2Layer* bn = dynamic_cast<BatchNorm2Layer*>(layer_ptr);
                 ActivationLayer* activ = dynamic_cast<ActivationLayer*>(layer_ptr);
-                //NaryEltwiseLayer* elemwise = dynamic_cast<NaryEltwiseLayer*>(layer_ptr);
+                NaryEltwiseLayer* elemwise = dynamic_cast<NaryEltwiseLayer*>(layer_ptr);
 
                 // merge convolution and batch norm
                 if (bn && ninputs == 1 &&
@@ -84,7 +84,7 @@ struct ModelFusionBasic
                 }
 
                 // merge residual 'add' into 'conv' node
-                /*if (elemwise && (elemwise->op == NaryEltwiseLayer::OPERATION::ADD ||
+                if (elemwise && (elemwise->op == NaryEltwiseLayer::OPERATION::ADD ||
                     elemwise->op == NaryEltwiseLayer::OPERATION::SUM) &&
                     ninputs == 2) {
 
@@ -113,7 +113,7 @@ struct ModelFusionBasic
                             break;
                         }
                     }
-                }*/
+                }
 
                 // merge convolution and activation
                 if (activ && ninputs == 1 &&

--- a/modules/dnn/src/graph_fusion_basic.cpp
+++ b/modules/dnn/src/graph_fusion_basic.cpp
@@ -1,0 +1,229 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+#if 0
+using std::vector;
+using std::string;
+
+typedef std::pair<int, int> int_pair;
+typedef std::pair<int, Arg> int_arg_pair;
+
+struct ModelFusionBasic
+{
+    ModelFusionBasic(Net* net_) : net(net_), netimpl(net_->getImpl()) {}
+
+    void fuse()
+    {
+        int i, niter = 10;
+        netimpl->useCounts(usecounts);
+        for (i = 0; i < niter; i++) {
+            bool fused_any = fuseGraph(netimpl->mainGraph);
+            if (!fused_any)
+                break;
+        }
+    }
+
+    bool isConstScalarTensor(Arg arg, float* compare_with) const
+    {
+        const Mat* m;
+        void* data;
+        if (!net->isConstArg(arg))
+            return false;
+        m = &netimpl->tensors.at(arg.idx);
+        data = m->data;
+        if (m->total() != 1 || m->type() != CV_32F)
+            return false;
+        if (compare_with && *(float*)data != *compare_with)
+            return false;
+        return true;
+    }
+
+    Layer* getLayer(std::vector<Ptr<Layer> >& newprog, int op_idx) const
+    {
+        return op_idx >= 0 ? newprog.at(op_idx).get() : 0;
+    }
+
+    /*template<typename _OpType>
+    int_arg_pair isUnary(std::vector<Node>& newprog, const std::vector<int>& producer_of,
+                         int t_inp, bool check_used_once) const
+    {
+        int op_idx;
+        const Node* node;
+        if (t_inp < 0) return std::make_pair(-1, Arg());
+        op_idx = producer_of.at(t_inp);
+        node = getNode(newprog, op_idx);
+        if (!node || (*node)->ninputs() != 1 || !getOp<_OpType>(node) ||
+            (check_used_once && usecounts.at((*node)->inputs(0).idx) != 1))
+            return std::make_pair(-1, Arg());
+        return std::make_pair(op_idx, (*node)->inputs(0));
+    }*/
+
+    bool fuseGraph(Ptr<Graph>& graph)
+    {
+        vector<Arg> removed_args;
+        bool modified = false;
+        const std::vector<Ptr<Layer> >& prog = graph->prog();
+        size_t i, nargs = netimpl->args.size(), nops = prog.size();
+        std::vector<int> producer_of(nargs, -1);
+        std::vector<Ptr<Layer> > newprog;
+        std::vector<Arg> fused_inputs;
+
+        for (i = 0; i < nops; i++) {
+            const Ptr<Layer>& layer = prog[i];
+            Layer* layer_ptr = (Layer*)layer.get();
+            std::vector<Ptr<Graph> >* subgraphs = layer->subgraphs();
+            if (subgraphs) {
+                for (Ptr<Graph>& g: *subgraphs) {
+                    if (fuseGraph(g))
+                        modified = true;
+                }
+            }
+            const std::vector<Arg>& inputs = layer->inputs;
+            const std::vector<Arg>& outputs = layer->outputs;
+            size_t ninputs = inputs.size();
+            Ptr<Layer> fused_layer;
+            int fused_node_idx = -1;
+            removed_args.clear();
+            fused_inputs.clear(); // leave it empty in the merge patterns below to re-use original fused node inputs as-is.
+
+            for(;;) {
+                BatchNormLayer* bn = dynamic_cast<BatchNormLayer*>(layer_ptr);
+                EltW  emwiseOp* elemwise = getOp<ElemwiseOp>(&node);
+
+                // merge convolution and batch norm
+                if (bn && ninputs == 1 &&
+                    usecounts.at(inputs[0].idx) == 1) {
+                    Arg bn_inp = inputs[0];
+                    int conv_node_idx = producer_of.at(bn_inp.idx);
+                    Node* conv_node = getNode(newprog, conv_node_idx);
+                    ConvOp* conv_op = getOp<ConvOp>(conv_node);
+                    if (conv_op && (*conv_node)->ninputs() == 1) {
+                        bool ok = conv_op->fuseBatchNorm(node->op());
+                        if (ok) {
+                            fused_node_idx = conv_node_idx;
+                            fused_op = (*conv_node)->op();
+                            removed_args.push_back(bn_inp);
+                            break;
+                        }
+                    }
+                }
+
+                // merge residual 'add' into 'conv' node
+                if (elemwise && elemwise->opcode == ELWISE_ADD && ninputs == 2) {
+                    ArgData& adata0 = netimpl->args[inputs[0].idx];
+                    ArgData& adata1 = netimpl->args[inputs[1].idx];
+
+                    if (adata0.type == adata1.type && adata0.shape == adata1.shape) {
+                        int op0 = producer_of.at(inputs[0].idx);
+                        int op1 = producer_of.at(inputs[1].idx);
+                        int conv_node_idx;
+                        Arg residual, conv_out;
+
+                        if (op0 > op1) { // choose the latter op to ensure that the other component is already computed
+                            conv_node_idx = op0;
+                            conv_out = inputs[0];
+                            residual = inputs[1];
+                        } else {
+                            conv_node_idx = op1;
+                            conv_out = inputs[1];
+                            residual = inputs[0];
+                        }
+
+                        Node* conv_node = getNode(newprog, conv_node_idx);
+                        ConvOp* conv_op = getOp<ConvOp>(conv_node);
+                        if (conv_op && !conv_op->activ && !conv_op->add_residual && usecounts[conv_out.idx] == 1) {
+                            conv_op->add_residual = true;
+                            fused_node_idx = conv_node_idx;
+                            fused_op = (*conv_node)->op();
+                            const std::vector<Arg>& conv_inputs = (*conv_node)->inputs();
+                            fused_inputs.assign(conv_inputs.begin(), conv_inputs.end());
+                            fused_inputs.push_back(residual);
+                            removed_args.push_back(conv_out);
+                            break;
+                        }
+                    }
+                }
+
+                // merge convolution and activation
+                if (elemwise && ninputs == 1 &&
+                    usecounts.at(inputs[0].idx) == 1) {
+                    Arg activ_inp = inputs[0];
+                    int conv_node_idx = producer_of.at(activ_inp.idx);
+                    Node* conv_node = getNode(newprog, conv_node_idx);
+                    ConvOp* conv_op = getOp<ConvOp>(conv_node);
+                    if (conv_op) {
+                        bool ok = conv_op->fuseActivation(node->op());
+                        if (ok) {
+                            fused_node_idx = conv_node_idx;
+                            fused_op = (*conv_node)->op();
+                            removed_args.push_back(activ_inp);
+                            break;
+                        }
+                    }
+                }
+                break;
+            }
+
+            if (fused_node_idx >= 0) {
+                modified = true;
+                const Node& orig_node = newprog.at(fused_node_idx);
+                if (fused_inputs.empty()) {
+                    const std::vector<Arg>& orig_inputs = orig_node->inputs();
+                    fused_inputs.assign(orig_inputs.begin(), orig_inputs.end());
+                }
+                Node fused_node = NodeData::create(orig_node->name(), fused_op,
+                                                   fused_inputs, outputs,
+                                                   orig_node->subgraphs());
+                newprog.at(fused_node_idx) = fused_node;
+                for (Arg new_out: outputs)
+                    producer_of[new_out.idx] = fused_node_idx;
+                for (Arg old_out: removed_args) {
+                    usecounts.at(old_out.idx) = 0;
+                    producer_of.at(old_out.idx) = -1;
+                }
+            } else {
+                for (auto out: outputs)
+                    producer_of[out.idx] = (int)newprog.size();
+                newprog.push_back(node);
+            }
+        }
+
+        if (modified) {
+            size_t i, j = 0, nops = newprog.size();
+            for (i = 0; i < nops; i++) {
+                if (newprog[i]->op()) {
+                    if (j < i)
+                        newprog[j] = newprog[i];
+                    j++;
+                }
+            }
+            newprog.resize(j);
+            printf("fused some ops in graph %s. size before: %zu ops, size after: %zu ops\n",
+                   graph->name().data(), nops, j);
+            graph->setProg(newprog);
+        }
+
+        return modified;
+    }
+
+    Net* net;
+    Net::Impl* netimpl;
+    vector<int> usecounts;
+};
+
+void Net::Impl::fuse()
+{
+    ModelFusionBasic basicFusion(net);
+    basicFusion.fuse();
+}
+#endif
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/graph_fusion_basic.cpp
+++ b/modules/dnn/src/graph_fusion_basic.cpp
@@ -65,7 +65,7 @@ struct ModelFusionBasic
             for(;;) {
                 BatchNorm2Layer* bn = dynamic_cast<BatchNorm2Layer*>(layer_ptr);
                 ActivationLayer* activ = dynamic_cast<ActivationLayer*>(layer_ptr);
-                NaryEltwiseLayer* elemwise = dynamic_cast<NaryEltwiseLayer*>(layer_ptr);
+                //NaryEltwiseLayer* elemwise = dynamic_cast<NaryEltwiseLayer*>(layer_ptr);
 
                 // merge convolution and batch norm
                 if (bn && ninputs == 1 &&
@@ -84,7 +84,7 @@ struct ModelFusionBasic
                 }
 
                 // merge residual 'add' into 'conv' node
-                if (elemwise && (elemwise->op == NaryEltwiseLayer::OPERATION::ADD ||
+                /*if (elemwise && (elemwise->op == NaryEltwiseLayer::OPERATION::ADD ||
                     elemwise->op == NaryEltwiseLayer::OPERATION::SUM) &&
                     ninputs == 2) {
 
@@ -113,7 +113,7 @@ struct ModelFusionBasic
                             break;
                         }
                     }
-                }
+                }*/
 
                 // merge convolution and activation
                 if (activ && ninputs == 1 &&

--- a/modules/dnn/src/graph_fusion_basic.cpp
+++ b/modules/dnn/src/graph_fusion_basic.cpp
@@ -90,11 +90,11 @@ struct ModelFusionBasic
 
                     int op0 = producer_of.at(inputs[0].idx);
                     int op1 = producer_of.at(inputs[1].idx);
-                    
+
                     if (op0 >= 0 && op1 >= 0) {
                         int conv_layer_idx;
                         Arg residual, conv_out;
-                        
+
                         if (op0 > op1) { // choose the latter op to ensure that the other component is already computed
                             conv_layer_idx = op0;
                             conv_out = inputs[0];
@@ -104,7 +104,7 @@ struct ModelFusionBasic
                             conv_out = inputs[1];
                             residual = inputs[0];
                         }
-                        
+
                         Conv2Layer* conv = getLayer<Conv2Layer>(newprog, conv_layer_idx);
                         if (conv && usecounts[conv_out.idx] == 1 &&
                             conv->fuseAddResidual(residual)) {

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -132,8 +132,11 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(AffineGrid,     AffineGridLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Convolution,    ConvolutionLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(Conv2,          Conv2Layer);
     CV_DNN_REGISTER_LAYER_CLASS(Deconvolution,  DeconvolutionLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Pooling,        PoolingLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(MaxPool,        MaxPoolLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(AveragePool,    AveragePoolLayer);
     CV_DNN_REGISTER_LAYER_CLASS(ROIPooling,     PoolingLayer);
     CV_DNN_REGISTER_LAYER_CLASS(PSROIPooling,   PoolingLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Reduce,         ReduceLayer);

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -278,13 +278,14 @@ void Layer::getTypes(const std::vector<MatType>&inputs,
     internals.assign(requiredInternals, inputs[0]);
 }
 
-void Layer::getLayouts(const std::vector<DataLayout>& actualInputs,
+int Layer::getLayouts(const std::vector<DataLayout>& actualInputs,
                        std::vector<DataLayout>& desiredInputs,
                        const int requiredOutputs,
                        std::vector<DataLayout>& outputs) const
 {
     desiredInputs.assign(actualInputs.size(), DATA_LAYOUT_UNKNOWN);
     outputs.assign(requiredOutputs, DATA_LAYOUT_UNKNOWN);
+    return 0;
 }
 
 int64 Layer::getFLOPS(const std::vector<MatShape>&,

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -278,6 +278,15 @@ void Layer::getTypes(const std::vector<MatType>&inputs,
     internals.assign(requiredInternals, inputs[0]);
 }
 
+void Layer::getLayouts(const std::vector<DataLayout>& actualInputs,
+                       std::vector<DataLayout>& desiredInputs,
+                       const int requiredOutputs,
+                       std::vector<DataLayout>& outputs) const
+{
+    desiredInputs.assign(actualInputs.size(), DATA_LAYOUT_UNKNOWN);
+    outputs.assign(requiredOutputs, DATA_LAYOUT_UNKNOWN);
+}
+
 int64 Layer::getFLOPS(const std::vector<MatShape>&,
                       const std::vector<MatShape>&) const
 {

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -1,0 +1,445 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+#include "conv2_common.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+
+namespace cv
+{
+namespace dnn
+{
+
+static void avgpool2d_32f(const void* inp_, void* out_, const ConvState& cs, bool count_include_pad)
+{
+    int C0_ = cs.inpshape.back();
+    int NC = cs.inpshape[0]*cs.inpshape[1];
+    int nlanes_ = VTraits<v_float32>::vlanes();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2);
+    CV_Assert(cs.nspatialdims == 2);
+
+    parallel_for_(Range(0, NC), [&](const Range& r) {
+        int nc0 = r.start, nc1 = r.end;
+        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi*C0;
+        int planesize = H*W*C0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
+        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
+        int ksize = (int)(cs.coordtab.size()/2);
+        const int* yxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+
+        const float* inp = (const float*)inp_ + nc0*iplanesize;
+        float* out = (float*)out_ + nc0*planesize;
+        v_float32 z = vx_setzero_f32();
+        v_float32 vscale0 = vx_setall_f32(1.f/ksize);
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                int yi_ = y0*SY - pad_y0;
+                for(;;) {
+                    
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            v_float32 s0 = z;
+                            int nitems = 0;
+                            for (int k = 0; k < ksize; k++) {
+                                int yi = yi_ + yxtab[k*2];
+                                int xi = xi_ + yxtab[k*2+1];
+                                v_float32 v0;
+                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                v0 = vx_load(inp + (yi*Wi + xi)*C0);
+                                s0 = v_add(s0, v0);
+                                nitems++;
+                            }
+                            s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*2) {
+                                v_float32 s0 = z, s1 = z;
+                                int nitems = 0;
+                                for (int k = 0; k < ksize; k++) {
+                                    int yi = yi_ + yxtab[k*2];
+                                    int xi = xi_ + yxtab[k*2+1];
+                                    v_float32 v0, v1;
+                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                        continue;
+                                    int ofs_k = (yi*Wi + xi)*C0 + c;
+                                    v0 = vx_load(inp + ofs_k);
+                                    v1 = vx_load(inp + ofs_k + nlanes);
+                                    s0 = v_add(s0, v0);
+                                    s1 = v_add(s1, v1);
+                                    nitems++;
+                                }
+                                v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
+                                s0 = v_mul(s0, vscale);
+                                s1 = v_mul(s1, vscale);
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                            }
+                        }
+                    }
+                    if (x0 == W)
+                        break;
+                    x1 = inner_x1;
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = vx_load(inp_xi + ofstab[0]);
+                            for (int k = 1; k < ksize; k++)
+                                s0 = v_add(s0, vx_load(inp_xi + ofstab[k]));
+                            s0 = v_mul(s0, vscale0);
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else if (nlanes*2 == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            int ofs_k = ofstab[0];
+                            v_float32 s0 = vx_load(inp_xi + ofs_k);
+                            v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
+                            for (int k = 1; k < ksize; k++) {
+                                ofs_k = ofstab[k];
+                                s0 = v_add(s0, vx_load(inp_xi + ofs_k));
+                                s1 = v_add(s1, vx_load(inp_xi + ofs_k + nlanes));
+                            }
+                            s0 = v_mul(s0, vscale0);
+                            s1 = v_mul(s1, vscale0);
+                            vx_store(out + x0*C0, s0);
+                            vx_store(out + x0*C0 + nlanes, s1);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*4) {
+                                const float* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
+
+                                int ofs_k = ofstab[0];
+                                v_float32 s0 = vx_load(inp_xi + ofs_k);
+                                v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
+                                v_float32 s2 = vx_load(inp_xi + ofs_k + nlanes*2);
+                                v_float32 s3 = vx_load(inp_xi + ofs_k + nlanes*3);
+                                for (int k = 1; k < ksize; k++) {
+                                    ofs_k = ofstab[k];
+                                    s0 = v_add(s0, vx_load(inp_xi + ofs_k));
+                                    s1 = v_add(s1, vx_load(inp_xi + ofs_k + nlanes));
+                                    s2 = v_add(s2, vx_load(inp_xi + ofs_k + nlanes*2));
+                                    s3 = v_add(s3, vx_load(inp_xi + ofs_k + nlanes*3));
+                                }
+                                s0 = v_mul(s0, vscale0);
+                                s1 = v_mul(s1, vscale0);
+                                s2 = v_mul(s2, vscale0);
+                                s3 = v_mul(s3, vscale0);
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                                vx_store(out + x0*C0 + c + nlanes*2, s2);
+                                vx_store(out + x0*C0 + c + nlanes*3, s3);
+                            }
+                        }
+                    }
+                    x1 = W;
+                }
+            }
+        }
+    });
+}
+
+template<typename _Tp>
+static void avgpool2d_16(const _Tp* inp_, _Tp* out_, const ConvState& cs, bool count_include_pad)
+{
+    int C0_ = cs.inpshape.back();
+    int NC = cs.inpshape[0]*cs.inpshape[1];
+    int nlanes_ = VTraits<v_float32>::vlanes();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.nspatialdims == 2);
+
+    parallel_for_(Range(0, NC), [&](const Range& r) {
+        int nc0 = r.start, nc1 = r.end;
+        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi*C0;
+        int planesize = H*W*C0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
+        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
+        int ksize = (int)(cs.coordtab.size()/2);
+        const int* yxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+
+        const _Tp* inp = inp_ + nc0*iplanesize;
+        _Tp* out = out_ + nc0*planesize;
+        v_float32 z = vx_setzero_f32();
+        v_float32 vscale0 = vx_setall_f32(1.f/ksize);
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                int yi_ = y0*SY - pad_y0;
+                for(;;) {
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            v_float32 s0 = z;
+                            int nitems = 0;
+                            for (int k = 0; k < ksize; k++) {
+                                int yi = yi_ + yxtab[k*2];
+                                int xi = xi_ + yxtab[k*2+1];
+                                v_float32 v0;
+                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                v0 = vx_load_expand(inp + (yi*Wi + xi)*C0);
+                                s0 = v_add(s0, v0);
+                                nitems++;
+                            }
+                            s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
+                            v_pack_store(out + x0*C0, s0);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*2) {
+                                v_float32 s0 = z, s1 = z;
+                                int nitems = 0;
+                                for (int k = 0; k < ksize; k++) {
+                                    int yi = yi_ + yxtab[k*2];
+                                    int xi = xi_ + yxtab[k*2+1];
+                                    v_float32 v0, v1;
+                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                        continue;
+                                    int ofs_k = (yi*Wi + xi)*C0 + c;
+                                    v0 = vx_load_expand(inp + ofs_k);
+                                    v1 = vx_load_expand(inp + ofs_k + nlanes);
+                                    s0 = v_add(s0, v0);
+                                    s1 = v_add(s1, v1);
+                                    nitems++;
+                                }
+                                v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
+                                v_pack_store(out + x0*C0 + c, v_mul(s0, vscale));
+                                v_pack_store(out + x0*C0 + c + nlanes, v_mul(s1, vscale));
+                            }
+                        }
+                    }
+                    if (x0 == W)
+                        break;
+                    x1 = inner_x1;
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
+                            for (int k = 1; k < ksize; k++)
+                                s0 = v_add(s0, vx_load_expand(inp_xi + ofstab[k]));
+                            s0 = v_mul(s0, vscale0);
+                            v_pack_store(out + x0*C0, s0);
+                        }
+                    } else if (nlanes*2 == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            int ofs_k = ofstab[0];
+                            v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
+                            v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
+                            for (int k = 1; k < ksize; k++) {
+                                ofs_k = ofstab[k];
+                                s0 = v_add(s0, vx_load_expand(inp_xi + ofs_k));
+                                s1 = v_add(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                            }
+                            s0 = v_mul(s0, vscale0);
+                            s1 = v_mul(s1, vscale0);
+                            v_pack_store(out + x0*C0, s0);
+                            v_pack_store(out + x0*C0 + nlanes, s1);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*4) {
+                                const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
+
+                                int ofs_k = ofstab[0];
+                                v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
+                                v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
+                                v_float32 s2 = vx_load_expand(inp_xi + ofs_k + nlanes*2);
+                                v_float32 s3 = vx_load_expand(inp_xi + ofs_k + nlanes*3);
+                                for (int k = 1; k < ksize; k++) {
+                                    ofs_k = ofstab[k];
+                                    s0 = v_add(s0, vx_load_expand(inp_xi + ofs_k));
+                                    s1 = v_add(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                                    s2 = v_add(s2, vx_load_expand(inp_xi + ofs_k + nlanes*2));
+                                    s3 = v_add(s3, vx_load_expand(inp_xi + ofs_k + nlanes*3));
+                                }
+                                s0 = v_mul(s0, vscale0);
+                                s1 = v_mul(s1, vscale0);
+                                s2 = v_mul(s2, vscale0);
+                                s3 = v_mul(s3, vscale0);
+                                v_pack_store(out + x0*C0 + c, s0);
+                                v_pack_store(out + x0*C0 + c + nlanes, s1);
+                                v_pack_store(out + x0*C0 + c + nlanes*2, s2);
+                                v_pack_store(out + x0*C0 + c + nlanes*3, s3);
+                            }
+                        }
+                    }
+                    x1 = W;
+                }
+            }
+        }
+    });
+}
+
+static void avgpool2d_16f(const void* inp_, void* out_,
+                          const ConvState& cs, bool countIncludePadding)
+{
+    avgpool2d_16((const hfloat*)inp_, (hfloat*)out_, cs, countIncludePadding);
+}
+
+static void avgpool2d_16bf(const void* inp_, void* out_,
+                           const ConvState& cs, bool countIncludePadding)
+{
+    avgpool2d_16((const bfloat*)inp_, (bfloat*)out_, cs, countIncludePadding);
+}
+
+typedef void (*avgpool_func_t)(const void* inp, void* out,
+                               const ConvState& cs, bool countIncludePadding);
+
+class AveragePoolLayerImpl : public AveragePoolLayer
+{
+public:
+    AveragePoolLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        auto_pad = getAutoPadding(params);
+        kernel_shape = params.getVector<int>("kernel_shape");
+        strides = params.getVector<int>("strides");
+        dilations = params.getVector<int>("dilations");
+        pads = params.getVector<int>("pads");
+        ceil_mode = params.get<bool>("ceil_mode", false);
+    }
+
+    virtual int64_t getFLOPS(const std::vector<MatShape> &inputs,
+                             const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        CV_Assert(outputs.size() == 1);
+        int ksize = 1;
+        for (auto sz: kernel_shape) ksize *= sz;
+        return (int64_t)(inputs[0].total()*ksize);
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inptypes,
+                          const int, const int,
+                          std::vector<MatType>& outtypes,
+                          std::vector<MatType>& temptypes) const CV_OVERRIDE
+    {
+        int ninputs = (int)inptypes.size();
+        CV_Assert(ninputs == 1);
+
+        outtypes.assign(1, inptypes[0]);
+        temptypes.clear();
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,
+                                 const int,
+                                 std::vector<MatShape> &outshapes,
+                                 std::vector<MatShape> &tempshapes) const CV_OVERRIDE
+    {
+        size_t ninputs = inpshapes.size();
+        CV_Assert(ninputs == 1);
+
+        outshapes.assign(1, convInferShape(inpshapes[0], MatShape(),
+                                           kernel_shape, 0, strides, dilations,
+                                           pads, auto_pad, ceil_mode));
+        tempshapes.clear();
+        return true;
+    }
+
+    void getLayouts(const std::vector<DataLayout>& actualInputs,
+                    std::vector<DataLayout>& desiredInputs,
+                    const int requiredOutputs,
+                    std::vector<DataLayout>& outputs) const CV_OVERRIDE
+    {
+        CV_Assert(actualInputs.size() == 1u);
+        desiredInputs.assign(1, DATA_LAYOUT_BLOCK);
+        outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        size_t ninputs = inputs_arr.total();
+        CV_Assert(ninputs == 1);
+
+        int inptype = inputs_arr.type(0);
+        MatShape inpshape = inputs_arr.shape(0);
+        MatShape outshape = convInferShape(inpshape, MatShape(),
+                                           kernel_shape, 0, strides, dilations,
+                                           pads, auto_pad, ceil_mode);
+        int outKind = outputs_arr.kind();
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        ConvState cs;
+        initPoolingState(inpshape, outshape, kernel_shape, strides, dilations, pads, auto_pad, ceil_mode, cs);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            runOp(inp, outs[0], cs);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            Mat temp(outshape, inptype);
+            runOp(inp, temp, cs);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& inp, Mat& out, const ConvState& cs)
+    {
+        int inptype = inp.type();
+        avgpool_func_t func =
+            inptype == CV_32F ? avgpool2d_32f :
+            inptype == CV_16F ? avgpool2d_16f :
+            inptype == CV_16BF ? avgpool2d_16bf : nullptr;
+
+        CV_Assert(func != nullptr && "AveragePool: unsupported data type");
+        func(inp.data, out.data, cs, count_include_pad);
+    }
+};
+
+Ptr<AveragePoolLayer> AveragePoolLayer::create(const LayerParams& params)
+{
+    return Ptr<AveragePoolLayer>(new AveragePoolLayerImpl(params));
+}
+
+}}

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -373,7 +373,7 @@ public:
         return true;
     }
 
-    void getLayouts(const std::vector<DataLayout>& actualInputs,
+    int getLayouts(const std::vector<DataLayout>& actualInputs,
                     std::vector<DataLayout>& desiredInputs,
                     const int requiredOutputs,
                     std::vector<DataLayout>& outputs) const CV_OVERRIDE
@@ -381,6 +381,7 @@ public:
         CV_Assert(actualInputs.size() == 1u);
         desiredInputs.assign(1, DATA_LAYOUT_BLOCK);
         outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+        return getNetImpl(this)->defaultC0;
     }
 
     void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
@@ -404,7 +405,8 @@ public:
                   outKind == _InputArray::STD_VECTOR_UMAT);
 
         ConvState cs;
-        initPoolingState(inpshape, outshape, kernel_shape, strides, dilations, pads, auto_pad, ceil_mode, cs);
+        cs.initPooling(inpshape, outshape, kernel_shape, strides,
+                       dilations, pads, auto_pad, ceil_mode);
 
         if (outKind == _InputArray::STD_VECTOR_MAT) {
             Mat inp = inputs_arr.getMat(0);

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -329,11 +329,40 @@ public:
     {
         setParamsFrom(params);
         auto_pad = getAutoPadding(params);
-        kernel_shape = params.getVector<int>("kernel_shape");
-        strides = params.getVector<int>("strides");
-        dilations = params.getVector<int>("dilations");
-        pads = params.getVector<int>("pads");
+        kernel_shape = params.getVector<int>("kernel_size");
+        strides = params.getVector<int>("stride");
+        dilations = params.getVector<int>("dilation");
+        pads = params.getVector<int>("pad");
         ceil_mode = params.get<bool>("ceil_mode", false);
+    }
+
+    virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
+    {
+        prindent(strm, indent);
+        strm << "kernel_size: [";
+        for (size_t k = 0; k < kernel_shape.size(); k++)
+            strm << (k > 0 ? ", " : "") << kernel_shape[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "dilation: [";
+        for (size_t k = 0; k < dilations.size(); k++)
+            strm << (k > 0 ? ", " : "") << dilations[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "pad: [";
+        for (size_t k = 0; k < pads.size(); k++)
+            strm << (k > 0 ? ", " : "") << pads[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "stride: [";
+        for (size_t k = 0; k < strides.size(); k++)
+            strm << (k > 0 ? ", " : "") << strides[k];
+        strm << "],\n";
+
+        return strm;
     }
 
     virtual int64_t getFLOPS(const std::vector<MatShape> &inputs,

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -13,28 +13,40 @@ namespace cv
 namespace dnn
 {
 
-static void avgpool2d_32f(const void* inp_, void* out_, const ConvState& cs, bool count_include_pad)
+static void avgPool32f(const void* inp_, void* out_,
+                       const ConvState& cs, bool count_include_pad_)
 {
+    constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
     int C0_ = cs.inpshape.back();
     int NC = cs.inpshape[0]*cs.inpshape[1];
     int nlanes_ = VTraits<v_float32>::vlanes();
 
-    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2);
-    CV_Assert(cs.nspatialdims == 2);
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
+    CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
     parallel_for_(Range(0, NC), [&](const Range& r) {
+        bool count_include_pad = count_include_pad_;
+        int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
         int nlanes = nlanes_, C0 = cs.inpshape.back();
-        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
-        int H = cs.outshape[2], W = cs.outshape[3];
-        int iplanesize = Hi*Wi*C0;
-        int planesize = H*W*C0;
-        int SY = cs.strides[0], SX = cs.strides[1];
-        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
-        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
-        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
-        int ksize = (int)(cs.coordtab.size()/2);
-        const int* yxtab = cs.coordtab.data();
+        int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
+        int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
+        int Wi = cs.inpshape[sdims + 1];
+        int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
+        int H = sdims > 1 ? cs.outshape[sdims] : 1;
+        int W = cs.outshape[sdims + 1];
+        int iplanesize = Di*Hi*Wi*C0;
+        int planesize = D*H*W*C0;
+        int SZ = cs.strides[0], SY = cs.strides[1], SX = cs.strides[2];
+        int padZ0 = cs.pads[0], padY0 = cs.pads[1], padX0 = cs.pads[2];
+        int inner_z0 = cs.inner[0], inner_z1 = cs.inner[MAX_POOL_DIMS];
+        int inner_y0 = cs.inner[1], inner_y1 = cs.inner[MAX_POOL_DIMS + 1];
+        int inner_x0 = cs.inner[2], inner_x1 = cs.inner[MAX_POOL_DIMS + 2];
+        int ksize = (int)cs.ofstab.size();
+        const int* zyxtab = cs.coordtab.data();
         const int* ofstab = cs.ofstab.data();
 
         const float* inp = (const float*)inp_ + nc0*iplanesize;
@@ -43,118 +55,126 @@ static void avgpool2d_32f(const void* inp_, void* out_, const ConvState& cs, boo
         v_float32 vscale0 = vx_setall_f32(1.f/ksize);
 
         for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
-            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
-                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
-                int yi_ = y0*SY - pad_y0;
-                for(;;) {
-                    
-                    if (nlanes == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            v_float32 s0 = z;
-                            int nitems = 0;
-                            for (int k = 0; k < ksize; k++) {
-                                int yi = yi_ + yxtab[k*2];
-                                int xi = xi_ + yxtab[k*2+1];
-                                v_float32 v0;
-                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
-                                    continue;
-                                v0 = vx_load(inp + (yi*Wi + xi)*C0);
-                                s0 = v_add(s0, v0);
-                                nitems++;
-                            }
-                            s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
-                            vx_store(out + x0*C0, s0);
-                        }
-                    } else {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            for (int c = 0; c < C0; c += nlanes*2) {
-                                v_float32 s0 = z, s1 = z;
+            for (int z0 = 0; z0 < D; z0++) {
+                int zi_ = z0*SZ - padZ0;
+                for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                    int x0 = 0;
+                    int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
+                        y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                    int yi_ = y0*SY - padY0;
+                    for(;;) {
+                        if (nlanes == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                v_float32 s0 = z;
                                 int nitems = 0;
                                 for (int k = 0; k < ksize; k++) {
-                                    int yi = yi_ + yxtab[k*2];
-                                    int xi = xi_ + yxtab[k*2+1];
-                                    v_float32 v0, v1;
-                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                    int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                    int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                    v_float32 v0;
+                                    if ((unsigned)zi >= (unsigned)Di ||
+                                        (unsigned)yi >= (unsigned)Hi ||
+                                        (unsigned)xi >= (unsigned)Wi)
                                         continue;
-                                    int ofs_k = (yi*Wi + xi)*C0 + c;
-                                    v0 = vx_load(inp + ofs_k);
-                                    v1 = vx_load(inp + ofs_k + nlanes);
+                                    v0 = vx_load(inp + ((zi*Hi + yi)*Wi + xi)*C0);
                                     s0 = v_add(s0, v0);
-                                    s1 = v_add(s1, v1);
                                     nitems++;
                                 }
-                                v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
-                                s0 = v_mul(s0, vscale);
-                                s1 = v_mul(s1, vscale);
-                                vx_store(out + x0*C0 + c, s0);
-                                vx_store(out + x0*C0 + c + nlanes, s1);
+                                s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
+                                vx_store(out + x0*C0, s0);
+                            }
+                        } else {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                for (int c = 0; c < C0; c += nlanes*2) {
+                                    v_float32 s0 = z, s1 = z;
+                                    int nitems = 0;
+                                    for (int k = 0; k < ksize; k++) {
+                                        int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                        int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                        int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                        v_float32 v0, v1;
+                                        if ((unsigned)zi >= (unsigned)Di ||
+                                            (unsigned)yi >= (unsigned)Hi ||
+                                            (unsigned)xi >= (unsigned)Wi)
+                                            continue;
+                                        int ofs_k = ((zi*Hi + yi)*Wi + xi)*C0 + c;
+                                        v0 = vx_load(inp + ofs_k);
+                                        v1 = vx_load(inp + ofs_k + nlanes);
+                                        s0 = v_add(s0, v0);
+                                        s1 = v_add(s1, v1);
+                                    }
+                                    v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
+                                    s0 = v_mul(s0, vscale);
+                                    s1 = v_mul(s1, vscale);
+                                    vx_store(out + x0*C0 + c, s0);
+                                    vx_store(out + x0*C0 + c + nlanes, s1);
+                                }
                             }
                         }
-                    }
-                    if (x0 == W)
-                        break;
-                    x1 = inner_x1;
-                    if (nlanes == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
-
-                            v_float32 s0 = vx_load(inp_xi + ofstab[0]);
-                            for (int k = 1; k < ksize; k++)
-                                s0 = v_add(s0, vx_load(inp_xi + ofstab[k]));
-                            s0 = v_mul(s0, vscale0);
-                            vx_store(out + x0*C0, s0);
-                        }
-                    } else if (nlanes*2 == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
-
-                            int ofs_k = ofstab[0];
-                            v_float32 s0 = vx_load(inp_xi + ofs_k);
-                            v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
-                            for (int k = 1; k < ksize; k++) {
-                                ofs_k = ofstab[k];
-                                s0 = v_add(s0, vx_load(inp_xi + ofs_k));
-                                s1 = v_add(s1, vx_load(inp_xi + ofs_k + nlanes));
+                        if (x0 == W)
+                            break;
+                        x1 = inner_x1;
+                        if (nlanes == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                
+                                v_float32 s0 = vx_load(inp_xi + ofstab[0]);
+                                for (int k = 1; k < ksize; k++)
+                                    s0 = v_add(s0, vx_load(inp_xi + ofstab[k]));
+                                vx_store(out + x0*C0, v_mul(s0, vscale0));
                             }
-                            s0 = v_mul(s0, vscale0);
-                            s1 = v_mul(s1, vscale0);
-                            vx_store(out + x0*C0, s0);
-                            vx_store(out + x0*C0 + nlanes, s1);
-                        }
-                    } else {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            for (int c = 0; c < C0; c += nlanes*4) {
-                                const float* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
-
+                        } else if (nlanes*2 == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
-                                v_float32 s2 = vx_load(inp_xi + ofs_k + nlanes*2);
-                                v_float32 s3 = vx_load(inp_xi + ofs_k + nlanes*3);
                                 for (int k = 1; k < ksize; k++) {
                                     ofs_k = ofstab[k];
                                     s0 = v_add(s0, vx_load(inp_xi + ofs_k));
                                     s1 = v_add(s1, vx_load(inp_xi + ofs_k + nlanes));
-                                    s2 = v_add(s2, vx_load(inp_xi + ofs_k + nlanes*2));
-                                    s3 = v_add(s3, vx_load(inp_xi + ofs_k + nlanes*3));
                                 }
                                 s0 = v_mul(s0, vscale0);
                                 s1 = v_mul(s1, vscale0);
-                                s2 = v_mul(s2, vscale0);
-                                s3 = v_mul(s3, vscale0);
-                                vx_store(out + x0*C0 + c, s0);
-                                vx_store(out + x0*C0 + c + nlanes, s1);
-                                vx_store(out + x0*C0 + c + nlanes*2, s2);
-                                vx_store(out + x0*C0 + c + nlanes*3, s3);
+                                vx_store(out + x0*C0, s0);
+                                vx_store(out + x0*C0 + nlanes, s1);
+                            }
+                        } else {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                for (int c = 0; c < C0; c += nlanes*4) {
+                                    const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    
+                                    int ofs_k = ofstab[0];
+                                    v_float32 s0 = vx_load(inp_xi + ofs_k);
+                                    v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
+                                    v_float32 s2 = vx_load(inp_xi + ofs_k + nlanes*2);
+                                    v_float32 s3 = vx_load(inp_xi + ofs_k + nlanes*3);
+                                    for (int k = 1; k < ksize; k++) {
+                                        ofs_k = ofstab[k];
+                                        s0 = v_add(s0, vx_load(inp_xi + ofs_k));
+                                        s1 = v_add(s1, vx_load(inp_xi + ofs_k + nlanes));
+                                        s2 = v_add(s2, vx_load(inp_xi + ofs_k + nlanes*2));
+                                        s3 = v_add(s3, vx_load(inp_xi + ofs_k + nlanes*3));
+                                    }
+                                    s0 = v_mul(s0, vscale0);
+                                    s1 = v_mul(s1, vscale0);
+                                    s2 = v_mul(s2, vscale0);
+                                    s3 = v_mul(s3, vscale0);
+                                    vx_store(out + x0*C0 + c, s0);
+                                    vx_store(out + x0*C0 + c + nlanes, s1);
+                                    vx_store(out + x0*C0 + c + nlanes*2, s2);
+                                    vx_store(out + x0*C0 + c + nlanes*3, s3);
+                                }
                             }
                         }
+                        x1 = W;
                     }
-                    x1 = W;
                 }
             }
         }
@@ -162,165 +182,188 @@ static void avgpool2d_32f(const void* inp_, void* out_, const ConvState& cs, boo
 }
 
 template<typename _Tp>
-static void avgpool2d_16(const _Tp* inp_, _Tp* out_, const ConvState& cs, bool count_include_pad)
+static void avgPool16xf(const _Tp* inp_, _Tp* out_,
+                        const ConvState& cs, bool count_include_pad_)
 {
+    constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
     int C0_ = cs.inpshape.back();
     int NC = cs.inpshape[0]*cs.inpshape[1];
     int nlanes_ = VTraits<v_float32>::vlanes();
 
     CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
-    CV_Assert(cs.nspatialdims == 2);
+    CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
+    CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
     parallel_for_(Range(0, NC), [&](const Range& r) {
+        bool count_include_pad = count_include_pad_;
+        int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
         int nlanes = nlanes_, C0 = cs.inpshape.back();
-        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
-        int H = cs.outshape[2], W = cs.outshape[3];
-        int iplanesize = Hi*Wi*C0;
-        int planesize = H*W*C0;
-        int SY = cs.strides[0], SX = cs.strides[1];
-        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
-        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
-        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
-        int ksize = (int)(cs.coordtab.size()/2);
-        const int* yxtab = cs.coordtab.data();
+        int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
+        int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
+        int Wi = cs.inpshape[sdims + 1];
+        int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
+        int H = sdims > 1 ? cs.outshape[sdims] : 1;
+        int W = cs.outshape[sdims + 1];
+        int iplanesize = Di*Hi*Wi*C0;
+        int planesize = D*H*W*C0;
+        int SZ = cs.strides[0], SY = cs.strides[1], SX = cs.strides[2];
+        int padZ0 = cs.pads[0], padY0 = cs.pads[1], padX0 = cs.pads[2];
+        int inner_z0 = cs.inner[0], inner_z1 = cs.inner[MAX_POOL_DIMS];
+        int inner_y0 = cs.inner[1], inner_y1 = cs.inner[MAX_POOL_DIMS + 1];
+        int inner_x0 = cs.inner[2], inner_x1 = cs.inner[MAX_POOL_DIMS + 2];
+        int ksize = (int)cs.ofstab.size();
+        const int* zyxtab = cs.coordtab.data();
         const int* ofstab = cs.ofstab.data();
 
-        const _Tp* inp = inp_ + nc0*iplanesize;
-        _Tp* out = out_ + nc0*planesize;
+        const _Tp* inp = (const _Tp*)inp_ + nc0*iplanesize;
+        _Tp* out = (_Tp*)out_ + nc0*planesize;
         v_float32 z = vx_setzero_f32();
         v_float32 vscale0 = vx_setall_f32(1.f/ksize);
 
         for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
-            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
-                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
-                int yi_ = y0*SY - pad_y0;
-                for(;;) {
-                    if (nlanes == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            v_float32 s0 = z;
-                            int nitems = 0;
-                            for (int k = 0; k < ksize; k++) {
-                                int yi = yi_ + yxtab[k*2];
-                                int xi = xi_ + yxtab[k*2+1];
-                                v_float32 v0;
-                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
-                                    continue;
-                                v0 = vx_load_expand(inp + (yi*Wi + xi)*C0);
-                                s0 = v_add(s0, v0);
-                                nitems++;
-                            }
-                            s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
-                            v_pack_store(out + x0*C0, s0);
-                        }
-                    } else {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            for (int c = 0; c < C0; c += nlanes*2) {
-                                v_float32 s0 = z, s1 = z;
+            for (int z0 = 0; z0 < D; z0++) {
+                int zi_ = z0*SZ - padZ0;
+                for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                    int x0 = 0;
+                    int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
+                        y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                    int yi_ = y0*SY - padY0;
+                    for(;;) {
+                        if (nlanes == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                v_float32 s0 = z;
                                 int nitems = 0;
                                 for (int k = 0; k < ksize; k++) {
-                                    int yi = yi_ + yxtab[k*2];
-                                    int xi = xi_ + yxtab[k*2+1];
-                                    v_float32 v0, v1;
-                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                    int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                    int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                    v_float32 v0;
+                                    if ((unsigned)zi >= (unsigned)Di ||
+                                        (unsigned)yi >= (unsigned)Hi ||
+                                        (unsigned)xi >= (unsigned)Wi)
                                         continue;
-                                    int ofs_k = (yi*Wi + xi)*C0 + c;
-                                    v0 = vx_load_expand(inp + ofs_k);
-                                    v1 = vx_load_expand(inp + ofs_k + nlanes);
+                                    v0 = vx_load_expand(inp + ((zi*Hi + yi)*Wi + xi)*C0);
                                     s0 = v_add(s0, v0);
-                                    s1 = v_add(s1, v1);
                                     nitems++;
                                 }
-                                v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
-                                v_pack_store(out + x0*C0 + c, v_mul(s0, vscale));
-                                v_pack_store(out + x0*C0 + c + nlanes, v_mul(s1, vscale));
+                                s0 = v_mul(s0, count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems));
+                                v_pack_store(out + x0*C0, s0);
+                            }
+                        } else {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                for (int c = 0; c < C0; c += nlanes*2) {
+                                    v_float32 s0 = z, s1 = z;
+                                    int nitems = 0;
+                                    for (int k = 0; k < ksize; k++) {
+                                        int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                        int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                        int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                        v_float32 v0, v1;
+                                        if ((unsigned)zi >= (unsigned)Di ||
+                                            (unsigned)yi >= (unsigned)Hi ||
+                                            (unsigned)xi >= (unsigned)Wi)
+                                            continue;
+                                        int ofs_k = ((zi*Hi + yi)*Wi + xi)*C0 + c;
+                                        v0 = vx_load_expand(inp + ofs_k);
+                                        v1 = vx_load_expand(inp + ofs_k + nlanes);
+                                        s0 = v_add(s0, v0);
+                                        s1 = v_add(s1, v1);
+                                    }
+                                    v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
+                                    s0 = v_mul(s0, vscale);
+                                    s1 = v_mul(s1, vscale);
+                                    v_pack_store(out + x0*C0 + c, s0);
+                                    v_pack_store(out + x0*C0 + c + nlanes, s1);
+                                }
                             }
                         }
-                    }
-                    if (x0 == W)
-                        break;
-                    x1 = inner_x1;
-                    if (nlanes == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
-
-                            v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
-                            for (int k = 1; k < ksize; k++)
-                                s0 = v_add(s0, vx_load_expand(inp_xi + ofstab[k]));
-                            s0 = v_mul(s0, vscale0);
-                            v_pack_store(out + x0*C0, s0);
-                        }
-                    } else if (nlanes*2 == C0) {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
-
-                            int ofs_k = ofstab[0];
-                            v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
-                            v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
-                            for (int k = 1; k < ksize; k++) {
-                                ofs_k = ofstab[k];
-                                s0 = v_add(s0, vx_load_expand(inp_xi + ofs_k));
-                                s1 = v_add(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                        if (x0 == W)
+                            break;
+                        x1 = inner_x1;
+                        if (nlanes == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                
+                                v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
+                                for (int k = 1; k < ksize; k++)
+                                    s0 = v_add(s0, vx_load_expand(inp_xi + ofstab[k]));
+                                v_pack_store(out + x0*C0, v_mul(s0, vscale0));
                             }
-                            s0 = v_mul(s0, vscale0);
-                            s1 = v_mul(s1, vscale0);
-                            v_pack_store(out + x0*C0, s0);
-                            v_pack_store(out + x0*C0 + nlanes, s1);
-                        }
-                    } else {
-                        for (; x0 < x1; x0++) {
-                            int xi_ = x0*SX - pad_x0;
-                            for (int c = 0; c < C0; c += nlanes*4) {
-                                const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
-
+                        } else if (nlanes*2 == C0) {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
-                                v_float32 s2 = vx_load_expand(inp_xi + ofs_k + nlanes*2);
-                                v_float32 s3 = vx_load_expand(inp_xi + ofs_k + nlanes*3);
                                 for (int k = 1; k < ksize; k++) {
                                     ofs_k = ofstab[k];
                                     s0 = v_add(s0, vx_load_expand(inp_xi + ofs_k));
                                     s1 = v_add(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
-                                    s2 = v_add(s2, vx_load_expand(inp_xi + ofs_k + nlanes*2));
-                                    s3 = v_add(s3, vx_load_expand(inp_xi + ofs_k + nlanes*3));
                                 }
                                 s0 = v_mul(s0, vscale0);
                                 s1 = v_mul(s1, vscale0);
-                                s2 = v_mul(s2, vscale0);
-                                s3 = v_mul(s3, vscale0);
-                                v_pack_store(out + x0*C0 + c, s0);
-                                v_pack_store(out + x0*C0 + c + nlanes, s1);
-                                v_pack_store(out + x0*C0 + c + nlanes*2, s2);
-                                v_pack_store(out + x0*C0 + c + nlanes*3, s3);
+                                v_pack_store(out + x0*C0, s0);
+                                v_pack_store(out + x0*C0 + nlanes, s1);
+                            }
+                        } else {
+                            for (; x0 < x1; x0++) {
+                                int xi_ = x0*SX - padX0;
+                                for (int c = 0; c < C0; c += nlanes*4) {
+                                    const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    
+                                    int ofs_k = ofstab[0];
+                                    v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
+                                    v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
+                                    v_float32 s2 = vx_load_expand(inp_xi + ofs_k + nlanes*2);
+                                    v_float32 s3 = vx_load_expand(inp_xi + ofs_k + nlanes*3);
+                                    for (int k = 1; k < ksize; k++) {
+                                        ofs_k = ofstab[k];
+                                        s0 = v_add(s0, vx_load_expand(inp_xi + ofs_k));
+                                        s1 = v_add(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                                        s2 = v_add(s2, vx_load_expand(inp_xi + ofs_k + nlanes*2));
+                                        s3 = v_add(s3, vx_load_expand(inp_xi + ofs_k + nlanes*3));
+                                    }
+                                    s0 = v_mul(s0, vscale0);
+                                    s1 = v_mul(s1, vscale0);
+                                    s2 = v_mul(s2, vscale0);
+                                    s3 = v_mul(s3, vscale0);
+                                    v_pack_store(out + x0*C0 + c, s0);
+                                    v_pack_store(out + x0*C0 + c + nlanes, s1);
+                                    v_pack_store(out + x0*C0 + c + nlanes*2, s2);
+                                    v_pack_store(out + x0*C0 + c + nlanes*3, s3);
+                                }
                             }
                         }
+                        x1 = W;
                     }
-                    x1 = W;
                 }
             }
         }
     });
 }
 
-static void avgpool2d_16f(const void* inp_, void* out_,
-                          const ConvState& cs, bool countIncludePadding)
+static void avgPool16f(const void* inp_, void* out_,
+                       const ConvState& cs, bool countIncludePadding)
 {
-    avgpool2d_16((const hfloat*)inp_, (hfloat*)out_, cs, countIncludePadding);
+    avgPool16xf((const hfloat*)inp_, (hfloat*)out_, cs, countIncludePadding);
 }
 
-static void avgpool2d_16bf(const void* inp_, void* out_,
-                           const ConvState& cs, bool countIncludePadding)
+static void avgPool16bf(const void* inp_, void* out_,
+                        const ConvState& cs, bool countIncludePadding)
 {
-    avgpool2d_16((const bfloat*)inp_, (bfloat*)out_, cs, countIncludePadding);
+    avgPool16xf((const bfloat*)inp_, (bfloat*)out_, cs, countIncludePadding);
 }
 
-typedef void (*avgpool_func_t)(const void* inp, void* out,
-                               const ConvState& cs, bool countIncludePadding);
+typedef void (*AvgPoolFunc)(const void* inp, void* out,
+                            const ConvState& cs, bool countIncludePadding);
 
 class AveragePoolLayerImpl : public AveragePoolLayer
 {
@@ -458,10 +501,10 @@ public:
     void runOp(const Mat& inp, Mat& out, const ConvState& cs)
     {
         int inptype = inp.type();
-        avgpool_func_t func =
-            inptype == CV_32F ? avgpool2d_32f :
-            inptype == CV_16F ? avgpool2d_16f :
-            inptype == CV_16BF ? avgpool2d_16bf : nullptr;
+        AvgPoolFunc func =
+            inptype == CV_32F ? avgPool32f :
+            inptype == CV_16F ? avgPool16f :
+            inptype == CV_16BF ? avgPool16bf : nullptr;
 
         CV_Assert(func != nullptr && "AveragePool: unsupported data type");
         func(inp.data, out.data, cs, count_include_pad);

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -104,6 +104,7 @@ static void avgPool32f(const void* inp_, void* out_,
                                         v1 = vx_load(inp + ofs_k + nlanes);
                                         s0 = v_add(s0, v0);
                                         s1 = v_add(s1, v1);
+                                        nitems++;
                                     }
                                     v_float32 vscale = count_include_pad ? vscale0 : vx_setall_f32(1.f/nitems);
                                     s0 = v_mul(s0, vscale);
@@ -119,7 +120,7 @@ static void avgPool32f(const void* inp_, void* out_,
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = vx_load(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
@@ -129,7 +130,7 @@ static void avgPool32f(const void* inp_, void* out_,
                         } else if (nlanes*2 == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load(inp_xi + ofs_k);
@@ -148,7 +149,7 @@ static void avgPool32f(const void* inp_, void* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                     
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load(inp_xi + ofs_k);
@@ -288,7 +289,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
@@ -298,7 +299,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                         } else if (nlanes*2 == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
@@ -317,7 +318,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                     
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
@@ -377,6 +378,7 @@ public:
         dilations = params.getVector<int>("dilation");
         pads = params.getVector<int>("pad");
         ceil_mode = params.get<bool>("ceil_mode", false);
+        count_include_pad = params.get<bool>("count_include_pad", false);
     }
 
     virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -17,21 +17,18 @@ static void avgPool32f(const void* inp_, void* out_,
                        const ConvState& cs, bool count_include_pad_)
 {
     constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
-    int C0_ = cs.inpshape.back();
-    int NC = cs.inpshape[0]*cs.inpshape[1];
-    int nlanes_ = VTraits<v_float32>::vlanes();
+    int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
     CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
-    parallel_for_(Range(0, NC), [&](const Range& r) {
+    parallel_for_(Range(0, NC1), [&](const Range& r) {
         bool count_include_pad = count_include_pad_;
         int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
-        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int C0 = cs.inpshape.back();
         int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
         int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
         int Wi = cs.inpshape[sdims + 1];
@@ -51,8 +48,14 @@ static void avgPool32f(const void* inp_, void* out_,
 
         const float* inp = (const float*)inp_ + nc0*iplanesize;
         float* out = (float*)out_ + nc0*planesize;
+        float iksize = 1.f/ksize;
+
+#if CV_SIMD || CV_SIMD_SCALABLE
+        int nlanes = VTraits<v_float32>::vlanes();
+        CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
         v_float32 z = vx_setzero_f32();
-        v_float32 vscale0 = vx_setall_f32(1.f/ksize);
+        v_float32 vscale0 = vx_setall_f32(iksize);
+#endif
 
         for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
             for (int z0 = 0; z0 < D; z0++) {
@@ -62,7 +65,13 @@ static void avgPool32f(const void* inp_, void* out_,
                     int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
+
+                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                    memset(out, 0, W*C0*sizeof(out[0]));
+                #endif
+
                     for(;;) {
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
@@ -114,14 +123,39 @@ static void avgPool32f(const void* inp_, void* out_,
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            int nitems = 0;
+                            for (int k = 0; k < ksize; k++) {
+                                int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                if ((unsigned)zi >= (unsigned)Di ||
+                                    (unsigned)yi >= (unsigned)Hi ||
+                                    (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                const float* inptr = inp + ((zi*Hi + yi)*Wi + xi)*C0;
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] += inptr[c];
+                                nitems++;
+                            }
+                            float scale = count_include_pad ? iksize : 1.f/nitems;
+                            for (int c = 0; c < C0; c++)
+                                out[x0*C0 + c] *= scale;
+                        }
+                    #endif
+
                         if (x0 == W)
                             break;
                         x1 = inner_x1;
+
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = vx_load(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
                                     s0 = v_add(s0, vx_load(inp_xi + ofstab[k]));
@@ -131,7 +165,7 @@ static void avgPool32f(const void* inp_, void* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
@@ -149,8 +183,8 @@ static void avgPool32f(const void* inp_, void* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                    
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0 + c;
+
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load(inp_xi + ofs_k);
                                     v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
@@ -174,6 +208,19 @@ static void avgPool32f(const void* inp_, void* out_,
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
+                            for (int k = 0; k < ksize; k++) {
+                                const float* inptr = inp_xi + ofstab[k];
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] += inptr[c];
+                            }
+                            for (int c = 0; c < C0; c++)
+                                out[x0*C0 + c] *= iksize;
+                        }
+                    #endif
                         x1 = W;
                     }
                 }
@@ -182,6 +229,9 @@ static void avgPool32f(const void* inp_, void* out_,
     });
 }
 
+// temporarily exclude fp16/bf16 versions,
+// since convolution and other layers don't support those types yet
+#if 0
 template<typename _Tp>
 static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                         const ConvState& cs, bool count_include_pad_)
@@ -290,7 +340,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
                                     s0 = v_add(s0, vx_load_expand(inp_xi + ofstab[k]));
@@ -300,7 +350,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
@@ -319,7 +369,7 @@ static void avgPool16xf(const _Tp* inp_, _Tp* out_,
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
                                     const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                    
+
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
                                     v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
@@ -362,6 +412,7 @@ static void avgPool16bf(const void* inp_, void* out_,
 {
     avgPool16xf((const bfloat*)inp_, (bfloat*)out_, cs, countIncludePadding);
 }
+#endif
 
 typedef void (*AvgPoolFunc)(const void* inp, void* out,
                             const ConvState& cs, bool countIncludePadding);
@@ -505,8 +556,9 @@ public:
         int inptype = inp.type();
         AvgPoolFunc func =
             inptype == CV_32F ? avgPool32f :
-            inptype == CV_16F ? avgPool16f :
-            inptype == CV_16BF ? avgPool16bf : nullptr;
+            /*inptype == CV_16F ? avgPool16f :
+            inptype == CV_16BF ? avgPool16bf :*/
+            nullptr;
 
         CV_Assert(func != nullptr && "AveragePool: unsupported data type");
         func(inp.data, out.data, cs, count_include_pad);

--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -16,15 +16,17 @@ namespace dnn
 static void avgPool32f(const void* inp_, void* out_,
                        const ConvState& cs, bool count_include_pad_)
 {
-    constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
     int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
     parallel_for_(Range(0, NC1), [&](const Range& r) {
+        constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
+
+        CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
+
         bool count_include_pad = count_include_pad_;
         int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -86,82 +86,82 @@ public:
     {
     }
 
-        std::vector<Mat> inputs;
-        inputs_arr.getMatVector(inputs);
+    virtual void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        CV_TRACE_FUNCTION();
+        CV_TRACE_ARG_VALUE(name, "name", name.c_str());
 
-        const Mat &X = inputs[0];
-        Mat Y;
-        Mat w, b;
+        size_t ninputs = inputs_arr.total(-1);
+        CV_Assert(ninputs > 0);
 
-        if (dynamicInputs) {
-            CV_Assert(inputs.size() == 5);
-
-            const Mat& scale   = inputs[1];
-            const Mat& beta    = inputs[2];
-            const Mat& mean    = inputs[3];
-            const Mat& var     = inputs[4];
-
-            w.create(scale.size(), CV_32F);
-            b.create(scale.size(), CV_32F);
-
-            cv::sqrt(var + epsilon, b);
-            cv::divide(scale, b, w);
-            b = beta - mean.mul(w);
-        } else {
-            w = weights_;
-            b = bias_;
+        if (ninputs > 1) {
+            CV_Assert(ninputs == 5);
+            Mat scale_ = inputs_arr.getMat(1);
+            Mat bias_ = inputs_arr.getMat(2);
+            Mat mean_ = inputs_arr.getMat(3);
+            Mat var_ = inputs_arr.getMat(4);
+            BatchNorm2Layer::getScaleBias(scale_, bias_, mean_, var_, epsilon, scale, bias);
         }
 
-        if (w.empty() || b.empty())
-             CV_Error(Error::StsBadArg, "BatchNorm2Layer: Weights not initialized");
+        MatShape inpShape = inputs_arr.shape(0);
+        int inpType = inputs_arr.type(0);
 
-        MatShape outShape = shape(X);
-        auto kind = outputs_arr.kind();
-        if (kind == _InputArray::STD_VECTOR_MAT) {
+        MatShape outShape = getOutShape(inpShape);
+        int outKind = outputs_arr.kind();
+
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
             std::vector<Mat>& outs = outputs_arr.getMatVecRef();
-            CV_Assert(outs.size() >= 1);
-            outs[0].fit(outShape, X.type());
-            Y = outs[0];
-        } else if (kind == _InputArray::STD_VECTOR_UMAT) {
-            std::vector<UMat>& uouts = outputs_arr.getUMatVecRef();
-            CV_Assert(uouts.size() >= 1);
-            uouts[0].fit(outShape, X.type());
-            Y = uouts[0].getMat(ACCESS_WRITE);
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            runOp(inp, outs[0]);
         } else {
-            CV_Error(Error::StsBadArg, "Unsupported output array kind");
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outShape, inpType);
+            Mat temp(outShape, inpType);
+            runOp(inp, temp);
+            temp.copyTo(outs[0]);
         }
+    }
 
-        const int C = (X.dims >= 2) ? X.size[1] : 1;
-        const int N = X.size[0];
-        const size_t planeSize = X.total() / (N * C);
+    void runOp(const Mat& inp, Mat& out)
+    {
+        auto netimpl_ = getNetImpl(this);
+        batchnorm(inp, out, scale, bias, netimpl_->originalLayout);
+    }
 
-        CV_Assert(w.total() == C);
+    virtual bool freezeScaleBias() CV_OVERRIDE
+    {
+        auto netimpl_ = getNetImpl(this);
+        size_t ninputs = inputs.size();
+        if (ninputs != 5)
+            return false;
+        if (netimpl_->isConstArg(inputs[1]) ||
+            netimpl_->isConstArg(inputs[2]) ||
+            netimpl_->isConstArg(inputs[3]) ||
+            netimpl_->isConstArg(inputs[4]))
+            return false;
+        Mat scale_ = netimpl_->argTensor(inputs[1]);
+        Mat bias_ = netimpl_->argTensor(inputs[2]);
+        Mat mean_ = netimpl_->argTensor(inputs[3]);
+        Mat var_ = netimpl_->argTensor(inputs[4]);
+        BatchNorm2Layer::getScaleBias(scale_, bias_, mean_, var_, epsilon, scale, bias);
+        inputs.resize(1);
+        return true;
+    }
 
-        parallel_for_(Range(0, N * C), [&](const Range& r) {
-            for (int i = r.start; i < r.end; ++i) {
-                int c = i % C;
-
-                float scale_val = w.ptr<float>()[c];
-                float shift_val = b.ptr<float>()[c];
-
-                const float* srcPtr = X.ptr<float>() + i * planeSize;
-                float* dstPtr = Y.ptr<float>() + i * planeSize;
-
-                int j = 0;
-#if CV_SIMD128
-                v_float32x4 v_scale = v_setall_f32(scale_val);
-                v_float32x4 v_shift = v_setall_f32(shift_val);
-                for (; j <= (int)planeSize - 4; j += 4) {
-                    v_float32x4 v_src = v_load(srcPtr + j);
-                    v_float32x4 v_dst = v_muladd(v_src, v_scale, v_shift);
-                    v_store(dstPtr + j, v_dst);
-                }
-#endif
-                for (; j < (int)planeSize; ++j) {
-                    dstPtr[j] = srcPtr[j] * scale_val + shift_val;
-                }
-            }
-        });
+    virtual void getScaleBias(OutputArray scale_, OutputArray bias_) const CV_OVERRIDE
+    {
+        scale.copyTo(scale_);
+        bias.copyTo(bias_);
     }
 private:
     bool dynamicInputs;

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -10,7 +10,341 @@
 namespace cv {
 namespace dnn {
 
-class BatchNorm2LayerImpl CV_FINAL : public BatchNorm2Layer {
+/*
+    Implementation of BatchNormalization, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__BatchNormalization.html
+
+    Opset's 1 to 15 are covered.
+*/
+
+#undef CV_SIMD_ONLY
+#if CV_SIMD || CV_SIMD_SCALABLE
+#define CV_SIMD_ONLY(expr) expr
+#else
+#define CV_SIMD_ONLY(expr)
+#endif
+
+// out must be pre-allocated
+static void batchnorm(const Mat& inp, Mat& out, const Mat& scale,
+                      const Mat& bias, DataLayout defaultLayout)
+{
+    CV_Assert_N(inp.isContinuous(), out.isContinuous());
+    CV_Assert_N(scale.dims == 1, bias.dims == 1);
+    CV_Assert_N(scale.type() == CV_32F, bias.type() == CV_32F);
+
+    MatShape shape = inp.shape();
+    DataLayout layout = shape.layout;
+    if (layout == DATA_LAYOUT_UNKNOWN)
+        layout = defaultLayout;
+    CV_Assert(layout == DATA_LAYOUT_BLOCK ||
+              layout == DATA_LAYOUT_NCHW ||
+              layout == DATA_LAYOUT_NHWC);
+    int N = shape[0];
+    int C_ = layout == DATA_LAYOUT_BLOCK ? shape.C :
+             layout == DATA_LAYOUT_NCHW ? shape[1] : shape[shape.dims-1];
+    CV_Assert_N(scale.cols == C_, bias.cols == C_);
+    int C1_ = layout != DATA_LAYOUT_NHWC ? shape[1] : 1;
+    int C0_ = layout != DATA_LAYOUT_NCHW ? shape[shape.dims-1] : 1;
+    int type_ = inp.type();
+    CV_SIMD_ONLY(int vlanes_ = VTraits<v_float32>::vlanes());
+
+    size_t esz = inp.elemSize();
+
+    CV_Assert(type_ == CV_32F || type_ == CV_16F || type_ == CV_16BF);
+
+    CV_Assert(inp.shape() == out.shape());
+    CV_Assert(inp.isContinuous());
+    CV_Assert(out.isContinuous());
+
+    int planesize_ = 1;
+    for (int i = 1; i < shape.dims; i++) {
+        planesize_ *= shape[i];
+    }
+    planesize_ /= (C0_*C1_);
+
+    parallel_for_(Range(0, N*C1_), [&](const Range& r) {
+        int C0 = C0_, C1 = C1_, C = C_;
+        int planesize_C0 = planesize_*C0;
+        int type = type_;
+        CV_SIMD_ONLY(int vlanes = vlanes_);
+        constexpr int max_lanes = VTraits<v_float32>::max_nlanes;
+        constexpr int MAX_UNROLL = 4;
+        float scalebuf[max_lanes*MAX_UNROLL], biasbuf[max_lanes*MAX_UNROLL];
+
+        for (int k = r.start; k < r.end; k++) {
+            int i = 0, n = k/C1, c1 = k % C1;
+            int c_start = c1*C0, c_end = std::min(C, c_start + C0), c_delta = c_end - c_start;
+            size_t ofs_k = (n*C1 + c1)*planesize_C0*esz;
+            const uchar* inptr_ = inp.data + ofs_k;
+            uchar* outptr_ = out.data + ofs_k;
+            const float* scaleptr = scale.ptr<float>() + c_start;
+            const float* biasptr = bias.ptr<float>() + c_start;
+
+            if (C0 == 1) {
+                // NCHW case
+                float scale_c = 0.f, bias_c = 0.f;
+                if (c_start < c_end) {
+                    scale_c = scaleptr[0];
+                    bias_c = biasptr[0];
+                }
+                CV_SIMD_ONLY(v_float32 vscale_c = vx_setall_f32(scale_c);
+                             v_float32 vbias_c = vx_setall_f32(bias_c));
+                if (type == CV_32F) {
+                    const float* inptr = (const float*)inptr_;
+                    float* outptr = (float*)outptr_;
+                    CV_SIMD_ONLY(for (; i <= planesize_C0 - vlanes*2; i += vlanes*2) {
+                        v_float32 x0 = vx_load(inptr + i);
+                        v_float32 x1 = vx_load(inptr + i + vlanes);
+                        x0 = v_fma(x0, vscale_c, vbias_c);
+                        x1 = v_fma(x1, vscale_c, vbias_c);
+                        v_store(outptr + i, x0);
+                        v_store(outptr + i + vlanes, x1);
+                    });
+                    for (; i < planesize_C0; i++) {
+                        outptr[i] = inptr[i]*scale_c + bias_c;
+                    }
+                } else if (type == CV_16F) {
+                    const hfloat* inptr = (const hfloat*)inptr_;
+                    hfloat* outptr = (hfloat*)outptr_;
+                    CV_SIMD_ONLY(for (; i <= planesize_C0 - vlanes*2; i += vlanes*2) {
+                        v_float32 x0 = vx_load_expand(inptr + i);
+                        v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                        x0 = v_fma(x0, vscale_c, vbias_c);
+                        x1 = v_fma(x1, vscale_c, vbias_c);
+                        v_pack_store(outptr + i, x0);
+                        v_pack_store(outptr + i + vlanes, x1);
+                    });
+                    for (; i < planesize_C0; i++) {
+                        outptr[i] = hfloat(float(inptr[i])*scale_c + bias_c);
+                    }
+                } else if (type == CV_16BF) {
+                    const bfloat* inptr = (const bfloat*)inptr_;
+                    bfloat* outptr = (bfloat*)outptr_;
+                    CV_SIMD_ONLY(for (; i <= planesize_C0 - vlanes*2; i += vlanes*2) {
+                        v_float32 x0 = vx_load_expand(inptr + i);
+                        v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                        x0 = v_fma(x0, vscale_c, vbias_c);
+                        x1 = v_fma(x1, vscale_c, vbias_c);
+                        v_pack_store(outptr + i, x0);
+                        v_pack_store(outptr + i + vlanes, x1);
+                    });
+                    for (; i < planesize_C0; i++) {
+                        outptr[i] = bfloat(float(inptr[i])*scale_c + bias_c);
+                    }
+                }
+            }
+        #if CV_SIMD || CV_SIMD_SCALABLE
+            /*
+                [TODO] support C0 == vlanes/2, maybe C0 == vlanes/4.
+                in this case, load everything into vsc0 and vb0, process
+                most part of the plane using vector code as if C0 == vlanes and
+                then process the tail using scalar code
+            */
+            else if (C0 == vlanes*4 || C0 == vlanes*2 || C0 == vlanes) {
+                // accelerated block layout case
+                int c = 0;
+                for (; c < c_delta; c++) {
+                    scalebuf[c] = scaleptr[c];
+                    biasbuf[c] = biasptr[c];
+                }
+                for (; c < MAX_UNROLL*vlanes; c++) {
+                    scalebuf[c] = biasbuf[c] = 0.f;
+                }
+                v_float32 vsc0, vsc1, vsc2, vsc3;
+                v_float32 vb0, vb1, vb2, vb3, vb4;
+                vsc0 = vx_load(scalebuf);
+                vsc1 = vx_load(scalebuf + vlanes);
+                vsc2 = vx_load(scalebuf + vlanes*2);
+                vsc3 = vx_load(scalebuf + vlanes*3);
+                vb0 = vx_load(biasbuf);
+                vb1 = vx_load(biasbuf + vlanes);
+                vb2 = vx_load(biasbuf + vlanes*2);
+                vb3 = vx_load(biasbuf + vlanes*3);
+                if (type == CV_32F) {
+                    const float* inptr = (const float*)inptr_;
+                    float* outptr = (float*)outptr_;
+                    if (C0 == vlanes*4) {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load(inptr + i);
+                            v_float32 x1 = vx_load(inptr + i + vlanes);
+                            v_float32 x2 = vx_load(inptr + i + vlanes*2);
+                            v_float32 x3 = vx_load(inptr + i + vlanes*3);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            x1 = v_fma(x1, vsc1, vb1);
+                            x2 = v_fma(x2, vsc2, vb2);
+                            x3 = v_fma(x3, vsc3, vb3);
+                            v_store(outptr + i, x0);
+                            v_store(outptr + i + vlanes, x1);
+                            v_store(outptr + i + vlanes*2, x2);
+                            v_store(outptr + i + vlanes*3, x3);
+                        }
+                    } else if (C0 == vlanes*2) {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load(inptr + i);
+                            v_float32 x1 = vx_load(inptr + i + vlanes);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            x1 = v_fma(x1, vsc1, vb1);
+                            v_store(outptr + i, x0);
+                            v_store(outptr + i + vlanes, x1);
+                        }
+                    } else {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load(inptr + i);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            v_store(outptr + i, x0);
+                        }
+                    }
+                } else if (type == CV_16F) {
+                    const hfloat* inptr = (const hfloat*)inptr_;
+                    hfloat* outptr = (hfloat*)outptr_;
+                    if (type == CV_32F) {
+                        if (C0 == vlanes*4) {
+                            for (; i < planesize_C0; i += C0) {
+                                v_float32 x0 = vx_load_expand(inptr + i);
+                                v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                                v_float32 x2 = vx_load_expand(inptr + i + vlanes*2);
+                                v_float32 x3 = vx_load_expand(inptr + i + vlanes*3);
+                                x0 = v_fma(x0, vsc0, vb0);
+                                x1 = v_fma(x1, vsc1, vb1);
+                                x2 = v_fma(x2, vsc2, vb2);
+                                x3 = v_fma(x3, vsc3, vb3);
+                                v_pack_store(outptr + i, x0);
+                                v_pack_store(outptr + i + vlanes, x1);
+                                v_pack_store(outptr + i + vlanes*2, x2);
+                                v_pack_store(outptr + i + vlanes*3, x3);
+                            }
+                        } else if (C0 == vlanes*2) {
+                            for (; i < planesize_C0; i += C0) {
+                                v_float32 x0 = vx_load_expand(inptr + i);
+                                v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                                x0 = v_fma(x0, vsc0, vb0);
+                                x1 = v_fma(x1, vsc1, vb1);
+                                v_pack_store(outptr + i, x0);
+                                v_pack_store(outptr + i + vlanes, x1);
+                            }
+                        } else {
+                            for (; i < planesize_C0; i += C0) {
+                                v_float32 x0 = vx_load_expand(inptr + i);
+                                x0 = v_fma(x0, vsc0, vb0);
+                                v_pack_store(outptr + i, x0);
+                            }
+                        }
+                    }
+                } else if (type == CV_16BF) {
+                    const bfloat* inptr = (const bfloat*)inptr_;
+                    bfloat* outptr = (bfloat*)outptr_;
+                    if (C0 == vlanes*4) {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load_expand(inptr + i);
+                            v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                            v_float32 x2 = vx_load_expand(inptr + i + vlanes*2);
+                            v_float32 x3 = vx_load_expand(inptr + i + vlanes*3);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            x1 = v_fma(x1, vsc1, vb1);
+                            x2 = v_fma(x2, vsc2, vb2);
+                            x3 = v_fma(x3, vsc3, vb3);
+                            v_pack_store(outptr + i, x0);
+                            v_pack_store(outptr + i + vlanes, x1);
+                            v_pack_store(outptr + i + vlanes*2, x2);
+                            v_pack_store(outptr + i + vlanes*3, x3);
+                        }
+                    } else if (C0 == vlanes*2) {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load_expand(inptr + i);
+                            v_float32 x1 = vx_load_expand(inptr + i + vlanes);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            x1 = v_fma(x1, vsc1, vb1);
+                            v_pack_store(outptr + i, x0);
+                            v_pack_store(outptr + i + vlanes, x1);
+                        }
+                    } else {
+                        for (; i < planesize_C0; i += C0) {
+                            v_float32 x0 = vx_load_expand(inptr + i);
+                            x0 = v_fma(x0, vsc0, vb0);
+                            v_pack_store(outptr + i, x0);
+                        }
+                    }
+                }
+            }
+        #endif
+            else {
+                // general block layout or NHWC case
+                if (type == CV_32F) {
+                    const float* inptr = (const float*)inptr_;
+                    float* outptr = (float*)outptr_;
+                    for (; i < planesize_C0; i += C0) {
+                        int c = 0;
+                        CV_SIMD_ONLY(for (; c <= c_delta - vlanes*2; c += vlanes*2) {
+                            v_float32 x0 = vx_load(inptr + i + c);
+                            v_float32 x1 = vx_load(inptr + i + c + vlanes);
+                            v_float32 sc0 = vx_load(scaleptr + c);
+                            v_float32 sc1 = vx_load(scaleptr + c + vlanes);
+                            v_float32 b0 = vx_load(biasptr + c);
+                            v_float32 b1 = vx_load(biasptr + c + vlanes);
+                            x0 = v_fma(x0, sc0, b0);
+                            x1 = v_fma(x1, sc1, b1);
+                            v_store(outptr + i + c, x0);
+                            v_store(outptr + i + c + vlanes, x1);
+                        });
+                        for (; c < c_delta; c++)
+                            outptr[i + c] = inptr[i + c]*scaleptr[c] + biasptr[c];
+                        for (; c < C0; c++)
+                            outptr[i + c] = 0.f;
+                    }
+                } else if (type == CV_16F) {
+                    const hfloat* inptr = (const hfloat*)inptr_;
+                    hfloat* outptr = (hfloat*)outptr_;
+                    hfloat z = hfloat(0.f);
+                    for (; i < planesize_C0; i += C0) {
+                        int c = 0;
+                        CV_SIMD_ONLY(for (; c <= c_delta - vlanes*2; c += vlanes*2) {
+                            v_float32 x0 = vx_load_expand(inptr + i + c);
+                            v_float32 x1 = vx_load_expand(inptr + i + c + vlanes);
+                            v_float32 sc0 = vx_load(scaleptr + c);
+                            v_float32 sc1 = vx_load(scaleptr + c + vlanes);
+                            v_float32 b0 = vx_load(biasptr + c);
+                            v_float32 b1 = vx_load(biasptr + c + vlanes);
+                            x0 = v_fma(x0, sc0, b0);
+                            x1 = v_fma(x1, sc1, b1);
+                            v_pack_store(outptr + i + c, x0);
+                            v_pack_store(outptr + i + c + vlanes, x1);
+                        });
+                        for (; c < c_delta; c++)
+                            outptr[i + c] = hfloat(float(inptr[i + c])*scaleptr[c] + biasptr[c]);
+                        for (; c < C0; c++)
+                            outptr[i + c] = z;
+                    }
+                } else if (type == CV_16BF) {
+                    const bfloat* inptr = (const bfloat*)inptr_;
+                    bfloat* outptr = (bfloat*)outptr_;
+                    bfloat z = bfloat(0.f);
+                    for (; i < planesize_C0; i += C0) {
+                        int c = 0;
+                        CV_SIMD_ONLY(for (; c <= c_delta - vlanes*2; c += vlanes*2) {
+                            v_float32 x0 = vx_load_expand(inptr + i + c);
+                            v_float32 x1 = vx_load_expand(inptr + i + c + vlanes);
+                            v_float32 sc0 = vx_load(scaleptr + c);
+                            v_float32 sc1 = vx_load(scaleptr + c + vlanes);
+                            v_float32 b0 = vx_load(biasptr + c);
+                            v_float32 b1 = vx_load(biasptr + c + vlanes);
+                            x0 = v_fma(x0, sc0, b0);
+                            x1 = v_fma(x1, sc1, b1);
+                            v_pack_store(outptr + i + c, x0);
+                            v_pack_store(outptr + i + c + vlanes, x1);
+                        });
+                        for (; c < c_delta; c++)
+                            outptr[i + c] = bfloat(float(inptr[i + c])*scaleptr[c] + biasptr[c]);
+                        for (; c < C0; c++)
+                            outptr[i + c] = z;
+                    }
+                }
+            }
+        }
+    }, (planesize_*C0_ > 1000000 ? N*C1_ : 1));
+}
+
+class BatchNorm2LayerImpl CV_FINAL : public BatchNorm2Layer
+{
 public:
     BatchNorm2LayerImpl(const LayerParams& params) {
         setParamsFrom(params);

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -67,10 +67,11 @@ static void batchnorm(const Mat& inp, Mat& out, const Mat& scale,
         int C0 = C0_, C1 = C1_, C = C_;
         int planesize_C0 = planesize_*C0;
         int type = type_;
-        CV_SIMD_ONLY(int vlanes = vlanes_);
+        CV_SIMD_ONLY(int vlanes = vlanes_;
         constexpr int max_lanes = VTraits<v_float32>::max_nlanes;
         constexpr int MAX_UNROLL = 4;
-        float scalebuf[max_lanes*MAX_UNROLL], biasbuf[max_lanes*MAX_UNROLL];
+        float scalebuf[max_lanes*MAX_UNROLL];
+        float biasbuf[max_lanes*MAX_UNROLL]);
 
         for (int k = r.start; k < r.end; k++) {
             int i = 0, n = k/C1, c1 = k % C1;

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -6,6 +6,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
+#include "../net_impl.hpp"
 
 namespace cv {
 namespace dnn {
@@ -348,29 +349,7 @@ class BatchNorm2LayerImpl CV_FINAL : public BatchNorm2Layer
 public:
     BatchNorm2LayerImpl(const LayerParams& params) {
         setParamsFrom(params);
-
-        epsilon = params.get<float>("epsilon", params.get<float>("eps", 1e-5f));
-        useGlobalStats = params.get<bool>("use_global_stats", true);
-        hasWeights = params.get<bool>("has_weight", false);
-        hasBias = params.get<bool>("has_bias", false);
-
-        if (blobs.size() >= 4) {
-            dynamicInputs = false;
-
-            const Mat& mean  = blobs[0];
-            const Mat& var   = blobs[1];
-            const Mat& scale = blobs[2];
-            const Mat& beta  = blobs[3];
-
-            weights_.create(scale.size(), CV_32F);
-            bias_.create(scale.size(), CV_32F);
-
-            cv::sqrt(var + epsilon, bias_);
-            cv::divide(scale, bias_, weights_);
-            bias_ = beta - mean.mul(weights_);
-        } else {
-            dynamicInputs = true;
-        }
+        epsilon = params.get<float>("epsilon", 1e-5);
     }
 
     bool supportBackend(int backendId) CV_OVERRIDE
@@ -378,29 +357,32 @@ public:
         return backendId == DNN_BACKEND_OPENCV;
     }
 
-    bool dynamicOutputShapes() const CV_OVERRIDE
+    MatShape getOutShape(const MatShape& inpShape) const
     {
-        return dynamicInputs;
+        return inpShape;
     }
 
-    bool getMemoryShapes(const std::vector<MatShape>& inputs,
-                                 const int requiredOutputs,
-                                 std::vector<MatShape>& outputs,
-                                 std::vector<MatShape>& internals) const CV_OVERRIDE
+    virtual bool getMemoryShapes(const std::vector<MatShape> &inputs,
+                         const int,
+                         std::vector<MatShape> &outputs,
+                         std::vector<MatShape> &internals) const CV_OVERRIDE
+    {
+        CV_Assert(!inputs.empty());
+        outputs.assign(1, getOutShape(inputs[0]));
+        internals.clear();
+        return true;
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inputs,
+        const int requiredOutputs,
+        const int requiredInternals,
+        std::vector<MatType>& outputs,
+        std::vector<MatType>& internals) const CV_OVERRIDE
     {
         CV_Assert(!inputs.empty());
         outputs.assign(requiredOutputs, inputs[0]);
-        return false;
-    }
-
-    void getTypes(const std::vector<MatType>& inputs,
-                          const int requiredOutputs,
-                          const int requiredInternals,
-                          std::vector<MatType>& outputs,
-                          std::vector<MatType>& internals) const CV_OVERRIDE
-    {
-        CV_Assert(!inputs.empty());
-        outputs.assign(requiredOutputs, inputs[0]);
+        CV_Assert(requiredInternals == 0);
+        internals.clear();
     }
 
     int getLayouts(const std::vector<DataLayout>& actualInputs,
@@ -478,10 +460,10 @@ public:
         size_t ninputs = inputs.size();
         if (ninputs != 5)
             return false;
-        if (netimpl_->isConstArg(inputs[1]) ||
-            netimpl_->isConstArg(inputs[2]) ||
-            netimpl_->isConstArg(inputs[3]) ||
-            netimpl_->isConstArg(inputs[4]))
+        if (!netimpl_->isConstArg(inputs[1]) ||
+            !netimpl_->isConstArg(inputs[2]) ||
+            !netimpl_->isConstArg(inputs[3]) ||
+            !netimpl_->isConstArg(inputs[4]))
             return false;
         Mat scale_ = netimpl_->argTensor(inputs[1]);
         Mat bias_ = netimpl_->argTensor(inputs[2]);
@@ -497,10 +479,60 @@ public:
         scale.copyTo(scale_);
         bias.copyTo(bias_);
     }
-private:
-    bool dynamicInputs;
-    Mat weights_, bias_;
+
+    Mat scale, bias;
 };
+
+void BatchNorm2Layer::getScaleBias(InputArray scale_, InputArray bias_,
+                                   InputArray mean_, InputArray variance_, float eps,
+                                   OutputArray outscale_, OutputArray outbias_)
+{
+    Mat scale = scale_.getMat(), bias = bias_.getMat();
+    Mat mean = mean_.getMat(), var = variance_.getMat();
+
+    int sctype = scale.type(), btype = bias.type();
+    int mtype = mean.type(), vtype = var.type();
+
+    CV_Assert(sctype == CV_32F || sctype == CV_16F || sctype == CV_16BF);
+    CV_Assert(btype == CV_32F || btype == CV_16F || btype == CV_16BF);
+    CV_Assert(mtype == CV_32F || mtype == CV_16F || mtype == CV_16BF);
+    CV_Assert(vtype == CV_32F || vtype == CV_16F || vtype == CV_16BF);
+
+    CV_Assert_N(scale.dims == 1, bias.dims == 1, mean.dims == 1, var.dims == 1);
+    int C = scale.cols;
+    CV_Assert_N(bias.cols == C, mean.cols == C, var.cols == C);
+
+    Mat outscale(1, &C, CV_32F);
+    Mat outbias(1, &C, CV_32F);
+
+    const uchar* scdata = scale.data;
+    const uchar* bdata = bias.data;
+    const uchar* mdata = mean.data;
+    const uchar* vdata = var.data;
+    float* outsc = outscale.ptr<float>();
+    float* outb = outbias.ptr<float>();
+
+    #undef LOAD_AS_FLOAT
+    #define LOAD_AS_FLOAT(typ, ptr, i) \
+        (typ == CV_32F ? ((const float*)ptr)[i] : \
+         typ == CV_16F ? float(((const hfloat*)ptr)[i]) : \
+         float(((const bfloat*)ptr)[i]))
+
+    // ONNX documentation: Y = (X - input_mean) / sqrt(input_var + epsilon) * scale + B
+    for (int i = 0; i < C; i++) {
+        float sc = LOAD_AS_FLOAT(sctype, scdata, i);
+        float b = LOAD_AS_FLOAT(btype, bdata, i);
+        float m = LOAD_AS_FLOAT(mtype, mdata, i);
+        float v = LOAD_AS_FLOAT(vtype, vdata, i);
+
+        float outscval = sc/sqrtf(fabsf(v) + eps);
+        float outbval = b - m*outscval;
+        outsc[i] = outscval;
+        outb[i] = outbval;
+    }
+    outscale.copyTo(outscale_);
+    outbias.copyTo(outbias_);
+}
 
 Ptr<BatchNorm2Layer> BatchNorm2Layer::create(const LayerParams& params)
 {

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -69,13 +69,22 @@ public:
         outputs.assign(requiredOutputs, inputs[0]);
     }
 
-    void forward(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr, OutputArrayOfArrays internals_arr) CV_OVERRIDE
+    int getLayouts(const std::vector<DataLayout>& actualInputs,
+                    std::vector<DataLayout>& desiredInputs,
+                    const int requiredOutputs,
+                    std::vector<DataLayout>& outputs) const CV_OVERRIDE
     {
-        if (inputs_arr.depth() == CV_16F)
-        {
-            forward_fallback(inputs_arr, outputs_arr, internals_arr);
-            return;
-        }
+        size_t ninputs = actualInputs.size();
+        CV_Assert(ninputs >= 1u);
+        desiredInputs.assign(ninputs, DATA_LAYOUT_UNKNOWN);
+        desiredInputs[0] = actualInputs[0];
+        outputs.assign(requiredOutputs, actualInputs[0]);
+        return 0;
+    }
+
+    virtual void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
 
         std::vector<Mat> inputs;
         inputs_arr.getMatVector(inputs);

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -176,7 +176,7 @@ void ConvState::initConv(const MatShape& inpshape_,
     int Cout = outshape.layout == DATA_LAYOUT_BLOCK ? outshape.C :
         outshape.layout == DATA_LAYOUT_NHWC ? outshape.back() : outshape[1];
     
-    bool depthwise = ngroups == C && ngroups == Cout;
+    depthwise = ngroups == C && ngroups == Cout;
 
     CV_Assert(inpshape_[0] == outshape_[0]);
     if (inpshape.layout == DATA_LAYOUT_BLOCK) {
@@ -392,8 +392,9 @@ void repackConvWeights(const void* inpw__, int inptype_,
         int C0 = C0_, K0 = C0_;
         int K = wshape[0], Cg = wshape[1];
         int C1g = (Cg + C0 - 1)/C0;
-        int Hk = wshape[2], Wk = wshape[3];
-        int ksize = Hk*Wk;
+        int ksize = 1;
+        for (int k = 2; k < wshape.dims; k++)
+            ksize *= wshape[k];
         size_t inp_step_c = ksize, inp_step_k = Cg*ksize;
         size_t out_microplane_size = ksize*C0*K0*out_esz;
 
@@ -444,6 +445,7 @@ void ConvState::initPooling(const MatShape& inpshape_,
     inpshape = inpshape_;
     outshape = outshape_;
     ngroups = C;
+    depthwise = true;
     
     for (int i = 0; i < MAX_CONV_DIMS; i++) {
         kshape[i] = strides[i] = dilations[i] = 1;

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -454,23 +454,23 @@ void ConvState::initOfs()
     CV_Assert(MAX_CONV_DIMS == 3);
     int sdims = nspatialdims;
     int KD = kshape[0], KH = kshape[1], KW = kshape[2];
-    int SZ = strides[0], SY = strides[1], SX = strides[2];
-    int padZ0 = pads[0], padY0 = pads[1], padX0 = pads[2];
+    int DZ = dilations[0], DY = dilations[1], DX = dilations[2];
     int Hi = sdims > 1 ? inpshape[sdims] : 1;
     int Wi = inpshape[sdims + 1];
     int ksize = KD*KH*KW;
+    int C0 = inpshape.back();
     coordtab.resize(ksize*MAX_CONV_DIMS);
     ofstab.resize(ksize);
     for (int z = 0, k = 0; z < KD; z++) {
-        int dz = z*SZ - padZ0;
+        int dz = z*DZ;
         for (int y = 0; y < KH; y++) {
-            int dy = y*SY - padY0;
+            int dy = y*DY;
             for (int x = 0; x < KW; x++, k++) {
-                int dx = x*SX - padX0;
+                int dx = x*DX;
                 coordtab[k*MAX_CONV_DIMS] = dz;
                 coordtab[k*MAX_CONV_DIMS + 1] = dy;
                 coordtab[k*MAX_CONV_DIMS + 2] = dx;
-                ofstab[k] = (dz*Hi + dy)*Wi + dx;
+                ofstab[k] = ((dz*Hi + dy)*Wi + dx)*C0;
             }
         }
     }

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -9,6 +9,7 @@
 #include <math.h>
 
 namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
 
 AutoPadding getAutoPadding(const LayerParams& params)
 {
@@ -27,24 +28,26 @@ AutoPadding getAutoPadding(const LayerParams& params)
 
 // computes shape of the output tensor of convolution
 // (including depth-wise convolution), max pooling or average pooling operations
-MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
-                        const std::vector<int>& kernel_shape, int ngroups,
+// computes shape of the output tensor of convolution
+// (including depth-wise convolution), max pooling or average pooling operations
+MatShape convInferShape(const MatShape& inpShape, const MatShape& wshape,
+                        const std::vector<int>& kernelShape, int ngroups,
                         const std::vector<int>& strides,
                         const std::vector<int>& dilations,
                         const std::vector<int>& pads,
-                        AutoPadding auto_pad, bool ceil_mode)
+                        AutoPadding autoPad, bool ceilMode)
 {
-    int blockLayout = inpshape.layout == DATA_LAYOUT_BLOCK;
-    int ndims = inpshape.dims;
-    size_t nspatialdims = (size_t)(ndims - 2 - blockLayout);
-    MatShape outshape = inpshape;
+    bool blockLayout = true;
+    int ndims = inpShape.dims;
+    size_t nspatialdims = (size_t)(ndims - 2 - int(blockLayout));
+    MatShape outshape = inpShape;
     int kshape[MatShape::MAX_DIMS];
 
-    if (!kernel_shape.empty()) {
-        size_t kshape_size = kernel_shape.size();
+    if (!kernelShape.empty()) {
+        size_t kshape_size = kernelShape.size();
         CV_Assert(kshape_size == nspatialdims || kshape_size == nspatialdims+2);
         for (size_t i = 0; i < nspatialdims; i++)
-            kshape[i] = kernel_shape[kshape_size - nspatialdims + i];
+            kshape[i] = kernelShape[kshape_size - nspatialdims + i];
     } else {
         CV_Assert(!wshape.empty() && wshape.dims == nspatialdims + 2);
         for (size_t i = 0; i < nspatialdims; i++)
@@ -52,9 +55,9 @@ MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
     }
 
     if (ngroups == 0 || wshape.empty()) {
-        outshape[1] = inpshape[1];
+        outshape[1] = inpShape[1];
     } else if (blockLayout) {
-        int C0 = inpshape[ndims-1];
+        int C0 = inpShape[ndims-1];
         outshape[1] = (wshape[0] + C0 - 1)/C0;
     } else {
         outshape[1] = wshape[0];
@@ -62,31 +65,31 @@ MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
 
     CV_Assert(strides.empty() || strides.size() == nspatialdims);
     CV_Assert(dilations.empty() || dilations.size() == nspatialdims);
-    CV_Assert(auto_pad == AUTO_PAD_NONE || pads.empty());
+    CV_Assert(autoPad == AUTO_PAD_NONE || pads.empty());
     CV_Assert(pads.empty() || pads.size() == nspatialdims*2);
 
     for (size_t i = 0; i < nspatialdims; i++) {
-        int inp_i = inpshape[i+2], k_i = kshape[i];
+        int inpsz = inpShape[i+2], k_i = kshape[i];
         int stride = strides.empty() ? 1 : strides[i];
         int dilation = dilations.empty() ? 1 : dilations[i];
-        int out_i;
-        if (auto_pad == AUTO_PAD_NONE || auto_pad == AUTO_PAD_VALID) {
+        int outsz;
+        if (autoPad == AUTO_PAD_NONE || autoPad == AUTO_PAD_VALID) {
             int pad = 0;
             if (!pads.empty()) {
                 pad = pads[i] + pads[i + nspatialdims];
             }
-            out_i = (inp_i + pad - 1 - dilation * (k_i - 1) + (ceil_mode ? stride - 1 : 0)) / stride + 1;
+            outsz = (inpsz + pad - 1 - dilation * (k_i - 1) + (ceilMode ? stride - 1 : 0)) / stride + 1;
         } else {
-            if (ceil_mode)
-                out_i = (inp_i + stride - 1)/stride;
+            if (ceilMode)
+                outsz = (inpsz + stride - 1)/stride;
             else
-                out_i = (inp_i - 1)/stride + 1;
+                outsz = (inpsz - 1)/stride + 1;
         }
-        outshape[i + 2] = out_i;
+        outshape[i + 2] = outsz;
     }
 
     if (blockLayout) {
-        outshape.C = ngroups == 0 || wshape.empty() ? inpshape.C : wshape[0];
+        outshape.C = ngroups == 0 || wshape.empty() ? inpShape.C : wshape[0];
     } else {
         outshape.C = 0;
     }
@@ -94,20 +97,304 @@ MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
     return outshape;
 }
 
+static inline void getPadding(const std::vector<int>& pads,
+                              int dim, int nspatialdims, AutoPadding autoPad,
+                              int ksize, int& pad0, int& pad1)
+{
+    CV_Assert(0 <= dim && dim < nspatialdims);
 
-void initPoolingState(const MatShape& inpshape,
-                      const MatShape& outshape,
-                      const std::vector<int>& kernel_shape,
-                      const std::vector<int>& strides,
-                      const std::vector<int>& dilations,
-                      const std::vector<int>& pads,
-                      AutoPadding auto_pad, bool ceil_mode,
-                      int mindims, ConvState& cs)
+    if (autoPad == AUTO_PAD_NONE || autoPad == AUTO_PAD_VALID) {
+        if (!pads.empty()) {
+            pad0 = pads[dim];
+            pad1 = pads[dim + nspatialdims];
+        } else {
+            pad0 = pad1 = 0;
+        }
+    } else {
+        CV_Assert(autoPad == AUTO_PAD_SAME_LOWER || autoPad == AUTO_PAD_SAME_UPPER);
+        pad0 = pad1 = ksize/2;
+        if (pad0*2 == ksize) {
+            pad0 -= autoPad == AUTO_PAD_SAME_UPPER;
+            pad1 -= autoPad == AUTO_PAD_SAME_LOWER;
+        }
+    }
+}
+
+void ConvState::initPooling(const MatShape& inpshape,
+                            const MatShape& outshape,
+                            const std::vector<int>& kernel_shape,
+                            const std::vector<int>& strides,
+                            const std::vector<int>& dilations,
+                            const std::vector<int>& pads,
+                            AutoPadding auto_pad, bool ceil_mode)
 {
     //size_t kshape_size =
     //CV_Assert(kernel_shape.size() <= (size_t)ConvState::MAX_CONV_DIMS);
     CV_Error(Error::StsNotImplemented, "");
 }
 
+bool ConvState::sameShape(const ConvState& cs) const
+{
+    return kshape == cs.kshape &&
+           inpshape == cs.inpshape &&
+           outshape == cs.outshape &&
+           strides == cs.strides &&
+           dilations == cs.dilations &&
+           pads == cs.pads;
 }
+
+void ConvState::initConv(const MatShape& inpShape_,
+                         const MatShape& wshape_,
+                         const MatShape& outShape_,
+                         int ngroups_,
+                         const std::vector<int>& strides_,
+                         const std::vector<int>& dilations_,
+                         const std::vector<int>& pads_,
+                         AutoPadding autoPad, bool ceilMode,
+                         FastActivation fastActivation_,
+                         const float* activParams_,
+                         size_t nactivParams_)
+{
+    nspatialdims = wshape_.dims - 2;
+    CV_Assert(0 < nspatialdims && nspatialdims <= ConvState::MAX_CONV_DIMS);
+    CV_Assert(strides_.empty() || (strides_.size() == size_t(nspatialdims)));
+    CV_Assert(dilations_.empty() || (dilations_.size() == size_t(nspatialdims)));
+    CV_Assert(pads_.empty() || (pads_.size() == size_t(nspatialdims*2)));
+    CV_Assert(inpShape_.dims == outShape_.dims);
+    CV_Assert(nspatialdims == inpShape_.dims - 3);
+    CV_Assert(inpShape_[1] % ngroups == 0);
+    CV_Assert(outShape_[1] % ngroups == 0);
+    CV_Assert(inpShape_[0] == outShape_[0]);
+    CV_Assert(inpShape_.back() == outShape_.back());
+
+    inpshape = inpShape_;
+    outshape = outShape_;
+    ngroups = ngroups_;
+
+    fastActivation = fastActivation_;
+    activation = nullptr;
+    memset(activParams, 0, sizeof(activParams));
+    if (activParams_ && nactivParams_ > 0) {
+        CV_Assert(nactivParams_ <= (size_t)MAX_ACTIV_PARAMS);
+        for (size_t i = 0; i < nactivParams_; i++)
+            activParams[i] = activParams_[i];
+    }
+
+    CV_Assert(wshape_[0] > 0 && wshape_[1] > 0);
+    for (size_t i = 0; i < size_t(MAX_CONV_DIMS); i++) {
+        kshape[i] = strides[i] = dilations[i] = 1;
+        pads[i] = pads[i + MAX_CONV_DIMS] = 0;
+        inner[i] = 0;
+        inner[i + MAX_CONV_DIMS] = 1;
+    }
+
+    for (int i = 0; i < nspatialdims; i++) {
+        int j = i + (MAX_CONV_DIMS - nspatialdims);
+        kshape[j] = wshape_[i+2];
+        CV_Assert(kshape[j] > 0);
+
+        strides[j] = strides_.empty() ? 1 : strides_[i];
+        dilations[j] = dilations_.empty() ? 1 : dilations_[i];
+
+        CV_Assert(strides[j] > 0);
+        CV_Assert(dilations[j] > 0);
+
+        int pad0, pad1;
+        getPadding(pads_, i, nspatialdims, autoPad, kshape[i], pad0, pad1);
+        CV_Assert_N(pad0 >= 0, pad1 >= 0);
+        pads[j] = pad0;
+        pads[j + MAX_CONV_DIMS] = pad1;
+
+        int inner0 = (pad0 + strides[j] - 1)/strides[j];
+        int inner1 = (inpshape[i+2] - (kshape[j] - 1)*dilations[j] + pad0)/strides[j];
+        inner1 += inner1*strides[j] - pad0 + (kshape[j] - 1)*dilations[j] < inpshape[i+2];
+        inner1 = std::min(inner1, outshape[i+2]);
+        if (inner0 >= inner1) {
+            inner0 = inner1 = outshape[i+2];
+        }
+        inner[j] = inner0;
+        inner[j + MAX_CONV_DIMS] = inner1;
+    }
 }
+
+void initConvTables(const ConvState& cs,
+                    std::vector<int32_t>& inpofs_,
+                    std::vector<int32_t>& ofsofs_)
+{
+    int sdims = cs.nspatialdims, ndims = sdims + 3;
+    int Dk = cs.kshape[0], Hk = cs.kshape[1], Wk = cs.kshape[2];
+    int DZ = cs.dilations[0], DY = cs.dilations[1], DX = cs.dilations[2];
+    int SZ = cs.strides[0], SY = cs.strides[1], SX = cs.strides[2];
+    int pad_z0 = cs.pads[0], pad_y0 = cs.pads[1], pad_x0 = cs.pads[2];
+    int Di = ndims > 2 ? cs.inpshape[ndims - 4] : 1;
+    int Hi = ndims > 1 ? cs.inpshape[ndims - 3] : 1;
+    int Wi = cs.inpshape[ndims - 2];
+    int D = ndims > 2 ? cs.outshape[ndims - 4] : 1;
+    int H = ndims > 1 ? cs.outshape[ndims - 3] : 1;
+    int W = cs.outshape[ndims - 2];
+    int C0 = cs.inpshape.back(), C1 = cs.inpshape[1];
+    int ngroups = cs.ngroups, C1g = C1/ngroups;
+    int inner_z0 = cs.inner[0], inner_y0 = cs.inner[1], inner_x0 = cs.inner[2];
+    int inner_z1 = cs.inner[3], inner_y1 = cs.inner[4], inner_x1 = cs.inner[5];
+
+    inpofs_.resize(D*H*W*2);
+
+    int ofs_blocksize = C1g*Dk*Hk*Wk;
+    bool have_inner = inner_z0 < inner_z1 && inner_y0 < inner_y1 && inner_x0 < inner_x1;
+
+    inpofs_.resize(ofs_blocksize);
+
+    if (have_inner) {
+        for (int c = 0, k = 0; c < C1g; c++) {
+            for (int dy = 0; dy < Hk; dy++) {
+                int yi = dy*DY;
+                for (int dx = 0; dx < Wk; dx++, k++) {
+                    int xi = dx*DX;
+                    inpofs_[k] = (int32_t)(((c*Hi + yi)*Wi + xi)*C0);
+                }
+            }
+        }
+    }
+
+    int32_t* ofsofs = ofsofs_.data();
+    int64_t curr_block = 1;
+
+    bool prev_z_inside = false;
+    for (int z0 = 0; z0 < D; z0++) {
+        int zi_ = z0*SZ - pad_z0;
+        bool z_inside = inner_z0 <= z0 && z0 < inner_z1;
+        bool prev_y_inside = false;
+
+        for (int y0 = 0; y0 < H; y0++) {
+            int yi_ = y0*SY - pad_y0;
+            bool y_inside = inner_y0 <= y0 && y0 < inner_y1;
+            bool prev_x_inside = false;
+
+            for (int x0 = 0; x0 < W; x0++) {
+                int xi_ = x0*SX - pad_x0;
+                bool x_inside = inner_x0 <= x0 && x0 < inner_x1;
+                int idx = (y0*W + x0)*2;
+
+                if (x_inside && y_inside && z_inside) {
+                    ofsofs[idx] = (int32_t)((yi_*Wi + xi_)*C0);
+                    ofsofs[idx + 1] = 0;
+                } else if (z_inside && prev_z_inside) {
+                    ofsofs[idx] = ofsofs[idx - W*H*2] + Wi*Hi*SZ*C0;
+                    ofsofs[idx + 1] = ofsofs[idx - W*H*2 + 1];
+                } else if (y_inside && prev_y_inside) {
+                    ofsofs[idx] = ofsofs[idx - W*2] + Wi*SY*C0;
+                    ofsofs[idx + 1] = ofsofs[idx - W*2 + 1];
+                } else if (x_inside && prev_x_inside) {
+                    ofsofs[idx] = ofsofs[idx - 2] + SX*C0;
+                    ofsofs[idx + 1] = ofsofs[idx - 1];
+                } else {
+                    int64_t curr_ofs = curr_block*ofs_blocksize;
+                    ofsofs[idx] = 0;
+                    ofsofs[idx + 1] = int(curr_ofs);
+                    curr_block++;
+                    inpofs_.resize(curr_ofs + ofs_blocksize);
+                    int32_t* inpofs = &inpofs_[curr_ofs];
+
+                    int firstofs = -1;
+                    for (int c = 0, k = 0; c < C1g; c++) {
+                        for (int dz = 0; dz < Dk; dz++) {
+                            int zi = zi_ + dz*DZ;
+                            bool zi_inside = 0 <= zi && zi < Di;
+
+                            for (int dy = 0; dy < Hk; dy++) {
+                                int yi = yi_ + dy*DY;
+                                bool yi_inside = 0 <= yi && yi < Hi;
+
+                                for (int dx = 0; dx < Wk; dx++, k++) {
+                                    int xi = xi_ + dx*DX;
+                                    bool xi_inside = 0 <= xi && xi < Wi;
+
+                                    if (zi_inside && yi_inside && xi_inside) {
+                                        int ofs = (((c*Di + zi)*Hi + yi)*Wi + xi)*C0;
+                                        if (firstofs < 0)
+                                            ofsofs[idx] = firstofs = ofs;
+                                        inpofs[k] = (int32_t)(ofs - firstofs);
+                                    } else {
+                                        inpofs[k] = INT_MIN/2;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                prev_x_inside = x_inside;
+            }
+            prev_y_inside = y_inside;
+        }
+        prev_z_inside = z_inside;
+    }
+}
+
+template<typename _InpT, typename _OutT> void
+repackConvWeights_(const _InpT* inpw_, _OutT* outw_,
+                   size_t inp_step_c, size_t inp_step_k, int ksize,
+                   int C0, int K0, int curr_C0, int curr_K0)
+{
+    const _InpT* inpw = inpw_;
+    _OutT* outw = outw_;
+    for (int xy = 0; xy < ksize; xy++, inpw++, outw += C0*K0) {
+        for (int c0 = 0; c0 < curr_C0; c0++) {
+            for (int k0 = 0; k0 < curr_K0; k0++) {
+                outw[c0*K0 + k0] = _OutT(inpw[inp_step_k*k0 + inp_step_c*c0]);
+            }
+        }
+    }
+}
+
+
+// K x (C/ngroups) x Dk x Hk x Wk => K1 x C1/ngroups x Dk x Hk x Wk x C0 x K0,
+// where K0 == C0
+void repackConvWeights(const void* inpw__, int inptype_,
+                       void* outw__, int outtype_,
+                       const MatShape& wshape, int C0_)
+{
+    CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F);
+    CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F);
+
+    int K1 = (wshape[0] + C0_ - 1)/C0_;
+    parallel_for_(Range(0, K1), [&](const Range& r) {
+        int inptype = inptype_, outtype = outtype_;
+        size_t inp_esz = CV_ELEM_SIZE(inptype);
+        size_t out_esz = CV_ELEM_SIZE(outtype);
+        int C0 = C0_, K0 = C0_;
+        int K = wshape[0], Cg = wshape[1];
+        int C1g = (Cg + C0 - 1)/C0;
+        int Hk = wshape[2], Wk = wshape[3];
+        int ksize = Hk*Wk;
+        size_t inp_step_c = ksize, inp_step_k = Cg*ksize;
+        size_t out_microplane_size = ksize*C0*K0*out_esz;
+
+        for (int k1 = r.start; k1 < r.end; k1++) {
+            int curr_K0 = std::min(K - k1*K0, K0);
+            for (int c1g = 0; c1g < C1g; c1g++) {
+                uint8_t* inpw_ = (uint8_t*)inpw__ + (k1*K0*inp_step_k + c1g*C0*inp_step_c)*inp_esz;
+                uint8_t* outw_ = (uint8_t*)outw__ + (k1*C1g + c1g)*out_microplane_size;
+                int curr_C0 = std::min(Cg - c1g*C0, C0);
+                if (curr_K0 != K0 || curr_C0 != C0)
+                    memset(outw_, 0, out_microplane_size);
+
+                if (inptype == CV_32F && outtype == CV_32F)
+                    repackConvWeights_((const float*)inpw_, (float*)outw_, inp_step_c,
+                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_32F && outtype == CV_16F)
+                    repackConvWeights_((const float*)inpw_, (hfloat*)outw_, inp_step_c,
+                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_16F && outtype == CV_32F)
+                    repackConvWeights_((const hfloat*)inpw_, (float*)outw_, inp_step_c,
+                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_16F && outtype == CV_16F)
+                    repackConvWeights_((const hfloat*)inpw_, (hfloat*)outw_, inp_step_c,
+                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else break;
+            }
+        }
+    });
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -149,8 +149,8 @@ void ConvState::initConv(const MatShape& inpshape_,
     CV_Assert(pads_.empty() || (pads_.size() == size_t(nspatialdims*2)));
     CV_Assert(inpshape_.dims == outshape_.dims);
     CV_Assert(nspatialdims == inpshape_.dims - 3);
-    CV_Assert(inpshape_[1] % ngroups == 0);
-    CV_Assert(outshape_[1] % ngroups == 0);
+    CV_Assert(inpshape_[1] % ngroups_ == 0);
+    CV_Assert(outshape_[1] % ngroups_ == 0);
     CV_Assert(inpshape_[0] == outshape_[0]);
     CV_Assert(inpshape_.back() == outshape_.back());
 
@@ -224,7 +224,7 @@ void initConvTables(const ConvState& cs,
     int inner_z0 = cs.inner[0], inner_y0 = cs.inner[1], inner_x0 = cs.inner[2];
     int inner_z1 = cs.inner[3], inner_y1 = cs.inner[4], inner_x1 = cs.inner[5];
 
-    inpofs_.resize(D*H*W*2);
+    ofsofs_.resize(D*H*W*2);
 
     int ofs_blocksize = C1g*Dk*Hk*Wk;
     bool have_inner = inner_z0 < inner_z1 && inner_y0 < inner_y1 && inner_x0 < inner_x1;

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -1,0 +1,113 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "../net_impl.hpp"
+#include "layers_common.hpp"
+#include "conv2_common.hpp"
+#include <math.h>
+
+namespace cv { namespace dnn {
+
+AutoPadding getAutoPadding(const LayerParams& params)
+{
+    std::string auto_pad = params.get<std::string>("auto_pad", "NOTSET");
+    if (auto_pad == "NOTSET")
+        return AUTO_PAD_NONE;
+    if (auto_pad == "SAME_UPPER")
+        return AUTO_PAD_SAME_UPPER;
+    if (auto_pad == "SAME_LOWER")
+        return AUTO_PAD_SAME_LOWER;
+    if (auto_pad != "VALID") {
+        CV_Error_(Error::StsBadArg, ("invalid auto_pad value '%s'", auto_pad.c_str()));
+    }
+    return AUTO_PAD_VALID;
+}
+
+// computes shape of the output tensor of convolution
+// (including depth-wise convolution), max pooling or average pooling operations
+MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
+                        const std::vector<int>& kernel_shape, int ngroups,
+                        const std::vector<int>& strides,
+                        const std::vector<int>& dilations,
+                        const std::vector<int>& pads,
+                        AutoPadding auto_pad, bool ceil_mode)
+{
+    int blockLayout = inpshape.layout == DATA_LAYOUT_BLOCK;
+    int ndims = inpshape.dims;
+    size_t nspatialdims = (size_t)(ndims - 2 - blockLayout);
+    MatShape outshape = inpshape;
+    int kshape[MatShape::MAX_DIMS];
+
+    if (!kernel_shape.empty()) {
+        size_t kshape_size = kernel_shape.size();
+        CV_Assert(kshape_size == nspatialdims || kshape_size == nspatialdims+2);
+        for (size_t i = 0; i < nspatialdims; i++)
+            kshape[i] = kernel_shape[kshape_size - nspatialdims + i];
+    } else {
+        CV_Assert(!wshape.empty() && wshape.dims == nspatialdims + 2);
+        for (size_t i = 0; i < nspatialdims; i++)
+            kshape[i] = wshape[wshape.dims - nspatialdims + i];
+    }
+
+    if (ngroups == 0 || wshape.empty()) {
+        outshape[1] = inpshape[1];
+    } else if (blockLayout) {
+        int C0 = inpshape[ndims-1];
+        outshape[1] = (wshape[0] + C0 - 1)/C0;
+    } else {
+        outshape[1] = wshape[0];
+    }
+
+    CV_Assert(strides.empty() || strides.size() == nspatialdims);
+    CV_Assert(dilations.empty() || dilations.size() == nspatialdims);
+    CV_Assert(auto_pad == AUTO_PAD_NONE || pads.empty());
+    CV_Assert(pads.empty() || pads.size() == nspatialdims*2);
+
+    for (size_t i = 0; i < nspatialdims; i++) {
+        int inp_i = inpshape[i+2], k_i = kshape[i];
+        int stride = strides.empty() ? 1 : strides[i];
+        int dilation = dilations.empty() ? 1 : dilations[i];
+        int out_i;
+        if (auto_pad == AUTO_PAD_NONE || auto_pad == AUTO_PAD_VALID) {
+            int pad = 0;
+            if (!pads.empty()) {
+                pad = pads[i] + pads[i + nspatialdims];
+            }
+            out_i = (inp_i + pad - 1 - dilation * (k_i - 1) + (ceil_mode ? stride - 1 : 0)) / stride + 1;
+        } else {
+            if (ceil_mode)
+                out_i = (inp_i + stride - 1)/stride;
+            else
+                out_i = (inp_i - 1)/stride + 1;
+        }
+        outshape[i + 2] = out_i;
+    }
+
+    if (blockLayout) {
+        outshape.C = ngroups == 0 || wshape.empty() ? inpshape.C : wshape[0];
+    } else {
+        outshape.C = 0;
+    }
+
+    return outshape;
+}
+
+
+void initPoolingState(const MatShape& inpshape,
+                      const MatShape& outshape,
+                      const std::vector<int>& kernel_shape,
+                      const std::vector<int>& strides,
+                      const std::vector<int>& dilations,
+                      const std::vector<int>& pads,
+                      AutoPadding auto_pad, bool ceil_mode,
+                      int mindims, ConvState& cs)
+{
+    //size_t kshape_size =
+    //CV_Assert(kernel_shape.size() <= (size_t)ConvState::MAX_CONV_DIMS);
+    CV_Error(Error::StsNotImplemented, "");
+}
+
+}
+}

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -147,10 +147,10 @@ bool ConvState::sameShape(const ConvState& cs) const
     return inpshape == cs.inpshape && outshape == cs.outshape;
 }
 
-static MatShape getWpackShapeAlt(const MatShape& wshape, int ngroups, int C0)
+static MatShape getWpackShape(const MatShape& wshape, int ngroups, int C0)
 {
     CV_Assert(wshape.dims >= 3);
-    int K = wshape[0], Cg = wshape[1], C = Cg*ngroups;
+    int K = wshape[0], Cg = wshape[1];
     int ksize = int(wshape.total())/(K*Cg);
     CV_Assert_N(K % ngroups == 0);
     int Kg = K / ngroups, K0 = C0;
@@ -191,16 +191,16 @@ void ConvState::initConv(const MatShape& inpshape_,
     outshape = outshape_;
     ngroups = ngroups_;
     Kblk = C1Max = 0;
-    
+
     int C = inpshape.channels();
     int K = outshape.channels();
-    
+
     depthwise = ngroups == C && ngroups == K;
-    
+
     if (inpshape.layout == DATA_LAYOUT_BLOCK) {
         CV_Assert(inpshape.back() == outshape.back());
     }
-    
+
     fastActivation = fastActivation_;
     activation = nullptr;
     memset(activParams, 0, sizeof(activParams));
@@ -245,220 +245,35 @@ void ConvState::initConv(const MatShape& inpshape_,
         inner[j] = inner0;
         inner[j + MAX_CONV_DIMS] = inner1;
     }
-    
+
     initOfs();
     if (!depthwise && inpshape.layout == DATA_LAYOUT_BLOCK) {
         int C0 = inpshape.back();
-        MatShape wpackShape = getWpackShapeAlt(wshape_, ngroups, C0);
-        
+        MatShape wpackShape = getWpackShape(wshape_, ngroups, C0);
+
         CV_Assert(wpackShape.dims == 5);
         Kblk = wpackShape[1];
         C1Max = wpackShape[3];
     }
 }
 
-void initConvTables(const ConvState& cs,
-                    std::vector<int32_t>& inpofs_,
-                    std::vector<int32_t>& ofsofs_)
-{
-    int sdims = cs.nspatialdims;
-    CV_Assert(sdims + 3 == cs.inpshape.dims);
-    int Dk = cs.kshape[0], Hk = cs.kshape[1], Wk = cs.kshape[2];
-    int DZ = cs.dilations[0], DY = cs.dilations[1], DX = cs.dilations[2];
-    int SZ = cs.strides[0], SY = cs.strides[1], SX = cs.strides[2];
-    int pad_z0 = cs.pads[0], pad_y0 = cs.pads[1], pad_x0 = cs.pads[2];
-    int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
-    int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
-    int Wi = cs.inpshape[sdims+1];
-    int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
-    int H = sdims > 1 ? cs.outshape[sdims] : 1;
-    int W = cs.outshape[sdims + 1];
-    int C0 = cs.inpshape.back(), C1 = cs.inpshape[1];
-    int ngroups = cs.ngroups, C1g = C1/ngroups;
-    int inner_z0 = cs.inner[0], inner_y0 = cs.inner[1], inner_x0 = cs.inner[2];
-    int inner_z1 = cs.inner[3], inner_y1 = cs.inner[4], inner_x1 = cs.inner[5];
-
-    ofsofs_.resize(D*H*W*2);
-
-    int ofs_blocksize = C1g*Dk*Hk*Wk;
-    bool have_inner = inner_z0 < inner_z1 && inner_y0 < inner_y1 && inner_x0 < inner_x1;
-
-    inpofs_.resize(ofs_blocksize);
-    
-    if (have_inner) {
-        for (int c = 0, k = 0; c < C1g; c++) {
-            for (int dz = 0; dz < Dk; dz++) {
-                int zi = dz*DZ;
-                for (int dy = 0; dy < Hk; dy++) {
-                    int yi = dy*DY;
-                    for (int dx = 0; dx < Wk; dx++, k++) {
-                        int xi = dx*DX;
-                        int ofs = (((c*Di + zi)*Hi + yi)*Wi + xi)*C0;
-                        inpofs_[k] = (int32_t)ofs;
-                    }
-                }
-            }
-        }
-    }
-
-    int32_t* ofsofs = ofsofs_.data();
-    int64_t curr_block = 1;
-
-    bool prev_z_inside = false;
-    for (int z0 = 0; z0 < D; z0++) {
-        int zi_ = z0*SZ - pad_z0;
-        bool z_inside = inner_z0 <= z0 && z0 < inner_z1;
-        bool prev_y_inside = false;
-
-        for (int y0 = 0; y0 < H; y0++) {
-            int yi_ = y0*SY - pad_y0;
-            bool y_inside = inner_y0 <= y0 && y0 < inner_y1;
-            bool prev_x_inside = false;
-
-            for (int x0 = 0; x0 < W; x0++) {
-                int xi_ = x0*SX - pad_x0;
-                bool x_inside = inner_x0 <= x0 && x0 < inner_x1;
-                int idx = ((z0*H + y0)*W + x0)*2;
-
-                if (x_inside && y_inside && z_inside) {
-                    ofsofs[idx] = (int32_t)(((zi_*Hi + yi_)*Wi + xi_)*C0);
-                    ofsofs[idx + 1] = 0;
-                } else if (z_inside && prev_z_inside) {
-                    ofsofs[idx] = ofsofs[idx - W*H*2] + Wi*Hi*SZ*C0;
-                    ofsofs[idx + 1] = ofsofs[idx - W*H*2 + 1];
-                } else if (y_inside && prev_y_inside) {
-                    ofsofs[idx] = ofsofs[idx - W*2] + Wi*SY*C0;
-                    ofsofs[idx + 1] = ofsofs[idx - W*2 + 1];
-                } else if (x_inside && prev_x_inside) {
-                    ofsofs[idx] = ofsofs[idx - 2] + SX*C0;
-                    ofsofs[idx + 1] = ofsofs[idx - 1];
-                } else {
-                    int64_t curr_ofs = curr_block*ofs_blocksize;
-                    ofsofs[idx] = 0;
-                    ofsofs[idx + 1] = int(curr_ofs);
-                    curr_block++;
-                    inpofs_.resize(curr_ofs + ofs_blocksize);
-                    int32_t* inpofs = &inpofs_[curr_ofs];
-
-                    int firstofs = -1;
-                    for (int c = 0, k = 0; c < C1g; c++) {
-                        for (int dz = 0; dz < Dk; dz++) {
-                            int zi = zi_ + dz*DZ;
-                            bool zi_inside = 0 <= zi && zi < Di;
-
-                            for (int dy = 0; dy < Hk; dy++) {
-                                int yi = yi_ + dy*DY;
-                                bool yi_inside = 0 <= yi && yi < Hi;
-
-                                for (int dx = 0; dx < Wk; dx++, k++) {
-                                    int xi = xi_ + dx*DX;
-                                    bool xi_inside = 0 <= xi && xi < Wi;
-
-                                    if (zi_inside && yi_inside && xi_inside) {
-                                        int ofs = (((c*Di + zi)*Hi + yi)*Wi + xi)*C0;
-                                        if (firstofs < 0)
-                                            ofsofs[idx] = firstofs = ofs;
-                                        inpofs[k] = (int32_t)(ofs - firstofs);
-                                    } else {
-                                        inpofs[k] = INT_MIN/2;
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-                prev_x_inside = x_inside;
-            }
-            prev_y_inside = y_inside;
-        }
-        prev_z_inside = z_inside;
-    }
-}
-
-template<typename _InpT, typename _OutT> void
-repackConvWeights_(const _InpT* inpw_, _OutT* outw_,
-                   size_t inp_step_c, size_t inp_step_k, int ksize,
-                   int C0, int K0, int curr_C0, int curr_K0)
-{
-    const _InpT* inpw = inpw_;
-    _OutT* outw = outw_;
-    for (int xy = 0; xy < ksize; xy++, inpw++, outw += C0*K0) {
-        for (int c0 = 0; c0 < curr_C0; c0++) {
-            for (int k0 = 0; k0 < curr_K0; k0++) {
-                outw[c0*K0 + k0] = _OutT(inpw[inp_step_k*k0 + inp_step_c*c0]);
-            }
-        }
-    }
-}
-
-
-// K x (C/ngroups) x Dk x Hk x Wk => K1 x C1/ngroups x Dk x Hk x Wk x C0 x K0,
-// where K0 == C0
-void repackConvWeights(const void* inpw__, int inptype_,
-                       void* outw__, int outtype_,
-                       const MatShape& wshape, int C0_)
-{
-    CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F);
-    CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F);
-
-    int K1 = (wshape[0] + C0_ - 1)/C0_;
-    parallel_for_(Range(0, K1), [&](const Range& r) {
-        int inptype = inptype_, outtype = outtype_;
-        size_t inp_esz = CV_ELEM_SIZE(inptype);
-        size_t out_esz = CV_ELEM_SIZE(outtype);
-        int C0 = C0_, K0 = C0_;
-        int K = wshape[0], Cg = wshape[1];
-        int C1g = (Cg + C0 - 1)/C0;
-        int ksize = 1;
-        for (int k = 2; k < wshape.dims; k++)
-            ksize *= wshape[k];
-        size_t inp_step_c = ksize, inp_step_k = Cg*ksize;
-        size_t out_microplane_size = ksize*C0*K0*out_esz;
-
-        for (int k1 = r.start; k1 < r.end; k1++) {
-            int curr_K0 = std::min(K - k1*K0, K0);
-            for (int c1g = 0; c1g < C1g; c1g++) {
-                uint8_t* inpw_ = (uint8_t*)inpw__ + (k1*K0*inp_step_k + c1g*C0*inp_step_c)*inp_esz;
-                uint8_t* outw_ = (uint8_t*)outw__ + (k1*C1g + c1g)*out_microplane_size;
-                int curr_C0 = std::min(Cg - c1g*C0, C0);
-                if (curr_K0 != K0 || curr_C0 != C0)
-                    memset(outw_, 0, out_microplane_size);
-
-                if (inptype == CV_32F && outtype == CV_32F)
-                    repackConvWeights_((const float*)inpw_, (float*)outw_, inp_step_c,
-                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
-                else if (inptype == CV_32F && outtype == CV_16F)
-                    repackConvWeights_((const float*)inpw_, (hfloat*)outw_, inp_step_c,
-                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
-                else if (inptype == CV_16F && outtype == CV_32F)
-                    repackConvWeights_((const hfloat*)inpw_, (float*)outw_, inp_step_c,
-                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
-                else if (inptype == CV_16F && outtype == CV_16F)
-                    repackConvWeights_((const hfloat*)inpw_, (hfloat*)outw_, inp_step_c,
-                                        inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
-                else break;
-            }
-        }
-    });
-}
-
-void repackConvWeightsAlt(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0_)
+void repackConvWeights(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0_)
 {
     CV_Assert(weights.isContinuous());
     CV_Assert_N(weights.type() == CV_32F, outtype == CV_32F);
     CV_Assert(ngroups > 0);
     CV_Assert((C0_ & (C0_ - 1)) == 0 && C0_ >= 4);
-    
+
     MatShape wshape = weights.shape();
     CV_Assert(wshape.dims >= 3);
-    
+
     int K = wshape[0];
     CV_Assert(K % ngroups == 0);
 
     if (!Wpack.isContinuous()) {
         Wpack.release();
     }
-    MatShape wpackShape = getWpackShapeAlt(weights.shape(), ngroups, C0_);
+    MatShape wpackShape = getWpackShape(weights.shape(), ngroups, C0_);
     Wpack.create(wpackShape, CV_32F);
     Wpack.setZero();
 
@@ -515,7 +330,7 @@ void ConvState::initPooling(const MatShape& inpshape_,
     outshape = outshape_;
     ngroups = C;
     depthwise = true;
-    
+
     for (int i = 0; i < MAX_CONV_DIMS; i++) {
         kshape[i] = strides[i] = dilations[i] = 1;
         pads[i] = pads[i + MAX_CONV_DIMS] = 0;

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -190,7 +190,6 @@ void ConvState::initConv(const MatShape& inpshape_,
     inpshape = inpshape_;
     outshape = outshape_;
     ngroups = ngroups_;
-    Kblk = C1Max = 0;
 
     int C = inpshape.channels();
     int K = outshape.channels();
@@ -249,11 +248,9 @@ void ConvState::initConv(const MatShape& inpshape_,
     initOfs();
     if (!depthwise && inpshape.layout == DATA_LAYOUT_BLOCK) {
         int C0 = inpshape.back();
-        MatShape wpackShape = getWpackShape(wshape_, ngroups, C0);
+        wshape = getWpackShape(wshape_, ngroups, C0);
 
-        CV_Assert(wpackShape.dims == 5);
-        Kblk = wpackShape[1];
-        C1Max = wpackShape[3];
+        CV_Assert(wshape.dims == 5);
     }
 }
 

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -183,11 +183,12 @@ void ConvState::initConv(const MatShape& inpshape_,
         CV_Assert(inpshape.back() == outshape.back());
     }
     
+    repackInp = repackOut = false;
     if (depthwise) {
         CV_Assert(outshape[1] == inpshape[1]);
     } else {
-        CV_Assert(inpshape[1] % ngroups == 0);
-        CV_Assert(outshape[1] % ngroups == 0);
+        repackInp = inpshape[1] % ngroups != 0;
+        repackOut = outshape[1] % ngroups != 0;
     }
 
     fastActivation = fastActivation_;
@@ -446,6 +447,7 @@ void ConvState::initPooling(const MatShape& inpshape_,
     outshape = outshape_;
     ngroups = C;
     depthwise = true;
+    repackInp = repackOut = false;
     
     for (int i = 0; i < MAX_CONV_DIMS; i++) {
         kshape[i] = strides[i] = dilations[i] = 1;

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -147,6 +147,24 @@ bool ConvState::sameShape(const ConvState& cs) const
     return inpshape == cs.inpshape && outshape == cs.outshape;
 }
 
+static MatShape getWpackShapeAlt(const MatShape& wshape, int ngroups, int C0)
+{
+    CV_Assert(wshape.dims >= 3);
+    int K = wshape[0], Cg = wshape[1], C = Cg*ngroups;
+    int ksize = int(wshape.total())/(K*Cg);
+    CV_Assert_N(K % ngroups == 0);
+    int Kg = K / ngroups, K0 = C0;
+    int Kblk = (Kg + K0 - 1)/K0;
+    int C1Max = 0;
+    for (int g = 0; g < ngroups; ++g) {
+        int c_start = g * Cg;
+        int c00 = c_start & (C0 - 1);
+        int cblocks = (c00 + Cg + C0 - 1)/C0;
+        C1Max = std::max(C1Max, cblocks);
+    }
+    return MatShape({ngroups, Kblk, ksize, C1Max, C0*K0}, DATA_LAYOUT_UNKNOWN);
+}
+
 void ConvState::initConv(const MatShape& inpshape_,
                          const MatShape& wshape_,
                          const MatShape& outshape_,
@@ -165,32 +183,24 @@ void ConvState::initConv(const MatShape& inpshape_,
     CV_Assert(dilations_.empty() || (dilations_.size() == size_t(nspatialdims)));
     CV_Assert(pads_.empty() || (pads_.size() == size_t(nspatialdims*2)));
     CV_Assert(inpshape_.dims == outshape_.dims);
-    CV_Assert(nspatialdims == inpshape_.dims - 3);
+    CV_Assert(inpshape_.dims == nspatialdims + 2 + int(inpshape_.layout == DATA_LAYOUT_BLOCK));
+    CV_Assert_N(inpshape_.layout == outshape_.layout,
+                inpshape_[0] == outshape_[0]);
 
     inpshape = inpshape_;
     outshape = outshape_;
     ngroups = ngroups_;
+    Kblk = C1Max = 0;
     
-    int C = inpshape.layout == DATA_LAYOUT_BLOCK ? inpshape.C :
-        inpshape.layout == DATA_LAYOUT_NHWC ? inpshape.back() : inpshape[1];
-    int Cout = outshape.layout == DATA_LAYOUT_BLOCK ? outshape.C :
-        outshape.layout == DATA_LAYOUT_NHWC ? outshape.back() : outshape[1];
+    int C = inpshape.channels();
+    int K = outshape.channels();
     
-    depthwise = ngroups == C && ngroups == Cout;
-
-    CV_Assert(inpshape_[0] == outshape_[0]);
+    depthwise = ngroups == C && ngroups == K;
+    
     if (inpshape.layout == DATA_LAYOUT_BLOCK) {
         CV_Assert(inpshape.back() == outshape.back());
     }
     
-    repackInp = repackOut = false;
-    if (depthwise) {
-        CV_Assert(outshape[1] == inpshape[1]);
-    } else {
-        repackInp = inpshape[1] % ngroups != 0;
-        repackOut = outshape[1] % ngroups != 0;
-    }
-
     fastActivation = fastActivation_;
     activation = nullptr;
     memset(activParams, 0, sizeof(activParams));
@@ -235,9 +245,15 @@ void ConvState::initConv(const MatShape& inpshape_,
         inner[j] = inner0;
         inner[j + MAX_CONV_DIMS] = inner1;
     }
+    
+    initOfs();
+    if (!depthwise && inpshape.layout == DATA_LAYOUT_BLOCK) {
+        int C0 = inpshape.back();
+        MatShape wpackShape = getWpackShapeAlt(wshape_, ngroups, C0);
         
-    if (depthwise) {
-        initOfs();
+        CV_Assert(wpackShape.dims == 5);
+        Kblk = wpackShape[1];
+        C1Max = wpackShape[3];
     }
 }
 
@@ -426,6 +442,58 @@ void repackConvWeights(const void* inpw__, int inptype_,
     });
 }
 
+void repackConvWeightsAlt(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0_)
+{
+    CV_Assert(weights.isContinuous());
+    CV_Assert_N(weights.type() == CV_32F, outtype == CV_32F);
+    CV_Assert(ngroups > 0);
+    CV_Assert((C0_ & (C0_ - 1)) == 0 && C0_ >= 4);
+    
+    MatShape wshape = weights.shape();
+    CV_Assert(wshape.dims >= 3);
+    
+    int K = wshape[0];
+    CV_Assert(K % ngroups == 0);
+
+    if (!Wpack.isContinuous()) {
+        Wpack.release();
+    }
+    MatShape wpackShape = getWpackShapeAlt(weights.shape(), ngroups, C0_);
+    Wpack.create(wpackShape, CV_32F);
+    Wpack.setZero();
+
+    parallel_for_(Range(0, K), [&](const Range& range) {
+        int Cg = wshape[1], Kg = K / ngroups;
+        int ksize = wpackShape[2], Kblk = wpackShape[1], C1Max = wpackShape[3];
+        int C0 = C0_, K0 = C0;
+        const float* wdata = weights.ptr<float>();
+        float* Wpackdata = Wpack.ptr<float>();
+
+        for (int k = range.start; k < range.end; ++k) {
+            int g = k / Kg;
+            int kin = k - g * Kg;
+            int kblk = kin / K0;
+            int k0   = kin & (K0 - 1);
+
+            int c_start = g * Cg;
+            int c00 = c_start & (C0 - 1);
+
+            for (int c = 0; c < Cg; ++c) {
+                int ch = c00 + c;
+                int c1  = ch / C0;
+                int c0  = ch & (C0 - 1);
+
+                const float* wptr = wdata + ((k * Cg + c) * ksize);
+                float* wpackptr = Wpackdata + (((g * Kblk + kblk) * ksize * C1Max + c1) * C0 + c0)*K0 + k0;
+                for (int i = 0; i < ksize; ++i) {
+                    wpackptr[i*(C1Max*C0*K0)] = wptr[i];
+                }
+            }
+        }
+    });
+}
+
+
 void ConvState::initPooling(const MatShape& inpshape_,
                             const MatShape& outshape_,
                             const std::vector<int>& kshape_,
@@ -447,7 +515,6 @@ void ConvState::initPooling(const MatShape& inpshape_,
     outshape = outshape_;
     ngroups = C;
     depthwise = true;
-    repackInp = repackOut = false;
     
     for (int i = 0; i < MAX_CONV_DIMS; i++) {
         kshape[i] = strides[i] = dilations[i] = 1;

--- a/modules/dnn/src/layers/conv2_common.cpp
+++ b/modules/dnn/src/layers/conv2_common.cpp
@@ -15,6 +15,7 @@ std::string fastActivationToString(FastActivation fastActivation)
 {
     return fastActivation == FAST_ACTIV_RELU ? "ReLU" :
            fastActivation == FAST_ACTIV_LEAKY_RELU ? "LeakyReLU" :
+           fastActivation == FAST_ACTIV_PRELU ? "PReLU" :
            fastActivation == FAST_ACTIV_CLIP ? "Clip" :
            fastActivation == FAST_ACTIV_NONE ? "None" : format("unknown(%d)", int(fastActivation));
 }
@@ -174,8 +175,7 @@ void ConvState::initConv(const MatShape& inpshape_,
                          const std::vector<int>& pads_,
                          AutoPadding autoPad, bool ceilMode,
                          FastActivation fastActivation_,
-                         const float* activParams_,
-                         size_t nactivParams_)
+                         const std::vector<float>& activParams_)
 {
     nspatialdims = wshape_.dims - 2;
     CV_Assert(0 < nspatialdims && nspatialdims <= ConvState::MAX_CONV_DIMS);
@@ -202,12 +202,7 @@ void ConvState::initConv(const MatShape& inpshape_,
 
     fastActivation = fastActivation_;
     activation = nullptr;
-    memset(activParams, 0, sizeof(activParams));
-    if (activParams_ && nactivParams_ > 0) {
-        CV_Assert(nactivParams_ <= (size_t)MAX_ACTIV_PARAMS);
-        for (size_t i = 0; i < nactivParams_; i++)
-            activParams[i] = activParams_[i];
-    }
+    activParams = activParams_;
 
     CV_Assert(wshape_[0] > 0 && wshape_[1] > 0);
     for (int i = 0; i < MAX_CONV_DIMS; i++) {

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -38,6 +38,7 @@ typedef void (*activation_func_t)(const void* input, void* output,
 struct ConvState
 {
     enum { MAX_CONV_DIMS = 3 };
+    bool depthwise;
     int ngroups, nspatialdims;
     int kshape[MAX_CONV_DIMS];
     int strides[MAX_CONV_DIMS];

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -30,6 +30,8 @@ enum FastActivation {
     FAST_ACTIV_CLIP
 };
 
+std::string fastActivationToString(FastActivation fastActivation);
+
 typedef void (*activation_func_t)(const void* input, void* output,
                                   size_t len, const float* params);
 

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -74,10 +74,13 @@ struct ConvState
                      const std::vector<int>& dilations,
                      const std::vector<int>& pads,
                      AutoPadding auto_pad, bool ceil_mode);
+    
+    // internal-use method to initialize coordtab and ofstab.
+    // it's called from initConv and initPooling
+    void initOfs();
 };
 
 AutoPadding getAutoPadding(const LayerParams& params);
-
 
 void initConvTables(const ConvState& cs,
                     std::vector<int32_t>& inpofs,

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -1,0 +1,105 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#ifndef __OPENCV_DNN_LAYERS_CONV2_COMMON_HPP__
+#define __OPENCV_DNN_LAYERS_CONV2_COMMON_HPP__
+
+#include <opencv2/dnn.hpp>
+#include <array>
+
+namespace cv
+{
+namespace dnn
+{
+    
+CV__DNN_INLINE_NS_BEGIN
+    
+// computes shape of the output tensor of convolution
+// (including depth-wise convolution), max pooling or average pooling operations
+MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
+                        const std::vector<int>& kernel_shape, int ngroups,
+                        const std::vector<int>& strides,
+                        const std::vector<int>& dilations,
+                        const std::vector<int>& pads,
+                        AutoPadding auto_pad, bool ceil_mode);
+
+enum FastActivation {
+    FAST_ACTIV_NONE=0,
+    FAST_ACTIV_RELU,
+    FAST_ACTIV_LEAKY_RELU,
+    FAST_ACTIV_CLIP
+};
+
+typedef void (*activation_func_t)(const void* input, void* output,
+                                  size_t len, const float* params);
+
+struct ConvState
+{
+    enum { MAX_CONV_DIMS = 3 };
+    int ngroups, nspatialdims;
+    int kshape[MAX_CONV_DIMS];
+    int strides[MAX_CONV_DIMS];
+    int dilations[MAX_CONV_DIMS];
+    int pads[MAX_CONV_DIMS*2];
+    MatShape inpshape, outshape;
+    int inner[MAX_CONV_DIMS*2];
+    std::vector<int> coordtab;
+    std::vector<int> ofstab;
+
+    FastActivation fastActivation;
+    enum {ACTIV_MAX_PARAMS = 16};
+    float activParams[ACTIV_MAX_PARAMS];
+    activation_func_t activation;
+
+    std::ostream& dump(std::ostream& strm);
+    bool sameShape(const ConvState& cs) const;
+};
+
+AutoPadding getAutoPadding(const LayerParams& params);
+
+void initConvState(const MatShape& inpshape,
+                   const MatShape& wshape,
+                   const MatShape& outshape,
+                   const Ptr<Layer>& activ,
+                   int ngroups,
+                   const std::vector<int>& strides,
+                   const std::vector<int>& dilations,
+                   const std::vector<int>& pads,
+                   AutoPadding auto_pad, bool ceil_mode,
+                   ConvState& cs);
+
+// initializes the structure of parameters for 1D/2D/3D
+// depth-wise convolution, max pooling or average pooling
+void initPoolingState(const MatShape& inpshape, const MatShape& outshape,
+                      const std::vector<int>& kernel_shape,
+                      const std::vector<int>& strides,
+                      const std::vector<int>& dilations,
+                      const std::vector<int>& pads,
+                      AutoPadding auto_pad, bool ceil_mode,
+                      ConvState& cs);
+
+typedef void (*ConvFunc)(const void* inp, const void* residual, void* out,
+                         const ConvState& cs, const void* weights,
+                         const float* scale, const float* bias,
+                         const int32_t* ofs, const int32_t* ofsofs);
+
+typedef void (*DepthwiseConvFunc)(const void* inp, const void* residual,
+                                  void* out, const ConvState& cs,
+                                  const void* weights,
+                                  const float* scale,
+                                  const float* bias);
+
+DepthwiseConvFunc getDepthwiseConvFunc(int depth);
+ConvFunc getConvFunc(int depth);
+
+void repackDepthwiseConvWeights(const void* inpw, int inptype,
+                                void* outw, int outtype,
+                                const MatShape& wsize, int C0);
+
+CV__DNN_INLINE_NS_END
+
+}
+}
+
+#endif

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -27,18 +27,19 @@ enum FastActivation {
     FAST_ACTIV_NONE=0,
     FAST_ACTIV_RELU,
     FAST_ACTIV_LEAKY_RELU,
+    FAST_ACTIV_PRELU,
     FAST_ACTIV_CLIP
 };
 
 std::string fastActivationToString(FastActivation fastActivation);
 
-typedef void (*activation_func_t)(const void* input, void* output,
-                                  size_t len, const float* params);
+typedef void (*ActivationFunc)(const void* input, void* output,
+                               size_t len, const float* params);
 
 struct ConvState
 {
     enum { MAX_CONV_DIMS = 3 };
-    bool depthwise;
+    bool depthwise = true;
     int ngroups, nspatialdims;
     int kshape[MAX_CONV_DIMS];
     int strides[MAX_CONV_DIMS];
@@ -50,10 +51,9 @@ struct ConvState
     std::vector<int> coordtab;
     std::vector<int> ofstab;
 
-    FastActivation fastActivation;
-    enum {MAX_ACTIV_PARAMS = 16};
-    float activParams[MAX_ACTIV_PARAMS];
-    activation_func_t activation;
+    FastActivation fastActivation = FAST_ACTIV_NONE;
+    ActivationFunc activation = nullptr;
+    std::vector<float> activParams;
 
     std::ostream& dump(std::ostream& strm);
     bool sameShape(const ConvState& cs) const;
@@ -67,8 +67,7 @@ struct ConvState
                   const std::vector<int>& pads,
                   AutoPadding autoPad, bool ceilMode,
                   FastActivation fastActivation,
-                  const float* activParams,
-                  size_t nactivParams);
+                  const std::vector<float>& activParams);
 
     // initializes the structure of parameters for 1D/2D/3D
     // depth-wise convolution, max pooling or average pooling

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -13,7 +13,7 @@ namespace cv
 namespace dnn
 {
 CV__DNN_INLINE_NS_BEGIN
-    
+
 // computes shape of the output tensor of convolution
 // (including depth-wise convolution), max pooling or average pooling operations
 MatShape convInferShape(const MatShape& inpshape, const MatShape& wshape,
@@ -53,7 +53,7 @@ struct ConvState
     enum {MAX_ACTIV_PARAMS = 16};
     float activParams[MAX_ACTIV_PARAMS];
     activation_func_t activation;
-    
+
     int Kblk, C1Max;
 
     std::ostream& dump(std::ostream& strm);
@@ -79,7 +79,7 @@ struct ConvState
                      const std::vector<int>& dilations,
                      const std::vector<int>& pads,
                      AutoPadding auto_pad, bool ceil_mode);
-    
+
     // internal-use method to initialize coordtab and ofstab.
     // it's called from initConv and initPooling
     void initOfs();
@@ -87,38 +87,15 @@ struct ConvState
 
 AutoPadding getAutoPadding(const LayerParams& params);
 
-void initConvTables(const ConvState& cs,
-                    std::vector<int32_t>& inpofs,
-                    std::vector<int32_t>& ofsofs);
-
 typedef void (*ConvFunc)(const void* inp, const void* residual, void* out,
                          const ConvState& cs, const void* weights,
-                         const float* scale, const float* bias,
-                         const int32_t* ofs, const int32_t* ofsofs);
+                         const float* scale, const float* bias);
 
-typedef void (*DepthwiseConvFunc)(const void* inp, const void* residual,
-                                  void* out, const ConvState& cs,
-                                  const void* weights,
-                                  const float* scale,
-                                  const float* bias);
+ConvFunc getConvFunc(int depth, int C0);
+ConvFunc getDepthwiseConvFunc(int depth);
 
-DepthwiseConvFunc getDepthwiseConvFunc(int depth);
-
-enum ConvKind {
-    CONV_KIND_MAIN = 0, // main convolution kernel
-    CONV_KIND_ALT = 1   // alternative, more universal, but a bit slower convolution kernel.
-                        // does not require precomputed tables of offsets
-};
-
-ConvFunc getConvFunc(int depth, int C0, ConvKind convkind);
-
-void repackDepthwiseConvWeights(const void* inpw, int inptype,
-                                void* outw, int outtype,
-                                const MatShape& wsize, int C0);
-void repackConvWeights(const void* inpw, int inptype,
-                       void* outw, int outtype,
-                       const MatShape& wshape, int C0);
-void repackConvWeightsAlt(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0);
+void repackDepthwiseConvWeights(const Mat& weights, Mat& Wpack, int outtype, int C0);
+void repackConvWeights(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0);
 
 CV__DNN_INLINE_NS_END
 }

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -45,6 +45,7 @@ struct ConvState
     int dilations[MAX_CONV_DIMS];
     int pads[MAX_CONV_DIMS*2];
     MatShape inpshape, outshape;
+    MatShape wshape; // (ngroups, Kblk, ksize, C1Max, C0*K0) in the case of non-depthwise convolution
     int inner[MAX_CONV_DIMS*2];
     std::vector<int> coordtab;
     std::vector<int> ofstab;
@@ -53,8 +54,6 @@ struct ConvState
     enum {MAX_ACTIV_PARAMS = 16};
     float activParams[MAX_ACTIV_PARAMS];
     activation_func_t activation;
-
-    int Kblk, C1Max;
 
     std::ostream& dump(std::ostream& strm);
     bool sameShape(const ConvState& cs) const;

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -53,6 +53,8 @@ struct ConvState
     enum {MAX_ACTIV_PARAMS = 16};
     float activParams[MAX_ACTIV_PARAMS];
     activation_func_t activation;
+    
+    bool unevenGroupedConv;
 
     std::ostream& dump(std::ostream& strm);
     bool sameShape(const ConvState& cs) const;

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -54,7 +54,7 @@ struct ConvState
     float activParams[MAX_ACTIV_PARAMS];
     activation_func_t activation;
     
-    bool unevenGroupedConv;
+    int Kblk, C1Max;
 
     std::ostream& dump(std::ostream& strm);
     bool sameShape(const ConvState& cs) const;
@@ -103,7 +103,14 @@ typedef void (*DepthwiseConvFunc)(const void* inp, const void* residual,
                                   const float* bias);
 
 DepthwiseConvFunc getDepthwiseConvFunc(int depth);
-ConvFunc getConvFunc(int depth, int C0);
+
+enum ConvKind {
+    CONV_KIND_MAIN = 0, // main convolution kernel
+    CONV_KIND_ALT = 1   // alternative, more universal, but a bit slower convolution kernel.
+                        // does not require precomputed tables of offsets
+};
+
+ConvFunc getConvFunc(int depth, int C0, ConvKind convkind);
 
 void repackDepthwiseConvWeights(const void* inpw, int inptype,
                                 void* outw, int outtype,
@@ -111,6 +118,7 @@ void repackDepthwiseConvWeights(const void* inpw, int inptype,
 void repackConvWeights(const void* inpw, int inptype,
                        void* outw, int outtype,
                        const MatShape& wshape, int C0);
+void repackConvWeightsAlt(const Mat& weights, Mat& Wpack, int outtype, int ngroups, int C0);
 
 CV__DNN_INLINE_NS_END
 }

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -1,0 +1,830 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "../net_impl.hpp"
+#include "layers_common.hpp"
+#include "conv2_common.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+
+namespace cv
+{
+namespace dnn
+{
+
+/*
+    Convolution layer, as defined in ONNX specification:
+    https://onnx.ai/onnx/operators/onnx__Conv.html
+
+    Opset's 1 to 22 are covered.
+*/
+
+static void initConv2DTables(const ConvState& cs,
+                             std::vector<int32_t>& ofsbuf_,
+                             std::vector<int32_t>& ofsofs_)
+{
+    int Hk_ = cs.kshape[0], Wk_ = cs.kshape[1];
+    int DY_ = cs.dilations[0], DX_ = cs.dilations[1];
+    int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+    int Hi_ = cs.inpshape[2], Wi_ = cs.inpshape[3], H = cs.outshape[2], W = cs.outshape[3];
+    int C0_ = cs.inpshape.back(), C1_ = cs.inpshape[1];
+    int ngroups = cs.ngroups, C1g = C1_/ngroups;
+    int inner_y0 = cs.inner[0], inner_y1 = cs.inner[1];
+    int inner_x0 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims + 1];
+
+    ofsofs_.resize(H*W*2);
+
+    int ofs_blocksize = C1g*Hk_*Wk_;
+    bool have_inner = inner_y0 < inner_y1 && inner_x0 < inner_x1;
+
+    int nblocks = have_inner ? 1 + (inner_y0 + (H - inner_y1))*W +
+        (inner_y1 - inner_y0)*(inner_x0 + W - inner_x1) : W*H;
+
+    ofsbuf_.resize(ofs_blocksize*nblocks);
+    int32_t* ofsbuf = ofsbuf_.data();
+
+    if (have_inner) {
+        for (int c = 0, k = 0; c < C1g; c++) {
+            for (int dy = 0; dy < Hk_; dy++) {
+                int yi = dy*DY_;
+                for (int dx = 0; dx < Wk_; dx++, k++) {
+                    int xi = dx*DX_;
+                    ofsbuf[k] = (int32_t)(((c*Hi_ + yi)*Wi_ + xi)*C0_);
+                }
+            }
+        }
+    }
+
+    parallel_for_(Range(0, H), [&](const Range& r) {
+        int C0 = C0_;
+        int Hk = Hk_, Wk = Wk_;
+        int Hi = Hi_, Wi = Wi_;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int DY = cs.dilations[0], DX = cs.dilations[1];
+        uint8_t* mask = mask_.data();
+        int32_t* ofs0 = ofs0_.data();
+        int32_t** ofsptrs = ofsptrs_.data();
+        int64_t curr_block = 1;
+        if (have_inner) {
+            curr_block += std::min(r.start, inner_y0)*W;
+            curr_block += std::min(std::max(r.start - inner_y0, 0),
+                                   inner_y1 - inner_y0)*(inner_x0 + W - inner_x1);
+            curr_block += std::max(r.start - inner_y1, 0)*W;
+        } else {
+            curr_block = r.start*W;
+        }
+        for (int y0 = r.start; y0 < r.end; y0++) {
+            int yi_ = y0*SY - pad_y0;
+            bool y_inside = inner_y0 <= y0 && y0 < inner_y1;
+
+            for (int x0 = 0; x0 < W; x0++) {
+                int xi_ = x0*SX - pad_x0;
+                bool x_inside = inner_x0 <= x0 && x0 < inner_x1;
+                uint8_t m = (uint8_t)(y_inside & x_inside);
+
+                mask[y0*W + x0] = m;
+
+                if (m) {
+                    ofs0[y0*W + x0] = (int32_t)((yi_*Wi + xi_)*C0);
+                    ofsptrs[y0*W + x0] = ofsbuf;
+                } else {
+                    ofs0[y0*W + x0] = 0;
+                    int32_t* ofsptr = ofsbuf + curr_block*ofs_blocksize;
+                    ofsptrs[y0*W + x0] = ofsptr;
+                    curr_block++;
+
+                    for (int c = 0, k = 0; c < C1g; c++) {
+                        for (int dy = 0; dy < Hk; dy++) {
+                            int yi = yi_ + dy*DY;
+                            bool yi_inside = 0 <= yi && yi < Hi;
+
+                            for (int dx = 0; dx < Wk; dx++, k++) {
+                                int xi = xi_ + dx*DX;
+                                bool xi_inside = 0 <= xi && xi < Wi;
+                                ofsptr[k] = (yi_inside & xi_inside) ?
+                                    (int32_t)(((c*Hi + yi)*Wi + xi)*C0) : INT_MIN/2;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+template<typename _InpT, typename _OutT> void
+repackConv2DWeights_(const _InpT* inpw_, _OutT* outw_,
+                     size_t inp_step_c, size_t inp_step_k, int ksize,
+                     int C0, int K0, int curr_C0, int curr_K0)
+{
+    const _InpT* inpw = inpw_;
+    _OutT* outw = outw_;
+    for (int xy = 0; xy < ksize; xy++, inpw++, outw += C0*K0) {
+        for (int c0 = 0; c0 < curr_C0; c0++) {
+            for (int k0 = 0; k0 < curr_K0; k0++) {
+                outw[c0*K0 + k0] = _OutT(inpw[inp_step_k*k0 + inp_step_c*c0]);
+            }
+        }
+    }
+}
+
+
+// K x (C/ngroups) x Hk x Wk => K1 x C1/ngroups x Hk x Wk x C0 x K0,
+// where K0 == C0
+static void repackConv2DWeights(const void* inpw__, int inptype_,
+                                void* outw__, int outtype_,
+                                const MatShape& wshape, int C0_)
+{
+    CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F);
+    CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F);
+
+    int K1 = (wshape[0] + C0_ - 1)/C0_;
+    parallel_for_(Range(0, K1), [&](const Range& r) {
+        int inptype = inptype_, outtype = outtype_;
+        size_t inp_esz = CV_ELEM_SIZE(inptype);
+        size_t out_esz = CV_ELEM_SIZE(outtype);
+        int C0 = C0_, K0 = C0_;
+        int K = wshape[0], Cg = wshape[1];
+        int C1g = (Cg + C0 - 1)/C0;
+        int Hk = wshape[2], Wk = wshape[3];
+        int ksize = Hk*Wk;
+        size_t inp_step_c = ksize, inp_step_k = Cg*ksize;
+        size_t out_microplane_size = ksize*C0*K0*out_esz;
+
+        for (int k1 = r.start; k1 < r.end; k1++) {
+            int curr_K0 = std::min(K - k1*K0, K0);
+            for (int c1g = 0; c1g < C1g; c1g++) {
+                uint8_t* inpw_ = (uint8_t*)inpw__ + (k1*K0*inp_step_k + c1g*C0*inp_step_c)*inp_esz;
+                uint8_t* outw_ = (uint8_t*)outw__ + (k1*C1g + c1g)*out_microplane_size;
+                int curr_C0 = std::min(Cg - c1g*C0, C0);
+                if (curr_K0 != K0 || curr_C0 != C0)
+                    memset(outw_, 0, out_microplane_size);
+
+                if (inptype == CV_32F && outtype == CV_32F)
+                    repackConv2DWeights_((const float*)inpw_, (float*)outw_, inp_step_c,
+                                         inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_32F && outtype == CV_16F)
+                    repackConv2DWeights_((const float*)inpw_, (hfloat*)outw_, inp_step_c,
+                                         inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_16F && outtype == CV_32F)
+                    repackConv2DWeights_((const hfloat*)inpw_, (float*)outw_, inp_step_c,
+                                         inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else if (inptype == CV_16F && outtype == CV_16F)
+                    repackConv2DWeights_((const hfloat*)inpw_, (hfloat*)outw_, inp_step_c,
+                                         inp_step_k, ksize, C0, K0, curr_C0, curr_K0);
+                else break;
+            }
+        }
+    });
+}
+
+static void conv2d_32f(const void* inp__, const void* residual__, void* out__,
+                       const ConvState& cs, const void* weights__,
+                       const float* scale__, const float* bias__,
+                       const int32_t* ofs0__, const int32_t** ofsptrs__,
+                       const uint8_t* mask__)
+{
+    int nlanes_ = VTraits<v_float32>::vlanes();
+    int C0_ = cs.inpshape.back();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
+
+    int NK1 = cs.outshape[0]*cs.outshape[1];
+
+    parallel_for_(Range(0, NK1), [&](const Range& r) {
+        const float* scale_ = scale__;
+        const float* bias_ = bias__;
+        const int32_t* ofs0_ = ofs0__;
+        const int32_t** ofsptrs_ = ofsptrs__;
+        constexpr int BLOCK_SIZE = 10;
+        int nk0 = r.start, nk1 = r.end;
+        int C0 = C0_, K0 = C0;
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi;
+        int planesize = H*W;
+        int Hk = cs.kshape[0], Wk = cs.kshape[1];
+        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
+        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
+        int nC = C1g*Hk*Wk*C0*K0;
+        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
+        float* sum = sumbuf.data();
+        float* scale = sum + BLOCK_SIZE*K0;
+        float* bias = sum + BLOCK_SIZE*K0*2;
+        const float* inptrs[BLOCK_SIZE];
+        const int32_t* ofsptrs[BLOCK_SIZE];
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+
+        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
+            scale[j] = 1.f;
+            bias[j] = 0.f;
+        }
+
+        for (int nk = nk0; nk < nk1; nk++) {
+            int n = nk/K1, k1 = nk - n*K1;
+            int g = k1/K1g;
+            float* out = (float*)out__ + nk*planesize*K0;
+            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
+            const float* resptr = residual__ ? (const float*)residual__ + nk*planesize*K0 : nullptr;
+            const float* wptr = (const float*)weights__ + k1*nC;
+
+            if (scale_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        scale[b*K0 + k] = scale_[k1*K0 + k];
+            }
+
+            if (bias_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        bias[b*K0 + k] = bias_[k1*K0 + k];
+            }
+
+            for (int xy0 = 0; xy0 < planesize; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
+                                            resptr += (resptr ? K0*BLOCK_SIZE : 0)) {
+                int j = 0, blocksize = std::min(planesize - xy0, BLOCK_SIZE);
+
+                for (; j < blocksize; j++) {
+                    inptrs[j] = inp0 + ofs0_[xy0 + j];
+                    ofsptrs[j] = ofsptrs_[xy0 + j];
+                }
+
+                if (j < BLOCK_SIZE) {
+                    const float* last_inptr = inptrs[blocksize-1];
+                    const int32_t* last_ofsptr = ofsptrs[blocksize-1];
+                    for (; j < BLOCK_SIZE; j++) {
+                        inptrs[j] = last_inptr;
+                        ofsptrs[j] = last_ofsptr;
+                    }
+                }
+
+                for (int i = 0; i < BLOCK_SIZE*K0; i++)
+                    sum[i] = 0.f;
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    for (j = 0; j < BLOCK_SIZE; j++) {
+                        int32_t ofs_ij = ofsptrs[j][i];
+                        const float* x = &inptrs[j][std::max(ofs_ij, 0)];
+                        float mij = (float)(ofs_ij >= 0);
+                        for (int c0 = 0; c0 < C0; c0++) {
+                            float xc = x[c0]*mij;
+                            for (int k = 0; k < K0; k++) {
+                                float w = wptr[c1 + c0*K0 + k];
+                                sum[K0*j + k] += xc*w;
+                            }
+                        }
+                    }
+                }
+
+                if (activation) {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            sum[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            sum[j] = v;
+                        }
+                    }
+                    activation(sum, out, blocksize*K0, activParams);
+                } else {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+static void conv2d_1x1_32f(const void* inp__, const void* residual__, void* out__,
+                           const ConvState& cs, const void* weights__,
+                           const float* scale__, const float* bias__,
+                           const int32_t*, const int32_t**, const uint8_t*)
+{
+    int nlanes_ = VTraits<v_float32>::vlanes();
+    int C0_ = cs.inpshape.back();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
+    CV_Assert(cs.kshape[0] == 1 && cs.kshape[1] == 1);
+    CV_Assert(cs.outshape.back() == cs.inpshape.back());
+    CV_Assert(cs.pads[0] == 0 && cs.pads[1] == 0 &&
+              cs.pads[cs.nspatialdims] == 0 && cs.pads[cs.nspatialdims+1] == 0);
+
+    int NK1 = cs.outshape[0]*cs.outshape[1];
+
+    parallel_for_(Range(0, NK1), [&](const Range& r) {
+        const float* scale_ = scale__;
+        const float* bias_ = bias__;
+        constexpr int BLOCK_SIZE = 10;
+        int nk0 = r.start, nk1 = r.end;
+        //int nlanes = nlanes_;
+        int C0 = C0_, K0 = C0;
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H0 = cs.outshape[2], W0 = cs.outshape[3];
+        int iplanesize = Hi*Wi;
+        int planesize = H0*W0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
+        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
+        int nC = C1g*C0*K0;
+        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
+        float* sum = sumbuf.data();
+        float* scale = sum + BLOCK_SIZE*K0;
+        float* bias = sum + BLOCK_SIZE*K0*2;
+        const float* inptrs[BLOCK_SIZE];
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+        bool S1 = SY == 1 && SX == 1;
+
+        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
+            scale[j] = 1.f;
+            bias[j] = 0.f;
+        }
+
+        for (int nk = nk0; nk < nk1; nk++) {
+            int n = nk/K1, k1 = nk - n*K1;
+            int g = k1/K1g;
+            float* out = (float*)out__ + nk*planesize*K0;
+            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
+            const float* resptr = residual__ ? (const float*)residual__ + nk*planesize*K0 : nullptr;
+            const float* wptr = (const float*)weights__ + k1*nC;
+
+            if (scale_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        scale[b*K0 + k] = scale_[k1*K0 + k];
+            }
+
+            if (bias_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        bias[b*K0 + k] = bias_[k1*K0 + k];
+            }
+
+            int yiWi = 0, xi = 0;
+            for (int xy0 = 0; xy0 < W0*H0; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
+                                               resptr += (resptr ? K0*BLOCK_SIZE : 0))
+            {
+                int j = 0, blocksize = std::min(W0*H0 - xy0, BLOCK_SIZE);
+
+                if (S1) {
+                    for (; j < blocksize; j++) {
+                        inptrs[j] = inp0 + (xy0 + j)*C0;
+                    }
+                } else {
+                    for (; j < blocksize; j++) {
+                        inptrs[j] = inp0 + (yiWi + xi)*C0;
+                        if ((xi += SX) >= Wi) {
+                            yiWi += Wi*SY;
+                            xi = 0;
+                        }
+                    }
+                }
+
+                if (j < BLOCK_SIZE) {
+                    const float* last_inptr = inptrs[blocksize-1];
+                    for (; j < BLOCK_SIZE; j++)
+                        inptrs[j] = last_inptr;
+                }
+
+                for (int i = 0; i < BLOCK_SIZE*K0; i++)
+                    sum[i] = 0.f;
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    int ofs_ij = i*iplanesize*C0;
+                    for (j = 0; j < BLOCK_SIZE; j++) {
+                        const float* x = &inptrs[j][ofs_ij];
+                        for (int c0 = 0; c0 < C0; c0++) {
+                            float xc = x[c0];
+                            for (int k = 0; k < K0; k++) {
+                                float w = wptr[c1 + c0*K0 + k];
+                                sum[K0*j + k] += xc*w;
+                            }
+                        }
+                    }
+                }
+
+                if (activation) {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            sum[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            sum[j] = v;
+                        }
+                    }
+                    activation(sum, out, blocksize*K0, activParams);
+                } else {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+
+typedef void (*conv2d_func_t)(const void* inp, const void* residual, void* out,
+                              const ConvState& cs, const void* weights,
+                              const float* scale, const float* bias,
+                              const int32_t* ofs0, const int32_t** ofsptrs,
+                              const uint8_t* mask);
+
+class Conv2LayerImpl : public Conv2Layer
+{
+public:
+    Conv2LayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        auto_pad = getAutoPadding(params);
+        ceil_mode = params.get<bool>("ceil_mode", false);
+        strides = params.getVector<int>("strides");
+        dilations = params.getVector<int>("dilations");
+        pads = params.getVector<int>("pads");
+        ngroups = params.get<int>("group", 1);
+        fused_batch_norm = false;
+        add_residual = false;
+    }
+
+    virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
+    {
+        prindent(strm, indent);
+        strm << "ngroups: " << ngroups << ",\n";
+
+        /*prindent(strm, indent);
+        strm << "ksizes: [";
+        for (int k = 0; k < wshape0.ndims; k++)
+            strm << (k > 0 ? ", " : "") << wshape0.size[k];
+        strm << "],\n";*/
+
+        prindent(strm, indent);
+        strm << "dilations: [";
+        for (size_t k = 0; k < dilations.size(); k++)
+            strm << (k > 0 ? ", " : "") << dilations[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "pads: [";
+        for (size_t k = 0; k < pads.size(); k++)
+            strm << (k > 0 ? ", " : "") << pads[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "strides: [";
+        for (size_t k = 0; k < strides.size(); k++)
+            strm << (k > 0 ? ", " : "") << strides[k];
+        strm << "],\n";
+
+        if (fused_batch_norm) {
+            prindent(strm, indent);
+            strm << "batch_norm: true,\n";
+        }
+
+        if (add_residual) {
+            prindent(strm, indent);
+            strm << "add_residual: true,\n";
+        }
+
+        if (activ) {
+            prindent(strm, indent);
+            strm << "activation: " << activ->name << ",\n";
+        }
+
+        return strm;
+    }
+
+    int inferType(int inptype0) const
+    {
+        return inptype0;
+    }
+
+    virtual void setWeights(InputArray weights_arr, InputArray bias_arr,
+                            int C0, int accuracy) CV_OVERRIDE
+    {
+        Mat weights_ = weights_arr.getMat();
+        Mat bias_ = bias_arr.getMat();
+        CV_Assert(!weights_.empty());
+        int wtype0 = weights_.type();
+        CV_Assert(wtype0 == CV_32F || wtype0 == CV_16F || wtype0 == CV_16BF);
+        CV_Assert(accuracy == -1 || accuracy == CV_32F);
+        int wtype = accuracy < 0 ? CV_32F : accuracy;
+
+        wshape0 = weights_.shape();
+        MatShape wshape1 = wshape0;
+        bool depthwise = ngroups == wshape0[0] && wshape0[1] == 1;
+
+        if (depthwise) {
+            wshape1.layout = DATA_LAYOUT_BLOCK;
+            wshape1.C = wshape1[0];
+            wshape1[0] = (wshape1[0] + C0 - 1)/C0;
+            for (int i = 2; i < wshape1.dims; i++)
+                wshape1[i-1] = wshape1[i];
+            wshape1[wshape1.dims-1] = C0;
+            weights.fit(wshape1, wtype);
+
+            repackDepthwiseConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);
+        } else {
+            wshape1.dims += 2;
+            wshape1[wshape1.dims-1] = wshape1[wshape1.dims-2] = C0;
+            wshape1[0] = (wshape1[0] + C0 - 1)/C0;
+            wshape1[1] = (wshape1[1] + C0 - 1)/C0;
+            weights.fit(wshape1, wtype);
+
+            repackConv2DWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);
+        }
+
+        if (!bias_.empty()) {
+            CV_Assert(bias_.isContinuous() && bias_.total() == wshape0[0]);
+            bias_.convertTo(bias, CV_32F);
+        }
+    }
+
+    void fuseBatchNormWeights(const BatchNorm2Layer* bn)
+    {
+        Mat bn_scale, bn_bias;
+        bn->getScaleBias(bn_scale, bn_bias);
+
+        CV_Assert(bn_scale.isContinuous() && bn_bias.isContinuous());
+        CV_Assert(bn_scale.type() == CV_32F && bn_bias.type() == CV_32F);
+        CV_Assert(bn_scale.total() == bn_bias.total());
+        int K = (int)bn_scale.total();
+        CV_Assert(bias.empty() || (bias.type() == CV_32F && bias.total() == (size_t)K));
+        const float* bias_data = bias.data ? bias.ptr<float>() : nullptr;
+
+        fused_scale.fit(1, &K, CV_32F);
+        fused_bias.fit(1, &K, CV_32F);
+
+        const float* bn_scale_data = bn_scale.ptr<float>();
+        const float* bn_bias_data = bn_bias.ptr<float>();
+        float* fused_scale_data = fused_scale.ptr<float>();
+        float* fused_bias_data = fused_bias.ptr<float>();
+
+        // (sum(x*w) + bias)*bn_scale + bn_bias => sum(x*w)*fused_scale + fused_bias,
+        // where fused_scale = bn_scale and fused_bias = bias*bn_scale + bn_bias.
+        for (size_t i = 0; i < K; i++) {
+            fused_scale_data[i] = bn_scale_data[i];
+            fused_bias_data[i] = (bias_data ? bn_scale_data[i]*bias_data[i] : 0.f) + bn_bias_data[i];
+        }
+    }
+
+    virtual bool fuseBatchNorm(const Ptr<Layer>& bnlayer) override
+    {
+        BatchNorm2Layer* bn = dynamic_cast<BatchNorm2Layer*>(bnlayer.get());
+        if (fused_batch_norm || !bn || bn->inputs.size() > 1)
+            return false;
+        fuseBatchNormWeights(bn);
+        fused_batch_norm = true;
+        return true;
+    }
+
+    virtual bool fuseAddBias(InputArray arr) CV_OVERRIDE
+    {
+        if (inputs.size() > 1 || fused_batch_norm || add_residual)
+            return false;
+        Mat new_bias = arr.getMat();
+        CV_Assert(new_bias.isContinuous() && new_bias.dims == 1);
+        if (new_bias.type() != CV_32F) {
+            Mat temp;
+            new_bias.convertTo(temp, CV_32F);
+            new_bias = temp;
+            CV_Assert(new_bias.type() == CV_32F);
+        }
+        if (!bias.empty()) {
+            CV_Assert(bias.shape() == new_bias.shape());
+            add(bias, new_bias, bias);
+        } else {
+            new_bias.copyTo(bias);
+        }
+        return true;
+    }
+
+    /*virtual bool fuseActivation(const Ptr<layer>& activ) override
+    {
+        ElemwiseOp* activ_ptr = dynamic_cast<ElemwiseOp*>(op.get());
+        if (activ || activ_ptr->maxNumInputs() != 1 || !activ_ptr || !activ_ptr->getActivation(CV_32F))
+            return false;
+        activ = op;
+        return true;
+    }*/
+
+    virtual int64_t getFLOPS(const std::vector<MatShape>& inputs,
+                             const std::vector<MatShape>& outputs) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() >= 1);
+        CV_Assert(outputs.size() == 1);
+        // probably, there should be a coefficient in the case of complex reduction functions
+        MatShape inpshape = inputs[0], wshape = inputs.size() > 1 ? inputs[1] : wshape0;
+        int C = inpshape[1]*inpshape.back();
+        size_t ksize = wshape.total();
+        return (int64_t)((inputs[0].total()/C)*ksize/ngroups);
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inptypes,
+                          const int, const int,
+                          std::vector<MatType>& outtypes,
+                          std::vector<MatType>& temptypes) const CV_OVERRIDE
+    {
+        int ninputs = (int)inptypes.size();
+        CV_Assert(ninputs == 1);
+
+        outtypes.assign(1, inferType(inptypes[0]));
+        temptypes.clear();
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,
+                                 const int,
+                                 std::vector<MatShape> &outshapes,
+                                 std::vector<MatShape> &tempshapes) const CV_OVERRIDE
+    {
+        size_t ninputs = inpshapes.size();
+        CV_Assert(ninputs >= 1);
+
+        MatShape wshape = ninputs > 1 ? inpshapes[1] : wshape0;
+        outshapes.assign(1, convInferShape(inpshapes[0], wshape, empty_kernel_shape,
+                                           ngroups, strides, dilations,
+                                           pads, auto_pad, ceil_mode));
+        tempshapes.clear();
+        return true;
+    }
+
+    void getLayouts(const std::vector<DataLayout>& actualInputs,
+                    std::vector<DataLayout>& desiredInputs,
+                    const int requiredOutputs,
+                    std::vector<DataLayout>& outputs) const CV_OVERRIDE
+    {
+        size_t ninputs = actualInputs.size();
+        CV_Assert(ninputs >= 1u && requiredOutputs == 1u);
+        desiredInputs = actualInputs;
+        desiredInputs[0] = DATA_LAYOUT_BLOCK;
+        for (size_t i = 1; i < ninputs; i++)
+            desiredInputs[i] = DATA_LAYOUT_UNKNOWN;
+        outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        auto* netimpl_ = getNetImpl(this);
+        int ninputs = (int)inputs_arr.total();
+        CV_Assert(ninputs >= 1);
+        const Mat& inp = inputs_arr.getMat(0);
+        Mat residual;
+        const void* resptr = nullptr;
+        int inptype = inp.type();
+        MatShape inpshape = inp.shape();
+        CV_Assert(inpshape.layout == DATA_LAYOUT_BLOCK);
+        CV_Assert(inp.isContinuous());
+
+        if (add_residual) {
+            residual = inputs_arr.getMat(ninputs-1);
+            resptr = residual.data;
+            ninputs--;
+        }
+
+        bool dynamic_weights = ninputs > 1;
+        if (dynamic_weights) {
+            setWeights(inputs_arr.getMat(1), ninputs > 2 ? inputs_arr.getMat(2) : Mat(),
+                       inpshape.back(), netimpl_->accuracy);
+        }
+
+        MatShape outshape = convInferShape(inpshape, wshape0, empty_kernel_shape,
+                                           ngroups, strides, dilations,
+                                           pads, auto_pad, ceil_mode);
+        int outtype = inferType(inptype);
+        int outkind = outputs_arr.kind();
+        CV_Assert(outkind == _InputArray::STD_VECTOR_MAT ||
+                  outkind == _InputArray::STD_VECTOR_UMAT);
+
+        if (add_residual) {
+            CV_Assert(outshape == residual.shape());
+            CV_Assert(outtype == residual.type());
+        }
+
+        int nspatialdims = inpshape.dims - 3;
+        CV_Assert(wshape0.dims == nspatialdims+2);
+
+        initConvState(inpshape, wshape0, outshape, activ, ngroups,
+                      strides, dilations, pads, auto_pad, ceil_mode, cs);
+        bool conv1x1 = cs.kshape[0]*cs.kshape[1]*cs.kshape[2] == 1;
+        bool depthwise = ngroups == cs.inpshape.C;
+
+        const float* scale_data = nullptr;
+        const float* bias_data = bias.ptr<float>();
+
+        if (fused_batch_norm) {
+            scale_data = fused_scale.ptr<float>();
+            bias_data = fused_bias.ptr<float>();
+        }
+
+        std::vector<Mat>* outs = nullptr;
+        std::vector<UMat>* uouts = nullptr;
+        Mat out;
+
+        if (outkind == _InputArray::STD_VECTOR_MAT) {
+            outs = &outputs_arr.getMatVecRef();
+            outs->resize(1);
+            outs->at(0).fit(outshape, outtype);
+            out = outs->at(0);
+        } else {
+            uouts = &outputs_arr.getUMatVecRef();
+            uouts->resize(1);
+            uouts->at(0).fit(outshape, outtype);
+            out.fit(outshape, outtype);
+        }
+
+        const void* inptr = inp.data;
+        void* outptr = out.data;
+        const void* wptr = weights.data;
+
+        if (depthwise) {
+            DepthwiseConvFunc func = getDepthwiseConvFunc(inptype);
+            CV_Assert(func != nullptr);
+
+            func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data);
+        } else {
+            if (!conv1x1 && (ofs0.empty() || !cs.sameShape(prev_cs))) {
+                initConv2DTables(cs, ofsbuf, ofsofs);
+                prev_cs = cs;
+            }
+
+            ConvFunc func = getConvFunc(inptype);
+            CV_Assert(func != nullptr);
+
+            func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data,
+                 ofsbuf.data(), ofsofs.data());
+        }
+
+        if (uouts) {
+            out.copyTo(uouts->at(0));
+        }
+
+        if (dynamic_weights) {
+            // to keep memory footprint low in the case of
+            // very rare situation of dynamic convolution weights,
+            // we release temporarily allocated and reordered copy of the weights
+            weights.release();
+        }
+    }
+
+    std::vector<int> empty_kernel_shape;
+    Ptr<Layer> activ, batchNorm;
+    Mat weights, bias, fused_scale, fused_bias;
+    MatShape wshape0;
+    ConvState cs, prev_cs;
+    std::vector<int32_t> ofsbuf;
+    std::vector<int32_t> ofs0;
+    std::vector<int32_t> ofsofs;
+    std::vector<uint8_t> mask;
+    bool fused_batch_norm;
+};
+
+Ptr<Conv2Layer> Conv2Layer::create(const LayerParams& params)
+{
+    return Ptr<Conv2Layer>(new Conv2LayerImpl(params));
+}
+
+}}

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -215,7 +215,7 @@ public:
                           std::vector<MatType>& temptypes) const CV_OVERRIDE
     {
         int ninputs = (int)inptypes.size();
-        CV_Assert(ninputs == 1);
+        CV_Assert(ninputs >= 1);
 
         outtypes.assign(1, inferType(inptypes[0]));
         temptypes.clear();
@@ -277,8 +277,12 @@ public:
             ninputs--;
         }
 
-        bool dynamic_weights = ninputs > 1;
-        if (dynamic_weights) {
+        bool dynamic_weights = false;
+        for (int i = 1; i < ninputs; i++) {
+            if (!netimpl_->isConstArg(inputs[i]))
+                dynamic_weights = true;
+        }
+        if (dynamic_weights || weights.empty()) {
             setWeights(inputs_arr.getMat(1), ninputs > 2 ? inputs_arr.getMat(2) : Mat(),
                        inpshape.back(), netimpl_->accuracy);
         }

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -448,8 +448,6 @@ public:
         cs.initConv(inpshape, wshape0, outshape, ngroups,
                     strides, dilations, pads, auto_pad, ceil_mode,
                     fast_activation, fast_activ_params, 0);
-        //bool conv1x1 = cs.kshape[0]*cs.kshape[1]*cs.kshape[2] == 1;
-        bool depthwise = ngroups == cs.inpshape.C;
 
         const float* scale_data = nullptr;
         const float* bias_data = bias.ptr<float>();
@@ -479,7 +477,7 @@ public:
         void* outptr = out.data;
         const void* wptr = weights.data;
 
-        if (depthwise) {
+        if (cs.depthwise) {
             DepthwiseConvFunc func = getDepthwiseConvFunc(inptype);
             CV_Assert(func != nullptr);
 

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -207,8 +207,9 @@ public:
             const Mat& slopes = activPRelu->blobs[0];
             int slopesType = slopes.type();
             CV_Assert_N((slopesType == CV_32F || slopesType == CV_16F || slopesType == CV_16BF),
-                        (slopes.rows == 1 || slopes.cols == 1));
-            slopes.convertTo(activParams, CV_32F);
+                        slopes.isContinuous());
+            int nslopes = int(slopes.total());
+            Mat(1, &nslopes, slopesType, (void*)slopes.data).convertTo(activParams, CV_32F);
         } else {
             //activ = activlayer;
             return false;

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -20,243 +20,6 @@ namespace dnn
     Opset's 1 to 22 are covered.
 */
 
-static void refConv32f(const void* inp__, const void* residual__, void* out__,
-                       const ConvState& cs, const void* weights__,
-                       const float* scale__, const float* bias__,
-                       const int32_t* inpofs__, const int32_t* ofsofs__)
-{
-    int C0_ = cs.inpshape.back();
-    int K1_ = cs.outshape[1];
-
-    CV_Assert(C0_ == 8);
-    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
-    CV_Assert(0 <= cs.nspatialdims && cs.nspatialdims <= ConvState::MAX_CONV_DIMS);
-    
-    parallel_for_(Range(0, K1_), [&](const Range& range) {
-        int sdims = cs.nspatialdims;
-        int C0 = C0_, K0 = C0_;
-        int K1 = K1_, C1 = cs.inpshape[1];
-        int K = cs.outshape.C, C = cs.inpshape.C;
-        int N = cs.inpshape[0];
-        
-        int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
-        int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
-        int Wi = cs.inpshape[sdims + 1];
-        int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
-        int H = sdims > 1 ? cs.outshape[sdims] : 1;
-        int W = cs.outshape[sdims + 1];
-        int iplanesize = Di*Hi*Wi*C0;
-        int planesize = D*H*W*C0;
-        
-        int ngroups = cs.ngroups;
-        int Cg = C/ngroups, Kg = K/ngroups;
-        int WCg = (Cg + C0 - 1)/C0;
-        int Sz = cs.strides[0], Sy = cs.strides[1], Sx = cs.strides[2];
-        int Dz = cs.dilations[0], Dy = cs.dilations[1], Dx = cs.dilations[2];
-        int padz = cs.pads[0], pady = cs.pads[1], padx = cs.pads[2];
-        
-        const float* scale_ = scale__;
-        const float* bias_ = bias__;
-        constexpr int BLOCK_SIZE = 8;
-        
-        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
-        
-        int k1start = range.start, nk1 = range.end;
-        constexpr int C0 = 8, K0 = C0;
-        int planesize = 1, iplanesize = 1, ksize = 1;
-        int nspatialdims = cs.nspatialdims;
-        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
-        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
-        int nC = C1g*ksize*C0*K0;
-        
-        float* sum = sumbuf.data();
-        float* scale = sum + BLOCK_SIZE*K0;
-        float* bias = sum + BLOCK_SIZE*K0*2;
-        const float* inptrs[BLOCK_SIZE];
-        const int32_t* ofsptrs[BLOCK_SIZE];
-        FastActivation fastActivation = cs.fastActivation;
-        const float* activParams = cs.activParams;
-        activation_func_t activation = cs.activation;
-        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
-        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
-                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
-
-        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
-            scale[j] = 1.f;
-            bias[j] = 0.f;
-        }
-
-        for (int k1 = range.start; k1 < range.end; k1++) {
-            for (int n = 0; n < N; n++) {
-                float* out = (float*)out__ + n*k1*planesize*K0;
-                const float* resptr = residual__ ? (const float*)residual__ + n*k1*planesize*K0 : nullptr;
-                
-                
-                
-            }
-            int n = nk/K1, k1 = nk - n*K1;
-            int g = k1/K1g;
-            
-            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
-            
-            const float* wptr = (const float*)weights__ + k1*nC;
-
-            if (scale_) {
-                for (int b = 0; b < BLOCK_SIZE; b++)
-                    for (int k = 0; k < K0; k++)
-                        scale[b*K0 + k] = scale_[k1*K0 + k];
-            }
-
-            if (bias_) {
-                for (int b = 0; b < BLOCK_SIZE; b++)
-                    for (int k = 0; k < K0; k++)
-                        bias[b*K0 + k] = bias_[k1*K0 + k];
-            }
-
-            for (int xy0 = 0; xy0 < planesize; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
-                 resptr += (resptr ? K0*BLOCK_SIZE : 0)) {
-                int j = 0, blocksize = std::min(planesize - xy0, BLOCK_SIZE);
-
-                for (; j < blocksize; j++) {
-                    int jj = (xy0 + j)*2;
-                    inptrs[j] = inp0 + ofsofs_[jj];
-                    ofsptrs[j] = inpofs_ + ofsofs_[jj+1];
-                }
-
-                if (j < BLOCK_SIZE) {
-                    const float* last_inptr = inptrs[blocksize-1];
-                    const int32_t* last_ofsptr = ofsptrs[blocksize-1];
-                    for (; j < BLOCK_SIZE; j++) {
-                        inptrs[j] = last_inptr;
-                        ofsptrs[j] = last_ofsptr;
-                    }
-                }
-
-                for (int i = 0; i < BLOCK_SIZE*K0; i++)
-                    sum[i] = 0.f;
-
-                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
-                    for (j = 0; j < BLOCK_SIZE; j++) {
-                        int32_t ofs_ij = ofsptrs[j][i];
-                        const float* x = &inptrs[j][std::max(ofs_ij, 0)];
-                        float mij = (float)(ofs_ij >= 0);
-                        for (int c0 = 0; c0 < C0; c0++) {
-                            float xc = x[c0]*mij;
-                            for (int k = 0; k < K0; k++) {
-                                float w = wptr[c1 + c0*K0 + k];
-                                sum[K0*j + k] += xc*w;
-                            }
-                        }
-                    }
-                }
-
-                if (activation) {
-                    if (resptr) {
-                        for (j = 0; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
-                            sum[j] = v;
-                        }
-                    } else {
-                        for (j = 0; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j];
-                            sum[j] = v;
-                        }
-                    }
-                    activation(sum, out, blocksize*K0, activParams);
-                } else {
-                    if (resptr) {
-                        for (j = 0; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
-                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
-                            out[j] = v;
-                        }
-                    } else {
-                        for (j = 0; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j];
-                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
-                            out[j] = v;
-                        }
-                    }
-                }
-            }
-        }
-    });
-}
-
-/*
-static void refConv2d(const Mat& inp, const Mat& weights, const MatShape& wshape0, const Mat& bias, Mat& out,
-                      const int* strides, const int* dilations,
-                      const int* pads, FastActivation activation,
-                      float activParam=0.f)
-{
-    CV_Assert(inp.type() == CV_32F);
-
-    MatShape inpshape = inp.size;
-    int ndims = inpshape.dims;
-    CV_Assert(ndims == 4 && wshape0.dims == 4);
-
-    MatShape outshape = fastConv2dInferShape(inpshape, wshape0, strides, dilations, pads);
-    CV_Assert(wshape0[0] == outshape[1] && inpshape[0] == outshape[0]);
-
-    out.fit(outshape, inp.type());
-
-    parallel_for_(Range(0, wshape0[0]), [&](const Range& range) {
-        int C0 = weights.size.back();
-        int K = wshape0[0], WC = wshape0[1], Hk = wshape0[2], Wk = wshape0[3];
-        int N = inpshape[0], C = inpshape[1];
-        int Hi = inpshape[2], Wi = inpshape[3];
-        int H0 = outshape[2], W0 = outshape[3];
-        int ngroups = C/WC;
-        int Cg = C/ngroups, Kg = K/ngroups;
-        int WCg = (Cg + C0 - 1)/C0;
-        int Sy = strides[1], Sx = strides[2];
-        int Dy = dilations[1], Dx = dilations[2];
-        int pady = pads[1], padx = pads[2];
-        float minval = activation == FAST_ACTIV_RELU || activation == FAST_ACTIV_CLIP ? 0.f : -FLT_MAX;
-        float maxval = activation == FAST_ACTIV_CLIP ? activParam : FLT_MAX;
-        const float* wptr = weights.ptr<float>();
-        const float* biasptr = bias.ptr<float>();
-        const float* inptr = inp.ptr<float>();
-        float* outptr = out.ptr<float>();
-
-        for (int k = range.start; k < range.end; k++) {
-            int k1 = k / C0, k0 = k % C0;
-            int g = k/Kg;
-            for (int n = 0; n < N; n++) {
-                for (int y0 = 0; y0 < H0; y0++) {
-                    for (int x0 = 0; x0 < W0; x0++) {
-                        int yi_ = y0*Sy - pady;
-                        int xi_ = x0*Sx - padx;
-                        float s = 0.f;
-
-                        for (int ky = 0; ky < Hk; ky++) {
-                            int yi = yi_ + ky*Dy;
-                            if (yi < 0 || yi >= Hi)
-                                continue;
-
-                            for (int kx = 0; kx < Wk; kx++) {
-                                int xi = xi_ + kx*Dx;
-                                if (xi < 0 || xi >= Wi)
-                                    continue;
-                                for (int c = 0; c < Cg; c++) {
-                                    size_t ofs = (((n*ngroups + g)*Cg + c)*Hi + yi)*Wi + xi;
-                                    float inpval = inptr[ofs];
-                                    int c1 = c / C0, c0 = c % C0;
-                                    float w = wptr[(((k1*WCg + c1)*Hk+ky)*Wk + kx)*C0*C0 + c0*C0 + k0];
-                                    s += inpval*w;
-                                }
-                            }
-                        }
-                        if (biasptr)
-                            s += biasptr[k];
-                        outptr[((n*K + k)*H0 + y0)*W0 + x0] = std::min(std::max(s, minval), maxval);
-                    }
-                }
-            }
-        }
-    });
-}*/
-
 class Conv2LayerImpl : public Conv2Layer
 {
 public:
@@ -349,10 +112,10 @@ public:
         int wtype = accuracy < 0 ? CV_32F : accuracy;
 
         wshape0 = weights_.shape();
-        MatShape wshape1 = wshape0;
         bool depthwise = ngroups == wshape0[0] && wshape0[1] == 1;
 
         if (depthwise) {
+            MatShape wshape1 = wshape0;
             wshape1.layout = DATA_LAYOUT_BLOCK;
             wshape1.C = wshape1[0];
             wshape1[0] = (wshape1[0] + C0 - 1)/C0;
@@ -363,13 +126,14 @@ public:
 
             repackDepthwiseConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);
         } else {
-            wshape1.dims += 2;
+            /*wshape1.dims += 2;
             wshape1[wshape1.dims-1] = wshape1[wshape1.dims-2] = C0;
             wshape1[0] = (wshape1[0] + C0 - 1)/C0;
             wshape1[1] = (wshape1[1] + C0 - 1)/C0;
             weights.fit(wshape1, wtype);
 
-            repackConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);
+            repackConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);*/
+            repackConvWeightsAlt(weights_, weights, wtype, ngroups, C0);
         }
 
         if (!bias_.empty()) {
@@ -629,7 +393,7 @@ public:
             }
 
             {
-                ConvFunc func = cs.unevenGroupedConv ? refConv32f : getConvFunc(inptype, C0);
+                ConvFunc func = getConvFunc(inptype, C0, CONV_KIND_ALT);
                 CV_Assert(func != nullptr);
                 func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data,
                      inpofs.data(), ofsofs.data());

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -32,11 +32,9 @@ public:
         dilations = params.getVector<int>("dilation");
         pads = params.getVector<int>("pad");
         ngroups = params.get<int>("group", 1);
-        fused_batch_norm = false;
-        fused_batch_norm = false;
-        fast_activation = FAST_ACTIV_NONE;
-        memset(fast_activ_params, 0, sizeof(fast_activ_params));
-        add_residual = false;
+        fusedBatchNorm = false;
+        fastActivation = FAST_ACTIV_NONE;
+        addResidual = false;
     }
 
     virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
@@ -70,21 +68,21 @@ public:
             strm << (k > 0 ? ", " : "") << pads[k];
         strm << "],\n";
 
-        if (fused_batch_norm) {
+        if (fusedBatchNorm) {
             prindent(strm, indent);
             strm << "batch_norm: true,\n";
         }
 
-        if (fast_activation != FAST_ACTIV_NONE || !activ.empty()) {
+        if (fastActivation != FAST_ACTIV_NONE || !activ.empty()) {
             prindent(strm, indent);
             strm << "fused_activation: " <<
-                (fast_activation != FAST_ACTIV_NONE ? fastActivationToString(fast_activation) :
+                (fastActivation != FAST_ACTIV_NONE ? fastActivationToString(fastActivation) :
                  activ->type) << ",\n";
         }
 
-        if (add_residual) {
+        if (addResidual) {
             prindent(strm, indent);
-            strm << "add_residual: true,\n";
+            strm << "addResidual: true,\n";
         }
 
         if (activ) {
@@ -138,13 +136,13 @@ public:
         CV_Assert(bias.empty() || (bias.type() == CV_32F && bias.total() == (size_t)K));
         const float* bias_data = bias.data ? bias.ptr<float>() : nullptr;
 
-        fused_scale.fit(1, &K, CV_32F);
-        fused_bias.fit(1, &K, CV_32F);
+        fusedScale.fit(1, &K, CV_32F);
+        fusedBias.fit(1, &K, CV_32F);
 
         const float* bn_scale_data = bn_scale.ptr<float>();
         const float* bn_bias_data = bn_bias.ptr<float>();
-        float* fused_scale_data = fused_scale.ptr<float>();
-        float* fused_bias_data = fused_bias.ptr<float>();
+        float* fused_scale_data = fusedScale.ptr<float>();
+        float* fused_bias_data = fusedBias.ptr<float>();
 
         // (sum(x*w) + bias)*bn_scale + bn_bias => sum(x*w)*fused_scale + fused_bias,
         // where fused_scale = bn_scale and fused_bias = bias*bn_scale + bn_bias.
@@ -157,16 +155,16 @@ public:
     virtual bool fuseBatchNorm(const Ptr<Layer>& bnlayer) override
     {
         BatchNorm2Layer* bn = dynamic_cast<BatchNorm2Layer*>(bnlayer.get());
-        if (fused_batch_norm || !bn || bn->inputs.size() > 1)
+        if (fusedBatchNorm || !bn || bn->inputs.size() > 1)
             return false;
         fuseBatchNormWeights(bn);
-        fused_batch_norm = true;
+        fusedBatchNorm = true;
         return true;
     }
 
     virtual bool fuseAddBias(InputArray arr) CV_OVERRIDE
     {
-        if (inputs.size() > 1 || fused_batch_norm || add_residual)
+        if (inputs.size() > 1 || fusedBatchNorm || addResidual)
             return false;
         Mat new_bias = arr.getMat();
         CV_Assert(new_bias.isContinuous() && new_bias.dims == 1);
@@ -188,17 +186,29 @@ public:
     virtual bool fuseActivation(const Ptr<Layer>& activlayer) override
     {
         ActivationLayer* activ_ptr = dynamic_cast<ActivationLayer*>(activlayer.get());
-        if (!activ_ptr || fast_activation != FAST_ACTIV_NONE)
+        if (!activ_ptr || fastActivation != FAST_ACTIV_NONE || !activ.empty())
             return false;
-        ReLULayer* relu = dynamic_cast<ReLULayer*>(activ_ptr);
-        if (relu) {
-            float alpha = relu->negativeSlope;
-            if (alpha > 0.f) {
-                fast_activation = FAST_ACTIV_LEAKY_RELU;
-                fast_activ_params[0] = alpha;
+        ReLULayer* activRelu = dynamic_cast<ReLULayer*>(activ_ptr);
+        ReLU6Layer* activClip = dynamic_cast<ReLU6Layer*>(activ_ptr);
+        ChannelsPReLULayer* activPRelu = dynamic_cast<ChannelsPReLULayer*>(activ_ptr);
+        if (activRelu) {
+            float alpha = activRelu->negativeSlope;
+            if (alpha == 0.f) {
+                fastActivation = FAST_ACTIV_RELU;
             } else {
-                fast_activation = FAST_ACTIV_RELU;
+                fastActivation = FAST_ACTIV_LEAKY_RELU;
+                activParams = {alpha};
             }
+        } else if (activClip && activClip->minValue == 0.f) {
+            fastActivation = FAST_ACTIV_CLIP;
+            activParams = {activClip->minValue, activClip->maxValue};
+        } else if (activPRelu && activPRelu->blobs.size() == 1) {
+            fastActivation = FAST_ACTIV_PRELU;
+            const Mat& slopes = activPRelu->blobs[0];
+            int slopesType = slopes.type();
+            CV_Assert_N((slopesType == CV_32F || slopesType == CV_16F || slopesType == CV_16BF),
+                        (slopes.rows == 1 || slopes.cols == 1));
+            slopes.convertTo(activParams, CV_32F);
         } else {
             //activ = activlayer;
             return false;
@@ -208,8 +218,8 @@ public:
 
     virtual bool fuseAddResidual(Arg residual) CV_OVERRIDE
     {
-        if (activ.empty() && fast_activation == FAST_ACTIV_NONE && !add_residual && residual.idx >= 0) {
-            add_residual = true;
+        if (activ.empty() && fastActivation == FAST_ACTIV_NONE && !addResidual && residual.idx >= 0) {
+            addResidual = true;
             inputs.push_back(residual);
             return true;
         }
@@ -246,12 +256,12 @@ public:
                                  std::vector<MatShape> &tempshapes) const CV_OVERRIDE
     {
         size_t ninputs = inpshapes.size();
-        if (add_residual)
+        if (addResidual)
             ninputs--;
         CV_Assert(ninputs >= 1);
 
         MatShape wshape = ninputs > 1 ? inpshapes[1] : wshape0;
-        outshapes.assign(1, convInferShape(inpshapes[0], wshape, empty_kernel_shape,
+        outshapes.assign(1, convInferShape(inpshapes[0], wshape, emptyKernelShape,
                                            ngroups, strides, dilations,
                                            pads, auto_pad, ceil_mode));
         tempshapes.clear();
@@ -282,7 +292,6 @@ public:
                  OutputArrayOfArrays temp_arrs) CV_OVERRIDE
     {
         auto* netimpl_ = getNetImpl(this);
-        DataLayout origLayout = netimpl_->originalLayout;
         std::vector<Mat>* temp_mats = &temp_arrs.getMatVecRef();
         temp_mats->resize(2);
         int ninputs = (int)input_arrs.total();
@@ -295,7 +304,7 @@ public:
         CV_Assert(inpshape.layout == DATA_LAYOUT_BLOCK);
         CV_Assert(inp.isContinuous());
 
-        if (add_residual) {
+        if (addResidual) {
             residual = input_arrs.getMat(ninputs-1);
             resptr = residual.data;
             ninputs--;
@@ -311,7 +320,7 @@ public:
                        inpshape.back(), netimpl_->accuracy);
         }
 
-        MatShape outshape = convInferShape(inpshape, wshape0, empty_kernel_shape,
+        MatShape outshape = convInferShape(inpshape, wshape0, emptyKernelShape,
                                            ngroups, strides, dilations,
                                            pads, auto_pad, ceil_mode);
         int outtype = inferType(inptype);
@@ -320,7 +329,7 @@ public:
         CV_Assert(outkind == _InputArray::STD_VECTOR_MAT ||
                   outkind == _InputArray::STD_VECTOR_UMAT);
 
-        if (add_residual && (residual.size != outshape || residual.type() != outtype))
+        if (addResidual && (residual.size != outshape || residual.type() != outtype))
         {
             CV_Error(Error::StsBadArg,
                     "residual added after convolution must have the same shape and the "
@@ -332,16 +341,19 @@ public:
         int nspatialdims = inpshape.dims - 3;
         CV_Assert(wshape0.dims == nspatialdims+2);
 
-        cs.initConv(inpshape, wshape0, outshape, ngroups,
-                    strides, dilations, pads, auto_pad, ceil_mode,
-                    fast_activation, fast_activ_params, ConvState::MAX_ACTIV_PARAMS);
+        if (inpshape != prevInpshape) {
+            cs.initConv(inpshape, wshape0, outshape, ngroups,
+                        strides, dilations, pads, auto_pad, ceil_mode,
+                        fastActivation, activParams);
+            prevInpshape = inpshape;
+        }
 
         const float* scale_data = nullptr;
         const float* bias_data = bias.ptr<float>();
 
-        if (fused_batch_norm) {
-            scale_data = fused_scale.ptr<float>();
-            bias_data = fused_bias.ptr<float>();
+        if (fusedBatchNorm) {
+            scale_data = fusedScale.ptr<float>();
+            bias_data = fusedBias.ptr<float>();
         }
 
         std::vector<Mat>* outs = nullptr;
@@ -380,15 +392,15 @@ public:
         }
     }
 
-    std::vector<int> empty_kernel_shape;
+    std::vector<int> emptyKernelShape;
     Ptr<Layer> activ, batchNorm;
-    Mat weights, bias, fused_scale, fused_bias;
-    MatShape wshape0;
+    Mat weights, bias, fusedScale, fusedBias;
+    MatShape wshape0, prevInpshape;
     ConvState cs;
-    bool fused_batch_norm;
-    FastActivation fast_activation;
-    float fast_activ_params[ConvState::MAX_ACTIV_PARAMS];
-    bool add_residual;
+    bool fusedBatchNorm;
+    FastActivation fastActivation;
+    std::vector<float> activParams;
+    bool addResidual;
 };
 
 Ptr<Conv2Layer> Conv2Layer::create(const LayerParams& params)

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -447,7 +447,7 @@ public:
 
         cs.initConv(inpshape, wshape0, outshape, ngroups,
                     strides, dilations, pads, auto_pad, ceil_mode,
-                    fast_activation, fast_activ_params, 0);
+                    fast_activation, fast_activ_params, ConvState::MAX_ACTIV_PARAMS);
 
         const float* scale_data = nullptr;
         const float* bias_data = bias.ptr<float>();

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -20,33 +20,170 @@ namespace dnn
     Opset's 1 to 22 are covered.
 */
 
-#if 0
-static MatShape fastConv2dInferShape(const MatShape& inpshape, const MatShape& wshape,
-                                     const int* strides,
-                                     const int* dilations,
-                                     const int* pads)
+static void refConv32f(const void* inp__, const void* residual__, void* out__,
+                       const ConvState& cs, const void* weights__,
+                       const float* scale__, const float* bias__,
+                       const int32_t* inpofs__, const int32_t* ofsofs__)
 {
-    int ndims = inpshape.dims, wdims = wshape.dims;
-    CV_Assert(ndims == 4 && wdims == 4);
+    int C0_ = cs.inpshape.back();
+    int K1_ = cs.outshape[1];
 
-    int N = inpshape[0], C = inpshape[1], H = inpshape[2], W = inpshape[3];
-    int K = wshape[0], WCg = wshape[1], Hk = wshape[2], Wk = wshape[3];
-    int ngroups = C/WCg;
+    CV_Assert(C0_ == 8);
+    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
+    CV_Assert(0 <= cs.nspatialdims && cs.nspatialdims <= ConvState::MAX_CONV_DIMS);
+    
+    parallel_for_(Range(0, K1_), [&](const Range& range) {
+        int sdims = cs.nspatialdims;
+        int C0 = C0_, K0 = C0_;
+        int K1 = K1_, C1 = cs.inpshape[1];
+        int K = cs.outshape.C, C = cs.inpshape.C;
+        int N = cs.inpshape[0];
+        
+        int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
+        int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
+        int Wi = cs.inpshape[sdims + 1];
+        int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
+        int H = sdims > 1 ? cs.outshape[sdims] : 1;
+        int W = cs.outshape[sdims + 1];
+        int iplanesize = Di*Hi*Wi*C0;
+        int planesize = D*H*W*C0;
+        
+        int ngroups = cs.ngroups;
+        int Cg = C/ngroups, Kg = K/ngroups;
+        int WCg = (Cg + C0 - 1)/C0;
+        int Sz = cs.strides[0], Sy = cs.strides[1], Sx = cs.strides[2];
+        int Dz = cs.dilations[0], Dy = cs.dilations[1], Dx = cs.dilations[2];
+        int padz = cs.pads[0], pady = cs.pads[1], padx = cs.pads[2];
+        
+        const float* scale_ = scale__;
+        const float* bias_ = bias__;
+        constexpr int BLOCK_SIZE = 8;
+        
+        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
+        
+        int k1start = range.start, nk1 = range.end;
+        constexpr int C0 = 8, K0 = C0;
+        int planesize = 1, iplanesize = 1, ksize = 1;
+        int nspatialdims = cs.nspatialdims;
+        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
+        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
+        int nC = C1g*ksize*C0*K0;
+        
+        float* sum = sumbuf.data();
+        float* scale = sum + BLOCK_SIZE*K0;
+        float* bias = sum + BLOCK_SIZE*K0*2;
+        const float* inptrs[BLOCK_SIZE];
+        const int32_t* ofsptrs[BLOCK_SIZE];
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
 
-    int pad_y = pads[1] + pads[4];
-    int pad_x = pads[2] + pads[5];
-    int H0 = (H + pad_y - dilations[1]*(Hk - 1) - 1)/strides[1] + 1;
-    int W0 = (W + pad_x - dilations[2]*(Wk - 1) - 1)/strides[2] + 1;
-    MatShape outshape(4);
-    outshape.layout = inpshape.layout;
-    outshape[0] = inpshape[0];
-    outshape[1] = K;
-    outshape[2] = H0;
-    outshape[3] = W0;
+        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
+            scale[j] = 1.f;
+            bias[j] = 0.f;
+        }
 
-    return outshape;
+        for (int k1 = range.start; k1 < range.end; k1++) {
+            for (int n = 0; n < N; n++) {
+                float* out = (float*)out__ + n*k1*planesize*K0;
+                const float* resptr = residual__ ? (const float*)residual__ + n*k1*planesize*K0 : nullptr;
+                
+                
+                
+            }
+            int n = nk/K1, k1 = nk - n*K1;
+            int g = k1/K1g;
+            
+            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
+            
+            const float* wptr = (const float*)weights__ + k1*nC;
+
+            if (scale_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        scale[b*K0 + k] = scale_[k1*K0 + k];
+            }
+
+            if (bias_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        bias[b*K0 + k] = bias_[k1*K0 + k];
+            }
+
+            for (int xy0 = 0; xy0 < planesize; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
+                 resptr += (resptr ? K0*BLOCK_SIZE : 0)) {
+                int j = 0, blocksize = std::min(planesize - xy0, BLOCK_SIZE);
+
+                for (; j < blocksize; j++) {
+                    int jj = (xy0 + j)*2;
+                    inptrs[j] = inp0 + ofsofs_[jj];
+                    ofsptrs[j] = inpofs_ + ofsofs_[jj+1];
+                }
+
+                if (j < BLOCK_SIZE) {
+                    const float* last_inptr = inptrs[blocksize-1];
+                    const int32_t* last_ofsptr = ofsptrs[blocksize-1];
+                    for (; j < BLOCK_SIZE; j++) {
+                        inptrs[j] = last_inptr;
+                        ofsptrs[j] = last_ofsptr;
+                    }
+                }
+
+                for (int i = 0; i < BLOCK_SIZE*K0; i++)
+                    sum[i] = 0.f;
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    for (j = 0; j < BLOCK_SIZE; j++) {
+                        int32_t ofs_ij = ofsptrs[j][i];
+                        const float* x = &inptrs[j][std::max(ofs_ij, 0)];
+                        float mij = (float)(ofs_ij >= 0);
+                        for (int c0 = 0; c0 < C0; c0++) {
+                            float xc = x[c0]*mij;
+                            for (int k = 0; k < K0; k++) {
+                                float w = wptr[c1 + c0*K0 + k];
+                                sum[K0*j + k] += xc*w;
+                            }
+                        }
+                    }
+                }
+
+                if (activation) {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            sum[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            sum[j] = v;
+                        }
+                    }
+                    activation(sum, out, blocksize*K0, activParams);
+                } else {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    }
+                }
+            }
+        }
+    });
 }
 
+/*
 static void refConv2d(const Mat& inp, const Mat& weights, const MatShape& wshape0, const Mat& bias, Mat& out,
                       const int* strides, const int* dilations,
                       const int* pads, FastActivation activation,
@@ -118,8 +255,7 @@ static void refConv2d(const Mat& inp, const Mat& weights, const MatShape& wshape
             }
         }
     });
-}
-#endif
+}*/
 
 class Conv2LayerImpl : public Conv2Layer
 {
@@ -393,14 +529,17 @@ public:
     {
     }
 
-    void forward(InputArrayOfArrays inputs_arr,
-                 OutputArrayOfArrays outputs_arr,
-                 OutputArrayOfArrays) CV_OVERRIDE
+    void forward(InputArrayOfArrays input_arrs,
+                 OutputArrayOfArrays output_arrs,
+                 OutputArrayOfArrays temp_arrs) CV_OVERRIDE
     {
         auto* netimpl_ = getNetImpl(this);
-        int ninputs = (int)inputs_arr.total();
+        DataLayout origLayout = netimpl_->originalLayout;
+        std::vector<Mat>* temp_mats = &temp_arrs.getMatVecRef();
+        temp_mats->resize(2);
+        int ninputs = (int)input_arrs.total();
         CV_Assert(ninputs >= 1);
-        const Mat& inp = inputs_arr.getMat(0);
+        const Mat& inp = input_arrs.getMat(0);
         Mat residual;
         const void* resptr = nullptr;
         int inptype = inp.type();
@@ -409,18 +548,18 @@ public:
         CV_Assert(inp.isContinuous());
         
         if (add_residual) {
-            residual = inputs_arr.getMat(ninputs-1);
+            residual = input_arrs.getMat(ninputs-1);
             resptr = residual.data;
             ninputs--;
         }
 
-        bool dynamic_weights = false;
+        bool dynamicWeights = false;
         for (int i = 1; i < ninputs; i++) {
             if (!netimpl_->isConstArg(inputs[i]))
-                dynamic_weights = true;
+                dynamicWeights = true;
         }
-        if (dynamic_weights || weights.empty()) {
-            setWeights(inputs_arr.getMat(1), ninputs > 2 ? inputs_arr.getMat(2) : Mat(),
+        if (dynamicWeights || weights.empty()) {
+            setWeights(input_arrs.getMat(1), ninputs > 2 ? input_arrs.getMat(2) : Mat(),
                        inpshape.back(), netimpl_->accuracy);
         }
 
@@ -429,7 +568,7 @@ public:
                                            pads, auto_pad, ceil_mode);
         int outtype = inferType(inptype);
         int C0 = inpshape.back();
-        int outkind = outputs_arr.kind();
+        int outkind = output_arrs.kind();
         CV_Assert(outkind == _InputArray::STD_VECTOR_MAT ||
                   outkind == _InputArray::STD_VECTOR_UMAT);
         
@@ -448,7 +587,7 @@ public:
         cs.initConv(inpshape, wshape0, outshape, ngroups,
                     strides, dilations, pads, auto_pad, ceil_mode,
                     fast_activation, fast_activ_params, ConvState::MAX_ACTIV_PARAMS);
-
+        
         const float* scale_data = nullptr;
         const float* bias_data = bias.ptr<float>();
 
@@ -462,12 +601,12 @@ public:
         Mat out;
 
         if (outkind == _InputArray::STD_VECTOR_MAT) {
-            outs = &outputs_arr.getMatVecRef();
+            outs = &output_arrs.getMatVecRef();
             outs->resize(1);
             outs->at(0).fit(outshape, outtype);
             out = outs->at(0);
         } else {
-            uouts = &outputs_arr.getUMatVecRef();
+            uouts = &output_arrs.getUMatVecRef();
             uouts->resize(1);
             uouts->at(0).fit(outshape, outtype);
             out.fit(outshape, outtype);
@@ -490,10 +629,11 @@ public:
             }
 
             {
-                ConvFunc func = getConvFunc(inptype, C0);
+                ConvFunc func = cs.unevenGroupedConv ? refConv32f : getConvFunc(inptype, C0);
                 CV_Assert(func != nullptr);
                 func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data,
                      inpofs.data(), ofsofs.data());
+
 #if 0
                 Mat inp0, out0, temp;
                 transformLayout(inp, inp0, DATA_LAYOUT_NCHW,
@@ -513,7 +653,7 @@ public:
             out.copyTo(uouts->at(0));
         }
 
-        if (dynamic_weights) {
+        if (dynamicWeights) {
             // to keep memory footprint low in the case of
             // very rare situation of dynamic convolution weights,
             // we release temporarily allocated and reordered copy of the weights

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -74,7 +74,7 @@ public:
             prindent(strm, indent);
             strm << "batch_norm: true,\n";
         }
-        
+
         if (fast_activation != FAST_ACTIV_NONE || !activ.empty()) {
             prindent(strm, indent);
             strm << "fused_activation: " <<
@@ -115,25 +115,9 @@ public:
         bool depthwise = ngroups == wshape0[0] && wshape0[1] == 1;
 
         if (depthwise) {
-            MatShape wshape1 = wshape0;
-            wshape1.layout = DATA_LAYOUT_BLOCK;
-            wshape1.C = wshape1[0];
-            wshape1[0] = (wshape1[0] + C0 - 1)/C0;
-            for (int i = 2; i < wshape1.dims; i++)
-                wshape1[i-1] = wshape1[i];
-            wshape1[wshape1.dims-1] = C0;
-            weights.fit(wshape1, wtype);
-
-            repackDepthwiseConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);
+            repackDepthwiseConvWeights(weights_, weights, wtype, C0);
         } else {
-            /*wshape1.dims += 2;
-            wshape1[wshape1.dims-1] = wshape1[wshape1.dims-2] = C0;
-            wshape1[0] = (wshape1[0] + C0 - 1)/C0;
-            wshape1[1] = (wshape1[1] + C0 - 1)/C0;
-            weights.fit(wshape1, wtype);
-
-            repackConvWeights(weights_.data, wtype0, weights.data, wtype, wshape0, C0);*/
-            repackConvWeightsAlt(weights_, weights, wtype, ngroups, C0);
+            repackConvWeights(weights_, weights, wtype, ngroups, C0);
         }
 
         if (!bias_.empty()) {
@@ -221,7 +205,7 @@ public:
         }
         return true;
     }
-    
+
     virtual bool fuseAddResidual(Arg residual) CV_OVERRIDE
     {
         if (activ.empty() && fast_activation == FAST_ACTIV_NONE && !add_residual && residual.idx >= 0) {
@@ -310,7 +294,7 @@ public:
         MatShape inpshape = inp.shape();
         CV_Assert(inpshape.layout == DATA_LAYOUT_BLOCK);
         CV_Assert(inp.isContinuous());
-        
+
         if (add_residual) {
             residual = input_arrs.getMat(ninputs-1);
             resptr = residual.data;
@@ -335,7 +319,7 @@ public:
         int outkind = output_arrs.kind();
         CV_Assert(outkind == _InputArray::STD_VECTOR_MAT ||
                   outkind == _InputArray::STD_VECTOR_UMAT);
-        
+
         if (add_residual && (residual.size != outshape || residual.type() != outtype))
         {
             CV_Error(Error::StsBadArg,
@@ -351,7 +335,7 @@ public:
         cs.initConv(inpshape, wshape0, outshape, ngroups,
                     strides, dilations, pads, auto_pad, ceil_mode,
                     fast_activation, fast_activ_params, ConvState::MAX_ACTIV_PARAMS);
-        
+
         const float* scale_data = nullptr;
         const float* bias_data = bias.ptr<float>();
 
@@ -380,38 +364,9 @@ public:
         void* outptr = out.data;
         const void* wptr = weights.data;
 
-        if (cs.depthwise) {
-            DepthwiseConvFunc func = getDepthwiseConvFunc(inptype);
-            CV_Assert(func != nullptr);
-
-            func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data);
-        } else {
-            // [TODO] add special 1x1 convolution kernels that don't need inpofs & ofsofs
-            if (inpofs.empty() || !cs.sameShape(prev_cs)) {
-                initConvTables(cs, inpofs, ofsofs);
-                prev_cs = cs;
-            }
-
-            {
-                ConvFunc func = getConvFunc(inptype, C0, CONV_KIND_ALT);
-                CV_Assert(func != nullptr);
-                func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data,
-                     inpofs.data(), ofsofs.data());
-
-#if 0
-                Mat inp0, out0, temp;
-                transformLayout(inp, inp0, DATA_LAYOUT_NCHW,
-                                DATA_LAYOUT_NCHW, inp.size.C);
-                refConv2d(inp0, weights, wshape0, bias, out0,
-                          cs.strides, cs.dilations, cs.pads,
-                          fast_activation, 0.f);
-                transformLayout(out0, temp, DATA_LAYOUT_BLOCK,
-                                DATA_LAYOUT_NCHW, out.size.back());
-                double err = norm(temp, out, NORM_INF);
-                CV_Assert(err < 1e-4);
-#endif
-            }
-        }
+        ConvFunc func = cs.depthwise ? getDepthwiseConvFunc(inptype) : getConvFunc(inptype, C0);
+        CV_Assert(func != nullptr);
+        func(inptr, resptr, outptr, cs, wptr, scale_data, bias_data);
 
         if (uouts) {
             out.copyTo(uouts->at(0));
@@ -429,9 +384,7 @@ public:
     Ptr<Layer> activ, batchNorm;
     Mat weights, bias, fused_scale, fused_bias;
     MatShape wshape0;
-    ConvState cs, prev_cs;
-    std::vector<int32_t> inpofs;
-    std::vector<int32_t> ofsofs;
+    ConvState cs;
     bool fused_batch_norm;
     FastActivation fast_activation;
     float fast_activ_params[ConvState::MAX_ACTIV_PARAMS];

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
@@ -1,0 +1,93 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../../precomp.hpp"
+#include "../../net_impl.hpp"
+#include "../conv2_common.hpp"
+#include "conv2_depthwise.simd.hpp"
+#include "layers/cpu_kernels/conv2_depthwise.simd_declarations.hpp"
+
+namespace cv { namespace dnn {
+
+DepthwiseConvFunc getDepthwiseConvFunc(int depth)
+{
+    CV_CPU_DISPATCH(getDepthwiseConvFunc_, (depth), CV_CPU_DISPATCH_MODES_ALL);
+}
+
+template <typename InpT, typename OutT>
+static void repackDepthwiseWeightsBlock(const InpT* inpw, OutT* outw,
+                                        int ksize, int C0, int currC0)
+{
+    for (int xy = 0; xy < ksize; xy++, inpw++, outw += C0) {
+        for (int c0 = 0; c0 < currC0; c0++) {
+            outw[c0] = OutT(inpw[ksize*c0]);
+        }
+    }
+}
+
+// C x 1 x Hk x Wk => C1 x Hk x Wk x C0
+void repackDepthwiseConvWeights(const void* inpw__, int inptype_, void* outw__, int outtype_,
+                                const MatShape& wshape, int C0_)
+{
+    CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F || inptype_ == CV_16BF);
+    CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F || outtype_ == CV_16BF);
+    CV_Assert(wshape.dims == 4 && wshape[1] == 1);
+
+    int C1_ = (wshape[0] + C0_ - 1)/C0_;
+    parallel_for_(Range(0, C1_), [&](const Range& r) {
+        int inptype = inptype_, outtype = outtype_;
+        size_t inpEsz = CV_ELEM_SIZE(inptype);
+        size_t outEsz = CV_ELEM_SIZE(outtype);
+        int C = wshape[0], C0 = C0_;
+        int ksize = wshape[2]*wshape[3];
+
+        for (int c1 = r.start; c1 < r.end; c1++) {
+            const uint8_t* inpw_ = (const uint8_t*)inpw__ + c1*ksize*C0*inpEsz;
+            uint8_t* outw_ = (uint8_t*)outw__ + c1*ksize*C0*outEsz;
+            int currC0 = std::min(C - c1*C0, C0);
+            if (currC0 < C0)
+                memset(outw_, 0, ksize*C0*outEsz);
+
+            if (inptype == CV_32F) {
+                const float* inpw = (const float*)inpw_;
+                if (outtype == CV_32F) {
+                    float* outw = (float*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16F) {
+                    hfloat* outw = (hfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16BF) {
+                    bfloat* outw = (bfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                }
+            } else if (inptype == CV_16F) {
+                const hfloat* inpw = (const hfloat*)inpw_;
+                if (outtype == CV_32F) {
+                    float* outw = (float*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16F) {
+                    hfloat* outw = (hfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16BF) {
+                    bfloat* outw = (bfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                }
+            } else if (inptype == CV_16BF) {
+                const bfloat* inpw = (const bfloat*)inpw_;
+                if (outtype == CV_32F) {
+                    float* outw = (float*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16F) {
+                    hfloat* outw = (hfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                } else if (outtype == CV_16BF) {
+                    bfloat* outw = (bfloat*)outw_;
+                    repackDepthwiseWeightsBlock(inpw, outw, ksize, C0, currC0);
+                }
+            }
+        }
+    });
+}
+
+}}

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
@@ -33,7 +33,6 @@ void repackDepthwiseConvWeights(const void* inpw__, int inptype_, void* outw__, 
 {
     CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F || inptype_ == CV_16BF);
     CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F || outtype_ == CV_16BF);
-    CV_Assert(wshape.dims == 4 && wshape[1] == 1);
 
     int C1_ = (wshape[0] + C0_ - 1)/C0_;
     parallel_for_(Range(0, C1_), [&](const Range& r) {
@@ -41,7 +40,9 @@ void repackDepthwiseConvWeights(const void* inpw__, int inptype_, void* outw__, 
         size_t inpEsz = CV_ELEM_SIZE(inptype);
         size_t outEsz = CV_ELEM_SIZE(outtype);
         int C = wshape[0], C0 = C0_;
-        int ksize = wshape[2]*wshape[3];
+        int ksize = 1;
+        for (int k = 2; k < wshape.dims; k++)
+            ksize *= wshape[k];
 
         for (int c1 = r.start; c1 < r.end; c1++) {
             const uint8_t* inpw_ = (const uint8_t*)inpw__ + c1*ksize*C0*inpEsz;

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
@@ -9,6 +9,7 @@
 #include "layers/cpu_kernels/conv2_depthwise.simd_declarations.hpp"
 
 namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
 
 DepthwiseConvFunc getDepthwiseConvFunc(int depth)
 {
@@ -90,4 +91,5 @@ void repackDepthwiseConvWeights(const void* inpw__, int inptype_, void* outw__, 
     });
 }
 
+CV__DNN_INLINE_NS_END
 }}

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.cpp
@@ -11,7 +11,7 @@
 namespace cv { namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
-DepthwiseConvFunc getDepthwiseConvFunc(int depth)
+ConvFunc getDepthwiseConvFunc(int depth)
 {
     CV_CPU_DISPATCH(getDepthwiseConvFunc_, (depth), CV_CPU_DISPATCH_MODES_ALL);
 }
@@ -27,26 +27,35 @@ static void repackDepthwiseWeightsBlock(const InpT* inpw, OutT* outw,
     }
 }
 
-// C x 1 x Hk x Wk => C1 x Hk x Wk x C0
-void repackDepthwiseConvWeights(const void* inpw__, int inptype_, void* outw__, int outtype_,
-                                const MatShape& wshape, int C0_)
+// C x 1 x ksize ... => C1 x ksize x C0
+void repackDepthwiseConvWeights(const Mat& weights, Mat& wpack, int outtype_, int C0_)
 {
+    int inptype_ = weights.type();
+    MatShape wshape = weights.shape();
+    CV_Assert(wshape.dims >= 3);
     CV_Assert(inptype_ == CV_32F || inptype_ == CV_16F || inptype_ == CV_16BF);
     CV_Assert(outtype_ == CV_32F || outtype_ == CV_16F || outtype_ == CV_16BF);
+    int ksize_ = 1;
+    for (int i = 2; i < wshape.dims; i++)
+        ksize_ *= wshape[i];
 
     int C1_ = (wshape[0] + C0_ - 1)/C0_;
+
+    if (!wpack.isContinuous())
+        wpack.release();
+
+    wpack.create(MatShape({C1_, ksize_, C0_}, DATA_LAYOUT_UNKNOWN), outtype_);
+
     parallel_for_(Range(0, C1_), [&](const Range& r) {
         int inptype = inptype_, outtype = outtype_;
         size_t inpEsz = CV_ELEM_SIZE(inptype);
         size_t outEsz = CV_ELEM_SIZE(outtype);
         int C = wshape[0], C0 = C0_;
-        int ksize = 1;
-        for (int k = 2; k < wshape.dims; k++)
-            ksize *= wshape[k];
+        int ksize = ksize_;
 
         for (int c1 = r.start; c1 < r.end; c1++) {
-            const uint8_t* inpw_ = (const uint8_t*)inpw__ + c1*ksize*C0*inpEsz;
-            uint8_t* outw_ = (uint8_t*)outw__ + c1*ksize*C0*outEsz;
+            const uint8_t* inpw_ = (const uint8_t*)weights.data + c1*ksize*C0*inpEsz;
+            uint8_t* outw_ = (uint8_t*)wpack.data + c1*ksize*C0*outEsz;
             int currC0 = std::min(C - c1*C0, C0);
             if (currC0 < C0)
                 memset(outw_, 0, ksize*C0*outEsz);

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -169,7 +169,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = z;
                                 for (int k = 0; k < ksize; k++) {
@@ -188,7 +188,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             v_float32 b0 = vx_load(bias), b1 = vx_load(bias + nlanes);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = z, s1 = z;
                                 for (int k = 0; k < ksize; k++) {
@@ -215,7 +215,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                     v_float32 s0 = z, s1 = z, s2 = z, s3 = z;
                                     for (int k = 0; k < ksize; k++) {
                                         int ofs_k = ofstab[k], ofs_w = k*C0 + c;

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -1,0 +1,257 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../conv2_common.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+
+// === dispatched calls (implemented here)
+
+namespace cv {
+namespace dnn {
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+cv::dnn::DepthwiseConvFunc getDepthwiseConvFunc_(int depth);
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+}} // cv::dnn::
+
+// === implementation
+
+#ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+namespace cv {
+namespace dnn {
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+static void depthwiseConv32f(const void* inp__, const void* residual__,
+                             void* out__, const ConvState& cs,
+                             const void* weights__, const float* scale__,
+                             const float* bias__)
+{
+    int nlanes_ = VTraits<v_float32>::vlanes();
+    int C0_ = cs.inpshape.back(), C1_ = cs.inpshape[1];
+    int NC = cs.inpshape[0]*C1_;
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.nspatialdims == 2);
+
+    parallel_for_(Range(0, NC), [&](const Range& r)
+    {
+        int nc0 = r.start, nc1 = r.end;
+        int nlanes = nlanes_, C0 = C0_, C1 = C1_;
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi*C0;
+        int planesize = H*W*C0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+        int inner_y0 = cs.inner[0], inner_y1 = cs.inner[1];
+        int inner_x0 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims + 1];
+        int ksize = (int)(cs.coordtab.size()/2);
+        const int* yxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+        const float* scale_ = scale__;
+        const float* bias_ = bias__;
+        AutoBuffer<float> buf(C0*3);
+        float* sum = buf.data();
+        float* scale = sum + C0;
+        float* bias = scale + C0;
+
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+        v_float32 v_maxval = vx_setall_f32(maxval);
+        v_float32 v_alpha = vx_setall_f32(alpha);
+
+        const float* inp = (const float*)inp__ + nc0*iplanesize;
+        float* out = (float*)out__ + nc0*planesize;
+        const float* residual = residual__ ? (const float*)residual__ + nc0*planesize : nullptr;
+        v_float32 z = vx_setzero_f32();
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            int n = nc / C1;
+            int c0 = (nc - n*C1)*C0;
+            const float* weights = (const float*)weights__ + (c0/C0)*ksize*C0;
+
+            for (int c = 0; c < C0; c++) {
+                scale[c] = scale_ ? scale_[c0 + c] : 1.f;
+                bias[c] = bias_ ? bias_[c0 + c] : 0.f;
+            }
+
+            for (int y0 = 0; y0 < H; y0++, out += W*C0, residual += (residual ? W*C0 : 0)) {
+                //int64_t x0 = 0, x1 = W;
+                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                int yi_ = y0*SY - pad_y0;
+                for(;;) {
+                    if (nlanes == C0) {
+                        v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            v_float32 s0 = z;
+                            for (int k = 0; k < ksize; k++) {
+                                int yi = yi_ + yxtab[k*2];
+                                int xi = xi_ + yxtab[k*2+1];
+                                v_float32 v0, w0;
+                                if ((unsigned)yi >= (unsigned)Hi || (uint64_t)xi >= (uint64_t)Wi)
+                                    continue;
+                                v0 = vx_load(inp + (yi*Wi + xi)*C0);
+                                w0 = vx_load(weights + k*C0);
+                                s0 = v_fma(v0, w0, s0);
+                            }
+                            s0 = v_fma(s0, sc0, b0);
+                            if (residual)
+                                s0 = v_add(s0, v_load(residual + x0*C0));
+                            s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*2) {
+                                v_float32 s0 = z, s1 = z;
+                                for (int k = 0; k < ksize; k++) {
+                                    int yi = yi_ + yxtab[k*2];
+                                    int xi = xi_ + yxtab[k*2+1];
+                                    v_float32 v0, v1, w0, w1;
+                                    if ((uint64_t)yi >= (uint64_t)Hi || (uint64_t)xi >= (uint64_t)Wi)
+                                        continue;
+                                    int ofs_k = (yi*Wi + xi)*C0 + c;
+                                    int ofs_w = k*C0;
+                                    v0 = vx_load(inp + ofs_k);
+                                    v1 = vx_load(inp + ofs_k + nlanes);
+                                    w0 = vx_load(weights + ofs_w);
+                                    w1 = vx_load(weights + ofs_w + nlanes);
+                                    s0 = v_fma(v0, w0, s0);
+                                    s1 = v_fma(v1, w1, s1);
+                                }
+                                s0 = v_fma(s0, vx_load(scale + c), vx_load(bias + c));
+                                s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
+                                if (residual) {
+                                    s0 = v_add(s0, v_load(residual + x0*C0 + c));
+                                    s1 = v_add(s1, v_load(residual + x0*C0 + c + nlanes));
+                                }
+                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                                s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                            }
+                        }
+                    }
+                    if (x0 == W)
+                        break;
+                    x1 = inner_x1;
+                    if (nlanes == C0) {
+                        v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = z;
+                            for (int k = 0; k < ksize; k++) {
+                                v_float32 v0 = vx_load(inp_xi + ofstab[k]);
+                                v_float32 w0 = vx_load(weights + k*C0);
+                                s0 = v_fma(v0, w0, s0);
+                            }
+                            s0 = v_fma(s0, sc0, b0);
+                            if (residual)
+                                s0 = v_add(s0, v_load(residual + x0*C0));
+                            s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else if (nlanes*2 == C0) {
+                        v_float32 sc0 = vx_load(scale), sc1 = vx_load(scale + nlanes);
+                        v_float32 b0 = vx_load(bias), b1 = vx_load(bias + nlanes);
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = z, s1 = z;
+                            for (int k = 0; k < ksize; k++) {
+                                int ofs_k = ofstab[k], ofs_w = k*C0;
+                                v_float32 v0 = vx_load(inp_xi + ofs_k);
+                                v_float32 v1 = vx_load(inp_xi + ofs_k + nlanes);
+                                v_float32 w0 = vx_load(weights + ofs_w);
+                                v_float32 w1 = vx_load(weights + ofs_w + nlanes);
+                                s0 = v_fma(v0, w0, s0);
+                                s1 = v_fma(v1, w1, s1);
+                            }
+                            s0 = v_fma(s0, sc0, b0);
+                            s1 = v_fma(s1, sc1, b1);
+                            if (residual) {
+                                s0 = v_add(s0, v_load(residual + x0*C0));
+                                s1 = v_add(s1, v_load(residual + x0*C0 + nlanes));
+                            }
+                            s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                            s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
+                            vx_store(out + x0*C0, s0);
+                            vx_store(out + x0*C0 + nlanes, s1);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*4) {
+                                const float* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
+                                v_float32 s0 = z, s1 = z, s2 = z, s3 = z;
+                                for (int k = 0; k < ksize; k++) {
+                                    int ofs_k = ofstab[k], ofs_w = k*C0 + c;
+                                    v_float32 v0 = vx_load(inp_xi + ofs_k);
+                                    v_float32 v1 = vx_load(inp_xi + ofs_k + nlanes);
+                                    v_float32 v2 = vx_load(inp_xi + ofs_k + nlanes*2);
+                                    v_float32 v3 = vx_load(inp_xi + ofs_k + nlanes*3);
+                                    v_float32 w0 = vx_load(weights + ofs_w);
+                                    v_float32 w1 = vx_load(weights + ofs_w + nlanes);
+                                    v_float32 w2 = vx_load(weights + ofs_w + nlanes*2);
+                                    v_float32 w3 = vx_load(weights + ofs_w + nlanes*3);
+                                    s0 = v_fma(v0, w0, s0);
+                                    s1 = v_fma(v1, w1, s1);
+                                    s2 = v_fma(v2, w2, s2);
+                                    s3 = v_fma(v3, w3, s3);
+                                }
+                                s0 = v_fma(s0, vx_load(scale + c), vx_load(bias + c));
+                                s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
+                                s2 = v_fma(s2, vx_load(scale + c + nlanes*2), vx_load(bias + c + nlanes*2));
+                                s3 = v_fma(s3, vx_load(scale + c + nlanes*3), vx_load(bias + c + nlanes*3));
+
+                                if (residual) {
+                                    s0 = v_add(s0, v_load(residual + x0*C0 + c));
+                                    s1 = v_add(s1, v_load(residual + x0*C0 + c + nlanes));
+                                    s2 = v_add(s2, v_load(residual + x0*C0 + c + nlanes*2));
+                                    s3 = v_add(s3, v_load(residual + x0*C0 + c + nlanes*3));
+                                }
+
+                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                                s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
+                                s2 = v_min(v_select(v_ge(s2, z), s2, v_mul(s2, v_alpha)), v_maxval);
+                                s3 = v_min(v_select(v_ge(s3, z), s3, v_mul(s3, v_alpha)), v_maxval);
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                                vx_store(out + x0*C0 + c + nlanes*2, s2);
+                                vx_store(out + x0*C0 + c + nlanes*3, s3);
+                            }
+                        }
+                    }
+                    x1 = W;
+                }
+            }
+
+            if (activation) {
+                activation(out - planesize, out - planesize, planesize, activParams);
+            }
+        }
+    });
+}
+
+DepthwiseConvFunc getDepthwiseConvFunc_(int depth)
+{
+    DepthwiseConvFunc func = depth == CV_32F ? depthwiseConv32f : nullptr;
+    return func;
+}
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+}}
+
+#endif

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -40,11 +40,11 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
-    parallel_for_(Range(0, NC1), [&](const Range& r)
+    parallel_for_(Range(0, NC1), [&](const Range& range)
     {
         int sdims = cs.nspatialdims;
-        int nc0 = r.start, nc1 = r.end;
         constexpr int C0 = 8;
+        int C = cs.inpshape.C;
         int C1 = cs.inpshape[1];
         CV_Assert(C0 == cs.inpshape.back());
         int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
@@ -65,37 +65,56 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
         const int* ofstab = cs.ofstab.data();
         const float* scale_ = scale__;
         const float* bias_ = bias__;
-        AutoBuffer<float> buf(C0*2);
-        float* scale = buf.data();
-        float* bias = scale + C0;
 
-        const float* inp = (const float*)inp__ + nc0*iplanesize;
-        float* out = (float*)out__ + nc0*planesize;
-        const float* residual = residual__ ? (const float*)residual__ + nc0*planesize : nullptr;
+        const float* inp = (const float*)inp__ + range.start*iplanesize;
+        float* out = (float*)out__ + range.start*planesize;
+        const float* residual = residual__ ? (const float*)residual__ + range.start*planesize : nullptr;
 
         FastActivation fastActivation = cs.fastActivation;
-        const float* activParams = cs.activParams;
-        activation_func_t activation = cs.activation;
-        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
-        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
-                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+        const float* activParams = cs.activParams.data();
+        ActivationFunc activation = cs.activation;
+        float maxval = FLT_MAX, defaultAlpha = 0.f;
+        float scalebuf[C0], biasbuf[C0], alphabuf[C0];
+        if (fastActivation == FAST_ACTIV_CLIP) {
+            CV_Assert(cs.activParams.size() == 2u);
+            maxval = activParams[1];
+        } else if (fastActivation == FAST_ACTIV_RELU) {
+            CV_Assert(!activParams);
+        } else if (fastActivation == FAST_ACTIV_LEAKY_RELU) {
+            CV_Assert(cs.activParams.size() == 1u);
+            defaultAlpha = activParams[0];
+        } else if (fastActivation == FAST_ACTIV_PRELU) {
+            CV_Assert(cs.activParams.size() == size_t(C));
+        } else {
+            CV_Assert(fastActivation == FAST_ACTIV_NONE);
+            defaultAlpha = 1.f;
+        }
 
     #if CV_SIMD || CV_SIMD_SCALABLE
         v_float32 v_maxval = vx_setall_f32(maxval);
-        v_float32 v_alpha = vx_setall_f32(alpha);
         v_float32 z = vx_setzero_f32();
         const int nlanes = VTraits<v_float32>::vlanes();
         CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
     #endif
 
-        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
-            int n = nc / C1;
-            int c0 = (nc - n*C1)*C0;
-            const float* weights = (const float*)weights__ + (c0/C0)*ksize*C0;
+        for (int nc1 = range.start; nc1 < range.end; nc1++, inp += iplanesize) {
+            int n = nc1 / C1;
+            int c_base = (nc1 - n*C1)*C0;
+            int c_count = std::min(C0, C - c_base);
+            const float* weights = (const float*)weights__ + (c_base/C0)*ksize*C0;
 
-            for (int c = 0; c < C0; c++) {
-                scale[c] = scale_ ? scale_[c0 + c] : 1.f;
-                bias[c] = bias_ ? bias_[c0 + c] : 0.f;
+            {
+                int c = 0;
+                for (; c < c_count; c++) {
+                    scalebuf[c] = scale_ ? scale_[c_base + c] : 1.f;
+                    biasbuf[c] = bias_ ? bias_[c_base + c] : 0.f;
+                    alphabuf[c] = fastActivation == FAST_ACTIV_PRELU ? activParams[c_base + c] : defaultAlpha;
+                }
+                for (; c < C0; c++) {
+                    scalebuf[c] = 0.f;
+                    biasbuf[c] = 0.f;
+                    alphabuf[c] = 0.f;
+                }
             }
 
             for (int z0 = 0; z0 < D; z0++) {
@@ -115,7 +134,8 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                     for(;;) {
                     #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
-                            v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
+                            v_float32 sc0 = vx_load(scalebuf), b0 = vx_load(biasbuf);
+                            v_float32 alpha0 = vx_load(alphabuf);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 v_float32 s0 = z;
@@ -135,7 +155,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 s0 = v_fma(s0, sc0, b0);
                                 if (residual)
                                     s0 = v_add(s0, vx_load(residual + x0*C0));
-                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, alpha0)), v_maxval);
                                 vx_store(out + x0*C0, s0);
                             }
                         } else {
@@ -161,14 +181,17 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                         s0 = v_fma(v0, w0, s0);
                                         s1 = v_fma(v1, w1, s1);
                                     }
-                                    s0 = v_fma(s0, vx_load(scale + c), vx_load(bias + c));
-                                    s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
+                                    s0 = v_fma(s0, vx_load(scalebuf + c), vx_load(biasbuf + c));
+                                    s1 = v_fma(s1, vx_load(scalebuf + c + nlanes), vx_load(biasbuf + c + nlanes));
                                     if (residual) {
                                         s0 = v_add(s0, vx_load(residual + x0*C0 + c));
                                         s1 = v_add(s1, vx_load(residual + x0*C0 + c + nlanes));
                                     }
-                                    s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
-                                    s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
+                                    v_float32 alpha0 = vx_load(alphabuf + c);
+                                    v_float32 alpha1 = vx_load(alphabuf + c + nlanes);
+
+                                    s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, alpha0)), v_maxval);
+                                    s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, alpha1)), v_maxval);
                                     vx_store(out + x0*C0 + c, s0);
                                     vx_store(out + x0*C0 + c + nlanes, s1);
                                 }
@@ -198,7 +221,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
 
                     #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
-                            v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
+                            v_float32 sc0 = vx_load(scalebuf), b0 = vx_load(biasbuf), alpha0 = vx_load(alphabuf);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
@@ -212,12 +235,13 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 s0 = v_fma(s0, sc0, b0);
                                 if (residual)
                                     s0 = v_add(s0, vx_load(residual + x0*C0));
-                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
+                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, alpha0)), v_maxval);
                                 vx_store(out + x0*C0, s0);
                             }
                         } else if (nlanes*2 == C0) {
-                            v_float32 sc0 = vx_load(scale), sc1 = vx_load(scale + nlanes);
-                            v_float32 b0 = vx_load(bias), b1 = vx_load(bias + nlanes);
+                            v_float32 sc0 = vx_load(scalebuf), sc1 = vx_load(scalebuf + nlanes);
+                            v_float32 b0 = vx_load(biasbuf), b1 = vx_load(biasbuf + nlanes);
+                            v_float32 alpha0 = vx_load(alphabuf), alpha1 = vx_load(alphabuf + nlanes);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
@@ -238,8 +262,8 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                     s0 = v_add(s0, vx_load(residual + x0*C0));
                                     s1 = v_add(s1, vx_load(residual + x0*C0 + nlanes));
                                 }
-                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
-                                s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
+                                s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, alpha0)), v_maxval);
+                                s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, alpha1)), v_maxval);
                                 vx_store(out + x0*C0, s0);
                                 vx_store(out + x0*C0 + nlanes, s1);
                             }
@@ -264,10 +288,14 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                         s2 = v_fma(v2, w2, s2);
                                         s3 = v_fma(v3, w3, s3);
                                     }
-                                    s0 = v_fma(s0, vx_load(scale + c), vx_load(bias + c));
-                                    s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
-                                    s2 = v_fma(s2, vx_load(scale + c + nlanes*2), vx_load(bias + c + nlanes*2));
-                                    s3 = v_fma(s3, vx_load(scale + c + nlanes*3), vx_load(bias + c + nlanes*3));
+                                    s0 = v_fma(s0, vx_load(scalebuf + c),
+                                               vx_load(biasbuf + c));
+                                    s1 = v_fma(s1, vx_load(scalebuf + c + nlanes),
+                                               vx_load(biasbuf + c + nlanes));
+                                    s2 = v_fma(s2, vx_load(scalebuf + c + nlanes*2),
+                                               vx_load(biasbuf + c + nlanes*2));
+                                    s3 = v_fma(s3, vx_load(scalebuf + c + nlanes*3),
+                                               vx_load(biasbuf + c + nlanes*3));
 
                                     if (residual) {
                                         s0 = v_add(s0, vx_load(residual + x0*C0 + c));
@@ -276,10 +304,15 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                         s3 = v_add(s3, vx_load(residual + x0*C0 + c + nlanes*3));
                                     }
 
-                                    s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
-                                    s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
-                                    s2 = v_min(v_select(v_ge(s2, z), s2, v_mul(s2, v_alpha)), v_maxval);
-                                    s3 = v_min(v_select(v_ge(s3, z), s3, v_mul(s3, v_alpha)), v_maxval);
+                                    v_float32 alpha0 = vx_load(alphabuf + c);
+                                    v_float32 alpha1 = vx_load(alphabuf + c + nlanes);
+                                    v_float32 alpha2 = vx_load(alphabuf + c + nlanes*2);
+                                    v_float32 alpha3 = vx_load(alphabuf + c + nlanes*3);
+
+                                    s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, alpha0)), v_maxval);
+                                    s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, alpha1)), v_maxval);
+                                    s2 = v_min(v_select(v_ge(s2, z), s2, v_mul(s2, alpha2)), v_maxval);
+                                    s3 = v_min(v_select(v_ge(s3, z), s3, v_mul(s3, alpha3)), v_maxval);
                                     vx_store(out + x0*C0 + c, s0);
                                     vx_store(out + x0*C0 + c + nlanes, s1);
                                     vx_store(out + x0*C0 + c + nlanes*2, s2);
@@ -307,16 +340,16 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                     if (residual) {
                         for (int x = 0; x < W*C0; x += C0) {
                             for (int c = 0; c < C0; c++) {
-                                float v = out[x + c]*scale[c] + bias[c] + residual[x + c];
-                                v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                                float v = out[x + c]*scalebuf[c] + biasbuf[c] + residual[x + c];
+                                v = std::min(v*(v >= 0 ? 1.f : alphabuf[c]), maxval);
                                 out[x + c] = v;
                             }
                         }
                     } else {
                         for (int x = 0; x < W*C0; x += C0) {
                             for (int c = 0; c < C0; c++) {
-                                float v = out[x + c]*scale[c] + bias[c];
-                                v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                                float v = out[x + c]*scalebuf[c] + biasbuf[c];
+                                v = std::min(v*(v >= 0 ? 1.f : alphabuf[c]), maxval);
                                 out[x + c] = v;
                             }
                         }

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -125,7 +125,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 }
                                 s0 = v_fma(s0, sc0, b0);
                                 if (residual)
-                                    s0 = v_add(s0, v_load(residual + x0*C0));
+                                    s0 = v_add(s0, vx_load(residual + x0*C0));
                                 s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
                                 vx_store(out + x0*C0, s0);
                             }
@@ -155,8 +155,8 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                     s0 = v_fma(s0, vx_load(scale + c), vx_load(bias + c));
                                     s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
                                     if (residual) {
-                                        s0 = v_add(s0, v_load(residual + x0*C0 + c));
-                                        s1 = v_add(s1, v_load(residual + x0*C0 + c + nlanes));
+                                        s0 = v_add(s0, vx_load(residual + x0*C0 + c));
+                                        s1 = v_add(s1, vx_load(residual + x0*C0 + c + nlanes));
                                     }
                                     s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
                                     s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
@@ -182,7 +182,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 }
                                 s0 = v_fma(s0, sc0, b0);
                                 if (residual)
-                                    s0 = v_add(s0, v_load(residual + x0*C0));
+                                    s0 = v_add(s0, vx_load(residual + x0*C0));
                                 s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
                                 vx_store(out + x0*C0, s0);
                             }
@@ -206,8 +206,8 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 s0 = v_fma(s0, sc0, b0);
                                 s1 = v_fma(s1, sc1, b1);
                                 if (residual) {
-                                    s0 = v_add(s0, v_load(residual + x0*C0));
-                                    s1 = v_add(s1, v_load(residual + x0*C0 + nlanes));
+                                    s0 = v_add(s0, vx_load(residual + x0*C0));
+                                    s1 = v_add(s1, vx_load(residual + x0*C0 + nlanes));
                                 }
                                 s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
                                 s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
@@ -241,10 +241,10 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                     s3 = v_fma(s3, vx_load(scale + c + nlanes*3), vx_load(bias + c + nlanes*3));
                                     
                                     if (residual) {
-                                        s0 = v_add(s0, v_load(residual + x0*C0 + c));
-                                        s1 = v_add(s1, v_load(residual + x0*C0 + c + nlanes));
-                                        s2 = v_add(s2, v_load(residual + x0*C0 + c + nlanes*2));
-                                        s3 = v_add(s3, v_load(residual + x0*C0 + c + nlanes*3));
+                                        s0 = v_add(s0, vx_load(residual + x0*C0 + c));
+                                        s1 = v_add(s1, vx_load(residual + x0*C0 + c + nlanes));
+                                        s2 = v_add(s2, vx_load(residual + x0*C0 + c + nlanes*2));
+                                        s3 = v_add(s3, vx_load(residual + x0*C0 + c + nlanes*3));
                                     }
                                     
                                     s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -33,21 +33,20 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                              const float* bias__)
 {
     constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
-    int nlanes_ = VTraits<v_float32>::vlanes();
-    int C0_ = cs.inpshape.back(), C1_ = cs.inpshape[1];
-    int NC = cs.inpshape[0]*C1_;
+    int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
     CV_Assert(cs.nspatialdims <= MAX_CONV_DIMS && MAX_CONV_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
-    parallel_for_(Range(0, NC), [&](const Range& r)
+    parallel_for_(Range(0, NC1), [&](const Range& r)
     {
         int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
-        int nlanes = nlanes_, C0 = C0_, C1 = C1_;
+        constexpr int C0 = 8;
+        int C1 = cs.inpshape[1];
+        CV_Assert(C0 == cs.inpshape.back());
         int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
         int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
         int Wi = cs.inpshape[sdims + 1];
@@ -66,10 +65,13 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
         const int* ofstab = cs.ofstab.data();
         const float* scale_ = scale__;
         const float* bias_ = bias__;
-        AutoBuffer<float> buf(C0*3);
-        float* sum = buf.data();
-        float* scale = sum + C0;
+        AutoBuffer<float> buf(C0*2);
+        float* scale = buf.data();
         float* bias = scale + C0;
+
+        const float* inp = (const float*)inp__ + nc0*iplanesize;
+        float* out = (float*)out__ + nc0*planesize;
+        const float* residual = residual__ ? (const float*)residual__ + nc0*planesize : nullptr;
 
         FastActivation fastActivation = cs.fastActivation;
         const float* activParams = cs.activParams;
@@ -77,24 +79,25 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
         float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
         float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
                     fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+
+    #if CV_SIMD || CV_SIMD_SCALABLE
         v_float32 v_maxval = vx_setall_f32(maxval);
         v_float32 v_alpha = vx_setall_f32(alpha);
-
-        const float* inp = (const float*)inp__ + nc0*iplanesize;
-        float* out = (float*)out__ + nc0*planesize;
-        const float* residual = residual__ ? (const float*)residual__ + nc0*planesize : nullptr;
         v_float32 z = vx_setzero_f32();
+        const int nlanes = VTraits<v_float32>::vlanes();
+        CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
+    #endif
 
         for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
             int n = nc / C1;
             int c0 = (nc - n*C1)*C0;
             const float* weights = (const float*)weights__ + (c0/C0)*ksize*C0;
-            
+
             for (int c = 0; c < C0; c++) {
                 scale[c] = scale_ ? scale_[c0 + c] : 1.f;
                 bias[c] = bias_ ? bias_[c0 + c] : 0.f;
             }
-            
+
             for (int z0 = 0; z0 < D; z0++) {
                 int zi_ = z0*SZ - padZ0;
                 for (int y0 = 0; y0 < H; y0++, out += W*C0,
@@ -104,7 +107,13 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                     int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
+
+                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                    memset(out, 0, W*C0*sizeof(out[0]));
+                #endif
+
                     for(;;) {
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
                             for (; x0 < x1; x0++) {
@@ -165,15 +174,35 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            for (int k = 0; k < ksize; k++) {
+                                int zi = zi_ + zyxtab[k*MAX_CONV_DIMS];
+                                int yi = yi_ + zyxtab[k*MAX_CONV_DIMS + 1];
+                                int xi = xi_ + zyxtab[k*MAX_CONV_DIMS + 2];
+                                if ((unsigned)zi >= (unsigned)Di ||
+                                    (unsigned)yi >= (unsigned)Hi ||
+                                    (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                const float* inptr = inp + ((zi*Hi + yi)*Wi + xi)*C0;
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] += inptr[c]*weights[k*C0 + c];
+                            }
+                        }
+                    #endif
+
                         if (x0 == W)
                             break;
                         x1 = inner_x1;
+
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             v_float32 sc0 = vx_load(scale), b0 = vx_load(bias);
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = z;
                                 for (int k = 0; k < ksize; k++) {
                                     v_float32 v0 = vx_load(inp_xi + ofstab[k]);
@@ -192,7 +221,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = z, s1 = z;
                                 for (int k = 0; k < ksize; k++) {
                                     int ofs_k = ofstab[k], ofs_w = k*C0;
@@ -218,7 +247,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0 + c;
                                     v_float32 s0 = z, s1 = z, s2 = z, s3 = z;
                                     for (int k = 0; k < ksize; k++) {
                                         int ofs_k = ofstab[k], ofs_w = k*C0 + c;
@@ -239,14 +268,14 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                     s1 = v_fma(s1, vx_load(scale + c + nlanes), vx_load(bias + c + nlanes));
                                     s2 = v_fma(s2, vx_load(scale + c + nlanes*2), vx_load(bias + c + nlanes*2));
                                     s3 = v_fma(s3, vx_load(scale + c + nlanes*3), vx_load(bias + c + nlanes*3));
-                                    
+
                                     if (residual) {
                                         s0 = v_add(s0, vx_load(residual + x0*C0 + c));
                                         s1 = v_add(s1, vx_load(residual + x0*C0 + c + nlanes));
                                         s2 = v_add(s2, vx_load(residual + x0*C0 + c + nlanes*2));
                                         s3 = v_add(s3, vx_load(residual + x0*C0 + c + nlanes*3));
                                     }
-                                    
+
                                     s0 = v_min(v_select(v_ge(s0, z), s0, v_mul(s0, v_alpha)), v_maxval);
                                     s1 = v_min(v_select(v_ge(s1, z), s1, v_mul(s1, v_alpha)), v_maxval);
                                     s2 = v_min(v_select(v_ge(s2, z), s2, v_mul(s2, v_alpha)), v_maxval);
@@ -258,10 +287,43 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
+
+                            for (int k = 0; k < ksize; k++) {
+                                const float* inptr = inp_xi + ofstab[k];
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] += inptr[c]*weights[k*C0 + c];
+                            }
+                        }
+                    #endif
+
                         x1 = W;
                     }
+
+                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                    if (residual) {
+                        for (int x = 0; x < W*C0; x += C0) {
+                            for (int c = 0; c < C0; c++) {
+                                float v = out[x + c]*scale[c] + bias[c] + residual[x + c];
+                                v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                                out[x + c] = v;
+                            }
+                        }
+                    } else {
+                        for (int x = 0; x < W*C0; x += C0) {
+                            for (int c = 0; c < C0; c++) {
+                                float v = out[x + c]*scale[c] + bias[c];
+                                v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                                out[x + c] = v;
+                            }
+                        }
+                    }
+                #endif
                 }
-                
+
                 if (activation) {
                     activation(out - planesize, out - planesize, planesize, activParams);
                 }

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-cv::dnn::DepthwiseConvFunc getDepthwiseConvFunc_(int depth);
+cv::dnn::ConvFunc getDepthwiseConvFunc_(int depth);
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 }} // cv::dnn::
@@ -24,6 +24,9 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
+//
+// [TODO] add special branch for 3x3 depthwise convolution
+//
 static void depthwiseConv32f(const void* inp__, const void* residual__,
                              void* out__, const ConvState& cs,
                              const void* weights__, const float* scale__,
@@ -267,9 +270,9 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
     });
 }
 
-DepthwiseConvFunc getDepthwiseConvFunc_(int depth)
+ConvFunc getDepthwiseConvFunc_(int depth)
 {
-    DepthwiseConvFunc func = depth == CV_32F ? depthwiseConv32f : nullptr;
+    ConvFunc func = depth == CV_32F ? depthwiseConv32f : nullptr;
     return func;
 }
 

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -32,21 +32,23 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                              const void* weights__, const float* scale__,
                              const float* bias__)
 {
-    constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
     int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(cs.nspatialdims <= MAX_CONV_DIMS && MAX_CONV_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
     parallel_for_(Range(0, NC1), [&](const Range& range)
     {
-        int sdims = cs.nspatialdims;
+        constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
         constexpr int C0 = 8;
+
+        CV_Assert(cs.nspatialdims <= MAX_CONV_DIMS && MAX_CONV_DIMS == 3);
+        CV_Assert(C0 == cs.inpshape.back());
+
+        int sdims = cs.nspatialdims;
         int C = cs.inpshape.C;
         int C1 = cs.inpshape[1];
-        CV_Assert(C0 == cs.inpshape.back());
         int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
         int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
         int Wi = cs.inpshape[sdims + 1];

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
@@ -1,0 +1,20 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../../precomp.hpp"
+#include "../../net_impl.hpp"
+#include "../conv2_common.hpp"
+#include "conv2_kernels.simd.hpp"
+#include "layers/cpu_kernels/conv2_kernels.simd_declarations.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+ConvFunc getConvFunc(int depth, int C0)
+{
+    CV_CPU_DISPATCH(getConvFunc_, (depth, C0), CV_CPU_DISPATCH_MODES_ALL);
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
@@ -11,9 +11,9 @@
 namespace cv { namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
-ConvFunc getConvFunc(int depth, int C0, ConvKind convkind)
+ConvFunc getConvFunc(int depth, int C0)
 {
-    CV_CPU_DISPATCH(getConvFunc_, (depth, C0, convkind), CV_CPU_DISPATCH_MODES_ALL);
+    CV_CPU_DISPATCH(getConvFunc_, (depth, C0), CV_CPU_DISPATCH_MODES_ALL);
 }
 
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.cpp
@@ -11,9 +11,9 @@
 namespace cv { namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
-ConvFunc getConvFunc(int depth, int C0)
+ConvFunc getConvFunc(int depth, int C0, ConvKind convkind)
 {
-    CV_CPU_DISPATCH(getConvFunc_, (depth, C0), CV_CPU_DISPATCH_MODES_ALL);
+    CV_CPU_DISPATCH(getConvFunc_, (depth, C0, convkind), CV_CPU_DISPATCH_MODES_ALL);
 }
 
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -36,6 +36,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     CV_Assert(C0_ == 8);
     CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
     CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
+    CV_Assert(0 <= cs.nspatialdims && cs.nspatialdims <= ConvState::MAX_CONV_DIMS);
 
     parallel_for_(Range(0, NK1), [&](const Range& range) {
         const float* scale_ = scale__;
@@ -50,7 +51,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
         for (int i = 0; i < nspatialdims; i++) {
             planesize *= cs.outshape[i + 2];
             iplanesize *= cs.inpshape[i + 2];
-            ksize *= cs.kshape[i];
+            ksize *= cs.kshape[ConvState::MAX_CONV_DIMS - nspatialdims + i];
         }
         int C1 = cs.inpshape[1], K1 = cs.outshape[1];
         int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
@@ -300,7 +301,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                 vx_store(sum + 8*5, s50); vx_store(sum + 8*5 + 4, s51);
                 vx_store(sum + 8*6, s60); vx_store(sum + 8*6 + 4, s61);
                 vx_store(sum + 8*7, s70); vx_store(sum + 8*7 + 4, s71);
-            #else
+#else
                 for (int i = 0; i < BLOCK_SIZE*K0; i++)
                     sum[i] = 0.f;
 
@@ -318,7 +319,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                         }
                     }
                 }
-            #endif
+#endif
 
                 if (activation) {
                     if (resptr) {

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -1,0 +1,358 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../conv2_common.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+
+// === dispatched calls (implemented here)
+
+namespace cv {
+namespace dnn {
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+cv::dnn::ConvFunc getConvFunc(int depth);
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+}} // cv::dnn::
+
+// === implementation
+
+#ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
+
+namespace cv {
+namespace dnn {
+CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
+
+void conv32f(const void* inp__, const void* residual__, void* out__,
+             const ConvState& cs, const void* weights__,
+             const float* scale__, const float* bias__,
+             const int32_t* ofs__, const int32_t* ofsbuf__)
+{
+    //printf("conv2d\n");
+    int nlanes_ = VTraits<v_float32>::vlanes();
+    int C0_ = cs.inpshape.back();
+
+    CV_Assert(C0_ == 8);
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
+
+    int NK1 = cs.outshape[0]*cs.outshape[1];
+
+    parallel_for_(Range(0, NK1), [&](const Range& r) {
+        const float* scale_ = scale__;
+        const float* bias_ = bias__;
+        const int32_t* ofs_ = ofs__;
+        const int32_t* ofsbuf_ = ofsbuf__;
+        constexpr int BLOCK_SIZE = 8;
+        int nk0 = r.start, nk1 = r.end;
+        constexpr int C0 = 8, K0 = C0;
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi;
+        int planesize = H*W;
+        int Hk = cs.kshape[0], Wk = cs.kshape[1];
+        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
+        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
+        int nC = C1g*Hk*Wk*C0*K0;
+        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
+        float* sum = sumbuf.data();
+        float* scale = sum + BLOCK_SIZE*K0;
+        float* bias = sum + BLOCK_SIZE*K0*2;
+        const float* inptrs[BLOCK_SIZE];
+        const int32_t* ofsptrs[BLOCK_SIZE];
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+        fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+
+        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
+            scale[j] = 1.f;
+            bias[j] = 0.f;
+        }
+
+        for (int nk = nk0; nk < nk1; nk++) {
+            int n = nk/K1, k1 = nk - n*K1;
+            int g = k1/K1g;
+            float* out = (float*)out__ + nk*planesize*K0;
+            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
+            const float* resptr = residual__ ? (const float*)residual__ + nk*planesize*K0 : nullptr;
+            const float* wptr = (const float*)weights__ + k1*nC;
+
+            if (scale_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        scale[b*K0 + k] = scale_[k1*K0 + k];
+            }
+
+            if (bias_) {
+                for (int b = 0; b < BLOCK_SIZE; b++)
+                    for (int k = 0; k < K0; k++)
+                        bias[b*K0 + k] = bias_[k1*K0 + k];
+            }
+
+            for (int xy0 = 0; xy0 < planesize; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
+                 resptr += (resptr ? K0*BLOCK_SIZE : 0)) {
+                int j = 0, blocksize = std::min(planesize - xy0, BLOCK_SIZE);
+
+                for (; j < blocksize; j++) {
+                    int jj = (xy0 + j)*2;
+                    inptrs[j] = inp0 + ofs_[jj];
+                    ofsptrs[j] = ofsbuf_ + ofs_[jj+1];
+                }
+
+                if (j < BLOCK_SIZE) {
+                    const float* last_inptr = inptrs[blocksize-1];
+                    const int32_t* last_ofsptr = ofsptrs[blocksize-1];
+                    for (; j < BLOCK_SIZE; j++) {
+                        inptrs[j] = last_inptr;
+                        ofsptrs[j] = last_ofsptr;
+                    }
+                }
+
+#if 0 //def __ARM_NEON
+                float32x4_t z = vdupq_n_f32(0.f);
+                float32x4_t s00 = z, s01 = z, s10 = z, s11 = z;
+                float32x4_t s20 = z, s21 = z, s30 = z, s31 = z;
+                float32x4_t s40 = z, s41 = z, s50 = z, s51 = z;
+                float32x4_t s60 = z, s61 = z, s70 = z, s71 = z;
+                const int32_t *ofs0 = ofsptrs[0], *ofs1 = ofsptrs[1];
+                const int32_t *ofs2 = ofsptrs[2], *ofs3 = ofsptrs[3];
+                const int32_t *ofs4 = ofsptrs[4], *ofs5 = ofsptrs[5];
+                const int32_t *ofs6 = ofsptrs[6], *ofs7 = ofsptrs[7];
+
+                const float *inptr0 = inptrs[0], *inptr1 = inptrs[1];
+                const float *inptr2 = inptrs[2], *inptr3 = inptrs[3];
+                const float *inptr4 = inptrs[4], *inptr5 = inptrs[5];
+                const float *inptr6 = inptrs[6], *inptr7 = inptrs[7];
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    float32x4_t w00 = vld1q_f32(wptr + c1 + 8*0), w01 = vld1q_f32(wptr + c1 + 8*0 + 4);
+                    float32x4_t w10 = vld1q_f32(wptr + c1 + 8*1), w11 = vld1q_f32(wptr + c1 + 8*1 + 4);
+                    float32x4_t w20 = vld1q_f32(wptr + c1 + 8*2), w21 = vld1q_f32(wptr + c1 + 8*2 + 4);
+                    float32x4_t w30 = vld1q_f32(wptr + c1 + 8*3), w31 = vld1q_f32(wptr + c1 + 8*3 + 4);
+                    float32x4_t w40 = vld1q_f32(wptr + c1 + 8*4), w41 = vld1q_f32(wptr + c1 + 8*4 + 4);
+                    float32x4_t w50 = vld1q_f32(wptr + c1 + 8*5), w51 = vld1q_f32(wptr + c1 + 8*5 + 4);
+                    float32x4_t w60 = vld1q_f32(wptr + c1 + 8*6), w61 = vld1q_f32(wptr + c1 + 8*6 + 4);
+                    float32x4_t w70 = vld1q_f32(wptr + c1 + 8*7), w71 = vld1q_f32(wptr + c1 + 8*7 + 4);
+
+                    int32_t ofs0i, ofs1i, ofs0p, ofs1p;
+                    float m0, m1;
+                    float32x4_t x0, x1;
+
+#undef UPDATE_SUM
+#define UPDATE_SUM(a, b) \
+ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
+m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
+ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
+x0 = vld1q_f32(inptr##a + ofs0p); \
+x1 = vld1q_f32(inptr##b + ofs1p); \
+x0 = vmulq_n_f32(x0, m0); \
+x1 = vmulq_n_f32(x1, m1); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w00, x0, 0); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w01, x0, 0); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w00, x1, 0); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w01, x1, 0); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w10, x0, 1); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w11, x0, 1); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w10, x1, 1); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w11, x1, 1); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w20, x0, 2); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w21, x0, 2); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w20, x1, 2); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w21, x1, 2); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w30, x0, 3); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w31, x0, 3); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w30, x1, 3); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w31, x1, 3); \
+x0 = vld1q_f32(inptr##a + ofs0p + 4); \
+x1 = vld1q_f32(inptr##b + ofs1p + 4); \
+x0 = vmulq_n_f32(x0, m0); \
+x1 = vmulq_n_f32(x1, m1); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w40, x0, 0); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w41, x0, 0); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w40, x1, 0); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w41, x1, 0); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w50, x0, 1); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w51, x0, 1); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w50, x1, 1); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w51, x1, 1); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w60, x0, 2); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w61, x0, 2); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w60, x1, 2); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w61, x1, 2); \
+s##a##0 = vfmaq_laneq_f32(s##a##0, w70, x0, 3); \
+s##a##1 = vfmaq_laneq_f32(s##a##1, w71, x0, 3); \
+s##b##0 = vfmaq_laneq_f32(s##b##0, w70, x1, 3); \
+s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
+
+                    UPDATE_SUM(0, 1);
+                    UPDATE_SUM(2, 3);
+                    UPDATE_SUM(4, 5);
+                    UPDATE_SUM(6, 7);
+                }
+
+                vst1q_f32(sum + 8*0, s00); vst1q_f32(sum + 8*0 + 4, s01);
+                vst1q_f32(sum + 8*1, s10); vst1q_f32(sum + 8*1 + 4, s11);
+                vst1q_f32(sum + 8*2, s20); vst1q_f32(sum + 8*2 + 4, s21);
+                vst1q_f32(sum + 8*3, s30); vst1q_f32(sum + 8*3 + 4, s31);
+                vst1q_f32(sum + 8*4, s40); vst1q_f32(sum + 8*4 + 4, s41);
+                vst1q_f32(sum + 8*5, s50); vst1q_f32(sum + 8*5 + 4, s51);
+                vst1q_f32(sum + 8*6, s60); vst1q_f32(sum + 8*6 + 4, s61);
+                vst1q_f32(sum + 8*7, s70); vst1q_f32(sum + 8*7 + 4, s71);
+#elif CV_SIMD128
+                v_float32 z = vx_setzero_f32();
+                v_float32 s00 = z, s01 = z, s10 = z, s11 = z;
+                v_float32 s20 = z, s21 = z, s30 = z, s31 = z;
+                v_float32 s40 = z, s41 = z, s50 = z, s51 = z;
+                v_float32 s60 = z, s61 = z, s70 = z, s71 = z;
+                const int32_t *ofs0 = ofsptrs[0], *ofs1 = ofsptrs[1];
+                const int32_t *ofs2 = ofsptrs[2], *ofs3 = ofsptrs[3];
+                const int32_t *ofs4 = ofsptrs[4], *ofs5 = ofsptrs[5];
+                const int32_t *ofs6 = ofsptrs[6], *ofs7 = ofsptrs[7];
+
+                const float *inptr0 = inptrs[0], *inptr1 = inptrs[1];
+                const float *inptr2 = inptrs[2], *inptr3 = inptrs[3];
+                const float *inptr4 = inptrs[4], *inptr5 = inptrs[5];
+                const float *inptr6 = inptrs[6], *inptr7 = inptrs[7];
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    v_float32 w00 = vx_load(wptr + c1 + 8*0), w01 = vx_load(wptr + c1 + 8*0 + 4);
+                    v_float32 w10 = vx_load(wptr + c1 + 8*1), w11 = vx_load(wptr + c1 + 8*1 + 4);
+                    v_float32 w20 = vx_load(wptr + c1 + 8*2), w21 = vx_load(wptr + c1 + 8*2 + 4);
+                    v_float32 w30 = vx_load(wptr + c1 + 8*3), w31 = vx_load(wptr + c1 + 8*3 + 4);
+                    v_float32 w40 = vx_load(wptr + c1 + 8*4), w41 = vx_load(wptr + c1 + 8*4 + 4);
+                    v_float32 w50 = vx_load(wptr + c1 + 8*5), w51 = vx_load(wptr + c1 + 8*5 + 4);
+                    v_float32 w60 = vx_load(wptr + c1 + 8*6), w61 = vx_load(wptr + c1 + 8*6 + 4);
+                    v_float32 w70 = vx_load(wptr + c1 + 8*7), w71 = vx_load(wptr + c1 + 8*7 + 4);
+
+                    int32_t ofs0i, ofs1i, ofs0p, ofs1p;
+                    float m0, m1;
+                    v_float32 x0, x1;
+
+#undef UPDATE_SUM
+#define UPDATE_SUM(a, b) \
+ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
+m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
+ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
+x0 = vx_setall_f32(inptr##a[ofs0p]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p]*m1); \
+s##a##0 = v_fma(w00, x0, s##a##0); \
+s##a##1 = v_fma(w01, x0, s##a##1); \
+s##b##0 = v_fma(w00, x1, s##b##0); \
+s##b##1 = v_fma(w01, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+1]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+1]*m1); \
+s##a##0 = v_fma(w10, x0, s##a##0); \
+s##a##1 = v_fma(w11, x0, s##a##1); \
+s##b##0 = v_fma(w10, x1, s##b##0); \
+s##b##1 = v_fma(w11, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+2]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+2]*m1); \
+s##a##0 = v_fma(w20, x0, s##a##0); \
+s##a##1 = v_fma(w21, x0, s##a##1); \
+s##b##0 = v_fma(w20, x1, s##b##0); \
+s##b##1 = v_fma(w21, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+3]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+3]*m1); \
+s##a##0 = v_fma(w30, x0, s##a##0); \
+s##a##1 = v_fma(w31, x0, s##a##1); \
+s##b##0 = v_fma(w30, x1, s##b##0); \
+s##b##1 = v_fma(w31, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+4]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+4]*m1); \
+s##a##0 = v_fma(w40, x0, s##a##0); \
+s##a##1 = v_fma(w41, x0, s##a##1); \
+s##b##0 = v_fma(w40, x1, s##b##0); \
+s##b##1 = v_fma(w41, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+5]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+5]*m1); \
+s##a##0 = v_fma(w50, x0, s##a##0); \
+s##a##1 = v_fma(w51, x0, s##a##1); \
+s##b##0 = v_fma(w50, x1, s##b##0); \
+s##b##1 = v_fma(w51, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+6]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+6]*m1); \
+s##a##0 = v_fma(w60, x0, s##a##0); \
+s##a##1 = v_fma(w61, x0, s##a##1); \
+s##b##0 = v_fma(w60, x1, s##b##0); \
+s##b##1 = v_fma(w61, x1, s##b##1); \
+x0 = vx_setall_f32(inptr##a[ofs0p+7]*m0); \
+x1 = vx_setall_f32(inptr##b[ofs1p+7]*m1); \
+s##a##0 = v_fma(w70, x0, s##a##0); \
+s##a##1 = v_fma(w71, x0, s##a##1); \
+s##b##0 = v_fma(w70, x1, s##b##0); \
+s##b##1 = v_fma(w71, x1, s##b##1)
+
+                    UPDATE_SUM(0, 1);
+                    UPDATE_SUM(2, 3);
+                    UPDATE_SUM(4, 5);
+                    UPDATE_SUM(6, 7);
+                }
+
+                vx_store(sum + 8*0, s00); vx_store(sum + 8*0 + 4, s01);
+                vx_store(sum + 8*1, s10); vx_store(sum + 8*1 + 4, s11);
+                vx_store(sum + 8*2, s20); vx_store(sum + 8*2 + 4, s21);
+                vx_store(sum + 8*3, s30); vx_store(sum + 8*3 + 4, s31);
+                vx_store(sum + 8*4, s40); vx_store(sum + 8*4 + 4, s41);
+                vx_store(sum + 8*5, s50); vx_store(sum + 8*5 + 4, s51);
+                vx_store(sum + 8*6, s60); vx_store(sum + 8*6 + 4, s61);
+                vx_store(sum + 8*7, s70); vx_store(sum + 8*7 + 4, s71);
+#else
+                for (int i = 0; i < BLOCK_SIZE*K0; i++)
+                    sum[i] = 0.f;
+
+                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
+                    for (j = 0; j < BLOCK_SIZE; j++) {
+                        int32_t ofs_ij = ofsptrs[j][i];
+                        const float* x = &inptrs[j][std::max(ofs_ij, 0)];
+                        float mij = (float)(ofs_ij >= 0);
+                        for (int c0 = 0; c0 < C0; c0++) {
+                            float xc = x[c0]*mij;
+                            for (int k = 0; k < K0; k++) {
+                                float w = wptr[c1 + c0*K0 + k];
+                                sum[K0*j + k] += xc*w;
+                            }
+                        }
+                    }
+                }
+#endif
+
+                if (activation) {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            sum[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            sum[j] = v;
+                        }
+                    }
+                    activation(sum, out, blocksize*K0, activParams);
+                } else {
+                    if (resptr) {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    } else {
+                        for (j = 0; j < blocksize*K0; j++) {
+                            float v = sum[j]*scale[j] + bias[j];
+                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                            out[j] = v;
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+CV_CPU_OPTIMIZATION_NAMESPACE_END
+}}
+#endif // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -202,7 +202,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                 vst1q_f32(sum + 8*5, s50); vst1q_f32(sum + 8*5 + 4, s51);
                 vst1q_f32(sum + 8*6, s60); vst1q_f32(sum + 8*6 + 4, s61);
                 vst1q_f32(sum + 8*7, s70); vst1q_f32(sum + 8*7 + 4, s71);
-            #elif CV_SIMD128
+#elif CV_SIMD128
                 v_float32 z = vx_setzero_f32();
                 v_float32 s00 = z, s01 = z, s10 = z, s11 = z;
                 v_float32 s20 = z, s21 = z, s30 = z, s31 = z;

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-cv::dnn::ConvFunc getConvFunc(int depth);
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0);
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 }} // cv::dnn::
@@ -24,37 +24,37 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-void conv32f(const void* inp__, const void* residual__, void* out__,
-             const ConvState& cs, const void* weights__,
-             const float* scale__, const float* bias__,
-             const int32_t* ofs__, const int32_t* ofsbuf__)
+static void conv32fC8(const void* inp__, const void* residual__, void* out__,
+                      const ConvState& cs, const void* weights__,
+                      const float* scale__, const float* bias__,
+                      const int32_t* inpofs__, const int32_t* ofsofs__)
 {
-    //printf("conv2d\n");
     int nlanes_ = VTraits<v_float32>::vlanes();
     int C0_ = cs.inpshape.back();
+    int NK1 = cs.outshape[0]*cs.outshape[1];
 
     CV_Assert(C0_ == 8);
     CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
     CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
 
-    int NK1 = cs.outshape[0]*cs.outshape[1];
-
-    parallel_for_(Range(0, NK1), [&](const Range& r) {
+    parallel_for_(Range(0, NK1), [&](const Range& range) {
         const float* scale_ = scale__;
         const float* bias_ = bias__;
-        const int32_t* ofs_ = ofs__;
-        const int32_t* ofsbuf_ = ofsbuf__;
+        const int32_t* inpofs_ = inpofs__;
+        const int32_t* ofsofs_ = ofsofs__;
         constexpr int BLOCK_SIZE = 8;
-        int nk0 = r.start, nk1 = r.end;
+        int nk0 = range.start, nk1 = range.end;
         constexpr int C0 = 8, K0 = C0;
-        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
-        int H = cs.outshape[2], W = cs.outshape[3];
-        int iplanesize = Hi*Wi;
-        int planesize = H*W;
-        int Hk = cs.kshape[0], Wk = cs.kshape[1];
+        int planesize = 1, iplanesize = 1, ksize = 1;
+        int nspatialdims = cs.nspatialdims;
+        for (int i = 0; i < nspatialdims; i++) {
+            planesize *= cs.outshape[i + 2];
+            iplanesize *= cs.inpshape[i + 2];
+            ksize *= cs.kshape[i];
+        }
         int C1 = cs.inpshape[1], K1 = cs.outshape[1];
         int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
-        int nC = C1g*Hk*Wk*C0*K0;
+        int nC = C1g*ksize*C0*K0;
         AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
         float* sum = sumbuf.data();
         float* scale = sum + BLOCK_SIZE*K0;
@@ -66,7 +66,7 @@ void conv32f(const void* inp__, const void* residual__, void* out__,
         activation_func_t activation = cs.activation;
         float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
         float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
-        fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
 
         for (int j = 0; j < BLOCK_SIZE*K0; j++) {
             scale[j] = 1.f;
@@ -99,8 +99,8 @@ void conv32f(const void* inp__, const void* residual__, void* out__,
 
                 for (; j < blocksize; j++) {
                     int jj = (xy0 + j)*2;
-                    inptrs[j] = inp0 + ofs_[jj];
-                    ofsptrs[j] = ofsbuf_ + ofs_[jj+1];
+                    inptrs[j] = inp0 + ofsofs_[jj];
+                    ofsptrs[j] = inpofs_ + ofsofs_[jj+1];
                 }
 
                 if (j < BLOCK_SIZE) {
@@ -112,7 +112,7 @@ void conv32f(const void* inp__, const void* residual__, void* out__,
                     }
                 }
 
-#if 0 //def __ARM_NEON
+#ifdef __ARM_NEON
                 float32x4_t z = vdupq_n_f32(0.f);
                 float32x4_t s00 = z, s01 = z, s10 = z, s11 = z;
                 float32x4_t s20 = z, s21 = z, s30 = z, s31 = z;
@@ -144,49 +144,49 @@ void conv32f(const void* inp__, const void* residual__, void* out__,
 
 #undef UPDATE_SUM
 #define UPDATE_SUM(a, b) \
-ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
-m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
-ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
-x0 = vld1q_f32(inptr##a + ofs0p); \
-x1 = vld1q_f32(inptr##b + ofs1p); \
-x0 = vmulq_n_f32(x0, m0); \
-x1 = vmulq_n_f32(x1, m1); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w00, x0, 0); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w01, x0, 0); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w00, x1, 0); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w01, x1, 0); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w10, x0, 1); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w11, x0, 1); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w10, x1, 1); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w11, x1, 1); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w20, x0, 2); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w21, x0, 2); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w20, x1, 2); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w21, x1, 2); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w30, x0, 3); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w31, x0, 3); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w30, x1, 3); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w31, x1, 3); \
-x0 = vld1q_f32(inptr##a + ofs0p + 4); \
-x1 = vld1q_f32(inptr##b + ofs1p + 4); \
-x0 = vmulq_n_f32(x0, m0); \
-x1 = vmulq_n_f32(x1, m1); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w40, x0, 0); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w41, x0, 0); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w40, x1, 0); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w41, x1, 0); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w50, x0, 1); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w51, x0, 1); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w50, x1, 1); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w51, x1, 1); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w60, x0, 2); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w61, x0, 2); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w60, x1, 2); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w61, x1, 2); \
-s##a##0 = vfmaq_laneq_f32(s##a##0, w70, x0, 3); \
-s##a##1 = vfmaq_laneq_f32(s##a##1, w71, x0, 3); \
-s##b##0 = vfmaq_laneq_f32(s##b##0, w70, x1, 3); \
-s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
+    ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
+    m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
+    ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
+    x0 = vld1q_f32(inptr##a + ofs0p); \
+    x1 = vld1q_f32(inptr##b + ofs1p); \
+    x0 = vmulq_n_f32(x0, m0); \
+    x1 = vmulq_n_f32(x1, m1); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w00, x0, 0); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w01, x0, 0); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w00, x1, 0); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w01, x1, 0); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w10, x0, 1); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w11, x0, 1); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w10, x1, 1); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w11, x1, 1); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w20, x0, 2); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w21, x0, 2); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w20, x1, 2); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w21, x1, 2); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w30, x0, 3); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w31, x0, 3); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w30, x1, 3); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w31, x1, 3); \
+    x0 = vld1q_f32(inptr##a + ofs0p + 4); \
+    x1 = vld1q_f32(inptr##b + ofs1p + 4); \
+    x0 = vmulq_n_f32(x0, m0); \
+    x1 = vmulq_n_f32(x1, m1); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w40, x0, 0); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w41, x0, 0); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w40, x1, 0); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w41, x1, 0); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w50, x0, 1); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w51, x0, 1); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w50, x1, 1); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w51, x1, 1); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w60, x0, 2); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w61, x0, 2); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w60, x1, 2); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w61, x1, 2); \
+    s##a##0 = vfmaq_laneq_f32(s##a##0, w70, x0, 3); \
+    s##a##1 = vfmaq_laneq_f32(s##a##1, w71, x0, 3); \
+    s##b##0 = vfmaq_laneq_f32(s##b##0, w70, x1, 3); \
+    s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
 
                     UPDATE_SUM(0, 1);
                     UPDATE_SUM(2, 3);
@@ -202,7 +202,7 @@ s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
                 vst1q_f32(sum + 8*5, s50); vst1q_f32(sum + 8*5 + 4, s51);
                 vst1q_f32(sum + 8*6, s60); vst1q_f32(sum + 8*6 + 4, s61);
                 vst1q_f32(sum + 8*7, s70); vst1q_f32(sum + 8*7 + 4, s71);
-#elif CV_SIMD128
+            #elif CV_SIMD128
                 v_float32 z = vx_setzero_f32();
                 v_float32 s00 = z, s01 = z, s10 = z, s11 = z;
                 v_float32 s20 = z, s21 = z, s30 = z, s31 = z;
@@ -234,57 +234,57 @@ s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
 
 #undef UPDATE_SUM
 #define UPDATE_SUM(a, b) \
-ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
-m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
-ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
-x0 = vx_setall_f32(inptr##a[ofs0p]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p]*m1); \
-s##a##0 = v_fma(w00, x0, s##a##0); \
-s##a##1 = v_fma(w01, x0, s##a##1); \
-s##b##0 = v_fma(w00, x1, s##b##0); \
-s##b##1 = v_fma(w01, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+1]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+1]*m1); \
-s##a##0 = v_fma(w10, x0, s##a##0); \
-s##a##1 = v_fma(w11, x0, s##a##1); \
-s##b##0 = v_fma(w10, x1, s##b##0); \
-s##b##1 = v_fma(w11, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+2]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+2]*m1); \
-s##a##0 = v_fma(w20, x0, s##a##0); \
-s##a##1 = v_fma(w21, x0, s##a##1); \
-s##b##0 = v_fma(w20, x1, s##b##0); \
-s##b##1 = v_fma(w21, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+3]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+3]*m1); \
-s##a##0 = v_fma(w30, x0, s##a##0); \
-s##a##1 = v_fma(w31, x0, s##a##1); \
-s##b##0 = v_fma(w30, x1, s##b##0); \
-s##b##1 = v_fma(w31, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+4]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+4]*m1); \
-s##a##0 = v_fma(w40, x0, s##a##0); \
-s##a##1 = v_fma(w41, x0, s##a##1); \
-s##b##0 = v_fma(w40, x1, s##b##0); \
-s##b##1 = v_fma(w41, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+5]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+5]*m1); \
-s##a##0 = v_fma(w50, x0, s##a##0); \
-s##a##1 = v_fma(w51, x0, s##a##1); \
-s##b##0 = v_fma(w50, x1, s##b##0); \
-s##b##1 = v_fma(w51, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+6]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+6]*m1); \
-s##a##0 = v_fma(w60, x0, s##a##0); \
-s##a##1 = v_fma(w61, x0, s##a##1); \
-s##b##0 = v_fma(w60, x1, s##b##0); \
-s##b##1 = v_fma(w61, x1, s##b##1); \
-x0 = vx_setall_f32(inptr##a[ofs0p+7]*m0); \
-x1 = vx_setall_f32(inptr##b[ofs1p+7]*m1); \
-s##a##0 = v_fma(w70, x0, s##a##0); \
-s##a##1 = v_fma(w71, x0, s##a##1); \
-s##b##0 = v_fma(w70, x1, s##b##0); \
-s##b##1 = v_fma(w71, x1, s##b##1)
+    ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
+    m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
+    ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
+    x0 = vx_setall_f32(inptr##a[ofs0p]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p]*m1); \
+    s##a##0 = v_fma(w00, x0, s##a##0); \
+    s##a##1 = v_fma(w01, x0, s##a##1); \
+    s##b##0 = v_fma(w00, x1, s##b##0); \
+    s##b##1 = v_fma(w01, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+1]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+1]*m1); \
+    s##a##0 = v_fma(w10, x0, s##a##0); \
+    s##a##1 = v_fma(w11, x0, s##a##1); \
+    s##b##0 = v_fma(w10, x1, s##b##0); \
+    s##b##1 = v_fma(w11, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+2]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+2]*m1); \
+    s##a##0 = v_fma(w20, x0, s##a##0); \
+    s##a##1 = v_fma(w21, x0, s##a##1); \
+    s##b##0 = v_fma(w20, x1, s##b##0); \
+    s##b##1 = v_fma(w21, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+3]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+3]*m1); \
+    s##a##0 = v_fma(w30, x0, s##a##0); \
+    s##a##1 = v_fma(w31, x0, s##a##1); \
+    s##b##0 = v_fma(w30, x1, s##b##0); \
+    s##b##1 = v_fma(w31, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+4]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+4]*m1); \
+    s##a##0 = v_fma(w40, x0, s##a##0); \
+    s##a##1 = v_fma(w41, x0, s##a##1); \
+    s##b##0 = v_fma(w40, x1, s##b##0); \
+    s##b##1 = v_fma(w41, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+5]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+5]*m1); \
+    s##a##0 = v_fma(w50, x0, s##a##0); \
+    s##a##1 = v_fma(w51, x0, s##a##1); \
+    s##b##0 = v_fma(w50, x1, s##b##0); \
+    s##b##1 = v_fma(w51, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+6]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+6]*m1); \
+    s##a##0 = v_fma(w60, x0, s##a##0); \
+    s##a##1 = v_fma(w61, x0, s##a##1); \
+    s##b##0 = v_fma(w60, x1, s##b##0); \
+    s##b##1 = v_fma(w61, x1, s##b##1); \
+    x0 = vx_setall_f32(inptr##a[ofs0p+7]*m0); \
+    x1 = vx_setall_f32(inptr##b[ofs1p+7]*m1); \
+    s##a##0 = v_fma(w70, x0, s##a##0); \
+    s##a##1 = v_fma(w71, x0, s##a##1); \
+    s##b##0 = v_fma(w70, x1, s##b##0); \
+    s##b##1 = v_fma(w71, x1, s##b##1)
 
                     UPDATE_SUM(0, 1);
                     UPDATE_SUM(2, 3);
@@ -300,7 +300,7 @@ s##b##1 = v_fma(w71, x1, s##b##1)
                 vx_store(sum + 8*5, s50); vx_store(sum + 8*5 + 4, s51);
                 vx_store(sum + 8*6, s60); vx_store(sum + 8*6 + 4, s61);
                 vx_store(sum + 8*7, s70); vx_store(sum + 8*7 + 4, s71);
-#else
+            #else
                 for (int i = 0; i < BLOCK_SIZE*K0; i++)
                     sum[i] = 0.f;
 
@@ -318,7 +318,7 @@ s##b##1 = v_fma(w71, x1, s##b##1)
                         }
                     }
                 }
-#endif
+            #endif
 
                 if (activation) {
                     if (resptr) {
@@ -351,6 +351,12 @@ s##b##1 = v_fma(w71, x1, s##b##1)
             }
         }
     });
+}
+
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0)
+{
+    ConvFunc func = depth == CV_32F && C0 == 8 ? conv32fC8 : nullptr;
+    return func;
 }
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -160,6 +160,109 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
         CONV_FINALIZE_OUT2(8, 9, CONV_ADD_NO_RESIDUAL2); \
     }
 
+#elif CV_SIMD256
+
+///////////// generic branch for arch's with 256-bit SIMD (however, it's tweaked for AVX2 with just 16 registers) ////////////////
+
+#undef CONV_INIT_SUMS
+#define CONV_INIT_SUMS() \
+    v_float32x8 zz = v256_setzero_f32(); \
+    v_float32x8 s0 = zz, s1 = zz, s2 = zz, s3 = zz, s4 = zz; \
+    v_float32x8 s5 = zz, s6 = zz, s7 = zz, s8 = zz, s9 = zz
+
+#undef CONV_UPDATE_BLOCK
+#define CONV_UPDATE_BLOCK2x8(ofs, idx0, idx1) \
+    x0 = v256_setall_f32(inptr[idx0][ofs]); \
+    x1 = v256_setall_f32(inptr[idx1][ofs]); \
+    s##idx0 = v_fma(x0, w0, s##idx0); \
+    s##idx1 = v_fma(x1, w0, s##idx1); \
+    x0 = v256_setall_f32(inptr[idx0][ofs+1]); \
+    x1 = v256_setall_f32(inptr[idx1][ofs+1]); \
+    s##idx0 = v_fma(x0, w1, s##idx0); \
+    s##idx1 = v_fma(x1, w1, s##idx1); \
+    x0 = v256_setall_f32(inptr[idx0][ofs+2]); \
+    x1 = v256_setall_f32(inptr[idx1][ofs+2]); \
+    s##idx0 = v_fma(x0, w2, s##idx0); \
+    s##idx1 = v_fma(x1, w2, s##idx1); \
+    x0 = v256_setall_f32(inptr[idx0][ofs+3]); \
+    x1 = v256_setall_f32(inptr[idx1][ofs+3]); \
+    s##idx0 = v_fma(x0, w3, s##idx0); \
+    s##idx1 = v_fma(x1, w3, s##idx1)
+
+#undef CONV_UPDATE_LOOP_BODY
+#define CONV_UPDATE_LOOP_BODY() \
+    v_float32x8 x0, x1; \
+    v_float32x8 w0, w1, w2, w3; \
+    \
+    w0 = v256_load(wptr + 0*K0); \
+    w1 = v256_load(wptr + 1*K0); \
+    w2 = v256_load(wptr + 2*K0); \
+    w3 = v256_load(wptr + 3*K0); \
+    \
+    CONV_UPDATE_BLOCK2x8(0, 0, 1); \
+    CONV_UPDATE_BLOCK2x8(0, 2, 3); \
+    CONV_UPDATE_BLOCK2x8(0, 4, 5); \
+    CONV_UPDATE_BLOCK2x8(0, 6, 7); \
+    CONV_UPDATE_BLOCK2x8(0, 8, 9); \
+    \
+    w0 = v256_load(wptr + 4*K0); \
+    w1 = v256_load(wptr + 5*K0); \
+    w2 = v256_load(wptr + 6*K0); \
+    w3 = v256_load(wptr + 7*K0); \
+    \
+    CONV_UPDATE_BLOCK2x8(4, 0, 1); \
+    CONV_UPDATE_BLOCK2x8(4, 2, 3); \
+    CONV_UPDATE_BLOCK2x8(4, 4, 5); \
+    CONV_UPDATE_BLOCK2x8(4, 6, 7); \
+    CONV_UPDATE_BLOCK2x8(4, 8, 9); \
+    \
+    inptr[0] += inpstep[0]; inptr[1] += inpstep[1]; \
+    inptr[2] += inpstep[2]; inptr[3] += inpstep[3]; \
+    inptr[4] += inpstep[4]; inptr[5] += inpstep[5]; \
+    inptr[6] += inpstep[6]; inptr[7] += inpstep[7]; \
+    inptr[8] += inpstep[8]; inptr[9] += inpstep[9]
+
+#undef CONV_START_FINALIZE_OUT
+#define CONV_START_FINALIZE_OUT() \
+    v_float32x8 vscale = v256_load(scalebuf); \
+    v_float32x8 vbias = v256_load(biasbuf); \
+    v_float32x8 valpha = v256_setall_f32(alpha); \
+    v_float32x8 vmaxval = v256_setall_f32(maxval)
+
+#define CONV_ADD_RESIDUAL2(idx0, idx1) \
+    s##idx0 = v_add(s##idx0, v256_load(tmpbuf + idx0*K0)); \
+    s##idx1 = v_add(s##idx1, v256_load(tmpbuf + idx1*K0))
+
+#undef CONV_FINALIZE_OUT2
+#define CONV_FINALIZE_OUT2(idx0, idx1, add_residual2) \
+    s##idx0 = v_fma(s##idx0, vscale, vbias); \
+    s##idx1 = v_fma(s##idx1, vscale, vbias); \
+    add_residual2(idx0, idx1); \
+    s##idx0 = v_select(v_ge(s##idx0, zz), s##idx0, v_mul(s##idx0, valpha)); \
+    s##idx1 = v_select(v_ge(s##idx1, zz), s##idx1, v_mul(s##idx1, valpha)); \
+    s##idx0 = v_min(s##idx0, vmaxval); \
+    s##idx1 = v_min(s##idx1, vmaxval); \
+    v_store(outbuf + idx0*K0, s##idx0); \
+    v_store(outbuf + idx1*K0, s##idx1)
+
+#undef CONV_FINALIZE_OUT_ALL
+#define CONV_FINALIZE_OUT_ALL() \
+    CONV_START_FINALIZE_OUT(); \
+    if (resptr) { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_RESIDUAL2); \
+    } else { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_NO_RESIDUAL2); \
+    }
+
+
 #elif CV_SIMD128
 
 /////////////////////////// generic branch for arch's with 128-bit SIMD /////////////////////////////
@@ -523,7 +626,10 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                 int yi_base = yj*Sy - padY;
                 int xi_base = xj*Sx - padX;
 
-            #if CV_SIMD128
+            #if CV_SIMD256
+                v_float32x8 zz = v256_setzero_f32();
+                v_float32x8 s0 = zz;
+            #elif CV_SIMD128
                 v_float32x4 zz = v_setzero_f32();
                 v_float32x4 s0 = zz, s1 = zz;
             #else
@@ -554,7 +660,22 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                     const float* wptr = wbaseptr + i*C1Max*K0*C0;
 
                     for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
-                    #if CV_SIMD128
+                    #if CV_SIMD256
+                        v_float32x8 w, x;
+                        #undef CONV_UPDATE_BLOCK1
+                        #define CONV_UPDATE_BLOCK1(ofs) \
+                            w = v256_load(wptr + ofs*K0); \
+                            x = v256_setall_f32(inptr[ofs]); \
+                            s0 = v_fma(x, w, s0)
+                        CONV_UPDATE_BLOCK1(0);
+                        CONV_UPDATE_BLOCK1(1);
+                        CONV_UPDATE_BLOCK1(2);
+                        CONV_UPDATE_BLOCK1(3);
+                        CONV_UPDATE_BLOCK1(4);
+                        CONV_UPDATE_BLOCK1(5);
+                        CONV_UPDATE_BLOCK1(6);
+                        CONV_UPDATE_BLOCK1(7);
+                    #elif CV_SIMD128
                         v_float32x4 w0, w1, x;
                         #undef CONV_UPDATE_BLOCK1
                         #define CONV_UPDATE_BLOCK1(ofs) \
@@ -581,7 +702,18 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
 
                 float* outbuf = aligned_k ? outptr + k_base*planeblocks : tmpbuf;
 
-            #if CV_SIMD128
+            #if CV_SIMD256
+                v_float32x8 vscale = v256_load(scalebuf);
+                v_float32x8 vbias = v256_load(biasbuf);
+                v_float32x8 valpha = v256_setall_f32(alpha);
+                v_float32x8 vmaxval = v256_setall_f32(maxval);
+
+                s0 = v_fma(s0, vscale, vbias);
+                s0 = v_add(s0, v256_load(resbuf));
+                s0 = v_select(v_ge(s0, zz), s0, v_mul(s0, valpha));
+                s0 = v_min(s0, vmaxval);
+                v_store(outbuf, s0);
+            #elif CV_SIMD128
                 v_float32x4 vscale_lo = v_load(scalebuf), vscale_hi = v_load(scalebuf + 4);
                 v_float32x4 vbias_lo = v_load(biasbuf), vbias_hi = v_load(biasbuf + 4);
                 v_float32x4 valpha = v_setall_f32(alpha);

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -397,13 +397,10 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                       const float* scale__, const float* bias__)
 {
     using FT = float;
-    constexpr int C0shift_ = 3;
-    constexpr int C0_ = 1 << C0shift_;
     const MatShape& inpshape = cs.inpshape;
     const MatShape& outshape = cs.outshape;
 
     CV_Assert_N(inpshape.layout == DATA_LAYOUT_BLOCK, outshape.layout == DATA_LAYOUT_BLOCK);
-    CV_Assert_N(inpshape.back() == C0_, outshape.back() == C0_);
 
     int K_ = outshape.channels();
     int ndims_ = outshape.dims;
@@ -418,7 +415,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     int C1Max_ = cs.wshape[3];
     int total_blocks = N * cs.ngroups * Kblk_;
 
-    if ((K_/cs.ngroups) % C0_ != 0) {
+    if ((K_/cs.ngroups) % inpshape.back() != 0) {
         // if there could be 'padding' channels in the output,
         // clear the output before the parallel loop
         // to make sure that all the padding channels are cleared.
@@ -427,9 +424,11 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
         constexpr int SPAT_BLOCK_SIZE = 10;
-        constexpr int C0shift = C0shift_, K0shift = C0shift_;
-        constexpr int C0 = C0_, K0 = C0_;
-        constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
+        constexpr int C0shift = 3, K0shift = C0shift;
+        constexpr int C0 = 1 << C0shift, K0 = C0;
+
+        CV_Assert_N(inpshape.back() == C0, outshape.back() == K0);
+
         const int C = inpshape.channels(), K = outshape.channels();
         const int C1 = (C + C0 - 1)/C0, K1 = (K + K0 - 1)/K0;
         const int ngroups = cs.ngroups, Kblk = Kblk_, C1Max = C1Max_;
@@ -451,6 +450,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
         int iplanesize = Di*Hi*Wi*C0;
 
     #ifdef CONV_ENABLE_SIMD
+        constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
         int innerZ0 = cs.inner[0], innerZ1 = cs.inner[MAX_CONV_DIMS];
         int innerY0 = cs.inner[1], innerY1 = cs.inner[MAX_CONV_DIMS+1];
         int innerX0 = cs.inner[2], innerX1 = cs.inner[MAX_CONV_DIMS+2];

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -29,7 +29,7 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 #undef CONV_ADD_NO_RESIDUAL2
 #define CONV_ADD_NO_RESIDUAL2(idx0, idx1) /* empty */
 
-#if CV_NEON_AARCH64
+#if (defined CV_NEON_AARCH64) && CV_NEON_AARCH64
 
 /////////////////////////// AARH64-optimized implementation /////////////////////////////
 
@@ -396,16 +396,14 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                       const ConvState& cs, const void* weights__,
                       const float* scale__, const float* bias__)
 {
-    constexpr int SPAT_BLOCK_SIZE = 10;
     using FT = float;
-    constexpr int C0shift = 3, K0shift = C0shift;
-    constexpr int C0 = 1 << C0shift;
-    constexpr int K0 = C0;
+    constexpr int C0shift_ = 3;
+    constexpr int C0_ = 1 << C0shift_;
     const MatShape& inpshape = cs.inpshape;
     const MatShape& outshape = cs.outshape;
 
     CV_Assert_N(inpshape.layout == DATA_LAYOUT_BLOCK, outshape.layout == DATA_LAYOUT_BLOCK);
-    CV_Assert_N(inpshape.back() == C0, outshape.back() == K0);
+    CV_Assert_N(inpshape.back() == C0_, outshape.back() == C0_);
 
     int K_ = outshape.channels();
     int ndims_ = outshape.dims;
@@ -420,7 +418,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     int C1Max_ = cs.wshape[3];
     int total_blocks = N * cs.ngroups * Kblk_;
 
-    if ((K_/cs.ngroups) % K0 != 0) {
+    if ((K_/cs.ngroups) % C0_ != 0) {
         // if there could be 'padding' channels in the output,
         // clear the output before the parallel loop
         // to make sure that all the padding channels are cleared.
@@ -428,6 +426,9 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     }
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
+        constexpr int SPAT_BLOCK_SIZE = 10;
+        constexpr int C0shift = C0shift_, K0shift = C0shift_;
+        constexpr int C0 = C0_, K0 = C0_;
         constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
         const int C = inpshape.channels(), K = outshape.channels();
         const int C1 = (C + C0 - 1)/C0, K1 = (K + K0 - 1)/K0;
@@ -449,7 +450,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
         int planesize = planeblocks*K0;
         int iplanesize = Di*Hi*Wi*C0;
 
-    #if CONV_ENABLE_SIMD
+    #ifdef CONV_ENABLE_SIMD
         int innerZ0 = cs.inner[0], innerZ1 = cs.inner[MAX_CONV_DIMS];
         int innerY0 = cs.inner[1], innerY1 = cs.inner[MAX_CONV_DIMS+1];
         int innerX0 = cs.inner[2], innerX1 = cs.inner[MAX_CONV_DIMS+2];
@@ -470,7 +471,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
             W *= D*H;
             Wi *= Di*Hi;
             D = Di = H = Hi = 1;
-        #if CONV_ENABLE_SIMD
+        #ifdef CONV_ENABLE_SIMD
             innerZ1 = innerY1 = 1;
             innerX1 = W;
         #endif
@@ -513,7 +514,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
             float tmpbuf[SPAT_BLOCK_SIZE*K0] = {};
             int p = p0;
 
-        #if CONV_ENABLE_SIMD
+        #ifdef CONV_ENABLE_SIMD
             for (; p < p1; p += SPAT_BLOCK_SIZE,
                            outptr += SPAT_BLOCK_SIZE*K0)
             {

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -114,7 +114,7 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 #define CONV_START_FINALIZE_OUT() \
     float32x4_t vscale_lo = vld1q_f32(scalebuf), vscale_hi = vld1q_f32(scalebuf + 4); \
     float32x4_t vbias_lo = vld1q_f32(biasbuf), vbias_hi = vld1q_f32(biasbuf + 4); \
-    float32x4_t valpha = vdupq_n_f32(alpha); \
+    float32x4_t valpha_lo = vld1q_f32(alphabuf), valpha_hi = vld1q_f32(alphabuf + 4); \
     float32x4_t vmaxval = vdupq_n_f32(maxval)
 
 #define CONV_ADD_RESIDUAL2(idx0, idx1) \
@@ -130,10 +130,10 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
     s##idx1##l = vfmaq_f32(vbias_lo, s##idx1##l, vscale_lo); \
     s##idx1##h = vfmaq_f32(vbias_hi, s##idx1##h, vscale_hi); \
     add_residual2(idx0, idx1); \
-    s##idx0##l = vbslq_f32(vcgeq_f32(s##idx0##l, zz), s##idx0##l, vmulq_f32(s##idx0##l, valpha)); \
-    s##idx0##h = vbslq_f32(vcgeq_f32(s##idx0##h, zz), s##idx0##h, vmulq_f32(s##idx0##h, valpha)); \
-    s##idx1##l = vbslq_f32(vcgeq_f32(s##idx1##l, zz), s##idx1##l, vmulq_f32(s##idx1##l, valpha)); \
-    s##idx1##h = vbslq_f32(vcgeq_f32(s##idx1##h, zz), s##idx1##h, vmulq_f32(s##idx1##h, valpha)); \
+    s##idx0##l = vbslq_f32(vcgeq_f32(s##idx0##l, zz), s##idx0##l, vmulq_f32(s##idx0##l, valpha_lo)); \
+    s##idx0##h = vbslq_f32(vcgeq_f32(s##idx0##h, zz), s##idx0##h, vmulq_f32(s##idx0##h, valpha_hi)); \
+    s##idx1##l = vbslq_f32(vcgeq_f32(s##idx1##l, zz), s##idx1##l, vmulq_f32(s##idx1##l, valpha_lo)); \
+    s##idx1##h = vbslq_f32(vcgeq_f32(s##idx1##h, zz), s##idx1##h, vmulq_f32(s##idx1##h, valpha_hi)); \
     s##idx0##l = vminq_f32(s##idx0##l, vmaxval); \
     s##idx0##h = vminq_f32(s##idx0##h, vmaxval); \
     s##idx1##l = vminq_f32(s##idx1##l, vmaxval); \
@@ -226,7 +226,7 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 #define CONV_START_FINALIZE_OUT() \
     v_float32x8 vscale = v256_load(scalebuf); \
     v_float32x8 vbias = v256_load(biasbuf); \
-    v_float32x8 valpha = v256_setall_f32(alpha); \
+    v_float32x8 valpha = v256_load(alphabuf); \
     v_float32x8 vmaxval = v256_setall_f32(maxval)
 
 #define CONV_ADD_RESIDUAL2(idx0, idx1) \
@@ -340,7 +340,7 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 #define CONV_START_FINALIZE_OUT() \
     v_float32x4 vscale_lo = v_load(scalebuf), vscale_hi = v_load(scalebuf + 4); \
     v_float32x4 vbias_lo = v_load(biasbuf), vbias_hi = v_load(biasbuf + 4); \
-    v_float32x4 valpha = v_setall_f32(alpha); \
+    v_float32x4 valpha_lo = v_load(alphabuf), valpha_hi = v_load(alphabuf + 4); \
     v_float32x4 vmaxval = v_setall_f32(maxval)
 
 #define CONV_ADD_RESIDUAL2(idx0, idx1) \
@@ -356,10 +356,10 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
     s##idx1##l = v_fma(s##idx1##l, vscale_lo, vbias_lo); \
     s##idx1##h = v_fma(s##idx1##h, vscale_hi, vbias_hi); \
     add_residual2(idx0, idx1); \
-    s##idx0##l = v_select(v_ge(s##idx0##l, zz), s##idx0##l, v_mul(s##idx0##l, valpha)); \
-    s##idx0##h = v_select(v_ge(s##idx0##h, zz), s##idx0##h, v_mul(s##idx0##h, valpha)); \
-    s##idx1##l = v_select(v_ge(s##idx1##l, zz), s##idx1##l, v_mul(s##idx1##l, valpha)); \
-    s##idx1##h = v_select(v_ge(s##idx1##h, zz), s##idx1##h, v_mul(s##idx1##h, valpha)); \
+    s##idx0##l = v_select(v_ge(s##idx0##l, zz), s##idx0##l, v_mul(s##idx0##l, valpha_lo)); \
+    s##idx0##h = v_select(v_ge(s##idx0##h, zz), s##idx0##h, v_mul(s##idx0##h, valpha_hi)); \
+    s##idx1##l = v_select(v_ge(s##idx1##l, zz), s##idx1##l, v_mul(s##idx1##l, valpha_lo)); \
+    s##idx1##h = v_select(v_ge(s##idx1##h, zz), s##idx1##h, v_mul(s##idx1##h, valpha_hi)); \
     s##idx0##l = v_min(s##idx0##l, vmaxval); \
     s##idx0##h = v_min(s##idx0##h, vmaxval); \
     s##idx1##l = v_min(s##idx1##l, vmaxval); \
@@ -458,12 +458,24 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     #endif
 
         FastActivation fastActivation = cs.fastActivation;
-        const float* activParams = cs.activParams;
-        activation_func_t activation = cs.activation;
-        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
-        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
-                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
-        float scalebuf[K0], biasbuf[K0];
+        const float* activParams = cs.activParams.data();
+        ActivationFunc activation = cs.activation;
+        float maxval = FLT_MAX, defaultAlpha = 0.f;
+        float scalebuf[K0], biasbuf[K0], alphabuf[K0];
+        if (fastActivation == FAST_ACTIV_CLIP) {
+            CV_Assert(cs.activParams.size() == 2u);
+            maxval = activParams[1];
+        } else if (fastActivation == FAST_ACTIV_RELU) {
+            CV_Assert(!activParams);
+        } else if (fastActivation == FAST_ACTIV_LEAKY_RELU) {
+            CV_Assert(cs.activParams.size() == 1u);
+            defaultAlpha = activParams[0];
+        } else if (fastActivation == FAST_ACTIV_PRELU) {
+            CV_Assert(cs.activParams.size() == size_t(K));
+        } else {
+            CV_Assert(fastActivation == FAST_ACTIV_NONE);
+            defaultAlpha = 1.f;
+        }
 
         // 1x1x1 convolution with (1,1,1) strides:
         // flatten input/output tensors in this case to accelerate address computations
@@ -502,10 +514,12 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                 for (; kk < k_count; kk++) {
                     scalebuf[kk] = scaleptr ? scaleptr[k_base + kk] : 1.f;
                     biasbuf[kk] = biasptr ? biasptr[k_base + kk] : 0.f;
+                    alphabuf[kk] = fastActivation == FAST_ACTIV_PRELU ? activParams[k_base + kk] : defaultAlpha;
                 }
                 for (; kk < K0; kk++) {
                     scalebuf[kk] = 0.f;
                     biasbuf[kk] = 0.f;
+                    alphabuf[kk] = 0.f;
                 }
             }
 
@@ -706,7 +720,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
             #if CV_SIMD256
                 v_float32x8 vscale = v256_load(scalebuf);
                 v_float32x8 vbias = v256_load(biasbuf);
-                v_float32x8 valpha = v256_setall_f32(alpha);
+                v_float32x8 valpha = v256_load(alphabuf);
                 v_float32x8 vmaxval = v256_setall_f32(maxval);
 
                 s0 = v_fma(s0, vscale, vbias);
@@ -717,15 +731,15 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
             #elif CV_SIMD128
                 v_float32x4 vscale_lo = v_load(scalebuf), vscale_hi = v_load(scalebuf + 4);
                 v_float32x4 vbias_lo = v_load(biasbuf), vbias_hi = v_load(biasbuf + 4);
-                v_float32x4 valpha = v_setall_f32(alpha);
+                v_float32x4 valpha_lo = v_load(alphabuf), valpha_hi = v_load(alphabuf + 4);
                 v_float32x4 vmaxval = v_setall_f32(maxval);
 
                 s0 = v_fma(s0, vscale_lo, vbias_lo);
                 s1 = v_fma(s1, vscale_hi, vbias_hi);
                 s0 = v_add(s0, v_load(resbuf));
                 s1 = v_add(s1, v_load(resbuf + 4));
-                s0 = v_select(v_ge(s0, zz), s0, v_mul(s0, valpha));
-                s1 = v_select(v_ge(s1, zz), s1, v_mul(s1, valpha));
+                s0 = v_select(v_ge(s0, zz), s0, v_mul(s0, valpha_lo));
+                s1 = v_select(v_ge(s1, zz), s1, v_mul(s1, valpha_hi));
                 s0 = v_min(s0, vmaxval);
                 s1 = v_min(s1, vmaxval);
                 v_store(outbuf, s0);
@@ -733,7 +747,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
             #else
                 for (int kk = 0; kk < K0; kk++) {
                     float v = tmpbuf[kk]*scalebuf[kk] + biasbuf[kk] + resbuf[kk];
-                    v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                    v = std::min(v*(v >= 0 ? 1.f : alphabuf[kk]), maxval);
                     outbuf[kk] = v;
                 }
             #endif

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-cv::dnn::ConvFunc getConvFunc_(int depth, int C0, ConvKind convkind);
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0);
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 }} // cv::dnn::
@@ -24,429 +24,274 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-static void conv32fC8(const void* inp__, const void* residual__, void* out__,
-                      const ConvState& cs, const void* weights__,
-                      const float* scale__, const float* bias__,
-                      const int32_t* inpofs__, const int32_t* ofsofs__)
-{
-    int nlanes_ = VTraits<v_float32>::vlanes();
-    int C0_ = cs.inpshape.back();
-    int NK1 = cs.outshape[0]*cs.outshape[1];
+#define CONV_ENABLE_SIMD 1
 
-    CV_Assert(C0_ == 8);
-    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
-    CV_Assert(cs.activation == nullptr || cs.fastActivation == FAST_ACTIV_NONE);
-    CV_Assert(0 <= cs.nspatialdims && cs.nspatialdims <= ConvState::MAX_CONV_DIMS);
+#undef CONV_ADD_NO_RESIDUAL2
+#define CONV_ADD_NO_RESIDUAL2(idx0, idx1) /* empty */
 
-    parallel_for_(Range(0, NK1), [&](const Range& range) {
-        const float* scale_ = scale__;
-        const float* bias_ = bias__;
-        const int32_t* inpofs_ = inpofs__;
-        const int32_t* ofsofs_ = ofsofs__;
-        constexpr int BLOCK_SIZE = 8;
-        int nk0 = range.start, nk1 = range.end;
-        constexpr int C0 = 8, K0 = C0;
-        int planesize = 1, iplanesize = 1, ksize = 1;
-        int nspatialdims = cs.nspatialdims;
-        for (int i = 0; i < nspatialdims; i++) {
-            planesize *= cs.outshape[i + 2];
-            iplanesize *= cs.inpshape[i + 2];
-            ksize *= cs.kshape[ConvState::MAX_CONV_DIMS - nspatialdims + i];
-        }
-        int C1 = cs.inpshape[1], K1 = cs.outshape[1];
-        int ngroups = cs.ngroups, K1g = K1/ngroups, C1g = C1/ngroups;
-        int nC = C1g*ksize*C0*K0;
-        AutoBuffer<float> sumbuf(BLOCK_SIZE*K0*3);
-        float* sum = sumbuf.data();
-        float* scale = sum + BLOCK_SIZE*K0;
-        float* bias = sum + BLOCK_SIZE*K0*2;
-        const float* inptrs[BLOCK_SIZE];
-        const int32_t* ofsptrs[BLOCK_SIZE];
-        FastActivation fastActivation = cs.fastActivation;
-        const float* activParams = cs.activParams;
-        activation_func_t activation = cs.activation;
-        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
-        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
-                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
-        int nlanes = nlanes_;
+#if CV_NEON_AARCH64
 
-        for (int j = 0; j < BLOCK_SIZE*K0; j++) {
-            scale[j] = 1.f;
-            bias[j] = 0.f;
-        }
+/////////////////////////// AARH64-optimized implementation /////////////////////////////
 
-        for (int nk = nk0; nk < nk1; nk++) {
-            int n = nk/K1, k1 = nk - n*K1;
-            int g = k1/K1g;
-            float* out = (float*)out__ + nk*planesize*K0;
-            const float* inp0 = (const float*)inp__ + (n*C1 + g*C1g)*iplanesize*C0;
-            const float* resptr = residual__ ? (const float*)residual__ + nk*planesize*K0 : nullptr;
-            const float* wptr = (const float*)weights__ + k1*nC;
+#undef CONV_INIT_SUMS
+#define CONV_INIT_SUMS() \
+    float32x4_t zz = vdupq_n_f32(0.f); \
+    float32x4_t s0l = zz, s0h = zz, s1l = zz, s1h = zz; \
+    float32x4_t s2l = zz, s2h = zz, s3l = zz, s3h = zz; \
+    float32x4_t s4l = zz, s4h = zz, s5l = zz, s5h = zz; \
+    float32x4_t s6l = zz, s6h = zz, s7l = zz, s7h = zz; \
+    float32x4_t s8l = zz, s8h = zz, s9l = zz, s9h = zz
 
-            if (scale_) {
-                for (int b = 0; b < BLOCK_SIZE; b++)
-                    for (int k = 0; k < K0; k++)
-                        scale[b*K0 + k] = scale_[k1*K0 + k];
-            }
+#undef CONV_UPDATE_BLOCK
+#define CONV_UPDATE_BLOCK(w_ofs, lane) \
+    wl = vld1q_f32(wptr + w_ofs*K0 + 0); \
+    wh = vld1q_f32(wptr + w_ofs*K0 + 4); \
+    s0l = vfmaq_laneq_f32(s0l, wl, x0, lane); \
+    s0h = vfmaq_laneq_f32(s0h, wh, x0, lane); \
+    s1l = vfmaq_laneq_f32(s1l, wl, x1, lane); \
+    s1h = vfmaq_laneq_f32(s1h, wh, x1, lane); \
+    s2l = vfmaq_laneq_f32(s2l, wl, x2, lane); \
+    s2h = vfmaq_laneq_f32(s2h, wh, x2, lane); \
+    s3l = vfmaq_laneq_f32(s3l, wl, x3, lane); \
+    s3h = vfmaq_laneq_f32(s3h, wh, x3, lane); \
+    s4l = vfmaq_laneq_f32(s4l, wl, x4, lane); \
+    s4h = vfmaq_laneq_f32(s4h, wh, x4, lane); \
+    s5l = vfmaq_laneq_f32(s5l, wl, x5, lane); \
+    s5h = vfmaq_laneq_f32(s5h, wh, x5, lane); \
+    s6l = vfmaq_laneq_f32(s6l, wl, x6, lane); \
+    s6h = vfmaq_laneq_f32(s6h, wh, x6, lane); \
+    s7l = vfmaq_laneq_f32(s7l, wl, x7, lane); \
+    s7h = vfmaq_laneq_f32(s7h, wh, x7, lane); \
+    s8l = vfmaq_laneq_f32(s8l, wl, x8, lane); \
+    s8h = vfmaq_laneq_f32(s8h, wh, x8, lane); \
+    s9l = vfmaq_laneq_f32(s9l, wl, x9, lane); \
+    s9h = vfmaq_laneq_f32(s9h, wh, x9, lane)
 
-            if (bias_) {
-                for (int b = 0; b < BLOCK_SIZE; b++)
-                    for (int k = 0; k < K0; k++)
-                        bias[b*K0 + k] = bias_[k1*K0 + k];
-            }
+#undef CONV_UPDATE_LOOP_BODY
+#define CONV_UPDATE_LOOP_BODY() \
+    float32x4_t x0, x1, x2, x3, x4, x5, x6, x7, x8, x9; \
+    float32x4_t wl, wh; \
+    \
+    x0 = vld1q_f32(inptr[0]); \
+    x1 = vld1q_f32(inptr[1]); \
+    x2 = vld1q_f32(inptr[2]); \
+    x3 = vld1q_f32(inptr[3]); \
+    x4 = vld1q_f32(inptr[4]); \
+    x5 = vld1q_f32(inptr[5]); \
+    x6 = vld1q_f32(inptr[6]); \
+    x7 = vld1q_f32(inptr[7]); \
+    x8 = vld1q_f32(inptr[8]); \
+    x9 = vld1q_f32(inptr[9]); \
+    \
+    CONV_UPDATE_BLOCK(0, 0); \
+    CONV_UPDATE_BLOCK(1, 1); \
+    CONV_UPDATE_BLOCK(2, 2); \
+    CONV_UPDATE_BLOCK(3, 3); \
+    \
+    x0 = vld1q_f32(inptr[0] + 4); \
+    x1 = vld1q_f32(inptr[1] + 4); \
+    x2 = vld1q_f32(inptr[2] + 4); \
+    x3 = vld1q_f32(inptr[3] + 4); \
+    x4 = vld1q_f32(inptr[4] + 4); \
+    x5 = vld1q_f32(inptr[5] + 4); \
+    x6 = vld1q_f32(inptr[6] + 4); \
+    x7 = vld1q_f32(inptr[7] + 4); \
+    x8 = vld1q_f32(inptr[8] + 4); \
+    x9 = vld1q_f32(inptr[9] + 4); \
+    \
+    inptr[0] += inpstep[0]; inptr[1] += inpstep[1]; \
+    inptr[2] += inpstep[2]; inptr[3] += inpstep[3]; \
+    inptr[4] += inpstep[4]; inptr[5] += inpstep[5]; \
+    inptr[6] += inpstep[6]; inptr[7] += inpstep[7]; \
+    inptr[8] += inpstep[8]; inptr[9] += inpstep[9]; \
+    \
+    CONV_UPDATE_BLOCK(4, 0); \
+    CONV_UPDATE_BLOCK(5, 1); \
+    CONV_UPDATE_BLOCK(6, 2); \
+    CONV_UPDATE_BLOCK(7, 3)
 
-            for (int xy0 = 0; xy0 < planesize; xy0 += BLOCK_SIZE, out += K0*BLOCK_SIZE,
-                 resptr += (resptr ? K0*BLOCK_SIZE : 0)) {
-                int j = 0, blocksize = std::min(planesize - xy0, BLOCK_SIZE);
+#undef CONV_START_FINALIZE_OUT
+#define CONV_START_FINALIZE_OUT() \
+    float32x4_t vscale_lo = vld1q_f32(scalebuf), vscale_hi = vld1q_f32(scalebuf + 4); \
+    float32x4_t vbias_lo = vld1q_f32(biasbuf), vbias_hi = vld1q_f32(biasbuf + 4); \
+    float32x4_t valpha = vdupq_n_f32(alpha); \
+    float32x4_t vmaxval = vdupq_n_f32(maxval)
 
-                for (; j < blocksize; j++) {
-                    int jj = (xy0 + j)*2;
-                    inptrs[j] = inp0 + ofsofs_[jj];
-                    ofsptrs[j] = inpofs_ + ofsofs_[jj+1];
-                }
+#define CONV_ADD_RESIDUAL2(idx0, idx1) \
+    s##idx0##l = vaddq_f32(s##idx0##l, vld1q_f32(tmpbuf + idx0*K0)); \
+    s##idx0##h = vaddq_f32(s##idx0##h, vld1q_f32(tmpbuf + idx0*K0 + 4)); \
+    s##idx1##l = vaddq_f32(s##idx1##l, vld1q_f32(tmpbuf + idx1*K0)); \
+    s##idx1##h = vaddq_f32(s##idx1##h, vld1q_f32(tmpbuf + idx1*K0 + 4))
 
-                if (j < BLOCK_SIZE) {
-                    const float* last_inptr = inptrs[blocksize-1];
-                    const int32_t* last_ofsptr = ofsptrs[blocksize-1];
-                    for (; j < BLOCK_SIZE; j++) {
-                        inptrs[j] = last_inptr;
-                        ofsptrs[j] = last_ofsptr;
-                    }
-                }
+#undef CONV_FINALIZE_OUT2
+#define CONV_FINALIZE_OUT2(idx0, idx1, add_residual2) \
+    s##idx0##l = vfmaq_f32(vbias_lo, s##idx0##l, vscale_lo); \
+    s##idx0##h = vfmaq_f32(vbias_hi, s##idx0##h, vscale_hi); \
+    s##idx1##l = vfmaq_f32(vbias_lo, s##idx1##l, vscale_lo); \
+    s##idx1##h = vfmaq_f32(vbias_hi, s##idx1##h, vscale_hi); \
+    add_residual2(idx0, idx1); \
+    s##idx0##l = vbslq_f32(vcgeq_f32(s##idx0##l, zz), s##idx0##l, vmulq_f32(s##idx0##l, valpha)); \
+    s##idx0##h = vbslq_f32(vcgeq_f32(s##idx0##h, zz), s##idx0##h, vmulq_f32(s##idx0##h, valpha)); \
+    s##idx1##l = vbslq_f32(vcgeq_f32(s##idx1##l, zz), s##idx1##l, vmulq_f32(s##idx1##l, valpha)); \
+    s##idx1##h = vbslq_f32(vcgeq_f32(s##idx1##h, zz), s##idx1##h, vmulq_f32(s##idx1##h, valpha)); \
+    s##idx0##l = vminq_f32(s##idx0##l, vmaxval); \
+    s##idx0##h = vminq_f32(s##idx0##h, vmaxval); \
+    s##idx1##l = vminq_f32(s##idx1##l, vmaxval); \
+    s##idx1##h = vminq_f32(s##idx1##h, vmaxval); \
+    vst1q_f32(outbuf + idx0*K0, s##idx0##l); \
+    vst1q_f32(outbuf + idx0*K0 + 4, s##idx0##h); \
+    vst1q_f32(outbuf + idx1*K0, s##idx1##l); \
+    vst1q_f32(outbuf + idx1*K0 + 4, s##idx1##h)
 
-#ifdef __ARM_NEON
-                float32x4_t z = vdupq_n_f32(0.f);
-                float32x4_t s00 = z, s01 = z, s10 = z, s11 = z;
-                float32x4_t s20 = z, s21 = z, s30 = z, s31 = z;
-                float32x4_t s40 = z, s41 = z, s50 = z, s51 = z;
-                float32x4_t s60 = z, s61 = z, s70 = z, s71 = z;
-                const int32_t *ofs0 = ofsptrs[0], *ofs1 = ofsptrs[1];
-                const int32_t *ofs2 = ofsptrs[2], *ofs3 = ofsptrs[3];
-                const int32_t *ofs4 = ofsptrs[4], *ofs5 = ofsptrs[5];
-                const int32_t *ofs6 = ofsptrs[6], *ofs7 = ofsptrs[7];
+#undef CONV_FINALIZE_OUT_ALL
+#define CONV_FINALIZE_OUT_ALL() \
+    CONV_START_FINALIZE_OUT(); \
+    if (resptr) { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_RESIDUAL2); \
+    } else { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_NO_RESIDUAL2); \
+    }
 
-                const float *inptr0 = inptrs[0], *inptr1 = inptrs[1];
-                const float *inptr2 = inptrs[2], *inptr3 = inptrs[3];
-                const float *inptr4 = inptrs[4], *inptr5 = inptrs[5];
-                const float *inptr6 = inptrs[6], *inptr7 = inptrs[7];
-
-                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
-                    float32x4_t w00 = vld1q_f32(wptr + c1 + 8*0), w01 = vld1q_f32(wptr + c1 + 8*0 + 4);
-                    float32x4_t w10 = vld1q_f32(wptr + c1 + 8*1), w11 = vld1q_f32(wptr + c1 + 8*1 + 4);
-                    float32x4_t w20 = vld1q_f32(wptr + c1 + 8*2), w21 = vld1q_f32(wptr + c1 + 8*2 + 4);
-                    float32x4_t w30 = vld1q_f32(wptr + c1 + 8*3), w31 = vld1q_f32(wptr + c1 + 8*3 + 4);
-                    float32x4_t w40 = vld1q_f32(wptr + c1 + 8*4), w41 = vld1q_f32(wptr + c1 + 8*4 + 4);
-                    float32x4_t w50 = vld1q_f32(wptr + c1 + 8*5), w51 = vld1q_f32(wptr + c1 + 8*5 + 4);
-                    float32x4_t w60 = vld1q_f32(wptr + c1 + 8*6), w61 = vld1q_f32(wptr + c1 + 8*6 + 4);
-                    float32x4_t w70 = vld1q_f32(wptr + c1 + 8*7), w71 = vld1q_f32(wptr + c1 + 8*7 + 4);
-
-                    int32_t ofs0i, ofs1i, ofs0p, ofs1p;
-                    float m0, m1;
-                    float32x4_t x0, x1;
-
-#undef UPDATE_SUM
-#define UPDATE_SUM(a, b) \
-    ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
-    m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
-    ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
-    x0 = vld1q_f32(inptr##a + ofs0p); \
-    x1 = vld1q_f32(inptr##b + ofs1p); \
-    x0 = vmulq_n_f32(x0, m0); \
-    x1 = vmulq_n_f32(x1, m1); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w00, x0, 0); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w01, x0, 0); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w00, x1, 0); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w01, x1, 0); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w10, x0, 1); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w11, x0, 1); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w10, x1, 1); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w11, x1, 1); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w20, x0, 2); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w21, x0, 2); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w20, x1, 2); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w21, x1, 2); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w30, x0, 3); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w31, x0, 3); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w30, x1, 3); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w31, x1, 3); \
-    x0 = vld1q_f32(inptr##a + ofs0p + 4); \
-    x1 = vld1q_f32(inptr##b + ofs1p + 4); \
-    x0 = vmulq_n_f32(x0, m0); \
-    x1 = vmulq_n_f32(x1, m1); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w40, x0, 0); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w41, x0, 0); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w40, x1, 0); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w41, x1, 0); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w50, x0, 1); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w51, x0, 1); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w50, x1, 1); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w51, x1, 1); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w60, x0, 2); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w61, x0, 2); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w60, x1, 2); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w61, x1, 2); \
-    s##a##0 = vfmaq_laneq_f32(s##a##0, w70, x0, 3); \
-    s##a##1 = vfmaq_laneq_f32(s##a##1, w71, x0, 3); \
-    s##b##0 = vfmaq_laneq_f32(s##b##0, w70, x1, 3); \
-    s##b##1 = vfmaq_laneq_f32(s##b##1, w71, x1, 3)
-
-                    UPDATE_SUM(0, 1);
-                    UPDATE_SUM(2, 3);
-                    UPDATE_SUM(4, 5);
-                    UPDATE_SUM(6, 7);
-                }
-
-                vst1q_f32(sum + 8*0, s00); vst1q_f32(sum + 8*0 + 4, s01);
-                vst1q_f32(sum + 8*1, s10); vst1q_f32(sum + 8*1 + 4, s11);
-                vst1q_f32(sum + 8*2, s20); vst1q_f32(sum + 8*2 + 4, s21);
-                vst1q_f32(sum + 8*3, s30); vst1q_f32(sum + 8*3 + 4, s31);
-                vst1q_f32(sum + 8*4, s40); vst1q_f32(sum + 8*4 + 4, s41);
-                vst1q_f32(sum + 8*5, s50); vst1q_f32(sum + 8*5 + 4, s51);
-                vst1q_f32(sum + 8*6, s60); vst1q_f32(sum + 8*6 + 4, s61);
-                vst1q_f32(sum + 8*7, s70); vst1q_f32(sum + 8*7 + 4, s71);
 #elif CV_SIMD128
-                v_float32 z = vx_setzero_f32();
-                v_float32 s00 = z, s01 = z, s10 = z, s11 = z;
-                v_float32 s20 = z, s21 = z, s30 = z, s31 = z;
-                v_float32 s40 = z, s41 = z, s50 = z, s51 = z;
-                v_float32 s60 = z, s61 = z, s70 = z, s71 = z;
-                const int32_t *ofs0 = ofsptrs[0], *ofs1 = ofsptrs[1];
-                const int32_t *ofs2 = ofsptrs[2], *ofs3 = ofsptrs[3];
-                const int32_t *ofs4 = ofsptrs[4], *ofs5 = ofsptrs[5];
-                const int32_t *ofs6 = ofsptrs[6], *ofs7 = ofsptrs[7];
 
-                const float *inptr0 = inptrs[0], *inptr1 = inptrs[1];
-                const float *inptr2 = inptrs[2], *inptr3 = inptrs[3];
-                const float *inptr4 = inptrs[4], *inptr5 = inptrs[5];
-                const float *inptr6 = inptrs[6], *inptr7 = inptrs[7];
+/////////////////////////// generic branch for arch's with 128-bit SIMD /////////////////////////////
 
-                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
-                    v_float32 w00 = vx_load(wptr + c1 + 8*0), w01 = vx_load(wptr + c1 + 8*0 + 4);
-                    v_float32 w10 = vx_load(wptr + c1 + 8*1), w11 = vx_load(wptr + c1 + 8*1 + 4);
-                    v_float32 w20 = vx_load(wptr + c1 + 8*2), w21 = vx_load(wptr + c1 + 8*2 + 4);
-                    v_float32 w30 = vx_load(wptr + c1 + 8*3), w31 = vx_load(wptr + c1 + 8*3 + 4);
-                    v_float32 w40 = vx_load(wptr + c1 + 8*4), w41 = vx_load(wptr + c1 + 8*4 + 4);
-                    v_float32 w50 = vx_load(wptr + c1 + 8*5), w51 = vx_load(wptr + c1 + 8*5 + 4);
-                    v_float32 w60 = vx_load(wptr + c1 + 8*6), w61 = vx_load(wptr + c1 + 8*6 + 4);
-                    v_float32 w70 = vx_load(wptr + c1 + 8*7), w71 = vx_load(wptr + c1 + 8*7 + 4);
+#undef CONV_INIT_SUMS
+#define CONV_INIT_SUMS() \
+    v_float32x4 zz = v_setzero_f32(); \
+    v_float32x4 s0l = zz, s0h = zz, s1l = zz, s1h = zz; \
+    v_float32x4 s2l = zz, s2h = zz, s3l = zz, s3h = zz; \
+    v_float32x4 s4l = zz, s4h = zz, s5l = zz, s5h = zz; \
+    v_float32x4 s6l = zz, s6h = zz, s7l = zz, s7h = zz; \
+    v_float32x4 s8l = zz, s8h = zz, s9l = zz, s9h = zz
 
-                    int32_t ofs0i, ofs1i, ofs0p, ofs1p;
-                    float m0, m1;
-                    v_float32 x0, x1;
+#undef CONV_UPDATE_BLOCK
+#define CONV_UPDATE_BLOCK2x8(ofs, idx0, idx1) \
+    x0 = v_setall_f32(inptr[idx0][ofs]); \
+    x1 = v_setall_f32(inptr[idx1][ofs]); \
+    s##idx0##l = v_fma(x0, w0l, s##idx0##l); \
+    s##idx0##h = v_fma(x0, w0h, s##idx0##h); \
+    s##idx1##l = v_fma(x1, w0l, s##idx1##l); \
+    s##idx1##h = v_fma(x1, w0h, s##idx1##h); \
+    x0 = v_setall_f32(inptr[idx0][ofs+1]); \
+    x1 = v_setall_f32(inptr[idx1][ofs+1]); \
+    s##idx0##l = v_fma(x0, w1l, s##idx0##l); \
+    s##idx0##h = v_fma(x0, w1h, s##idx0##h); \
+    s##idx1##l = v_fma(x1, w1l, s##idx1##l); \
+    s##idx1##h = v_fma(x1, w1h, s##idx1##h); \
+    x0 = v_setall_f32(inptr[idx0][ofs+2]); \
+    x1 = v_setall_f32(inptr[idx1][ofs+2]); \
+    s##idx0##l = v_fma(x0, w2l, s##idx0##l); \
+    s##idx0##h = v_fma(x0, w2h, s##idx0##h); \
+    s##idx1##l = v_fma(x1, w2l, s##idx1##l); \
+    s##idx1##h = v_fma(x1, w2h, s##idx1##h); \
+    x0 = v_setall_f32(inptr[idx0][ofs+3]); \
+    x1 = v_setall_f32(inptr[idx1][ofs+3]); \
+    s##idx0##l = v_fma(x0, w3l, s##idx0##l); \
+    s##idx0##h = v_fma(x0, w3h, s##idx0##h); \
+    s##idx1##l = v_fma(x1, w3l, s##idx1##l); \
+    s##idx1##h = v_fma(x1, w3h, s##idx1##h)
 
-#undef UPDATE_SUM
-#define UPDATE_SUM(a, b) \
-    ofs0i = ofs##a[i]; ofs1i = ofs##b[i]; \
-    m0 = float(ofs0i >= 0); m1 = float(ofs1i >= 0); \
-    ofs0p = std::max(ofs0i, 0); ofs1p = std::max(ofs1i, 0); \
-    x0 = vx_setall_f32(inptr##a[ofs0p]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p]*m1); \
-    s##a##0 = v_fma(w00, x0, s##a##0); \
-    s##a##1 = v_fma(w01, x0, s##a##1); \
-    s##b##0 = v_fma(w00, x1, s##b##0); \
-    s##b##1 = v_fma(w01, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+1]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+1]*m1); \
-    s##a##0 = v_fma(w10, x0, s##a##0); \
-    s##a##1 = v_fma(w11, x0, s##a##1); \
-    s##b##0 = v_fma(w10, x1, s##b##0); \
-    s##b##1 = v_fma(w11, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+2]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+2]*m1); \
-    s##a##0 = v_fma(w20, x0, s##a##0); \
-    s##a##1 = v_fma(w21, x0, s##a##1); \
-    s##b##0 = v_fma(w20, x1, s##b##0); \
-    s##b##1 = v_fma(w21, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+3]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+3]*m1); \
-    s##a##0 = v_fma(w30, x0, s##a##0); \
-    s##a##1 = v_fma(w31, x0, s##a##1); \
-    s##b##0 = v_fma(w30, x1, s##b##0); \
-    s##b##1 = v_fma(w31, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+4]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+4]*m1); \
-    s##a##0 = v_fma(w40, x0, s##a##0); \
-    s##a##1 = v_fma(w41, x0, s##a##1); \
-    s##b##0 = v_fma(w40, x1, s##b##0); \
-    s##b##1 = v_fma(w41, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+5]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+5]*m1); \
-    s##a##0 = v_fma(w50, x0, s##a##0); \
-    s##a##1 = v_fma(w51, x0, s##a##1); \
-    s##b##0 = v_fma(w50, x1, s##b##0); \
-    s##b##1 = v_fma(w51, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+6]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+6]*m1); \
-    s##a##0 = v_fma(w60, x0, s##a##0); \
-    s##a##1 = v_fma(w61, x0, s##a##1); \
-    s##b##0 = v_fma(w60, x1, s##b##0); \
-    s##b##1 = v_fma(w61, x1, s##b##1); \
-    x0 = vx_setall_f32(inptr##a[ofs0p+7]*m0); \
-    x1 = vx_setall_f32(inptr##b[ofs1p+7]*m1); \
-    s##a##0 = v_fma(w70, x0, s##a##0); \
-    s##a##1 = v_fma(w71, x0, s##a##1); \
-    s##b##0 = v_fma(w70, x1, s##b##0); \
-    s##b##1 = v_fma(w71, x1, s##b##1)
+#undef CONV_UPDATE_LOOP_BODY
+#define CONV_UPDATE_LOOP_BODY() \
+    v_float32x4 x0, x1; \
+    v_float32x4 w0l, w0h, w1l, w1h, w2l, w2h, w3l, w3h; \
+    \
+    w0l = v_load(wptr + 0*K0); w0h = v_load(wptr + 0*K0 + 4); \
+    w1l = v_load(wptr + 1*K0); w1h = v_load(wptr + 1*K0 + 4); \
+    w2l = v_load(wptr + 2*K0); w2h = v_load(wptr + 2*K0 + 4); \
+    w3l = v_load(wptr + 3*K0); w3h = v_load(wptr + 3*K0 + 4); \
+    \
+    CONV_UPDATE_BLOCK2x8(0, 0, 1); \
+    CONV_UPDATE_BLOCK2x8(0, 2, 3); \
+    CONV_UPDATE_BLOCK2x8(0, 4, 5); \
+    CONV_UPDATE_BLOCK2x8(0, 6, 7); \
+    CONV_UPDATE_BLOCK2x8(0, 8, 9); \
+    \
+    w0l = v_load(wptr + 4*K0); w0h = v_load(wptr + 4*K0 + 4); \
+    w1l = v_load(wptr + 5*K0); w1h = v_load(wptr + 5*K0 + 4); \
+    w2l = v_load(wptr + 6*K0); w2h = v_load(wptr + 6*K0 + 4); \
+    w3l = v_load(wptr + 7*K0); w3h = v_load(wptr + 7*K0 + 4); \
+    \
+    CONV_UPDATE_BLOCK2x8(4, 0, 1); \
+    CONV_UPDATE_BLOCK2x8(4, 2, 3); \
+    CONV_UPDATE_BLOCK2x8(4, 4, 5); \
+    CONV_UPDATE_BLOCK2x8(4, 6, 7); \
+    CONV_UPDATE_BLOCK2x8(4, 8, 9); \
+    \
+    inptr[0] += inpstep[0]; inptr[1] += inpstep[1]; \
+    inptr[2] += inpstep[2]; inptr[3] += inpstep[3]; \
+    inptr[4] += inpstep[4]; inptr[5] += inpstep[5]; \
+    inptr[6] += inpstep[6]; inptr[7] += inpstep[7]; \
+    inptr[8] += inpstep[8]; inptr[9] += inpstep[9]
 
-                    UPDATE_SUM(0, 1);
-                    UPDATE_SUM(2, 3);
-                    UPDATE_SUM(4, 5);
-                    UPDATE_SUM(6, 7);
-                }
+#undef CONV_START_FINALIZE_OUT
+#define CONV_START_FINALIZE_OUT() \
+    v_float32x4 vscale_lo = v_load(scalebuf), vscale_hi = v_load(scalebuf + 4); \
+    v_float32x4 vbias_lo = v_load(biasbuf), vbias_hi = v_load(biasbuf + 4); \
+    v_float32x4 valpha = v_setall_f32(alpha); \
+    v_float32x4 vmaxval = v_setall_f32(maxval)
 
-                vx_store(sum + 8*0, s00); vx_store(sum + 8*0 + 4, s01);
-                vx_store(sum + 8*1, s10); vx_store(sum + 8*1 + 4, s11);
-                vx_store(sum + 8*2, s20); vx_store(sum + 8*2 + 4, s21);
-                vx_store(sum + 8*3, s30); vx_store(sum + 8*3 + 4, s31);
-                vx_store(sum + 8*4, s40); vx_store(sum + 8*4 + 4, s41);
-                vx_store(sum + 8*5, s50); vx_store(sum + 8*5 + 4, s51);
-                vx_store(sum + 8*6, s60); vx_store(sum + 8*6 + 4, s61);
-                vx_store(sum + 8*7, s70); vx_store(sum + 8*7 + 4, s71);
+#define CONV_ADD_RESIDUAL2(idx0, idx1) \
+    s##idx0##l = v_add(s##idx0##l, v_load(tmpbuf + idx0*K0)); \
+    s##idx0##h = v_add(s##idx0##h, v_load(tmpbuf + idx0*K0 + 4)); \
+    s##idx1##l = v_add(s##idx1##l, v_load(tmpbuf + idx1*K0)); \
+    s##idx1##h = v_add(s##idx1##h, v_load(tmpbuf + idx1*K0 + 4))
+
+#undef CONV_FINALIZE_OUT2
+#define CONV_FINALIZE_OUT2(idx0, idx1, add_residual2) \
+    s##idx0##l = v_fma(s##idx0##l, vscale_lo, vbias_lo); \
+    s##idx0##h = v_fma(s##idx0##h, vscale_hi, vbias_hi); \
+    s##idx1##l = v_fma(s##idx1##l, vscale_lo, vbias_lo); \
+    s##idx1##h = v_fma(s##idx1##h, vscale_hi, vbias_hi); \
+    add_residual2(idx0, idx1); \
+    s##idx0##l = v_select(v_ge(s##idx0##l, zz), s##idx0##l, v_mul(s##idx0##l, valpha)); \
+    s##idx0##h = v_select(v_ge(s##idx0##h, zz), s##idx0##h, v_mul(s##idx0##h, valpha)); \
+    s##idx1##l = v_select(v_ge(s##idx1##l, zz), s##idx1##l, v_mul(s##idx1##l, valpha)); \
+    s##idx1##h = v_select(v_ge(s##idx1##h, zz), s##idx1##h, v_mul(s##idx1##h, valpha)); \
+    s##idx0##l = v_min(s##idx0##l, vmaxval); \
+    s##idx0##h = v_min(s##idx0##h, vmaxval); \
+    s##idx1##l = v_min(s##idx1##l, vmaxval); \
+    s##idx1##h = v_min(s##idx1##h, vmaxval); \
+    v_store(outbuf + idx0*K0, s##idx0##l); \
+    v_store(outbuf + idx0*K0 + 4, s##idx0##h); \
+    v_store(outbuf + idx1*K0, s##idx1##l); \
+    v_store(outbuf + idx1*K0 + 4, s##idx1##h)
+
+#undef CONV_FINALIZE_OUT_ALL
+#define CONV_FINALIZE_OUT_ALL() \
+    CONV_START_FINALIZE_OUT(); \
+    if (resptr) { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_RESIDUAL2); \
+    } else { \
+        CONV_FINALIZE_OUT2(0, 1, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(2, 3, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(4, 5, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(6, 7, CONV_ADD_NO_RESIDUAL2); \
+        CONV_FINALIZE_OUT2(8, 9, CONV_ADD_NO_RESIDUAL2); \
+    }
+
 #else
-                for (int i = 0; i < BLOCK_SIZE*K0; i++)
-                    sum[i] = 0.f;
 
-                for (int c1 = 0, i = 0; c1 < nC; c1 += K0*C0, i++) {
-                    for (j = 0; j < BLOCK_SIZE; j++) {
-                        int32_t ofs_ij = ofsptrs[j][i];
-                        const float* x = &inptrs[j][std::max(ofs_ij, 0)];
-                        float mij = (float)(ofs_ij >= 0);
-                        for (int c0 = 0; c0 < C0; c0++) {
-                            float xc = x[c0]*mij;
-                            for (int k = 0; k < K0; k++) {
-                                float w = wptr[c1 + c0*K0 + k];
-                                sum[K0*j + k] += xc*w;
-                            }
-                        }
-                    }
-                }
+#undef CONV_ENABLE_SIMD
+
 #endif
 
-                if (activation) {
-                    if (resptr) {
-                        j = 0;
-                    #if CV_SIMD || CV_SIMD_SCALABLE
-                        for (; j <= blocksize*K0 - nlanes*2; j += nlanes*2) {
-                            v_float32 v0 = vx_load(sum + j);
-                            v_float32 v1 = vx_load(sum + j + nlanes);
-                            v_float32 scale0 = vx_load(scale + j);
-                            v_float32 scale1 = vx_load(scale + j + nlanes);
-                            v_float32 bias0 = vx_load(bias + j);
-                            v_float32 bias1 = vx_load(bias + j + nlanes);
-                            v_float32 res0 = vx_load(resptr + j);
-                            v_float32 res1 = vx_load(resptr + j + nlanes);
-                            v0 = v_fma(v0, scale0, v_add(bias0, res0));
-                            v1 = v_fma(v1, scale1, v_add(bias1, res1));
-                            vx_store(sum + j, v0);
-                            vx_store(sum + j + nlanes, v1);
-                        }
-                    #endif
-                        for (; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
-                            sum[j] = v;
-                        }
-                    } else {
-                        j = 0;
-                    #if CV_SIMD || CV_SIMD_SCALABLE
-                        for (; j <= blocksize*K0 - nlanes*2; j += nlanes*2) {
-                            v_float32 v0 = vx_load(sum + j);
-                            v_float32 v1 = vx_load(sum + j + nlanes);
-                            v_float32 scale0 = vx_load(scale + j);
-                            v_float32 scale1 = vx_load(scale + j + nlanes);
-                            v_float32 bias0 = vx_load(bias + j);
-                            v_float32 bias1 = vx_load(bias + j + nlanes);
-                            v0 = v_fma(v0, scale0, bias0);
-                            v1 = v_fma(v1, scale1, bias1);
-                            vx_store(sum + j, v0);
-                            vx_store(sum + j + nlanes, v1);
-                        }
-                    #endif
-                        for (; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j];
-                            sum[j] = v;
-                        }
-                    }
-                    activation(sum, out, blocksize*K0, activParams);
-                } else {
-                    if (resptr) {
-                        j = 0;
-                    #if CV_SIMD || CV_SIMD_SCALABLE
-                        v_float32 valpha = v_setall_f32(alpha);
-                        v_float32 vmaxval = v_setall_f32(maxval);
-                        v_float32 vzero = v_setzero_f32();
-                        
-                        for (; j < blocksize*K0; j += nlanes*2) {
-                            if (j + nlanes*2 > blocksize*K0) {
-                                if (j == 0)
-                                    break;
-                                j = blocksize*K0 - nlanes*2;
-                            }
-                            v_float32 v0 = vx_load(sum + j);
-                            v_float32 v1 = vx_load(sum + j + nlanes);
-                            v_float32 scale0 = vx_load(scale + j);
-                            v_float32 scale1 = vx_load(scale + j + nlanes);
-                            v_float32 bias0 = vx_load(bias + j);
-                            v_float32 bias1 = vx_load(bias + j + nlanes);
-                            v_float32 res0 = vx_load(resptr + j);
-                            v_float32 res1 = vx_load(resptr + j + nlanes);
-                            v0 = v_fma(v0, scale0, v_add(bias0, res0));
-                            v1 = v_fma(v1, scale1, v_add(bias1, res1));
-                            v0 = v_min(v_select(v_ge(v0, vzero), v0, v_mul(v0, valpha)), vmaxval);
-                            v1 = v_min(v_select(v_ge(v1, vzero), v1, v_mul(v1, valpha)), vmaxval);
-                            vx_store(out + j, v0);
-                            vx_store(out + j + nlanes, v1);
-                        }
-                    #endif
-                        for (; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j] + resptr[j];
-                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
-                            out[j] = v;
-                        }
-                    } else {
-                        j = 0;
-                    #if CV_SIMD || CV_SIMD_SCALABLE
-                        v_float32 valpha = v_setall_f32(alpha);
-                        v_float32 vmaxval = v_setall_f32(maxval);
-                        v_float32 vzero = v_setzero_f32();
-                        
-                        for (; j < blocksize*K0; j += nlanes*2) {
-                            if (j + nlanes*2 > blocksize*K0) {
-                                if (j == 0)
-                                    break;
-                                j = blocksize*K0 - nlanes*2;
-                            }
-                            v_float32 v0 = vx_load(sum + j);
-                            v_float32 v1 = vx_load(sum + j + nlanes);
-                            v_float32 scale0 = vx_load(scale + j);
-                            v_float32 scale1 = vx_load(scale + j + nlanes);
-                            v_float32 bias0 = vx_load(bias + j);
-                            v_float32 bias1 = vx_load(bias + j + nlanes);
-                            v0 = v_fma(v0, scale0, bias0);
-                            v1 = v_fma(v1, scale1, bias1);
-                            v0 = v_min(v_select(v_ge(v0, vzero), v0, v_mul(v0, valpha)), vmaxval);
-                            v1 = v_min(v_select(v_ge(v1, vzero), v1, v_mul(v1, valpha)), vmaxval);
-                            vx_store(out + j, v0);
-                            vx_store(out + j + nlanes, v1);
-                        }
-                    #endif
-                        for (; j < blocksize*K0; j++) {
-                            float v = sum[j]*scale[j] + bias[j];
-                            v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
-                            out[j] = v;
-                        }
-                    }
-                }
-            }
-        }
-    });
-}
-
-#undef __ARM_NEON
-
-static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
-                         const ConvState& cs, const void* weights__,
-                         const float* scale__, const float* bias__,
-                         const int32_t* inpofs__, const int32_t* ofsofs__)
+static void conv32fC8(const void* inp__, const void* residual__, void* out__,
+                      const ConvState& cs, const void* weights__,
+                      const float* scale__, const float* bias__)
 {
     using FT = float;
     constexpr int C0shift = 3, K0shift = C0shift;
@@ -454,36 +299,22 @@ static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
     constexpr int K0 = C0;
     const MatShape& inpshape = cs.inpshape;
     const MatShape& outshape = cs.outshape;
-    
+
     CV_Assert_N(inpshape.layout == DATA_LAYOUT_BLOCK, outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert_N(inpshape.back() == C0, outshape.back() == K0);
-    CV_Assert(!scale__ && !residual__ && cs.fastActivation == FAST_ACTIV_NONE && !cs.activation);
-    
-    int N = inpshape[0];
-    
-    int ksize_ = 1;
-    for (int i = 0; i < ConvState::MAX_CONV_DIMS; i++)
-        ksize_ *= cs.kshape[i];
-    
-    int Dk_ = cs.kshape[0], Hk_ = cs.kshape[1], Wk_ = cs.kshape[2];
 
-    // precompute (oz,oy,ox) for each i
-    AutoBuffer<int> ofsZYXbuf(ksize_ * 3);
-    for (int zk = 0, i3 = 0; zk < Dk_; zk++) {
-        int oz = zk * cs.dilations[0] - cs.pads[0];
-        for (int yk = 0; yk < Hk_; yk++) {
-            int oy = yk * cs.dilations[1] - cs.pads[1];
-            for (int xk = 0; xk < Wk_; xk++, i3 += 3) {
-                int ox = xk * cs.dilations[2] - cs.pads[2];
-                ofsZYXbuf[i3] = oz;
-                ofsZYXbuf[i3 + 1] = oy;
-                ofsZYXbuf[i3 + 2] = ox;
-            }
-        }
-    }
+    int K_ = outshape.channels();
+    int N = inpshape[0];
 
     const int total_blocks = N * cs.ngroups * cs.Kblk;
-    memset(out__, 0, outshape.total()*sizeof(FT));
+
+    if ((K_/cs.ngroups) % K0 != 0) {
+        // if there could be 'padding' channels in the output,
+        // clear the output before the parallel loop
+        // to make sure that all the padding channels are cleared.
+        size_t outtotal = outshape.total()*sizeof(FT);
+        memset(out__, 0, outtotal);
+    }
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
         constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
@@ -492,28 +323,53 @@ static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
         const int ngroups = cs.ngroups, Kblk = cs.Kblk, C1Max = cs.C1Max;
         const int Cg = C / ngroups;
         const int Kg = K / ngroups;
-        int ksize = ksize_;
+        int ksize = 1;
+        for (int i = 0; i < MAX_CONV_DIMS; i++)
+            ksize *= cs.kshape[i];
         int ndims = inpshape.dims;
-        const int D = ndims >= 6 ? outshape[ndims-4] : 1;
-        const int H = ndims >= 5 ? outshape[ndims-3] : 1;
-        const int W = outshape[ndims-2];
-        const int Di = ndims >= 6 ? inpshape[ndims-4] : 1;
-        const int Hi = ndims >= 5 ? inpshape[ndims-3] : 1;
-        const int Wi = inpshape[ndims-2];
-        //const int Dk = cs.kshape[0], Hk = cs.kshape[1], Wk = cs.kshape[2];
+        int D = ndims >= 6 ? outshape[ndims-4] : 1;
+        int H = ndims >= 5 ? outshape[ndims-3] : 1;
+        int W = outshape[ndims-2];
+        int Di = ndims >= 6 ? inpshape[ndims-4] : 1;
+        int Hi = ndims >= 5 ? inpshape[ndims-3] : 1;
+        int Wi = inpshape[ndims-2];
         const int Sz = cs.strides[0], Sy = cs.strides[1], Sx = cs.strides[2];
-        //const int Dz = cs.dilations[0], Dy = cs.dilations[1], Dx = cs.dilations[2];
-        //const int padZ = cs.pads[0], padY = cs.pads[1], padX = cs.pads[2];
+        const int padZ = cs.pads[0], padY = cs.pads[1], padX = cs.pads[2];
+        const float* scaleptr = (const float*)scale__;
         const float* biasptr = (const float*)bias__;
-        const int* ofsZYX = ofsZYXbuf.data();
-        int planesize = D*H*W*K0;
+        const int* ofsZYX = cs.coordtab.data();
+        int planeblocks = D*H*W;
+        int planesize = planeblocks*K0;
         int iplanesize = Di*Hi*Wi*C0;
-        
+
+    #if CONV_ENABLE_SIMD
         int innerZ0 = cs.inner[0], innerZ1 = cs.inner[MAX_CONV_DIMS];
         int innerY0 = cs.inner[1], innerY1 = cs.inner[MAX_CONV_DIMS+1];
         int innerX0 = cs.inner[2], innerX1 = cs.inner[MAX_CONV_DIMS+2];
-        
-        for (int t = range.start; t < range.end; ++t) {
+        float zbuf[C0] = {};
+    #endif
+
+        FastActivation fastActivation = cs.fastActivation;
+        const float* activParams = cs.activParams;
+        activation_func_t activation = cs.activation;
+        float maxval = fastActivation == FAST_ACTIV_CLIP ? activParams[1] : FLT_MAX;
+        float alpha = fastActivation == FAST_ACTIV_LEAKY_RELU ? activParams[0] :
+                    fastActivation == FAST_ACTIV_NONE ? 1.f : 0.f;
+        float scalebuf[K0], biasbuf[K0];
+
+        // 1x1x1 convolution with (1,1,1) strides:
+        // flatten input/output tensors in this case to accelerate address computations
+        if (ksize == 1 && Sz*Sy*Sx == 1) {
+            W *= D*H;
+            Wi *= Di*Hi;
+            D = Di = H = Hi = 1;
+        #if CONV_ENABLE_SIMD
+            innerZ1 = innerY1 = 1;
+            innerX1 = W;
+        #endif
+        }
+
+        for (int t = range.start; t < range.end; t++) {
             const int n = t / (ngroups * Kblk);
             const int rem = t - n * (ngroups * Kblk);
             const int g = rem / Kblk;
@@ -523,198 +379,237 @@ static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
             if (k_base >= K) continue;
 
             const int k_count = std::min(std::min(K0, Kg - kblk*K0), K - k_base);
-            //printf("(%d,%d). t=%d, n=%d, g=%d, kblk=%d, k_base=%d, k_count=%d\n", begin, end, t, n, g, kblk, k_base, k_count);
+            bool aligned_k = (k_base & (K0-1)) == 0 && k_count == K0;
 
             const int c_start  = g * Cg;
             const int c00      = c_start & (C0-1);
             const int c1_start = c_start >> C0shift;
             const int cblocks  = (c00 + Cg + C0 - 1) >> C0shift;
-            const float* inptr0 = (float*)inp__ + (n * C1 + c1_start) * iplanesize;
-            const float* wptr0 = (float*)weights__ + (g*Kblk + kblk)*(ksize*C1Max*C0*K0);
-            const int b_count = biasptr ? k_count : 0;
+            const float* inpbaseptr = (float*)inp__ + (n * C1 + c1_start) * iplanesize;
+            const float* wbaseptr = (float*)weights__ + (g*Kblk + kblk)*(ksize*C1Max*C0*K0);
 
-#ifdef __ARM_NEON
-            float32x4_t vbias_lo = {
-                (b_count > 0) ? biasptr[k_base + 0] : 0.0f,
-                (b_count > 1) ? biasptr[k_base + 1] : 0.0f,
-                (b_count > 2) ? biasptr[k_base + 2] : 0.0f,
-                (b_count > 3) ? biasptr[k_base + 3] : 0.0f
-            };
-            float32x4_t vbias_hi = {
-                (b_count > 4) ? biasptr[k_base + 4] : 0.0f,
-                (b_count > 5) ? biasptr[k_base + 5] : 0.0f,
-                (b_count > 6) ? biasptr[k_base + 6] : 0.0f,
-                (b_count > 7) ? biasptr[k_base + 7] : 0.0f
-            };
-            const int xi_step = Sx * C0;
-#endif
+            {
+                int kk = 0;
+                for (; kk < k_count; kk++) {
+                    scalebuf[kk] = scaleptr ? scaleptr[k_base + kk] : 1.f;
+                    biasbuf[kk] = biasptr ? biasptr[k_base + kk] : 0.f;
+                }
+                for (; kk < K0; kk++) {
+                    scalebuf[kk] = 0.f;
+                    biasbuf[kk] = 0.f;
+                }
+            }
 
-            for (int z = 0; z < D; z++) {
-                const int zi_base = z * Sz;
-                const bool z_inner = (z >= innerZ0 && z < innerZ1);
+            constexpr int SPAT_BLOCK_SIZE = 10;
+            float* outptr = (float*)out__ + n*(K1*planesize);
+            const float* resptr = residual__ ? (float*)residual__ + n*(K1*planesize) : nullptr;
+            float tmpbuf[SPAT_BLOCK_SIZE*K0] = {};
+            int p = 0;
 
-                for (int y = 0; y < H; y++) {
-                    const int yi_base = y * Sy;
-                    const bool zy_inner = z_inner && (y >= innerY0 && y < innerY1);
+        #if CONV_ENABLE_SIMD
+            for (; p < planeblocks; p += SPAT_BLOCK_SIZE,
+                                    outptr += SPAT_BLOCK_SIZE*K0)
+            {
+                Vec3i pt[SPAT_BLOCK_SIZE];
+                bool inner[SPAT_BLOCK_SIZE];
 
-                    int dx = 1;
-                    float* outptr0 = (float*)out__ + n*(K1*planesize) + (z*H + y)*(W*K0);
+                if (p + SPAT_BLOCK_SIZE > planeblocks) {
+                    if (p == 0)
+                        break;
+                    int p_new = planeblocks - SPAT_BLOCK_SIZE;
+                    int dp = p_new - p;
+                    outptr += dp*K0;
+                    resptr += (resptr ? dp*K0 : 0);
+                    p = p_new;
+                }
 
-                    for (int x = 0; x < W; x += dx) {
-                        float* outptr = outptr0 + x*K0;
-                        const int xi_base = x * Sx;
-
-#ifdef __ARM_NEON
-                        const int SPAT_BLOCK_SIZE = 6;
-                        if (zy_inner &&
-                            innerX0 <= x &&
-                            x + SPAT_BLOCK_SIZE <= innerX1) {
-                            dx = SPAT_BLOCK_SIZE;
-
-                            float32x4_t acc0_lo = vbias_lo, acc0_hi = vbias_hi;
-                            float32x4_t acc1_lo = vbias_lo, acc1_hi = vbias_hi;
-                            float32x4_t acc2_lo = vbias_lo, acc2_hi = vbias_hi;
-                            float32x4_t acc3_lo = vbias_lo, acc3_hi = vbias_hi;
-                            float32x4_t acc4_lo = vbias_lo, acc4_hi = vbias_hi;
-                            float32x4_t acc5_lo = vbias_lo, acc5_hi = vbias_hi;
-
-                            for (int i = 0; i < ksize; ++i) {
-                                const int zi = zi_base + ofsZYX[i * 3 + 0];
-                                const int yi = yi_base + ofsZYX[i * 3 + 1];
-                                const int xi = xi_base + ofsZYX[i * 3 + 2];
-
-                                const float* inptr = inptr0 + (((zi * Hi) + yi) * Wi + xi) * C0;
-                                const float* wptr = wptr0 + i*C1Max*K0*C0;
-
-                                for (int c1 = 0; c1 < cblocks; ++c1, wptr += C0*K0, inptr += iplanesize) {
-                                    float32x4_t x0_lo = vld1q_f32(inptr + 0);
-                                    float32x4_t x0_hi = vld1q_f32(inptr + 4);
-                                    float32x4_t x1_lo = vld1q_f32(inptr + xi_step + 0);
-                                    float32x4_t x1_hi = vld1q_f32(inptr + xi_step + 4);
-                                    float32x4_t x2_lo = vld1q_f32(inptr + xi_step*2 + 0);
-                                    float32x4_t x2_hi = vld1q_f32(inptr + xi_step*2 + 4);
-                                    float32x4_t x3_lo = vld1q_f32(inptr + xi_step*3 + 0);
-                                    float32x4_t x3_hi = vld1q_f32(inptr + xi_step*3 + 4);
-                                    float32x4_t x4_lo = vld1q_f32(inptr + xi_step*4 + 0);
-                                    float32x4_t x4_hi = vld1q_f32(inptr + xi_step*4 + 4);
-                                    float32x4_t x5_lo = vld1q_f32(inptr + xi_step*5 + 0);
-                                    float32x4_t x5_hi = vld1q_f32(inptr + xi_step*5 + 4);
-                                    float32x4_t w_lo, w_hi;
-
-#undef ACCROW6
-#define ACCROW6(w_ofs, suffix, lane) \
-    w_lo = vld1q_f32(wptr + w_ofs*K0 + 0); \
-    w_hi = vld1q_f32(wptr + w_ofs*K0 + 4); \
-    acc0_lo = vfmaq_laneq_f32(acc0_lo, w_lo, x0_##suffix, lane); \
-    acc0_hi = vfmaq_laneq_f32(acc0_hi, w_hi, x0_##suffix, lane); \
-    acc1_lo = vfmaq_laneq_f32(acc1_lo, w_lo, x1_##suffix, lane); \
-    acc1_hi = vfmaq_laneq_f32(acc1_hi, w_hi, x1_##suffix, lane); \
-    acc2_lo = vfmaq_laneq_f32(acc2_lo, w_lo, x2_##suffix, lane); \
-    acc2_hi = vfmaq_laneq_f32(acc2_hi, w_hi, x2_##suffix, lane); \
-    acc3_lo = vfmaq_laneq_f32(acc3_lo, w_lo, x3_##suffix, lane); \
-    acc3_hi = vfmaq_laneq_f32(acc3_hi, w_hi, x3_##suffix, lane); \
-    acc4_lo = vfmaq_laneq_f32(acc4_lo, w_lo, x4_##suffix, lane); \
-    acc4_hi = vfmaq_laneq_f32(acc4_hi, w_hi, x4_##suffix, lane); \
-    acc5_lo = vfmaq_laneq_f32(acc5_lo, w_lo, x5_##suffix, lane); \
-    acc5_hi = vfmaq_laneq_f32(acc5_hi, w_hi, x5_##suffix, lane); \
-
-                                    ACCROW6(0, lo, 0);
-                                    ACCROW6(1, lo, 1);
-                                    ACCROW6(2, lo, 2);
-                                    ACCROW6(3, lo, 3);
-
-                                    ACCROW6(4, hi, 0);
-                                    ACCROW6(5, hi, 1);
-                                    ACCROW6(6, hi, 2);
-                                    ACCROW6(7, hi, 3);
-                                }
-                            }
-
-                            float tmp[SPAT_BLOCK_SIZE*C0];
-                            vst1q_f32(tmp + 0, acc0_lo); vst1q_f32(tmp + 4, acc0_hi);
-                            vst1q_f32(tmp + 8, acc1_lo); vst1q_f32(tmp + 8 + 4, acc1_hi);
-                            vst1q_f32(tmp + 8*2, acc2_lo); vst1q_f32(tmp + 8*2 + 4, acc2_hi);
-                            vst1q_f32(tmp + 8*3, acc3_lo); vst1q_f32(tmp + 8*3 + 4, acc3_hi);
-                            vst1q_f32(tmp + 8*4, acc4_lo); vst1q_f32(tmp + 8*4 + 4, acc4_hi);
-                            vst1q_f32(tmp + 8*5, acc5_lo); vst1q_f32(tmp + 8*5 + 4, acc5_hi);
-
-                            for (int kk = 0; kk < k_count; ++kk) {
-                                const int k = k_base + kk;
-                                int kofs = (k >> K0shift) * planesize + (k & (K0-1));
-                                outptr[kofs + 0 * 8] = tmp[kk];
-                                outptr[kofs + 1 * 8] = tmp[kk+8];
-                                outptr[kofs + 2 * 8] = tmp[kk+8*2];
-                                outptr[kofs + 3 * 8] = tmp[kk+8*3];
-                                outptr[kofs + 4 * 8] = tmp[kk+8*4];
-                                outptr[kofs + 5 * 8] = tmp[kk+8*5];
-                            }
-
-                            continue;
-                        }
-#endif
-                        dx = 1;
-
-                        float accs[8];
-
-#ifdef __ARM_NEON
-                        float32x4_t acc0 = vbias_lo, acc1 = vbias_hi;
-#else
-                        for (int kk = 0; kk < K0; ++kk)
-                            accs[kk] = (kk < b_count) ? biasptr[k_base + kk] : 0.0f;
-#endif
-
-                        for (int i = 0; i < ksize; ++i) {
-                            size_t i3 = size_t(i)*3u;
-                            const int zi = zi_base + ofsZYX[i3 + 0];
-                            const int yi = yi_base + ofsZYX[i3 + 1];
-                            const int xi = xi_base + ofsZYX[i3 + 2];
-                            if ((((unsigned)zi >= (unsigned)Di) |
-                                ((unsigned)yi >= (unsigned)Hi) |
-                                ((unsigned)xi >= (unsigned)Wi)) != 0)
-                                continue;
-
-                            const float* inptr = inptr0 + (((zi * Hi) + yi) * Wi + xi) * C0;
-                            const float* wptr = wptr0 + i*C1Max*K0*C0;
-
-#ifdef __ARM_NEON
-                            for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
-                                float32x4_t x0 = vld1q_f32(inptr), x1 = vld1q_f32(inptr + 4);
-                                float32x4_t w0, w1;
-#undef ACCROW1
-#define ACCROW1(w_ofs, idx, lane) \
-    w0 = vld1q_f32(wptr + w_ofs*K0); \
-    w1 = vld1q_f32(wptr + w_ofs*K0 + 4); \
-    acc0 = vfmaq_laneq_f32(acc0, w0, x##idx, lane); \
-    acc1 = vfmaq_laneq_f32(acc1, w1, x##idx, lane)
-
-                                ACCROW1(0, 0, 0);
-                                ACCROW1(1, 0, 1);
-                                ACCROW1(2, 0, 2);
-                                ACCROW1(3, 0, 3);
-                                ACCROW1(4, 1, 0);
-                                ACCROW1(5, 1, 1);
-                                ACCROW1(6, 1, 2);
-                                ACCROW1(7, 1, 3);
-                            }
-#else
-                            for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
-                                for (int c0 = 0; c0 < C0; ++c0) {
-                                    const float xval = inptr[c0];
-                                    for (int kk = 0; kk < K0; ++kk)
-                                        accs[kk] += xval * wptr[c0*K0 + kk];
-                                }
-                            }
-#endif
-                        }
-#ifdef __ARM_NEON
-                        vst1q_f32(accs, acc0);
-                        vst1q_f32(accs + 4, acc1);
-#endif
+                if (resptr) {
+                    if (aligned_k) {
+                        memcpy(tmpbuf, resptr + k_base*planeblocks, SPAT_BLOCK_SIZE*K0*sizeof(FT));
+                    } else {
                         for (int kk = 0; kk < k_count; ++kk) {
                             const int k = k_base + kk;
                             int kofs = (k >> K0shift) * planesize + (k & (K0-1));
-                            outptr[kofs] = accs[kk];
+                            for (int j = 0; j < SPAT_BLOCK_SIZE; j++)
+                                tmpbuf[kk + j*K0] = resptr[kofs + j*K0];
                         }
+                    }
+                    resptr += SPAT_BLOCK_SIZE*K0;
+                }
+
+                if ((p % W) + SPAT_BLOCK_SIZE <= W) {
+                    int zj = p / (H*W);
+                    int yxj = p - zj*(H*W);
+                    int yj = yxj / W;
+                    int x = yxj - yj*W;
+                    const bool zy_inner = (zj >= innerZ0 && zj < innerZ1) && (yj >= innerY0 && yj < innerY1);
+                    for (int j = 0; j < SPAT_BLOCK_SIZE; j++) {
+                        int xj = x + j;
+                        pt[j] = Vec3i(zj*Sz - padZ, yj*Sy - padY, xj*Sx - padX);
+                        inner[j] = zy_inner && (xj >= innerX0 && xj < innerX1);
+                    }
+                } else {
+                    for (int j = 0; j < SPAT_BLOCK_SIZE; j++) {
+                        int pj = p + j;
+                        int zj = pj / (H*W);
+                        int yxj = pj - zj*(H*W);
+                        int yj = yxj / W;
+                        int xj = yxj - yj*W;
+                        pt[j] = Vec3i(zj*Sz - padZ, yj*Sy - padY, xj*Sx - padX);
+                        inner[j] = (zj >= innerZ0 && zj < innerZ1) &&
+                                   (yj >= innerY0 && yj < innerY1) &&
+                                   (xj >= innerX0 && xj < innerX1);
+                    }
+                }
+
+                CONV_INIT_SUMS();
+
+                for (int i = 0; i < ksize; i++) {
+                    const float* inptr[SPAT_BLOCK_SIZE];
+                    int inpstep[SPAT_BLOCK_SIZE];
+                    for (int j = 0; j < SPAT_BLOCK_SIZE; j++) {
+                        Vec3i ptj = pt[j];
+                        int zij = ptj[0] + ofsZYX[i*3 + 0];
+                        int yij = ptj[1] + ofsZYX[i*3 + 1];
+                        int xij = ptj[2] + ofsZYX[i*3 + 2];
+                        if (inner[j] || ((((unsigned)zij < (unsigned)Di)&
+                                          ((unsigned)yij < (unsigned)Hi)&
+                                          ((unsigned)xij < (unsigned)Wi)) != 0)) {
+                            inptr[j] = inpbaseptr + (((zij * Hi) + yij) * Wi + xij) * C0;
+                            inpstep[j] = iplanesize;
+                        } else {
+                            inptr[j] = zbuf;
+                            inpstep[j] = 0;
+                        }
+                    }
+                    const float* wptr = wbaseptr + i*C1Max*K0*C0;
+
+                    for (int c1 = 0; c1 < cblocks; c1++, wptr += C0*K0) {
+                        CONV_UPDATE_LOOP_BODY();
+                    }
+                }
+
+                float* outbuf = aligned_k ? outptr + k_base*planeblocks : tmpbuf;
+                CONV_FINALIZE_OUT_ALL();
+
+                if (activation) {
+                    activation(outbuf, outbuf, SPAT_BLOCK_SIZE*K0, activParams);
+                }
+
+                if (!aligned_k) {
+                    for (int kk = 0; kk < k_count; ++kk) {
+                        const int k = k_base + kk;
+                        int kofs = (k >> K0shift) * planesize + (k & (K0-1));
+                        for (int j = 0; j < SPAT_BLOCK_SIZE; j++)
+                            outptr[kofs + j*K0] = tmpbuf[kk + j*K0];
+                    }
+                }
+            }
+        #endif
+
+            float resbuf[K0] = {};
+
+            for (; p < planeblocks; p++, outptr += K0, resptr += (resptr ? K0 : 0))
+            {
+                int zj = p / (H*W);
+                int yxj = p - zj*(H*W);
+                int yj = yxj / W;
+                int xj = yxj - yj*W;
+                int zi_base = zj*Sz - padZ;
+                int yi_base = yj*Sy - padY;
+                int xi_base = xj*Sx - padX;
+
+            #if CV_SIMD128
+                v_float32x4 zz = v_setzero_f32();
+                v_float32x4 s0 = zz, s1 = zz;
+            #else
+                for (int kk = 0; kk < K0; kk++) {
+                    tmpbuf[kk] = 0.f;
+                }
+            #endif
+
+                if (resptr) {
+                    for (int kk = 0; kk < k_count; ++kk) {
+                        const int k = k_base + kk;
+                        int kofs = (k >> K0shift) * planesize + (k & (K0-1));
+                        resbuf[kk] = resptr[kofs];
+                    }
+                }
+
+                for (int i = 0; i < ksize; i++) {
+                    int zi = zi_base + ofsZYX[i*3 + 0];
+                    int yi = yi_base + ofsZYX[i*3 + 1];
+                    int xi = xi_base + ofsZYX[i*3 + 2];
+
+                    if ((((unsigned)zi >= (unsigned)Di) |
+                         ((unsigned)yi >= (unsigned)Hi) |
+                         ((unsigned)xi >= (unsigned)Wi)) != 0)
+                        continue;
+
+                    const float* inptr = inpbaseptr + (((zi * Hi) + yi) * Wi + xi) * C0;
+                    const float* wptr = wbaseptr + i*C1Max*K0*C0;
+
+                    for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
+                    #if CV_SIMD128
+                        v_float32x4 w0, w1, x;
+                        #undef CONV_UPDATE_BLOCK1
+                        #define CONV_UPDATE_BLOCK1(ofs) \
+                            w0 = v_load(wptr + ofs*K0); w1 = v_load(wptr + ofs*K0 + 4); \
+                            x = v_setall_f32(inptr[ofs]); \
+                            s0 = v_fma(x, w0, s0); s1 = v_fma(x, w1, s1)
+                        CONV_UPDATE_BLOCK1(0);
+                        CONV_UPDATE_BLOCK1(1);
+                        CONV_UPDATE_BLOCK1(2);
+                        CONV_UPDATE_BLOCK1(3);
+                        CONV_UPDATE_BLOCK1(4);
+                        CONV_UPDATE_BLOCK1(5);
+                        CONV_UPDATE_BLOCK1(6);
+                        CONV_UPDATE_BLOCK1(7);
+                    #else
+                        for (int c0 = 0; c0 < C0; ++c0) {
+                            const float xval = inptr[c0];
+                            for (int kk = 0; kk < K0; ++kk)
+                                tmpbuf[kk] += xval * wptr[c0*K0 + kk];
+                        }
+                    #endif
+                    }
+                }
+
+                float* outbuf = aligned_k ? outptr + k_base*planeblocks : tmpbuf;
+
+            #if CV_SIMD128
+                v_float32x4 vscale_lo = v_load(scalebuf), vscale_hi = v_load(scalebuf + 4);
+                v_float32x4 vbias_lo = v_load(biasbuf), vbias_hi = v_load(biasbuf + 4);
+                v_float32x4 valpha = v_setall_f32(alpha);
+                v_float32x4 vmaxval = v_setall_f32(maxval);
+
+                s0 = v_fma(s0, vscale_lo, vbias_lo);
+                s1 = v_fma(s1, vscale_hi, vbias_hi);
+                s0 = v_add(s0, v_load(resbuf));
+                s1 = v_add(s1, v_load(resbuf + 4));
+                s0 = v_select(v_ge(s0, zz), s0, v_mul(s0, valpha));
+                s1 = v_select(v_ge(s1, zz), s1, v_mul(s1, valpha));
+                s0 = v_min(s0, vmaxval);
+                s1 = v_min(s1, vmaxval);
+                v_store(outbuf, s0);
+                v_store(outbuf + 4, s1);
+            #else
+                for (int kk = 0; kk < K0; kk++) {
+                    float v = tmpbuf[kk]*scalebuf[kk] + biasbuf[kk] + resbuf[kk];
+                    v = std::min(v*(v >= 0 ? 1.f : alpha), maxval);
+                    outbuf[kk] = v;
+                }
+            #endif
+
+                if (activation) {
+                    activation(outbuf, outbuf, K0, activParams);
+                }
+
+                if (!aligned_k) {
+                    for (int kk = 0; kk < k_count; kk++) {
+                        const int k = k_base + kk;
+                        int kofs = (k >> K0shift) * planesize + (k & (K0-1));
+                        outptr[kofs] = tmpbuf[kk];
                     }
                 }
             }
@@ -722,11 +617,11 @@ static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
     });
 }
 
-cv::dnn::ConvFunc getConvFunc_(int depth, int C0, ConvKind convkind)
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0)
 {
     ConvFunc func = nullptr;
     if (depth == CV_32F && C0 == 8) {
-        func = convkind == CONV_KIND_MAIN ? conv32fC8 : convAlt32fC8;
+        func = conv32fC8;
     }
     return func;
 }

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace dnn {
 CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
-cv::dnn::ConvFunc getConvFunc_(int depth, int C0);
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0, ConvKind convkind);
 
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 }} // cv::dnn::
@@ -441,9 +441,293 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     });
 }
 
-cv::dnn::ConvFunc getConvFunc_(int depth, int C0)
+#undef __ARM_NEON
+
+static void convAlt32fC8(const void* inp__, const void* residual__, void* out__,
+                         const ConvState& cs, const void* weights__,
+                         const float* scale__, const float* bias__,
+                         const int32_t* inpofs__, const int32_t* ofsofs__)
 {
-    ConvFunc func = depth == CV_32F && C0 == 8 ? conv32fC8 : nullptr;
+    using FT = float;
+    constexpr int C0shift = 3, K0shift = C0shift;
+    constexpr int C0 = 1 << C0shift;
+    constexpr int K0 = C0;
+    const MatShape& inpshape = cs.inpshape;
+    const MatShape& outshape = cs.outshape;
+    
+    CV_Assert_N(inpshape.layout == DATA_LAYOUT_BLOCK, outshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert_N(inpshape.back() == C0, outshape.back() == K0);
+    CV_Assert(!scale__ && !residual__ && cs.fastActivation == FAST_ACTIV_NONE && !cs.activation);
+    
+    int N = inpshape[0];
+    
+    int ksize_ = 1;
+    for (int i = 0; i < ConvState::MAX_CONV_DIMS; i++)
+        ksize_ *= cs.kshape[i];
+    
+    int Dk_ = cs.kshape[0], Hk_ = cs.kshape[1], Wk_ = cs.kshape[2];
+
+    // precompute (oz,oy,ox) for each i
+    AutoBuffer<int> ofsZYXbuf(ksize_ * 3);
+    for (int zk = 0, i3 = 0; zk < Dk_; zk++) {
+        int oz = zk * cs.dilations[0] - cs.pads[0];
+        for (int yk = 0; yk < Hk_; yk++) {
+            int oy = yk * cs.dilations[1] - cs.pads[1];
+            for (int xk = 0; xk < Wk_; xk++, i3 += 3) {
+                int ox = xk * cs.dilations[2] - cs.pads[2];
+                ofsZYXbuf[i3] = oz;
+                ofsZYXbuf[i3 + 1] = oy;
+                ofsZYXbuf[i3 + 2] = ox;
+            }
+        }
+    }
+
+    const int total_blocks = N * cs.ngroups * cs.Kblk;
+    memset(out__, 0, outshape.total()*sizeof(FT));
+
+    parallel_for_(Range(0, total_blocks), [&](const Range& range) {
+        constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
+        const int C = inpshape.channels(), K = outshape.channels();
+        const int C1 = (C + C0 - 1)/C0, K1 = (K + K0 - 1)/K0;
+        const int ngroups = cs.ngroups, Kblk = cs.Kblk, C1Max = cs.C1Max;
+        const int Cg = C / ngroups;
+        const int Kg = K / ngroups;
+        int ksize = ksize_;
+        int ndims = inpshape.dims;
+        const int D = ndims >= 6 ? outshape[ndims-4] : 1;
+        const int H = ndims >= 5 ? outshape[ndims-3] : 1;
+        const int W = outshape[ndims-2];
+        const int Di = ndims >= 6 ? inpshape[ndims-4] : 1;
+        const int Hi = ndims >= 5 ? inpshape[ndims-3] : 1;
+        const int Wi = inpshape[ndims-2];
+        //const int Dk = cs.kshape[0], Hk = cs.kshape[1], Wk = cs.kshape[2];
+        const int Sz = cs.strides[0], Sy = cs.strides[1], Sx = cs.strides[2];
+        //const int Dz = cs.dilations[0], Dy = cs.dilations[1], Dx = cs.dilations[2];
+        //const int padZ = cs.pads[0], padY = cs.pads[1], padX = cs.pads[2];
+        const float* biasptr = (const float*)bias__;
+        const int* ofsZYX = ofsZYXbuf.data();
+        int planesize = D*H*W*K0;
+        int iplanesize = Di*Hi*Wi*C0;
+        
+        int innerZ0 = cs.inner[0], innerZ1 = cs.inner[MAX_CONV_DIMS];
+        int innerY0 = cs.inner[1], innerY1 = cs.inner[MAX_CONV_DIMS+1];
+        int innerX0 = cs.inner[2], innerX1 = cs.inner[MAX_CONV_DIMS+2];
+        
+        for (int t = range.start; t < range.end; ++t) {
+            const int n = t / (ngroups * Kblk);
+            const int rem = t - n * (ngroups * Kblk);
+            const int g = rem / Kblk;
+            const int kblk = rem - g * Kblk;
+
+            const int k_base = g * Kg + kblk * K0;
+            if (k_base >= K) continue;
+
+            const int k_count = std::min(std::min(K0, Kg - kblk*K0), K - k_base);
+            //printf("(%d,%d). t=%d, n=%d, g=%d, kblk=%d, k_base=%d, k_count=%d\n", begin, end, t, n, g, kblk, k_base, k_count);
+
+            const int c_start  = g * Cg;
+            const int c00      = c_start & (C0-1);
+            const int c1_start = c_start >> C0shift;
+            const int cblocks  = (c00 + Cg + C0 - 1) >> C0shift;
+            const float* inptr0 = (float*)inp__ + (n * C1 + c1_start) * iplanesize;
+            const float* wptr0 = (float*)weights__ + (g*Kblk + kblk)*(ksize*C1Max*C0*K0);
+            const int b_count = biasptr ? k_count : 0;
+
+#ifdef __ARM_NEON
+            float32x4_t vbias_lo = {
+                (b_count > 0) ? biasptr[k_base + 0] : 0.0f,
+                (b_count > 1) ? biasptr[k_base + 1] : 0.0f,
+                (b_count > 2) ? biasptr[k_base + 2] : 0.0f,
+                (b_count > 3) ? biasptr[k_base + 3] : 0.0f
+            };
+            float32x4_t vbias_hi = {
+                (b_count > 4) ? biasptr[k_base + 4] : 0.0f,
+                (b_count > 5) ? biasptr[k_base + 5] : 0.0f,
+                (b_count > 6) ? biasptr[k_base + 6] : 0.0f,
+                (b_count > 7) ? biasptr[k_base + 7] : 0.0f
+            };
+            const int xi_step = Sx * C0;
+#endif
+
+            for (int z = 0; z < D; z++) {
+                const int zi_base = z * Sz;
+                const bool z_inner = (z >= innerZ0 && z < innerZ1);
+
+                for (int y = 0; y < H; y++) {
+                    const int yi_base = y * Sy;
+                    const bool zy_inner = z_inner && (y >= innerY0 && y < innerY1);
+
+                    int dx = 1;
+                    float* outptr0 = (float*)out__ + n*(K1*planesize) + (z*H + y)*(W*K0);
+
+                    for (int x = 0; x < W; x += dx) {
+                        float* outptr = outptr0 + x*K0;
+                        const int xi_base = x * Sx;
+
+#ifdef __ARM_NEON
+                        const int SPAT_BLOCK_SIZE = 6;
+                        if (zy_inner &&
+                            innerX0 <= x &&
+                            x + SPAT_BLOCK_SIZE <= innerX1) {
+                            dx = SPAT_BLOCK_SIZE;
+
+                            float32x4_t acc0_lo = vbias_lo, acc0_hi = vbias_hi;
+                            float32x4_t acc1_lo = vbias_lo, acc1_hi = vbias_hi;
+                            float32x4_t acc2_lo = vbias_lo, acc2_hi = vbias_hi;
+                            float32x4_t acc3_lo = vbias_lo, acc3_hi = vbias_hi;
+                            float32x4_t acc4_lo = vbias_lo, acc4_hi = vbias_hi;
+                            float32x4_t acc5_lo = vbias_lo, acc5_hi = vbias_hi;
+
+                            for (int i = 0; i < ksize; ++i) {
+                                const int zi = zi_base + ofsZYX[i * 3 + 0];
+                                const int yi = yi_base + ofsZYX[i * 3 + 1];
+                                const int xi = xi_base + ofsZYX[i * 3 + 2];
+
+                                const float* inptr = inptr0 + (((zi * Hi) + yi) * Wi + xi) * C0;
+                                const float* wptr = wptr0 + i*C1Max*K0*C0;
+
+                                for (int c1 = 0; c1 < cblocks; ++c1, wptr += C0*K0, inptr += iplanesize) {
+                                    float32x4_t x0_lo = vld1q_f32(inptr + 0);
+                                    float32x4_t x0_hi = vld1q_f32(inptr + 4);
+                                    float32x4_t x1_lo = vld1q_f32(inptr + xi_step + 0);
+                                    float32x4_t x1_hi = vld1q_f32(inptr + xi_step + 4);
+                                    float32x4_t x2_lo = vld1q_f32(inptr + xi_step*2 + 0);
+                                    float32x4_t x2_hi = vld1q_f32(inptr + xi_step*2 + 4);
+                                    float32x4_t x3_lo = vld1q_f32(inptr + xi_step*3 + 0);
+                                    float32x4_t x3_hi = vld1q_f32(inptr + xi_step*3 + 4);
+                                    float32x4_t x4_lo = vld1q_f32(inptr + xi_step*4 + 0);
+                                    float32x4_t x4_hi = vld1q_f32(inptr + xi_step*4 + 4);
+                                    float32x4_t x5_lo = vld1q_f32(inptr + xi_step*5 + 0);
+                                    float32x4_t x5_hi = vld1q_f32(inptr + xi_step*5 + 4);
+                                    float32x4_t w_lo, w_hi;
+
+#undef ACCROW6
+#define ACCROW6(w_ofs, suffix, lane) \
+    w_lo = vld1q_f32(wptr + w_ofs*K0 + 0); \
+    w_hi = vld1q_f32(wptr + w_ofs*K0 + 4); \
+    acc0_lo = vfmaq_laneq_f32(acc0_lo, w_lo, x0_##suffix, lane); \
+    acc0_hi = vfmaq_laneq_f32(acc0_hi, w_hi, x0_##suffix, lane); \
+    acc1_lo = vfmaq_laneq_f32(acc1_lo, w_lo, x1_##suffix, lane); \
+    acc1_hi = vfmaq_laneq_f32(acc1_hi, w_hi, x1_##suffix, lane); \
+    acc2_lo = vfmaq_laneq_f32(acc2_lo, w_lo, x2_##suffix, lane); \
+    acc2_hi = vfmaq_laneq_f32(acc2_hi, w_hi, x2_##suffix, lane); \
+    acc3_lo = vfmaq_laneq_f32(acc3_lo, w_lo, x3_##suffix, lane); \
+    acc3_hi = vfmaq_laneq_f32(acc3_hi, w_hi, x3_##suffix, lane); \
+    acc4_lo = vfmaq_laneq_f32(acc4_lo, w_lo, x4_##suffix, lane); \
+    acc4_hi = vfmaq_laneq_f32(acc4_hi, w_hi, x4_##suffix, lane); \
+    acc5_lo = vfmaq_laneq_f32(acc5_lo, w_lo, x5_##suffix, lane); \
+    acc5_hi = vfmaq_laneq_f32(acc5_hi, w_hi, x5_##suffix, lane); \
+
+                                    ACCROW6(0, lo, 0);
+                                    ACCROW6(1, lo, 1);
+                                    ACCROW6(2, lo, 2);
+                                    ACCROW6(3, lo, 3);
+
+                                    ACCROW6(4, hi, 0);
+                                    ACCROW6(5, hi, 1);
+                                    ACCROW6(6, hi, 2);
+                                    ACCROW6(7, hi, 3);
+                                }
+                            }
+
+                            float tmp[SPAT_BLOCK_SIZE*C0];
+                            vst1q_f32(tmp + 0, acc0_lo); vst1q_f32(tmp + 4, acc0_hi);
+                            vst1q_f32(tmp + 8, acc1_lo); vst1q_f32(tmp + 8 + 4, acc1_hi);
+                            vst1q_f32(tmp + 8*2, acc2_lo); vst1q_f32(tmp + 8*2 + 4, acc2_hi);
+                            vst1q_f32(tmp + 8*3, acc3_lo); vst1q_f32(tmp + 8*3 + 4, acc3_hi);
+                            vst1q_f32(tmp + 8*4, acc4_lo); vst1q_f32(tmp + 8*4 + 4, acc4_hi);
+                            vst1q_f32(tmp + 8*5, acc5_lo); vst1q_f32(tmp + 8*5 + 4, acc5_hi);
+
+                            for (int kk = 0; kk < k_count; ++kk) {
+                                const int k = k_base + kk;
+                                int kofs = (k >> K0shift) * planesize + (k & (K0-1));
+                                outptr[kofs + 0 * 8] = tmp[kk];
+                                outptr[kofs + 1 * 8] = tmp[kk+8];
+                                outptr[kofs + 2 * 8] = tmp[kk+8*2];
+                                outptr[kofs + 3 * 8] = tmp[kk+8*3];
+                                outptr[kofs + 4 * 8] = tmp[kk+8*4];
+                                outptr[kofs + 5 * 8] = tmp[kk+8*5];
+                            }
+
+                            continue;
+                        }
+#endif
+                        dx = 1;
+
+                        float accs[8];
+
+#ifdef __ARM_NEON
+                        float32x4_t acc0 = vbias_lo, acc1 = vbias_hi;
+#else
+                        for (int kk = 0; kk < K0; ++kk)
+                            accs[kk] = (kk < b_count) ? biasptr[k_base + kk] : 0.0f;
+#endif
+
+                        for (int i = 0; i < ksize; ++i) {
+                            size_t i3 = size_t(i)*3u;
+                            const int zi = zi_base + ofsZYX[i3 + 0];
+                            const int yi = yi_base + ofsZYX[i3 + 1];
+                            const int xi = xi_base + ofsZYX[i3 + 2];
+                            if ((((unsigned)zi >= (unsigned)Di) |
+                                ((unsigned)yi >= (unsigned)Hi) |
+                                ((unsigned)xi >= (unsigned)Wi)) != 0)
+                                continue;
+
+                            const float* inptr = inptr0 + (((zi * Hi) + yi) * Wi + xi) * C0;
+                            const float* wptr = wptr0 + i*C1Max*K0*C0;
+
+#ifdef __ARM_NEON
+                            for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
+                                float32x4_t x0 = vld1q_f32(inptr), x1 = vld1q_f32(inptr + 4);
+                                float32x4_t w0, w1;
+#undef ACCROW1
+#define ACCROW1(w_ofs, idx, lane) \
+    w0 = vld1q_f32(wptr + w_ofs*K0); \
+    w1 = vld1q_f32(wptr + w_ofs*K0 + 4); \
+    acc0 = vfmaq_laneq_f32(acc0, w0, x##idx, lane); \
+    acc1 = vfmaq_laneq_f32(acc1, w1, x##idx, lane)
+
+                                ACCROW1(0, 0, 0);
+                                ACCROW1(1, 0, 1);
+                                ACCROW1(2, 0, 2);
+                                ACCROW1(3, 0, 3);
+                                ACCROW1(4, 1, 0);
+                                ACCROW1(5, 1, 1);
+                                ACCROW1(6, 1, 2);
+                                ACCROW1(7, 1, 3);
+                            }
+#else
+                            for (int c1 = 0; c1 < cblocks; ++c1, inptr += iplanesize, wptr += K0*C0) {
+                                for (int c0 = 0; c0 < C0; ++c0) {
+                                    const float xval = inptr[c0];
+                                    for (int kk = 0; kk < K0; ++kk)
+                                        accs[kk] += xval * wptr[c0*K0 + kk];
+                                }
+                            }
+#endif
+                        }
+#ifdef __ARM_NEON
+                        vst1q_f32(accs, acc0);
+                        vst1q_f32(accs + 4, acc1);
+#endif
+                        for (int kk = 0; kk < k_count; ++kk) {
+                            const int k = k_base + kk;
+                            int kofs = (k >> K0shift) * planesize + (k & (K0-1));
+                            outptr[kofs] = accs[kk];
+                        }
+                    }
+                }
+            }
+        }
+    });
+}
+
+cv::dnn::ConvFunc getConvFunc_(int depth, int C0, ConvKind convkind)
+{
+    ConvFunc func = nullptr;
+    if (depth == CV_32F && C0 == 8) {
+        func = convkind == CONV_KIND_MAIN ? conv32fC8 : convAlt32fC8;
+    }
     return func;
 }
 

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -293,6 +293,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                       const ConvState& cs, const void* weights__,
                       const float* scale__, const float* bias__)
 {
+    constexpr int SPAT_BLOCK_SIZE = 10;
     using FT = float;
     constexpr int C0shift = 3, K0shift = C0shift;
     constexpr int C0 = 1 << C0shift;
@@ -304,32 +305,35 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
     CV_Assert_N(inpshape.back() == C0, outshape.back() == K0);
 
     int K_ = outshape.channels();
-    int N = inpshape[0];
+    int ndims_ = outshape.dims;
+    int N = outshape[0];
+    int D_ = ndims_ >= 6 ? outshape[ndims_ - 4] : 1;
+    int H_ = ndims_ >= 5 ? outshape[ndims_ - 3] : 1;
+    int W_ = outshape[ndims_-2];
+    int planeblocks_ = D_*H_*W_;
+    size_t outtotal = outshape.total();
 
-    const int total_blocks = N * cs.ngroups * cs.Kblk;
+    int Kblk_ = cs.wshape[1];
+    int C1Max_ = cs.wshape[3];
+    int total_blocks = N * cs.ngroups * Kblk_;
 
     if ((K_/cs.ngroups) % K0 != 0) {
         // if there could be 'padding' channels in the output,
         // clear the output before the parallel loop
         // to make sure that all the padding channels are cleared.
-        size_t outtotal = outshape.total()*sizeof(FT);
-        memset(out__, 0, outtotal);
+        memset(out__, 0, outtotal*sizeof(FT));
     }
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
         constexpr int MAX_CONV_DIMS = ConvState::MAX_CONV_DIMS;
         const int C = inpshape.channels(), K = outshape.channels();
         const int C1 = (C + C0 - 1)/C0, K1 = (K + K0 - 1)/K0;
-        const int ngroups = cs.ngroups, Kblk = cs.Kblk, C1Max = cs.C1Max;
+        const int ngroups = cs.ngroups, Kblk = Kblk_, C1Max = C1Max_;
         const int Cg = C / ngroups;
         const int Kg = K / ngroups;
-        int ksize = 1;
-        for (int i = 0; i < MAX_CONV_DIMS; i++)
-            ksize *= cs.kshape[i];
-        int ndims = inpshape.dims;
-        int D = ndims >= 6 ? outshape[ndims-4] : 1;
-        int H = ndims >= 5 ? outshape[ndims-3] : 1;
-        int W = outshape[ndims-2];
+        int ksize = cs.wshape[2];
+        int ndims = ndims_;
+        int D = D_, H = H_, W = W_;
         int Di = ndims >= 6 ? inpshape[ndims-4] : 1;
         int Hi = ndims >= 5 ? inpshape[ndims-3] : 1;
         int Wi = inpshape[ndims-2];
@@ -338,7 +342,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
         const float* scaleptr = (const float*)scale__;
         const float* biasptr = (const float*)bias__;
         const int* ofsZYX = cs.coordtab.data();
-        int planeblocks = D*H*W;
+        int planeblocks = planeblocks_;
         int planesize = planeblocks*K0;
         int iplanesize = Di*Hi*Wi*C0;
 
@@ -370,6 +374,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
         }
 
         for (int t = range.start; t < range.end; t++) {
+            const int p0 = 0, p1 = planeblocks;
             const int n = t / (ngroups * Kblk);
             const int rem = t - n * (ngroups * Kblk);
             const int g = rem / Kblk;
@@ -400,23 +405,22 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
                 }
             }
 
-            constexpr int SPAT_BLOCK_SIZE = 10;
-            float* outptr = (float*)out__ + n*(K1*planesize);
-            const float* resptr = residual__ ? (float*)residual__ + n*(K1*planesize) : nullptr;
+            float* outptr = (float*)out__ + n*(K1*planesize) + p0*K0;
+            const float* resptr = residual__ ? (float*)residual__ + n*(K1*planesize) + p0*K0 : nullptr;
             float tmpbuf[SPAT_BLOCK_SIZE*K0] = {};
-            int p = 0;
+            int p = p0;
 
         #if CONV_ENABLE_SIMD
-            for (; p < planeblocks; p += SPAT_BLOCK_SIZE,
-                                    outptr += SPAT_BLOCK_SIZE*K0)
+            for (; p < p1; p += SPAT_BLOCK_SIZE,
+                           outptr += SPAT_BLOCK_SIZE*K0)
             {
                 Vec3i pt[SPAT_BLOCK_SIZE];
                 bool inner[SPAT_BLOCK_SIZE];
 
-                if (p + SPAT_BLOCK_SIZE > planeblocks) {
-                    if (p == 0)
+                if (p + SPAT_BLOCK_SIZE > p1) {
+                    if (p == p0)
                         break;
-                    int p_new = planeblocks - SPAT_BLOCK_SIZE;
+                    int p_new = p1 - SPAT_BLOCK_SIZE;
                     int dp = p_new - p;
                     outptr += dp*K0;
                     resptr += (resptr ? dp*K0 : 0);
@@ -509,7 +513,7 @@ static void conv32fC8(const void* inp__, const void* residual__, void* out__,
 
             float resbuf[K0] = {};
 
-            for (; p < planeblocks; p++, outptr += K0, resptr += (resptr ? K0 : 0))
+            for (; p < p1; p++, outptr += K0, resptr += (resptr ? K0 : 0))
             {
                 int zj = p / (H*W);
                 int yxj = p - zj*(H*W);

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -93,6 +93,18 @@ using std::sin;
 using std::sinh;
 using std::tan;
 
+int ActivationLayer::getLayouts(const std::vector<DataLayout>& actualInputs,
+                                std::vector<DataLayout>& desiredInputs,
+                                const int requiredOutputs,
+                                std::vector<DataLayout>& outputs) const
+{
+    size_t ninputs = actualInputs.size();
+    CV_Assert(ninputs >= 1u);
+    desiredInputs = actualInputs;
+    outputs.assign(requiredOutputs, actualInputs[0]);
+    return 0;
+}
+
 struct PowerFunctor;
 
 template<typename Func>

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -415,6 +415,7 @@ public:
                                  std::vector<MatShape> &outshapes,
                                  std::vector<MatShape> &tempshapes) const CV_OVERRIDE
     {
+        CV_Assert(outputs.size() == 1u);
         size_t ninputs = inpshapes.size();
         CV_Assert(ninputs == 1);
 

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -109,7 +109,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = vx_load(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
@@ -119,7 +119,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                         } else if (nlanes*2 == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load(inp_xi + ofs_k);
@@ -136,7 +136,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                     
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load(inp_xi + ofs_k);
@@ -262,7 +262,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
@@ -272,7 +272,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                         } else if (nlanes*2 == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
-                                const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                 
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
@@ -289,7 +289,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const _Tp* inp_xi = inp + ((Hi*zi_ + Wi)*yi_ + xi_)*C0;
+                                    const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
                                     
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load_expand(inp_xi + ofs_k);

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -1,0 +1,422 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+#include "conv2_common.hpp"
+#include "opencv2/core/hal/intrin.hpp"
+
+namespace cv
+{
+namespace dnn
+{
+
+static void maxpool2d_32f(const void* inp_, void* out_, const ConvState& cs)
+{
+    int C0_ = cs.inpshape.back();
+    int NC = cs.inpshape[0]*cs.inpshape[1];
+    int nlanes_ = VTraits<v_float32>::vlanes();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.nspatialdims == 2);
+
+    parallel_for_(Range(0, NC), [&](const Range& r) {
+        int nc0 = r.start, nc1 = r.end;
+        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi*C0;
+        int planesize = H*W*C0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
+        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
+        int ksize = (int)(cs.coordtab.size()/2);
+        const int* yxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+
+        const float* inp = (const float*)inp_ + nc0*iplanesize;
+        float* out = (float*)out_ + nc0*planesize;
+        v_float32 s_min = vx_setall_f32(-FLT_MAX);
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                int yi_ = y0*SY - pad_y0;
+                for(;;) {
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            v_float32 s0 = s_min;
+                            for (int k = 0; k < ksize; k++) {
+                                int yi = yi_ + yxtab[k*2];
+                                int xi = xi_ + yxtab[k*2+1];
+                                v_float32 v0;
+                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                v0 = vx_load(inp + (yi*Wi + xi)*C0);
+                                s0 = v_max(s0, v0);
+                            }
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*2) {
+                                v_float32 s0 = s_min, s1 = s_min;
+                                for (int k = 0; k < ksize; k++) {
+                                    int yi = yi_ + yxtab[k*2];
+                                    int xi = xi_ + yxtab[k*2+1];
+                                    v_float32 v0, v1;
+                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                        continue;
+                                    int ofs_k = (yi*Wi + xi)*C0 + c;
+                                    v0 = vx_load(inp + ofs_k);
+                                    v1 = vx_load(inp + ofs_k + nlanes);
+                                    s0 = v_max(s0, v0);
+                                    s1 = v_max(s1, v1);
+                                }
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                            }
+                        }
+                    }
+                    if (x0 == W)
+                        break;
+                    x1 = inner_x1;
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = vx_load(inp_xi + ofstab[0]);
+                            for (int k = 1; k < ksize; k++)
+                                s0 = v_max(s0, vx_load(inp_xi + ofstab[k]));
+                            vx_store(out + x0*C0, s0);
+                        }
+                    } else if (nlanes*2 == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const float* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            int ofs_k = ofstab[0];
+                            v_float32 s0 = vx_load(inp_xi + ofs_k);
+                            v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
+                            for (int k = 1; k < ksize; k++) {
+                                ofs_k = ofstab[k];
+                                s0 = v_max(s0, vx_load(inp_xi + ofs_k));
+                                s1 = v_max(s1, vx_load(inp_xi + ofs_k + nlanes));
+                            }
+                            vx_store(out + x0*C0, s0);
+                            vx_store(out + x0*C0 + nlanes, s1);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*4) {
+                                const float* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
+
+                                int ofs_k = ofstab[0];
+                                v_float32 s0 = vx_load(inp_xi + ofs_k);
+                                v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
+                                v_float32 s2 = vx_load(inp_xi + ofs_k + nlanes*2);
+                                v_float32 s3 = vx_load(inp_xi + ofs_k + nlanes*3);
+                                for (int k = 1; k < ksize; k++) {
+                                    ofs_k = ofstab[k];
+                                    s0 = v_max(s0, vx_load(inp_xi + ofs_k));
+                                    s1 = v_max(s1, vx_load(inp_xi + ofs_k + nlanes));
+                                    s2 = v_max(s2, vx_load(inp_xi + ofs_k + nlanes*2));
+                                    s3 = v_max(s3, vx_load(inp_xi + ofs_k + nlanes*3));
+                                }
+                                vx_store(out + x0*C0 + c, s0);
+                                vx_store(out + x0*C0 + c + nlanes, s1);
+                                vx_store(out + x0*C0 + c + nlanes*2, s2);
+                                vx_store(out + x0*C0 + c + nlanes*3, s3);
+                            }
+                        }
+                    }
+                    x1 = W;
+                }
+            }
+        }
+    });
+}
+
+template<typename _Tp>
+static void maxpool2d_16(const _Tp* inp_, _Tp* out_, const ConvState& cs)
+{
+    int C0_ = cs.inpshape.back();
+    int NC = cs.inpshape[0]*cs.inpshape[1];
+    int nlanes_ = VTraits<v_float32>::vlanes();
+
+    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
+    CV_Assert(cs.nspatialdims == 2);
+
+    parallel_for_(Range(0, NC), [&](const Range& r) {
+        int nc0 = r.start, nc1 = r.end;
+        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int Hi = cs.inpshape[2], Wi = cs.inpshape[3];
+        int H = cs.outshape[2], W = cs.outshape[3];
+        int iplanesize = Hi*Wi*C0;
+        int planesize = H*W*C0;
+        int SY = cs.strides[0], SX = cs.strides[1];
+        int pad_y0 = cs.pads[0], pad_x0 = cs.pads[1];
+        int inner_y0 = cs.inner[0], inner_x0 = cs.inner[1];
+        int inner_y1 = cs.inner[cs.nspatialdims], inner_x1 = cs.inner[cs.nspatialdims+1];
+        int ksize = (int)(cs.coordtab.size()/2);
+        const int* yxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+
+        const _Tp* inp = inp_ + nc0*iplanesize;
+        _Tp* out = out_ + nc0*planesize;
+        v_float32 s_min = vx_setall_f32(-FLT_MAX);
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                int x0 = 0, x1 = y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                int yi_ = y0*SY - pad_y0;
+                for(;;) {
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            v_float32 s0 = s_min;
+                            for (int k = 0; k < ksize; k++) {
+                                int yi = yi_ + yxtab[k*2];
+                                int xi = xi_ + yxtab[k*2+1];
+                                v_float32 v0;
+                                if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                v0 = vx_load_expand(inp + (yi*Wi + xi)*C0);
+                                s0 = v_max(s0, v0);
+                            }
+                            v_pack_store(out + x0*C0, s0);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*2) {
+                                v_float32 s0 = s_min, s1 = s_min;
+                                for (int k = 0; k < ksize; k++) {
+                                    int yi = yi_ + yxtab[k*2];
+                                    int xi = xi_ + yxtab[k*2+1];
+                                    v_float32 v0, v1;
+                                    if ((unsigned)yi >= (unsigned)Hi || (unsigned)xi >= (unsigned)Wi)
+                                        continue;
+                                    int ofs_k = (yi*Wi + xi)*C0 + c;
+                                    v0 = vx_load_expand(inp + ofs_k);
+                                    v1 = vx_load_expand(inp + ofs_k + nlanes);
+                                    s0 = v_max(s0, v0);
+                                    s1 = v_max(s1, v1);
+                                }
+                                v_pack_store(out + x0*C0 + c, s0);
+                                v_pack_store(out + x0*C0 + c + nlanes, s1);
+                            }
+                        }
+                    }
+                    if (x0 == W)
+                        break;
+                    x1 = inner_x1;
+                    if (nlanes == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
+                            for (int k = 1; k < ksize; k++)
+                                s0 = v_max(s0, vx_load_expand(inp_xi + ofstab[k]));
+                            v_pack_store(out + x0*C0, s0);
+                        }
+                    } else if (nlanes*2 == C0) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0;
+
+                            int ofs_k = ofstab[0];
+                            v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
+                            v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
+                            for (int k = 1; k < ksize; k++) {
+                                ofs_k = ofstab[k];
+                                s0 = v_max(s0, vx_load_expand(inp_xi + ofs_k));
+                                s1 = v_max(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                            }
+                            v_pack_store(out + x0*C0, s0);
+                            v_pack_store(out + x0*C0 + nlanes, s1);
+                        }
+                    } else {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - pad_x0;
+                            for (int c = 0; c < C0; c += nlanes*4) {
+                                const _Tp* inp_xi = inp + (Wi*yi_ + xi_)*C0 + c;
+
+                                int ofs_k = ofstab[0];
+                                v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
+                                v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
+                                v_float32 s2 = vx_load_expand(inp_xi + ofs_k + nlanes*2);
+                                v_float32 s3 = vx_load_expand(inp_xi + ofs_k + nlanes*3);
+                                for (int k = 1; k < ksize; k++) {
+                                    ofs_k = ofstab[k];
+                                    s0 = v_max(s0, vx_load_expand(inp_xi + ofs_k));
+                                    s1 = v_max(s1, vx_load_expand(inp_xi + ofs_k + nlanes));
+                                    s2 = v_max(s2, vx_load_expand(inp_xi + ofs_k + nlanes*2));
+                                    s3 = v_max(s3, vx_load_expand(inp_xi + ofs_k + nlanes*3));
+                                }
+                                v_pack_store(out + x0*C0 + c, s0);
+                                v_pack_store(out + x0*C0 + c + nlanes, s1);
+                                v_pack_store(out + x0*C0 + c + nlanes*2, s2);
+                                v_pack_store(out + x0*C0 + c + nlanes*3, s3);
+                            }
+                        }
+                    }
+                    x1 = W;
+                }
+            }
+        }
+    });
+}
+
+static void maxpool2d_16f(const void* inp_, void* out_, const ConvState& cs)
+{
+    maxpool2d_16((const hfloat*)inp_, (hfloat*)out_, cs);
+}
+
+static void maxpool2d_16bf(const void* inp_, void* out_, const ConvState& cs)
+{
+    maxpool2d_16((const bfloat*)inp_, (bfloat*)out_, cs);
+}
+
+typedef void (*maxpool_func_t)(const void* inp, void* out, const ConvState& cs);
+
+class MaxPoolLayerImpl : public MaxPoolLayer
+{
+public:
+    MaxPoolLayerImpl(const LayerParams& params)
+    {
+        setParamsFrom(params);
+        auto_pad = getAutoPadding(params);
+        kernel_shape = params.getVector<int>("kernel_shape");
+        strides = params.getVector<int>("strides");
+        dilations = params.getVector<int>("dilations");
+        pads = params.getVector<int>("pads");
+        ceil_mode = params.get<bool>("ceil_mode", false);
+        storage_order = params.get<int>("storage_order", 0);
+    }
+
+    virtual bool supportBackend(int backendId) CV_OVERRIDE
+    {
+        return backendId == DNN_BACKEND_OPENCV;
+    }
+
+    virtual int64_t getFLOPS(const std::vector<MatShape> &inputs,
+                           const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        CV_Assert(outputs.size() == 1);
+        int ksize = 1;
+        for (auto sz: kernel_shape) ksize *= sz;
+        return (int64_t)(inputs[0].total()*ksize);
+    }
+
+    int inferType(int inptype0) const
+    {
+        return inptype0;
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inptypes,
+                          const int, const int,
+                          std::vector<MatType>& outtypes,
+                          std::vector<MatType>& temptypes) const CV_OVERRIDE
+    {
+        int ninputs = (int)inptypes.size();
+        CV_Assert(ninputs == 1);
+
+        outtypes.assign(1, inferType(inptypes[0]));
+        temptypes.clear();
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,
+                                 const int,
+                                 std::vector<MatShape> &outshapes,
+                                 std::vector<MatShape> &tempshapes) const CV_OVERRIDE
+    {
+        size_t ninputs = inpshapes.size();
+        CV_Assert(ninputs == 1);
+
+        outshapes.assign(1, convInferShape(inpshapes[0], MatShape(),
+                                           kernel_shape, 0, strides, dilations,
+                                           pads, auto_pad, ceil_mode));
+        tempshapes.clear();
+        return true;
+    }
+
+    void getLayouts(const std::vector<DataLayout>& actualInputs,
+                    std::vector<DataLayout>& desiredInputs,
+                    const int requiredOutputs,
+                    std::vector<DataLayout>& outputs) const CV_OVERRIDE
+    {
+        CV_Assert(actualInputs.size() == 1u);
+        desiredInputs.assign(1, DATA_LAYOUT_BLOCK);
+        outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        size_t ninputs = inputs_arr.total();
+        CV_Assert(ninputs == 1);
+
+        int inptype = inputs_arr.type(0);
+        MatShape inpshape = inputs_arr.shape(0);
+        MatShape outshape = convInferShape(inpshape, MatShape(),
+                                           kernel_shape, 0, strides, dilations,
+                                           pads, auto_pad, ceil_mode);
+        int outKind = outputs_arr.kind();
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        ConvState cs;
+        initPoolingState(inpshape, outshape, kernel_shape, strides, dilations, pads, auto_pad, ceil_mode, cs);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            runOp(inp, outs[0], cs);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            Mat temp(outshape, inptype);
+            runOp(inp, temp, cs);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& inp, Mat& out, const ConvState& cs)
+    {
+        int inptype = inp.type();
+        maxpool_func_t func =
+            inptype == CV_32F ? maxpool2d_32f :
+            inptype == CV_16F ? maxpool2d_16f :
+            inptype == CV_16BF ? maxpool2d_16bf : nullptr;
+
+        CV_Assert(func != nullptr && "MaxPool: unsupported data type");
+        func(inp.data, out.data, cs);
+    }
+};
+
+Ptr<MaxPoolLayer> MaxPoolLayer::create(const LayerParams& params)
+{
+    return Ptr<MaxPoolLayer>(new MaxPoolLayerImpl(params));
+}
+
+}}

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -350,7 +350,7 @@ public:
         return true;
     }
 
-    void getLayouts(const std::vector<DataLayout>& actualInputs,
+    int getLayouts(const std::vector<DataLayout>& actualInputs,
                     std::vector<DataLayout>& desiredInputs,
                     const int requiredOutputs,
                     std::vector<DataLayout>& outputs) const CV_OVERRIDE
@@ -358,6 +358,7 @@ public:
         CV_Assert(actualInputs.size() == 1u);
         desiredInputs.assign(1, DATA_LAYOUT_BLOCK);
         outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+        return getNetImpl(this)->defaultC0;
     }
 
     void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
@@ -381,7 +382,8 @@ public:
                   outKind == _InputArray::STD_VECTOR_UMAT);
 
         ConvState cs;
-        initPoolingState(inpshape, outshape, kernel_shape, strides, dilations, pads, auto_pad, ceil_mode, cs);
+        cs.initPooling(inpshape, outshape, kernel_shape, strides,
+                       dilations, pads, auto_pad, ceil_mode);
 
         if (outKind == _InputArray::STD_VECTOR_MAT) {
             Mat inp = inputs_arr.getMat(0);

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -295,12 +295,45 @@ public:
     {
         setParamsFrom(params);
         auto_pad = getAutoPadding(params);
-        kernel_shape = params.getVector<int>("kernel_shape");
-        strides = params.getVector<int>("strides");
-        dilations = params.getVector<int>("dilations");
-        pads = params.getVector<int>("pads");
+        kernel_shape = params.getVector<int>("kernel_size");
+        strides = params.getVector<int>("stride");
+        dilations = params.getVector<int>("dilation");
+        pads = params.getVector<int>("pad");
         ceil_mode = params.get<bool>("ceil_mode", false);
         storage_order = params.get<int>("storage_order", 0);
+    }
+
+    virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
+    {
+        prindent(strm, indent);
+        strm << "kernel_size: [";
+        for (size_t k = 0; k < kernel_shape.size(); k++)
+            strm << (k > 0 ? ", " : "") << kernel_shape[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "dilation: [";
+        for (size_t k = 0; k < dilations.size(); k++)
+            strm << (k > 0 ? ", " : "") << dilations[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "pad: [";
+        for (size_t k = 0; k < pads.size(); k++)
+            strm << (k > 0 ? ", " : "") << pads[k];
+        strm << "],\n";
+
+        prindent(strm, indent);
+        strm << "stride: [";
+        for (size_t k = 0; k < strides.size(); k++)
+            strm << (k > 0 ? ", " : "") << strides[k];
+        strm << "],\n";
+
+        if (outputs.size() > 1u) {
+            prindent(strm, indent);
+            strm << "storage_order: " << storage_order << ",\n";
+        }
+        return strm;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -15,15 +15,17 @@ namespace dnn
 
 static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
 {
-    constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
     int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
     parallel_for_(Range(0, NC1), [&](const Range& r) {
+        constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
+
+        CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
+
         int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
         int C0 = cs.inpshape.back();

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -16,20 +16,17 @@ namespace dnn
 static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
 {
     constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
-    int C0_ = cs.inpshape.back();
-    int NC = cs.inpshape[0]*cs.inpshape[1];
-    int nlanes_ = VTraits<v_float32>::vlanes();
+    int NC1 = cs.inpshape[0]*cs.inpshape[1];
 
-    CV_Assert(C0_ == nlanes_ || C0_ == nlanes_*2 || C0_ % (nlanes_*4) == 0);
     CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
     CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
     CV_Assert(cs.inpshape.dims == cs.outshape.dims);
 
-    parallel_for_(Range(0, NC), [&](const Range& r) {
+    parallel_for_(Range(0, NC1), [&](const Range& r) {
         int sdims = cs.nspatialdims;
         int nc0 = r.start, nc1 = r.end;
-        int nlanes = nlanes_, C0 = cs.inpshape.back();
+        int C0 = cs.inpshape.back();
         int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
         int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
         int Wi = cs.inpshape[sdims + 1];
@@ -49,7 +46,13 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
 
         const float* inp = (const float*)inp_ + nc0*iplanesize;
         float* out = (float*)out_ + nc0*planesize;
-        v_float32 s_min = vx_setall_f32(-FLT_MAX);
+        const float INITVAL = -FLT_MAX;
+
+    #if CV_SIMD || CV_SIMD_SCALABLE
+        int nlanes = VTraits<v_float32>::vlanes();
+        v_float32 s_min = vx_setall_f32(INITVAL);
+        CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
+    #endif
 
         for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
             for (int z0 = 0; z0 < D; z0++) {
@@ -59,7 +62,14 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                     int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
+
+                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                    for (int c = 0; c < C0*W; c++)
+                        out[c] = INITVAL;
+                #endif
+
                     for(;;) {
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
@@ -103,14 +113,33 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            for (int k = 0; k < ksize; k++) {
+                                int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                if ((unsigned)zi >= (unsigned)Di ||
+                                    (unsigned)yi >= (unsigned)Hi ||
+                                    (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                const float* inptr = inp + ((zi*Hi + yi)*Wi + xi)*C0;
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] = std::max(out[x0*C0 + c], inptr[c]);
+                            }
+                        }
+                    #endif
                         if (x0 == W)
                             break;
                         x1 = inner_x1;
+
+                    #if CV_SIMD || CV_SIMD_SCALABLE
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = vx_load(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
                                     s0 = v_max(s0, vx_load(inp_xi + ofstab[k]));
@@ -120,7 +149,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
@@ -136,8 +165,8 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
-                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                    
+                                    const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0 + c;
+
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load(inp_xi + ofs_k);
                                     v_float32 s1 = vx_load(inp_xi + ofs_k + nlanes);
@@ -157,6 +186,17 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                                 }
                             }
                         }
+                    #else
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            const float* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
+                            for (int k = 0; k < ksize; k++) {
+                                const float* inptr = inp_xi + ofstab[k];
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] = std::max(out[x0*C0 + c], inptr[c]);
+                            }
+                        }
+                    #endif
                         x1 = W;
                     }
                 }
@@ -165,6 +205,9 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
     });
 }
 
+// temporarily exclude fp16/bf16 versions,
+// since convolution and other layers don't support those types yet
+#if 0
 template<typename _Tp>
 static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
 {
@@ -263,7 +306,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 v_float32 s0 = vx_load_expand(inp_xi + ofstab[0]);
                                 for (int k = 1; k < ksize; k++)
                                     s0 = v_max(s0, vx_load_expand(inp_xi + ofstab[k]));
@@ -273,7 +316,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
                                 const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                
+
                                 int ofs_k = ofstab[0];
                                 v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
                                 v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
@@ -290,7 +333,7 @@ static void maxPool16xf(const _Tp* inp_, _Tp* out_, const ConvState& cs)
                                 int xi_ = x0*SX - padX0;
                                 for (int c = 0; c < C0; c += nlanes*4) {
                                     const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
-                                    
+
                                     int ofs_k = ofstab[0];
                                     v_float32 s0 = vx_load_expand(inp_xi + ofs_k);
                                     v_float32 s1 = vx_load_expand(inp_xi + ofs_k + nlanes);
@@ -327,8 +370,9 @@ static void maxPool16bf(const void* inp_, void* out_, const ConvState& cs)
 {
     maxPool16xf((const bfloat*)inp_, (bfloat*)out_, cs);
 }
+#endif
 
-typedef void (*maxpool_func_t)(const void* inp, void* out, const ConvState& cs);
+typedef void (*MaxPoolFunc)(const void* inp, void* out, const ConvState& cs);
 
 class MaxPoolLayerImpl : public MaxPoolLayer
 {
@@ -482,10 +526,11 @@ public:
     void runOp(const Mat& inp, Mat& out, const ConvState& cs)
     {
         int inptype = inp.type();
-        maxpool_func_t func =
+        MaxPoolFunc func =
             inptype == CV_32F ? maxPool32f :
-            inptype == CV_16F ? maxPool16f :
-            inptype == CV_16BF ? maxPool16bf : nullptr;
+            /*inptype == CV_16F ? maxPool16f :
+            inptype == CV_16BF ? maxPool16bf :*/
+            nullptr;
 
         CV_Assert(func != nullptr && "MaxPool: unsupported data type");
         func(inp.data, out.data, cs);

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -308,7 +308,7 @@ public:
                 int inpsz = j < delta ? 1 : inpShape[j - delta];
                 int outsz = outShape[j];
                 CV_Assert(inpsz == outsz || inpsz == 1 || outsz == 1);
-                outShape[j] = std::max(outsz, inpsz);
+                outShape[j] = inpsz != 1 ? inpsz : outsz;
             }
         }
 

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -171,39 +171,11 @@ class NaryEltwiseLayerImpl CV_FINAL : public NaryEltwiseLayer
 {
     NaryEltwiseHelper helper;
 public:
-    enum class OPERATION
-    {
-        AND = 0,
-        EQUAL,
-        GREATER,
-        GREATER_EQUAL,
-        LESS,
-        LESS_EQUAL,
-        OR,
-        POW,
-        XOR,
-        BITSHIFT,
-        MAX,
-        MEAN,
-        MIN,
-        MOD,  // Integer Mod. Reminder's sign = Divisor's sign.
-        FMOD, // Floating-point Mod. Reminder's sign = Dividend's sign.
-        PROD,
-        SUB,
-        SUM,
-        ADD,
-        DIV,
-        WHERE,
-        BITWISE_AND,
-        BITWISE_OR,
-        BITWISE_XOR,
-    } op;
     std::string operation;
 
     NaryEltwiseLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
-
         operation = toLowerCase(params.get<String>("operation", "sum"));
 
         if (operation == "equal")

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -427,7 +427,7 @@ public:
         auto* netimpl_ = getNetImpl(this);
         DataLayout defaultLayout = netimpl_->originalLayout;
         size_t ninputs = actualInputs.size(), nblockInputs = 0;
-        CV_Assert(ninputs > 1u);
+        CV_Assert(ninputs >= 1u);
         for (size_t i = 0; i < ninputs; i++) {
             DataLayout layout = actualInputs[i];
             nblockInputs += layout == DATA_LAYOUT_BLOCK;

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "../precomp.hpp"
+#include "../net_impl.hpp"
 #include "layers_common.hpp"
 #include "../op_cuda.hpp"
 #include "../op_cann.hpp"
@@ -197,12 +198,13 @@ public:
         BITWISE_OR,
         BITWISE_XOR,
     } op;
+    std::string operation;
 
     NaryEltwiseLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
 
-        String operation = toLowerCase(params.get<String>("operation", "sum"));
+        operation = toLowerCase(params.get<String>("operation", "sum"));
 
         if (operation == "equal")
             op = OPERATION::EQUAL;
@@ -254,6 +256,13 @@ public:
             op = OPERATION::BITWISE_XOR;
         else
             CV_Error(cv::Error::StsBadArg, "Unknown operation type \"" + operation + "\"");
+    }
+
+    virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
+    {
+        prindent(strm, indent);
+        strm << "operation: \"" << operation << "\",\n";
+        return strm;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE
@@ -428,6 +437,34 @@ public:
             outputs.assign(requiredOutputs, inputs[0]);
     }
 
+    int getLayouts(const std::vector<DataLayout>& actualInputs,
+                   std::vector<DataLayout>& desiredInputs,
+                   const int requiredOutputs,
+                   std::vector<DataLayout>& outputs) const CV_OVERRIDE
+    {
+        auto* netimpl_ = getNetImpl(this);
+        DataLayout defaultLayout = netimpl_->originalLayout;
+        size_t ninputs = actualInputs.size(), nblockInputs = 0;
+        CV_Assert(ninputs > 1u);
+        for (size_t i = 0; i < ninputs; i++) {
+            DataLayout layout = actualInputs[i];
+            nblockInputs += layout == DATA_LAYOUT_BLOCK;
+        }
+
+        desiredInputs = actualInputs;
+        if (nblockInputs == ninputs) {
+            outputs.assign(requiredOutputs, DATA_LAYOUT_BLOCK);
+        } else {
+            if (nblockInputs < ninputs) {
+                for (size_t i = 0; i < ninputs; i++) {
+                    DataLayout layout = actualInputs[i];
+                    desiredInputs[i] = layout == DATA_LAYOUT_BLOCK ? defaultLayout : layout;
+                }
+            }
+            outputs.assign(requiredOutputs, DATA_LAYOUT_UNKNOWN);
+        }
+        return outputs[0] == DATA_LAYOUT_BLOCK ? netimpl_->defaultC0 : 0;
+    }
 
     template <typename T, typename RESULT_T, typename Functor>
     void binary_forward_impl(const Functor& op, int ndims, const std::vector<int>& shape,

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -303,35 +303,45 @@ public:
         return backendId == DNN_BACKEND_OPENCV;
     }
 
-    static MatShape findCommonShape(std::vector<MatShape> shapes)
+    // [TODO] move it to MatShape
+    static MatShape findCommonShape(const std::vector<MatShape>& shapes)
     {
-        CV_Assert(!shapes.empty());
-        const size_t dim = std::max_element(shapes.begin(), shapes.end(),
-                                            [](const MatShape& a, const MatShape& b)
-                                            { return a.size() < b.size(); })->size();
+        size_t i, ninputs = shapes.size();
+        CV_Assert(ninputs > 0u);
 
-        for (auto& shape : shapes)
-        {
-            shape.insert(shape.begin(), dim - shape.size(), 1);
+        int C0 = shapes[0].C, dims0 = shapes[0].dims, maxdims = dims0;
+        bool constC = true;
+        bool allBlock = true;
+        bool constDims = true;
+        for (i = 0; i < ninputs; i++) {
+            const MatShape& inpShape = shapes[i];
+            int dims = inpShape.dims;
+            allBlock = allBlock && inpShape.layout == DATA_LAYOUT_BLOCK;
+            constC = constC && inpShape.C == C0;
+            constDims = constDims && dims == dims0;
+            maxdims = std::max(maxdims, dims);
         }
 
-        MatShape outShape(dim, 1);
-        for (size_t i = 0; i < dim; ++i)
+        MatShape outShape(maxdims, 1);
+        if (allBlock && constC && constDims) {
+            outShape.layout = DATA_LAYOUT_BLOCK;
+            outShape.C = C0;
+        }
+
+        for (i = 0; i < ninputs; i++)
         {
-            for (const auto& shape : shapes)
-            {
-                if (shape[i] != outShape[i])
-                {
-                    CV_Assert(shape[i] == 1 || outShape[i] == 1);
-                    if (outShape[i] == 1)
-                        outShape[i] = shape[i];
-                }
+            const MatShape& inpShape = shapes[i];
+            int dims = inpShape.dims, delta = maxdims - dims;
+            for (int j = 0; j < maxdims; j++) {
+                int inpsz = j < delta ? 1 : inpShape[j - delta];
+                int outsz = outShape[j];
+                CV_Assert(inpsz == outsz || inpsz == 1 || outsz == 1);
+                outShape[j] = std::max(outsz, inpsz);
             }
         }
 
         return outShape;
     }
-
 
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE {
         std::vector<Mat> inputs, outputs;

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -1,0 +1,342 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../precomp.hpp"
+#include "layers_common.hpp"
+#include "../net_impl.hpp"
+
+namespace cv
+{
+namespace dnn
+{
+
+template <typename _Tp>
+void transform_layout_(const _Tp* inp_, int istep, int istep0, int istep1,
+                      _Tp* out_, int ostep, int ostep0, int ostep1,
+                      int npix, int C0, int C1, int C)
+{
+    CV_Assert(C0 % 8 == 0 || C0 == 4 || C1 == 1);
+    CV_Assert(istep0 == 1 || ostep0 == 1);
+    const int dC0 = std::min(C0, (int)8);
+    for (int c1 = 0; c1 < C1; c1++) {
+        for (int c0 = 0; c0 < C0; c0 += dC0) {
+            const _Tp* inp = inp_ + istep0*c0 + istep1*c1;
+            _Tp* out = out_ + ostep0*c0 + ostep1*c1;
+            int dc = std::min(C - (c1*C0 + c0), dC0);
+            if (dc == 8) {
+                if (istep0 == 1) {
+                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
+                        _Tp x4 = inp[4], x5 = inp[5], x6 = inp[6], x7 = inp[7];
+                        out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
+                        out[ostep0*4] = x4; out[ostep0*5] = x5; out[ostep0*6] = x6; out[ostep0*7] = x7;
+                    }
+                } else {
+                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
+                        _Tp x4 = inp[istep0*4], x5 = inp[istep0*5], x6 = inp[istep0*6], x7 = inp[istep0*7];
+                        out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
+                        out[4] = x4; out[5] = x5; out[6] = x6; out[7] = x7;
+                    }
+                }
+            } else if (dc == 4) {
+                if (istep0 == 1) {
+                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
+                        out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
+                    }
+                } else {
+                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
+                        out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
+                    }
+                }
+            } else if (dc == 3 && ostep0 == 1 && ostep == C0) {
+                memset(out, 0, npix*C0*sizeof(out[0]));
+                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                    _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2];
+                    out[0] = x0; out[1] = x1; out[2] = x2;
+                }
+            } else {
+                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                    int c = 0;
+                    for (; c < dc; c++)
+                        out[ostep0*c] = inp[istep0*c];
+                    if (ostep == C0) {
+                        for (; c < dC0; c++)
+                            out[ostep0*c] = 0;
+                    }
+                }
+            }
+        }
+    }
+}
+
+#undef CV_TRANSFORM_LAYOUT_IMPL
+#define CV_TRANSFORM_LAYOUT_IMPL(typ, suffix) \
+static void transform_layout_##suffix(const void* inp_, int istep, int istep0, int istep1, \
+                                      void* out_, int ostep, int ostep0, int ostep1, \
+                                      int npix, int C0, int C1, int C) \
+{ \
+    transform_layout_((const typ*)inp_, istep, istep0, istep1, \
+                     (typ*)out_, ostep, ostep0, ostep1, npix, C0, C1, C); \
+}
+
+CV_TRANSFORM_LAYOUT_IMPL(uint8_t, 8u)
+CV_TRANSFORM_LAYOUT_IMPL(uint16_t, 16u)
+CV_TRANSFORM_LAYOUT_IMPL(uint32_t, 32u)
+CV_TRANSFORM_LAYOUT_IMPL(uint, 64u)
+
+typedef void (*transform_layout_func_t)(const void* inp, int istep, int istep0, int istep1,
+                                        void* out, int ostep, int ostep0, int ostep1,
+                                        int npix, int C0, int C1, int C);
+
+static void transform_layout(const Mat& inp, Mat& out)
+{
+    MatShape inpshape = inp.shape();
+    MatShape outshape = out.shape();
+    DataLayout inplayout = inpshape.layout;
+    DataLayout outlayout = outshape.layout;
+
+    if (inp.empty())
+        return;
+
+    if (inplayout == outlayout) {
+        inp.copyTo(out);
+        return;
+    }
+
+    int inp_ndims = inpshape.dims;
+    int out_ndims = outshape.dims;
+    int N = inpshape[0];
+    int C = inplayout == DATA_LAYOUT_BLOCK ? inpshape.C :
+        inpshape[inplayout == DATA_LAYOUT_NCHW ? 1 : inp_ndims-1];
+    int inptotal = (int)inp.total();
+    int outtotal = (int)out.total();
+    int inplanesize_C = inptotal / N;
+    int outplanesize_C = outtotal / N;
+    int planesize = (inplayout != DATA_LAYOUT_BLOCK ? inplanesize_C : outplanesize_C)/C;
+    int allplanes = planesize*N;
+
+    constexpr int BLOCK_SIZE = 1 << 17;
+    int nblocks = (outtotal + BLOCK_SIZE - 1)/BLOCK_SIZE;
+    nblocks = std::min(nblocks, allplanes);
+
+    size_t esz = inp.elemSize();
+    int istep0, istep1, istep;
+    int ostep0, ostep1, ostep;
+    int C0_ = C, C1_ = 1;
+
+    if (inplayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_BLOCK) {
+        C0_ = inplayout == DATA_LAYOUT_BLOCK ? inpshape[inp_ndims-1] : outshape[out_ndims-1];
+        C1_ = (C + C0_ - 1)/C0_;
+    }
+
+    if (inplayout == DATA_LAYOUT_NCHW) {
+        istep = 1;
+        istep0 = planesize;
+        istep1 = planesize*C0_;
+    } else if (inplayout == DATA_LAYOUT_NHWC) {
+        istep = C;
+        istep0 = 1;
+        istep1 = C0_;
+    } else {
+        istep = C0_;
+        istep0 = 1;
+        istep1 = planesize*C0_;
+    }
+
+    if (outlayout == DATA_LAYOUT_NCHW) {
+        ostep = 1;
+        ostep0 = planesize;
+        ostep1 = planesize*C0_;
+    } else if (outlayout == DATA_LAYOUT_NHWC) {
+        ostep = C;
+        ostep0 = 1;
+        ostep1 = C0_;
+    } else {
+        ostep = C0_;
+        ostep0 = 1;
+        ostep1 = planesize*C0_;
+    }
+
+    const char* inptr0 = (const char*)inp.data;
+    char* outptr0 = (char*)out.data;
+
+    transform_layout_func_t transform_layout_func =
+        esz == 1 ? transform_layout_8u :
+        esz == 2 ? transform_layout_16u :
+        esz == 4 ? transform_layout_32u :
+        esz == 8 ? transform_layout_64u : nullptr;
+
+    CV_Assert(transform_layout_func != nullptr);
+
+    parallel_for_(Range(0, nblocks), [&](const Range& r) {
+        int start = r.start*allplanes/nblocks;
+        int end = r.end*allplanes/nblocks;
+        int npix = 0;
+
+        for (int ofs = start; ofs < end; ofs += npix) {
+            int sample_idx = ofs/planesize;
+            int rawofs = ofs - sample_idx*planesize;
+            npix = std::min(planesize - rawofs, end - ofs);
+            const char* inptr = inptr0 + (inplanesize_C*sample_idx + istep*rawofs)*esz;
+            char* outptr = outptr0 + (outplanesize_C*sample_idx + ostep*rawofs)*esz;
+            transform_layout_func(inptr, istep, istep0, istep1,
+                                  outptr, ostep, ostep0, ostep1,
+                                  npix, C0_, C1_, C);
+        }
+    });
+}
+
+class TransformLayoutLayerImpl : public TransformLayoutLayer
+{
+public:
+    TransformLayoutLayerImpl(const LayerParams& params)
+    {
+        layout = (DataLayout)params.get<int>("layout");
+        C0 = params.get<int>("C0", 1);
+    }
+
+    virtual std::ostream& dumpAttrs(std::ostream& strm, int indent) const CV_OVERRIDE
+    {
+        prindent(strm, indent);
+        strm << "layout: " << layoutToString(layout) << ",\n";
+
+        if (layout == DATA_LAYOUT_BLOCK) {
+            prindent(strm, indent);
+            strm << "C0: " << C0 << ",\n";
+        }
+        return strm;
+    }
+
+    virtual bool alwaysSupportInplace() const CV_OVERRIDE
+    {
+        return false;
+    }
+
+    virtual int64_t getFLOPS(const std::vector<MatShape> &inputs,
+                             const std::vector<MatShape> &outputs) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size() == 1);
+        CV_Assert(outputs.size() == 1);
+        // probably, there should be a coefficient in the case of complex reduction functions
+        return (int64_t)std::max(inputs[0].total(), outputs[0].total());
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inptypes,
+                          const int, const int,
+                          std::vector<MatType>& outtypes,
+                          std::vector<MatType>& temptypes) const CV_OVERRIDE
+    {
+        int ninputs = (int)inptypes.size();
+        CV_Assert(ninputs == 1);
+
+        outtypes.assign(1, inptypes[0]);
+        temptypes.clear();
+    }
+
+    MatShape inferShape(const MatShape& inpshape) const
+    {
+        int ndims = inpshape.dims;
+        DataLayout inplayout = inpshape.layout;
+        CV_Assert(layout == DATA_LAYOUT_BLOCK || layout == DATA_LAYOUT_NCHW || layout == DATA_LAYOUT_NHWC);
+        CV_Assert(inplayout == DATA_LAYOUT_BLOCK || inplayout == DATA_LAYOUT_NCHW || inplayout == DATA_LAYOUT_NHWC);
+
+        if (layout == inplayout) {
+            // identity
+            CV_Assert(layout != DATA_LAYOUT_BLOCK || C0 == inpshape[ndims-1]);
+            return inpshape;
+        }
+
+        // non-block => block
+        if (layout == DATA_LAYOUT_BLOCK)
+            return inpshape.toBlock(C0);
+
+        // block => non-block
+        if (inplayout == DATA_LAYOUT_BLOCK)
+            return inpshape.fromBlock(layout);
+
+        MatShape outshape = inpshape;
+        outshape.layout = layout;
+
+        // NHWC => NCHW
+        if (layout == DATA_LAYOUT_NCHW) {
+            CV_Assert(inplayout == DATA_LAYOUT_NHWC);
+            int C = inpshape[ndims-1];
+            for (int i = 2; i < ndims; i++)
+                outshape[i] = inpshape[i-1];
+            outshape[1] = C;
+        } else {
+            // NCHW => NHWC
+            CV_Assert(layout == DATA_LAYOUT_NHWC && inplayout == DATA_LAYOUT_NCHW);
+            int C = inpshape[1];
+            for (int i = 2; i < ndims; i++)
+                outshape[i-1] = inpshape[i];
+            outshape[ndims-1] = C;
+        }
+        return outshape;
+    }
+
+    virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,
+                                 const int,
+                                 std::vector<MatShape> &outshapes,
+                                 std::vector<MatShape> &tempshapes) const CV_OVERRIDE
+    {
+        size_t ninputs = inpshapes.size();
+        CV_Assert(ninputs == 1);
+
+        outshapes.assign(1, inferShape(inpshapes[0]));
+        tempshapes.clear();
+        return true;
+    }
+
+    void finalize(InputArrayOfArrays, OutputArrayOfArrays outputs_arr) CV_OVERRIDE
+    {
+    }
+
+    void forward(InputArrayOfArrays inputs_arr,
+                 OutputArrayOfArrays outputs_arr,
+                 OutputArrayOfArrays) CV_OVERRIDE
+    {
+        size_t ninputs = inputs_arr.total();
+        CV_Assert(ninputs == 1);
+
+        int inptype = inputs_arr.type(0);
+        MatShape inpshape = inputs_arr.shape(0);
+        MatShape outshape = inferShape(inpshape);
+        int outKind = outputs_arr.kind();
+        CV_Assert(outKind == _InputArray::STD_VECTOR_MAT ||
+                  outKind == _InputArray::STD_VECTOR_UMAT);
+
+        if (outKind == _InputArray::STD_VECTOR_MAT) {
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<Mat>& outs = outputs_arr.getMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            runOp(inp, outs[0]);
+        } else {
+            // [TODO] more efficient OpenCL implementation
+            Mat inp = inputs_arr.getMat(0);
+            std::vector<UMat>& outs = outputs_arr.getUMatVecRef();
+            outs.resize(1);
+            outs[0].fit(outshape, inptype);
+            Mat temp(outshape, inptype);
+            runOp(inp, temp);
+            temp.copyTo(outs[0]);
+        }
+    }
+
+    void runOp(const Mat& inp, Mat& out)
+    {
+        transform_layout(inp, out);
+    }
+};
+
+Ptr<TransformLayoutLayer> TransformLayoutLayer::create(const LayerParams& params)
+{
+    return Ptr<TransformLayoutLayer>(new TransformLayoutLayerImpl(params));
+}
+
+}}

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -105,6 +105,11 @@ void transform_layout_(const _Tp* inp_, int istep, int istep0, int istep1,
                     _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2];
                     out[0] = x0; out[1] = x1; out[2] = x2;
                 }
+            } else if (dc == 1 && ostep0 == 1 && ostep == C0) {
+                memset(out, 0, npix*C0*sizeof(out[0]));
+                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
+                    out[0] = inp[0];
+                }
             } else {
                 for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
                     int c = 0;
@@ -350,6 +355,12 @@ public:
     {
         DataLayout origLayout = getNetImpl(this)->originalLayout;
         transformLayout(inp, out, layout, origLayout, C0);
+#if 0
+        Mat temp;
+        transformLayout(out, temp, layout == DATA_LAYOUT_BLOCK ? origLayout : DATA_LAYOUT_BLOCK, origLayout, C0);
+        double err = norm(temp, inp, NORM_INF);
+        CV_Assert(err == 0.);
+#endif
     }
 };
 

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -147,6 +147,8 @@ void transformLayout(const Mat& inp, Mat& out,
     MatShape inpshape = inp.size;
     MatShape outshape = inferTransformLayoutShape(inpshape, outlayout, defaultLayout, C0);
     DataLayout inplayout = inpshape.layout;
+    if (inplayout == DATA_LAYOUT_UNKNOWN && outlayout == DATA_LAYOUT_BLOCK)
+        inplayout = defaultLayout;
     
     out.fit(outshape, inp.type());
 
@@ -346,7 +348,8 @@ public:
 
     void runOp(const Mat& inp, Mat& out)
     {
-        transformLayout(inp, out, layout, getNetImpl(this)->originalLayout, C0);
+        DataLayout origLayout = getNetImpl(this)->originalLayout;
+        transformLayout(inp, out, layout, origLayout, C0);
     }
 };
 

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -14,225 +14,278 @@ namespace dnn
 static MatShape inferTransformLayoutShape(const MatShape& inpshape_,
                                           DataLayout outlayout,
                                           DataLayout defaultLayout,
-                                          int C0, int ninpgroups, int noutgroups)
+                                          int C0)
 {
     MatShape inpshape = inpshape_;
     if (inpshape.layout == DATA_LAYOUT_UNKNOWN) {
         inpshape.layout = defaultLayout;
     }
 
-    if (ninpgroups > 1) {
-        CV_Assert(inpshape.layout == DATA_LAYOUT_BLOCK);
-        inpshape = inpshape.toLayout(DATA_LAYOUT_NCHW);
-    }
-
-    return inpshape.toLayout(outlayout, C0, noutgroups);
+    return inpshape.toLayout(outlayout, C0);
 }
 
-// NCHW <=> NHWC or
-// NCHW/NHWC <=> BLOCK
-template <typename _Tp>
-void transformLayout_(const _Tp* inp_, size_t istep, size_t istep0, size_t istep1,
-                      _Tp* out_, size_t ostep, size_t ostep0, size_t ostep1,
-                      size_t npix, int C0, int C1g, int Cg, int ngroups)
+template<typename _Tp>
+static inline void transpose8x8(const _Tp* inp_, size_t istep,
+                                _Tp* out_, size_t ostep)
 {
-    int C = ngroups*Cg;
-    CV_Assert(C0 % 8 == 0 || C0 == 4 || C == C0);
-    CV_Assert(istep0 == 1u || ostep0 == 1u);
-    const int dC0 = std::min(C0, 8);
-    for (int g = 0; g < ngroups; g++) {
-        for (int c1 = 0; c1 < C1g; c1++) {
-            for (int c0 = 0; c0 < C0; c0 += dC0) {
-                int dc = std::min(Cg - g*C1g - c0, dC0);
-                const _Tp* inp = inp_ + istep0*c0 + istep1*c1 + istepg*g;
-                _Tp* out = out_ + ostep0*c0 + ostep1*c1 + ostepg*g;
-                
-                if (dc == 8) {
-                    if (istep0 == 1) {
-                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                            _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
-                            _Tp x4 = inp[4], x5 = inp[5], x6 = inp[6], x7 = inp[7];
-                            out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
-                            out[ostep0*4] = x4; out[ostep0*5] = x5; out[ostep0*6] = x6; out[ostep0*7] = x7;
-                        }
-                    } else {
-                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                            _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
-                            _Tp x4 = inp[istep0*4], x5 = inp[istep0*5], x6 = inp[istep0*6], x7 = inp[istep0*7];
-                            out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
-                            out[4] = x4; out[5] = x5; out[6] = x6; out[7] = x7;
-                        }
-                    }
-                } else if (dc == 4) {
-                    if (istep0 == 1) {
-                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                            _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
-                            out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
-                        }
-                    } else {
-                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                            _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
-                            out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
-                        }
-                    }
-                } else if (dc == 3 && ostep0 == 1 && ostep == C0) {
-                    memset(out, 0, npix*C0*sizeof(out[0]));
-                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2];
-                        out[0] = x0; out[1] = x1; out[2] = x2;
-                    }
-                } else if (dc == 1 && ostep0 == 1 && ostep == C0) {
-                    memset(out, 0, npix*C0*sizeof(out[0]));
-                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        out[0] = inp[0];
-                    }
-                } else {
-                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        int c = 0;
-                        for (; c < dc; c++)
-                            out[ostep0*c] = inp[istep0*c];
-                        if (ostep == C0) {
-                            for (; c < dC0; c++)
-                                out[ostep0*c] = 0;
-                        }
-                    }
-                }
-            }
+#if CV_SIMD128
+    if constexpr (sizeof(_Tp) == 4u) {
+        const uint32_t* inp = (const uint32_t*)inp_;
+        uint32_t* out = (uint32_t*)out_;
+        v_uint32 a0, a1, a2, a3, b0, b1, b2, b3;
+        
+        a0 = vx_load(inp + istep*0);
+        a1 = vx_load(inp + istep*1);
+        a2 = vx_load(inp + istep*2);
+        a3 = vx_load(inp + istep*3);
+        v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
+        v_store(out + ostep*0, b0);
+        v_store(out + ostep*1, b1);
+        v_store(out + ostep*2, b2);
+        v_store(out + ostep*3, b3);
+        
+        a0 = vx_load(inp + istep*0 + 4);
+        a1 = vx_load(inp + istep*1 + 4);
+        a2 = vx_load(inp + istep*2 + 4);
+        a3 = vx_load(inp + istep*3 + 4);
+        v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
+        v_store(out + ostep*4, b0);
+        v_store(out + ostep*5, b1);
+        v_store(out + ostep*6, b2);
+        v_store(out + ostep*7, b3);
+        
+        a0 = vx_load(inp + istep*4);
+        a1 = vx_load(inp + istep*5);
+        a2 = vx_load(inp + istep*6);
+        a3 = vx_load(inp + istep*7);
+        v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
+        v_store(out + ostep*0 + 4, b0);
+        v_store(out + ostep*1 + 4, b1);
+        v_store(out + ostep*2 + 4, b2);
+        v_store(out + ostep*3 + 4, b3);
+        
+        a0 = vx_load(inp + istep*4 + 4);
+        a1 = vx_load(inp + istep*5 + 4);
+        a2 = vx_load(inp + istep*6 + 4);
+        a3 = vx_load(inp + istep*7 + 4);
+        v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
+        v_store(out + ostep*4 + 4, b0);
+        v_store(out + ostep*5 + 4, b1);
+        v_store(out + ostep*6 + 4, b2);
+        v_store(out + ostep*7 + 4, b3);
+    } else
+#endif
+    {
+    for (int i = 0; i < 8; i++)
+        for (int j = 0; j < 8; j++)
+            out_[i * ostep + j] = inp_[j * istep + i];
+    }
+}
+
+template <typename _Tp>
+void transformLayoutInterleave_(const _Tp* inp_base, _Tp* out_base, int C, size_t len,
+                                int nc, int nzc, size_t dlen)
+{
+    size_t i = 0;
+#if 0
+    for (; i + 7u < dlen; i += 8u)
+    {
+        int c = 0;
+        
+        for (; c + 7u < nzc; c += 8u) {
+            transpose8x8<_Tp>(inp_base + c * len + i, len, out_base + i * nc + c, nc);
+        }
+        
+        for (; c < nzc; ++c) {
+            _Tp* outptr = out_base + i * nc + c;
+            const _Tp* inptr = inp_base + c * len + i;
+            outptr[0 * nc] = inptr[0];
+            outptr[1 * nc] = inptr[1];
+            outptr[2 * nc] = inptr[2];
+            outptr[3 * nc] = inptr[3];
+            outptr[4 * nc] = inptr[4];
+            outptr[5 * nc] = inptr[5];
+            outptr[6 * nc] = inptr[6];
+            outptr[7 * nc] = inptr[7];
+        }
+        
+        for (; c < nc; ++c) {
+            _Tp* outptr = out_base + i * nc + c;
+            outptr[0 * nc] = (_Tp)0; outptr[1 * nc] = (_Tp)0; outptr[2 * nc] = (_Tp)0; outptr[3 * nc] = (_Tp)0;
+            outptr[4 * nc] = (_Tp)0; outptr[5 * nc] = (_Tp)0; outptr[6 * nc] = (_Tp)0; outptr[7 * nc] = (_Tp)0;
+        }
+    }
+#endif
+    for (; i < dlen; ++i) {
+        _Tp* outptr = out_base + i * nc;
+        for (int c = 0; c < nc; ++c) {
+            outptr[c] = c < nzc ? inp_base[c*len + i] : (_Tp)0;
         }
     }
 }
 
-#undef CV_TRANSFORM_LAYOUT_IMPL
-#define CV_TRANSFORM_LAYOUT_IMPL(typ, suffix) \
-static void transformLayout##suffix(const void* inp_, size_t istep, size_t istep0, \
-                                    size_t istep1, size_t istepg, \
-                                    void* out_, size_t ostep, size_t ostep0, \
-                                    size_t ostep1, size_t ostepg, \
-                                    size_t npix, int C0, int C1g, int Cg, int ngroups) \
-{ \
-    transformLayout_((const typ*)inp_, istep, istep0, istep1, istepg, \
-                     (typ*)out_, ostep, ostep0, ostep1, ostepg, \
-                     npix, C0, C1g, Cg, ngroups); \
+template <typename _Tp>
+void transformLayoutDeinterleave_(const _Tp* inp_base, _Tp* out_base, int C, size_t len,
+                                  int nc, int nzc, size_t dlen)
+{
+    size_t i = 0;
+#if 0
+    for (; i + 7u < dlen; i += 8u)
+    {
+        int c = 0;
+
+        for (; c + 7u < nzc; c += 8u)
+        {
+            transpose8x8<_Tp>(inp_base + i * nc + c, nc, out_base + c * len + i, len);
+        }
+
+        for (; c < nzc; ++c)
+        {
+            const _Tp* inptr = inp_base + i * nc + c;
+            _Tp* outptr = out_base + c * len + i;
+            outptr[0] = inptr[0 * nc];
+            outptr[1] = inptr[1 * nc];
+            outptr[2] = inptr[2 * nc];
+            outptr[3] = inptr[3 * nc];
+            outptr[4] = inptr[4 * nc];
+            outptr[5] = inptr[5 * nc];
+            outptr[6] = inptr[6 * nc];
+            outptr[7] = inptr[7 * nc];
+        }
+    }
+#endif
+    for (; i < dlen; ++i)
+    {
+        const _Tp* inptr = inp_base + i * nc;
+        for (int c = 0; c < nzc; ++c) {
+            out_base[c*len + i] = inptr[c];
+        }
+    }
 }
 
-CV_TRANSFORM_LAYOUT_IMPL(uint8_t, 8u)
-CV_TRANSFORM_LAYOUT_IMPL(uint16_t, 16u)
-CV_TRANSFORM_LAYOUT_IMPL(uint32_t, 32u)
-CV_TRANSFORM_LAYOUT_IMPL(uint64_t, 64u)
+typedef void (*TransformLayoutFunc)(const void* inp, void* out, int C, size_t planesize,
+                                    int nc, int nzc, size_t dlen);
 
-typedef void (*TransformLayoutFunc)(const void*, size_t, size_t, size_t, size_t,
-                                    void*, size_t, size_t, size_t, size_t,
-                                    size_t, int, int, int, int);
+#undef DECL_TRANSFORM_LAYOUT
+#define DECL_TRANSFORM_LAYOUT(suffix, _Tp) \
+static void transformLayoutInterleave_##suffix(const void* inp, void* out, int C, size_t planesize, \
+                                               int nc, int nzc, size_t dlen) \
+{ \
+    transformLayoutInterleave_((const _Tp*)inp, (_Tp*)out, C, planesize, nc, nzc, dlen); \
+} \
+static void transformLayoutDeinterleave_##suffix(const void* inp, void* out, int C, size_t planesize, \
+                                                 int nc, int nzc, size_t dlen) \
+{ \
+    transformLayoutDeinterleave_((const _Tp*)inp, (_Tp*)out, C, planesize, nc, nzc, dlen); \
+}
+
+DECL_TRANSFORM_LAYOUT(8u, uint8_t)
+DECL_TRANSFORM_LAYOUT(16u, uint16_t)
+DECL_TRANSFORM_LAYOUT(32u, uint32_t)
+DECL_TRANSFORM_LAYOUT(64u, uint64_t)
+
+TransformLayoutFunc getTransformLayoutFunc(DataLayout inplayout, DataLayout outlayout, size_t esz)
+{
+    if (inplayout == DATA_LAYOUT_NCHW &&
+        (outlayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_NHWC)) {
+        return esz == 1u ? transformLayoutInterleave_8u :
+               esz == 2u ? transformLayoutInterleave_16u :
+               esz == 4u ? transformLayoutInterleave_32u :
+               esz == 8u ? transformLayoutInterleave_64u : nullptr;
+    }
+    if ((inplayout == DATA_LAYOUT_BLOCK || inplayout == DATA_LAYOUT_NHWC) &&
+        outlayout == DATA_LAYOUT_NCHW) {
+        return esz == 1u ? transformLayoutDeinterleave_8u :
+               esz == 2u ? transformLayoutDeinterleave_16u :
+               esz == 4u ? transformLayoutDeinterleave_32u :
+               esz == 8u ? transformLayoutDeinterleave_64u : nullptr;
+    }
+    return nullptr;
+}
 
 void transformLayout(const Mat& inp, Mat& out,
                      DataLayout outlayout,
                      DataLayout defaultLayout,
-                     int C0, int ninpgroups, int noutgroups)
+                     int C0)
 {
     CV_Assert(defaultLayout == DATA_LAYOUT_NCHW || defaultLayout == DATA_LAYOUT_NHWC);
     CV_Assert(outlayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_NCHW || outlayout == DATA_LAYOUT_NHWC);
 
     MatShape inpshape = inp.size;
+    if (inpshape.layout == DATA_LAYOUT_NCHW &&
+        inpshape.dims == 4 && inpshape[1] == 272 && inpshape[2] == 14 && inpshape[3] == 14) {
+        putchar('.');
+    }
 
     if (inpshape.layout == DATA_LAYOUT_UNKNOWN) {
         inpshape.layout = defaultLayout;
     }
     DataLayout inplayout = inpshape.layout;
-    MatShape outshape = inferTransformLayoutShape(inpshape, outlayout, defaultLayout,
-                                                  C0, ninpgroups, noutgroups);
+    MatShape outshape = inferTransformLayoutShape(inpshape, outlayout, defaultLayout, C0);
     out.fit(outshape, inp.type());
 
     if (inp.empty())
         return;
 
-    int inp_ndims = inpshape.dims;
-    int out_ndims = outshape.dims;
-    int C = inplayout == DATA_LAYOUT_BLOCK ? inpshape.C :
-        inpshape[inplayout == DATA_LAYOUT_NCHW ? 1 : inp_ndims-1];
-    int inpC0 = inplayout == DATA_LAYOUT_BLOCK ? inpshape.back() : inplayout == DATA_LAYOUT_NCHW ? 1 : C;
-    int outC0 = outlayout == DATA_LAYOUT_BLOCK ? C0 : outlayout == DATA_LAYOUT_NCHW ? 1 : C;
-
-    if (inplayout == outlayout && inpC0 == outC0 && ninpgroups == noutgroups) {
+    if (inplayout == outlayout) {
         inp.copyTo(out);
         return;
     }
-
-    CV_Assert(ninpgroups == 1 || inplayout == DATA_LAYOUT_BLOCK);
-    CV_Assert(noutgroups == 1 || outlayout == DATA_LAYOUT_BLOCK);
-    CV_Assert_N(ninpgroups > 0, C % ninpgroups == 0);
-    CV_Assert_N(noutgroups > 0, C % noutgroups == 0);
+    
+    CV_Assert_N(inp.isContinuous(), out.isContinuous());
+    
+    size_t esz = inp.elemSize();
+    TransformLayoutFunc kernel = getTransformLayoutFunc(inplayout, outlayout, esz);
+    CV_Assert(kernel != nullptr);
 
     int N = inpshape[0];
-    size_t inptotal = inp.total();
-    size_t outtotal = out.total();
-    size_t inplanesize_C = inptotal / N;
-    size_t outplanesize_C = outtotal / N;
+    int C = inpshape.channels();
+    C0 = inplayout == DATA_LAYOUT_BLOCK ? inpshape.back() : C0;
+    int C1 = (C + C0 - 1) / C0;
+    
     size_t planesize = 1;
     int inp_sp0 = inplayout == DATA_LAYOUT_NHWC ? 1 : 2;
-    int inp_sp1 = inplayout == DATA_LAYOUT_NCHW ? inp_ndims : inp_ndims-1;
+    int inp_sp1 = inplayout == DATA_LAYOUT_NCHW ? inpshape.dims : inpshape.dims-1;
     for (int i = inp_sp0; i < inp_sp1; i++) {
         planesize *= (size_t)inpshape[i];
     }
+    
+    /*size_t total = N*C1*planesize*C0;
+    constexpr size_t min_elems_per_chunk = 1 << 17;
+    size_t nblocks = (total + min_elems_per_chunk/2) / min_elems_per_chunk;
+    nblocks = std::clamp(nblocks, size_t(1), size_t(128));
+    nblocks = (nblocks + N*C1 - 1)/(N*C1);*/
+    int nblocks = 1;
 
-    size_t allplanes = planesize*N;
+    //parallel_for_(Range(0, N*C1*nblocks), [&](const Range& range) {
+    {
+        Range range(0, N*C1*nblocks);
+        int dchunk = 1u;
+        bool interleave = inplayout == DATA_LAYOUT_NCHW;
+        const uint8_t* inptr = (const uint8_t*)inp.data;
+        uint8_t* outptr = (uint8_t*)out.data;
+        
+        for (int chunk = range.start; chunk < range.end; chunk += dchunk)
+        {
+            int n = chunk/(C1*nblocks);
+            int c1 = (chunk % (C1*nblocks))/nblocks;
+            int block = chunk % nblocks;
+            int nc = C0;
+            int nzc = std::min(nc, C - c1*C0);
+            dchunk = std::min(nblocks - block, range.end - chunk);
+            size_t block_start = block * planesize / nblocks;
+            size_t block_end = (block + dchunk) * planesize / nblocks;
+            size_t dlen = block_end - block_start;
+            size_t inpofs = ((n * C1 + c1) * planesize + block_start) * nc * esz;
+            size_t outofs = ((n * C + c1 * C0) * planesize + block_start) * esz;
+            if (interleave) {
+                std::swap(inpofs, outofs);
+            }
 
-    constexpr size_t BLOCK_SIZE = 1u << 17;
-    size_t nblocks = (outtotal + BLOCK_SIZE - 1)/BLOCK_SIZE;
-    nblocks = std::min(nblocks, allplanes);
-
-    size_t esz = inp.elemSize();
-    size_t istep0, istep1, istepg, istep;
-    size_t ostep0, ostep1, ostepg, ostep;
-
-    if (inplayout == DATA_LAYOUT_NCHW) {
-        istep = 1;
-        istep0 = planesize;
-    } else if (inplayout == DATA_LAYOUT_NHWC) {
-        istep = C;
-        istep0 = 1;
-    } else {
-        istep = inpC0;
-        istep0 = 1;
-    }
-
-    if (outlayout == DATA_LAYOUT_NCHW) {
-        ostep = 1;
-        ostep0 = planesize;
-    } else if (outlayout == DATA_LAYOUT_NHWC) {
-        ostep = C;
-        ostep0 = 1;
-    } else {
-        ostep = outC0;
-        ostep0 = 1;
-    }
-
-    const char* inptr0 = (const char*)inp.data;
-    char* outptr0 = (char*)out.data;
-
-    TransformLayoutFunc transformLayoutFunc =
-        esz == 1 ? transformLayout8u :
-        esz == 2 ? transformLayout16u :
-        esz == 4 ? transformLayout32u :
-        esz == 8 ? transformLayout64u : nullptr;
-
-    CV_Assert(transformLayoutFunc != nullptr);
-
-    parallel_for_(Range(0, int(nblocks)), [&](const Range& range) {
-        size_t start = range.start*allplanes/nblocks;
-        size_t end = range.end*allplanes/nblocks;
-        size_t npix = 0;
-
-        for (size_t ofs = start; ofs < end; ofs += npix) {
-            size_t sample_idx = ofs/planesize;
-            size_t rawofs = ofs - sample_idx*planesize;
-            npix = std::min(planesize - rawofs, end - ofs);
-            const char* inptr = inptr0 + (inplanesize_C*sample_idx + istep*rawofs)*esz;
-            char* outptr = outptr0 + (outplanesize_C*sample_idx + ostep*rawofs)*esz;
-            transformLayoutFunc(inptr, istep, istep0, istep1, istepg,
-                                outptr, ostep, ostep0, ostep1, ostepg,
-                                npix, C0, C1g, Cg, ngroups);
+            kernel(inptr + inpofs, outptr + outofs, C, planesize, nc, nzc, dlen);
         }
-    });
+    }
+    //);
 }
 
 class TransformLayoutLayerImpl : public TransformLayoutLayer
@@ -286,7 +339,7 @@ public:
     MatShape inferShape(const MatShape& inpshape_) const
     {
         return inferTransformLayoutShape(inpshape_, layout,
-                                         getNetImpl(this)->originalLayout, C0, 1, 1);
+                                         getNetImpl(this)->originalLayout, C0);
     }
 
     virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,
@@ -342,10 +395,16 @@ public:
     {
         DataLayout origLayout = getNetImpl(this)->originalLayout;
         transformLayout(inp, out, layout, origLayout, C0);
-#if 0
+#if 1
         Mat temp;
         transformLayout(out, temp, layout == DATA_LAYOUT_BLOCK ? origLayout : DATA_LAYOUT_BLOCK, origLayout, C0);
         double err = norm(temp, inp, NORM_INF);
+        size_t i, N = inp.total();
+        const float* inpdata = inp.ptr<float>();
+        const float* tempdata = temp.ptr<float>();
+        for (i = 0; i < N; i++) {
+            CV_Assert_N(!cvIsNaN(inpdata[i]), !cvIsNaN(tempdata[i]));
+        }
         CV_Assert(err == 0.);
 #endif
     }

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -14,110 +14,87 @@ namespace dnn
 static MatShape inferTransformLayoutShape(const MatShape& inpshape_,
                                           DataLayout outlayout,
                                           DataLayout defaultLayout,
-                                          int C0)
+                                          int C0, int ninpgroups, int noutgroups)
 {
     MatShape inpshape = inpshape_;
-    int ndims = inpshape.dims;
-    DataLayout inplayout = inpshape_.layout == DATA_LAYOUT_UNKNOWN ? defaultLayout : inpshape.layout;
-    inpshape.layout = inplayout;
-
-    if (inplayout == outlayout) {
-        return inpshape;
-    }
-    
-    // non-block => block
-    if (outlayout == DATA_LAYOUT_BLOCK) {
-        CV_Assert(inplayout != DATA_LAYOUT_BLOCK);
-        return inpshape.toBlock(C0);
+    if (inpshape.layout == DATA_LAYOUT_UNKNOWN) {
+        inpshape.layout = defaultLayout;
     }
 
-    // block => non-block
-    if (inplayout == DATA_LAYOUT_BLOCK) {
-        CV_Assert(outlayout != DATA_LAYOUT_BLOCK);
-        return inpshape.fromBlock(outlayout);
+    if (ninpgroups > 1) {
+        CV_Assert(inpshape.layout == DATA_LAYOUT_BLOCK);
+        inpshape = inpshape.toLayout(DATA_LAYOUT_NCHW);
     }
 
-    MatShape outshape = inpshape;
-    outshape.layout = outlayout;
-
-    // NHWC => NCHW
-    if (outlayout == DATA_LAYOUT_NCHW) {
-        CV_Assert(inplayout == DATA_LAYOUT_NHWC);
-        int C = inpshape[ndims-1];
-        for (int i = 2; i < ndims; i++)
-            outshape[i] = inpshape[i-1];
-        outshape[1] = C;
-    } else {
-        // NCHW => NHWC
-        CV_Assert(outlayout == DATA_LAYOUT_NHWC && inplayout == DATA_LAYOUT_NCHW);
-        int C = inpshape[1];
-        for (int i = 2; i < ndims; i++)
-            outshape[i-1] = inpshape[i];
-        outshape[ndims-1] = C;
-    }
-    return outshape;
+    return inpshape.toLayout(outlayout, C0, noutgroups);
 }
 
+// NCHW <=> NHWC or
+// NCHW/NHWC <=> BLOCK
 template <typename _Tp>
-void transform_layout_(const _Tp* inp_, int istep, int istep0, int istep1,
-                      _Tp* out_, int ostep, int ostep0, int ostep1,
-                      int npix, int C0, int C1, int C)
+void transformLayout_(const _Tp* inp_, size_t istep, size_t istep0, size_t istep1,
+                      _Tp* out_, size_t ostep, size_t ostep0, size_t ostep1,
+                      size_t npix, int C0, int C1g, int Cg, int ngroups)
 {
-    CV_Assert(C0 % 8 == 0 || C0 == 4 || C1 == 1);
-    CV_Assert(istep0 == 1 || ostep0 == 1);
-    const int dC0 = std::min(C0, (int)8);
-    for (int c1 = 0; c1 < C1; c1++) {
-        for (int c0 = 0; c0 < C0; c0 += dC0) {
-            const _Tp* inp = inp_ + istep0*c0 + istep1*c1;
-            _Tp* out = out_ + ostep0*c0 + ostep1*c1;
-            int dc = std::min(C - (c1*C0 + c0), dC0);
-            if (dc == 8) {
-                if (istep0 == 1) {
-                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
-                        _Tp x4 = inp[4], x5 = inp[5], x6 = inp[6], x7 = inp[7];
-                        out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
-                        out[ostep0*4] = x4; out[ostep0*5] = x5; out[ostep0*6] = x6; out[ostep0*7] = x7;
+    int C = ngroups*Cg;
+    CV_Assert(C0 % 8 == 0 || C0 == 4 || C == C0);
+    CV_Assert(istep0 == 1u || ostep0 == 1u);
+    const int dC0 = std::min(C0, 8);
+    for (int g = 0; g < ngroups; g++) {
+        for (int c1 = 0; c1 < C1g; c1++) {
+            for (int c0 = 0; c0 < C0; c0 += dC0) {
+                int dc = std::min(Cg - g*C1g - c0, dC0);
+                const _Tp* inp = inp_ + istep0*c0 + istep1*c1 + istepg*g;
+                _Tp* out = out_ + ostep0*c0 + ostep1*c1 + ostepg*g;
+                
+                if (dc == 8) {
+                    if (istep0 == 1) {
+                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                            _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
+                            _Tp x4 = inp[4], x5 = inp[5], x6 = inp[6], x7 = inp[7];
+                            out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
+                            out[ostep0*4] = x4; out[ostep0*5] = x5; out[ostep0*6] = x6; out[ostep0*7] = x7;
+                        }
+                    } else {
+                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                            _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
+                            _Tp x4 = inp[istep0*4], x5 = inp[istep0*5], x6 = inp[istep0*6], x7 = inp[istep0*7];
+                            out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
+                            out[4] = x4; out[5] = x5; out[6] = x6; out[7] = x7;
+                        }
+                    }
+                } else if (dc == 4) {
+                    if (istep0 == 1) {
+                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                            _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
+                            out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
+                        }
+                    } else {
+                        for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                            _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
+                            out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
+                        }
+                    }
+                } else if (dc == 3 && ostep0 == 1 && ostep == C0) {
+                    memset(out, 0, npix*C0*sizeof(out[0]));
+                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2];
+                        out[0] = x0; out[1] = x1; out[2] = x2;
+                    }
+                } else if (dc == 1 && ostep0 == 1 && ostep == C0) {
+                    memset(out, 0, npix*C0*sizeof(out[0]));
+                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        out[0] = inp[0];
                     }
                 } else {
-                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
-                        _Tp x4 = inp[istep0*4], x5 = inp[istep0*5], x6 = inp[istep0*6], x7 = inp[istep0*7];
-                        out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
-                        out[4] = x4; out[5] = x5; out[6] = x6; out[7] = x7;
-                    }
-                }
-            } else if (dc == 4) {
-                if (istep0 == 1) {
-                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        _Tp x0 = inp[0], x1 = inp[1], x2 = inp[2], x3 = inp[3];
-                        out[0] = x0; out[ostep0] = x1; out[ostep0*2] = x2; out[ostep0*3] = x3;
-                    }
-                } else {
-                    for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                        _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2], x3 = inp[istep0*3];
-                        out[0] = x0; out[1] = x1; out[2] = x2; out[3] = x3;
-                    }
-                }
-            } else if (dc == 3 && ostep0 == 1 && ostep == C0) {
-                memset(out, 0, npix*C0*sizeof(out[0]));
-                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                    _Tp x0 = inp[0], x1 = inp[istep0], x2 = inp[istep0*2];
-                    out[0] = x0; out[1] = x1; out[2] = x2;
-                }
-            } else if (dc == 1 && ostep0 == 1 && ostep == C0) {
-                memset(out, 0, npix*C0*sizeof(out[0]));
-                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                    out[0] = inp[0];
-                }
-            } else {
-                for (int i = 0; i < npix; i++, inp += istep, out += ostep) {
-                    int c = 0;
-                    for (; c < dc; c++)
-                        out[ostep0*c] = inp[istep0*c];
-                    if (ostep == C0) {
-                        for (; c < dC0; c++)
-                            out[ostep0*c] = 0;
+                    for (size_t i = 0; i < npix; i++, inp += istep, out += ostep) {
+                        int c = 0;
+                        for (; c < dc; c++)
+                            out[ostep0*c] = inp[istep0*c];
+                        if (ostep == C0) {
+                            for (; c < dC0; c++)
+                                out[ostep0*c] = 0;
+                        }
                     }
                 }
             }
@@ -127,123 +104,133 @@ void transform_layout_(const _Tp* inp_, int istep, int istep0, int istep1,
 
 #undef CV_TRANSFORM_LAYOUT_IMPL
 #define CV_TRANSFORM_LAYOUT_IMPL(typ, suffix) \
-static void transform_layout_##suffix(const void* inp_, int istep, int istep0, int istep1, \
-                                      void* out_, int ostep, int ostep0, int ostep1, \
-                                      int npix, int C0, int C1, int C) \
+static void transformLayout##suffix(const void* inp_, size_t istep, size_t istep0, \
+                                    size_t istep1, size_t istepg, \
+                                    void* out_, size_t ostep, size_t ostep0, \
+                                    size_t ostep1, size_t ostepg, \
+                                    size_t npix, int C0, int C1g, int Cg, int ngroups) \
 { \
-    transform_layout_((const typ*)inp_, istep, istep0, istep1, \
-                     (typ*)out_, ostep, ostep0, ostep1, npix, C0, C1, C); \
+    transformLayout_((const typ*)inp_, istep, istep0, istep1, istepg, \
+                     (typ*)out_, ostep, ostep0, ostep1, ostepg, \
+                     npix, C0, C1g, Cg, ngroups); \
 }
 
 CV_TRANSFORM_LAYOUT_IMPL(uint8_t, 8u)
 CV_TRANSFORM_LAYOUT_IMPL(uint16_t, 16u)
 CV_TRANSFORM_LAYOUT_IMPL(uint32_t, 32u)
-CV_TRANSFORM_LAYOUT_IMPL(uint, 64u)
+CV_TRANSFORM_LAYOUT_IMPL(uint64_t, 64u)
 
-typedef void (*transform_layout_func_t)(const void* inp, int istep, int istep0, int istep1,
-                                        void* out, int ostep, int ostep0, int ostep1,
-                                        int npix, int C0, int C1, int C);
+typedef void (*TransformLayoutFunc)(const void*, size_t, size_t, size_t, size_t,
+                                    void*, size_t, size_t, size_t, size_t,
+                                    size_t, int, int, int, int);
 
 void transformLayout(const Mat& inp, Mat& out,
                      DataLayout outlayout,
                      DataLayout defaultLayout,
-                     int C0)
+                     int C0, int ninpgroups, int noutgroups)
 {
+    CV_Assert(defaultLayout == DATA_LAYOUT_NCHW || defaultLayout == DATA_LAYOUT_NHWC);
+    CV_Assert(outlayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_NCHW || outlayout == DATA_LAYOUT_NHWC);
+
     MatShape inpshape = inp.size;
-    MatShape outshape = inferTransformLayoutShape(inpshape, outlayout, defaultLayout, C0);
+
+    if (inpshape.layout == DATA_LAYOUT_UNKNOWN) {
+        inpshape.layout = defaultLayout;
+    }
     DataLayout inplayout = inpshape.layout;
-    if (inplayout == DATA_LAYOUT_UNKNOWN && outlayout == DATA_LAYOUT_BLOCK)
-        inplayout = defaultLayout;
-    
+    MatShape outshape = inferTransformLayoutShape(inpshape, outlayout, defaultLayout,
+                                                  C0, ninpgroups, noutgroups);
     out.fit(outshape, inp.type());
 
     if (inp.empty())
         return;
 
-    if (inplayout == outlayout) {
+    int inp_ndims = inpshape.dims;
+    int out_ndims = outshape.dims;
+    int C = inplayout == DATA_LAYOUT_BLOCK ? inpshape.C :
+        inpshape[inplayout == DATA_LAYOUT_NCHW ? 1 : inp_ndims-1];
+    int inpC0 = inplayout == DATA_LAYOUT_BLOCK ? inpshape.back() : inplayout == DATA_LAYOUT_NCHW ? 1 : C;
+    int outC0 = outlayout == DATA_LAYOUT_BLOCK ? C0 : outlayout == DATA_LAYOUT_NCHW ? 1 : C;
+
+    if (inplayout == outlayout && inpC0 == outC0 && ninpgroups == noutgroups) {
         inp.copyTo(out);
         return;
     }
 
-    int inp_ndims = inpshape.dims;
-    int out_ndims = outshape.dims;
-    int N = inpshape[0];
-    int C = inplayout == DATA_LAYOUT_BLOCK ? inpshape.C :
-        inpshape[inplayout == DATA_LAYOUT_NCHW ? 1 : inp_ndims-1];
-    int inptotal = (int)inp.total();
-    int outtotal = (int)out.total();
-    int inplanesize_C = inptotal / N;
-    int outplanesize_C = outtotal / N;
-    int planesize = (inplayout != DATA_LAYOUT_BLOCK ? inplanesize_C : outplanesize_C)/C;
-    int allplanes = planesize*N;
+    CV_Assert(ninpgroups == 1 || inplayout == DATA_LAYOUT_BLOCK);
+    CV_Assert(noutgroups == 1 || outlayout == DATA_LAYOUT_BLOCK);
+    CV_Assert_N(ninpgroups > 0, C % ninpgroups == 0);
+    CV_Assert_N(noutgroups > 0, C % noutgroups == 0);
 
-    constexpr int BLOCK_SIZE = 1 << 17;
-    int nblocks = (outtotal + BLOCK_SIZE - 1)/BLOCK_SIZE;
+    int N = inpshape[0];
+    size_t inptotal = inp.total();
+    size_t outtotal = out.total();
+    size_t inplanesize_C = inptotal / N;
+    size_t outplanesize_C = outtotal / N;
+    size_t planesize = 1;
+    int inp_sp0 = inplayout == DATA_LAYOUT_NHWC ? 1 : 2;
+    int inp_sp1 = inplayout == DATA_LAYOUT_NCHW ? inp_ndims : inp_ndims-1;
+    for (int i = inp_sp0; i < inp_sp1; i++) {
+        planesize *= (size_t)inpshape[i];
+    }
+
+    size_t allplanes = planesize*N;
+
+    constexpr size_t BLOCK_SIZE = 1u << 17;
+    size_t nblocks = (outtotal + BLOCK_SIZE - 1)/BLOCK_SIZE;
     nblocks = std::min(nblocks, allplanes);
 
     size_t esz = inp.elemSize();
-    int istep0, istep1, istep;
-    int ostep0, ostep1, ostep;
-    int C0_ = C, C1_ = 1;
-
-    if (inplayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_BLOCK) {
-        C0_ = inplayout == DATA_LAYOUT_BLOCK ? inpshape[inp_ndims-1] : outshape[out_ndims-1];
-        C1_ = (C + C0_ - 1)/C0_;
-    }
+    size_t istep0, istep1, istepg, istep;
+    size_t ostep0, ostep1, ostepg, ostep;
 
     if (inplayout == DATA_LAYOUT_NCHW) {
         istep = 1;
         istep0 = planesize;
-        istep1 = planesize*C0_;
     } else if (inplayout == DATA_LAYOUT_NHWC) {
         istep = C;
         istep0 = 1;
-        istep1 = C0_;
     } else {
-        istep = C0_;
+        istep = inpC0;
         istep0 = 1;
-        istep1 = planesize*C0_;
     }
 
     if (outlayout == DATA_LAYOUT_NCHW) {
         ostep = 1;
         ostep0 = planesize;
-        ostep1 = planesize*C0_;
     } else if (outlayout == DATA_LAYOUT_NHWC) {
         ostep = C;
         ostep0 = 1;
-        ostep1 = C0_;
     } else {
-        ostep = C0_;
+        ostep = outC0;
         ostep0 = 1;
-        ostep1 = planesize*C0_;
     }
 
     const char* inptr0 = (const char*)inp.data;
     char* outptr0 = (char*)out.data;
 
-    transform_layout_func_t transform_layout_func =
-        esz == 1 ? transform_layout_8u :
-        esz == 2 ? transform_layout_16u :
-        esz == 4 ? transform_layout_32u :
-        esz == 8 ? transform_layout_64u : nullptr;
+    TransformLayoutFunc transformLayoutFunc =
+        esz == 1 ? transformLayout8u :
+        esz == 2 ? transformLayout16u :
+        esz == 4 ? transformLayout32u :
+        esz == 8 ? transformLayout64u : nullptr;
 
-    CV_Assert(transform_layout_func != nullptr);
+    CV_Assert(transformLayoutFunc != nullptr);
 
-    parallel_for_(Range(0, nblocks), [&](const Range& r) {
-        int start = r.start*allplanes/nblocks;
-        int end = r.end*allplanes/nblocks;
-        int npix = 0;
+    parallel_for_(Range(0, int(nblocks)), [&](const Range& range) {
+        size_t start = range.start*allplanes/nblocks;
+        size_t end = range.end*allplanes/nblocks;
+        size_t npix = 0;
 
-        for (int ofs = start; ofs < end; ofs += npix) {
-            int sample_idx = ofs/planesize;
-            int rawofs = ofs - sample_idx*planesize;
+        for (size_t ofs = start; ofs < end; ofs += npix) {
+            size_t sample_idx = ofs/planesize;
+            size_t rawofs = ofs - sample_idx*planesize;
             npix = std::min(planesize - rawofs, end - ofs);
             const char* inptr = inptr0 + (inplanesize_C*sample_idx + istep*rawofs)*esz;
             char* outptr = outptr0 + (outplanesize_C*sample_idx + ostep*rawofs)*esz;
-            transform_layout_func(inptr, istep, istep0, istep1,
-                                  outptr, ostep, ostep0, ostep1,
-                                  npix, C0_, C1_, C);
+            transformLayoutFunc(inptr, istep, istep0, istep1, istepg,
+                                outptr, ostep, ostep0, ostep1, ostepg,
+                                npix, C0, C1g, Cg, ngroups);
         }
     });
 }
@@ -299,7 +286,7 @@ public:
     MatShape inferShape(const MatShape& inpshape_) const
     {
         return inferTransformLayoutShape(inpshape_, layout,
-                                         getNetImpl(this)->originalLayout, C0);
+                                         getNetImpl(this)->originalLayout, C0, 1, 1);
     }
 
     virtual bool getMemoryShapes(const std::vector<MatShape>& inpshapes,

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -32,42 +32,42 @@ static inline void transpose8x8(const _Tp* inp_, size_t istep,
     if constexpr (sizeof(_Tp) == 4u) {
         const uint32_t* inp = (const uint32_t*)inp_;
         uint32_t* out = (uint32_t*)out_;
-        v_uint32 a0, a1, a2, a3, b0, b1, b2, b3;
+        v_uint32x4 a0, a1, a2, a3, b0, b1, b2, b3;
 
-        a0 = vx_load(inp + istep*0);
-        a1 = vx_load(inp + istep*1);
-        a2 = vx_load(inp + istep*2);
-        a3 = vx_load(inp + istep*3);
+        a0 = v_load(inp + istep*0);
+        a1 = v_load(inp + istep*1);
+        a2 = v_load(inp + istep*2);
+        a3 = v_load(inp + istep*3);
         v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
         v_store(out + ostep*0, b0);
         v_store(out + ostep*1, b1);
         v_store(out + ostep*2, b2);
         v_store(out + ostep*3, b3);
 
-        a0 = vx_load(inp + istep*0 + 4);
-        a1 = vx_load(inp + istep*1 + 4);
-        a2 = vx_load(inp + istep*2 + 4);
-        a3 = vx_load(inp + istep*3 + 4);
+        a0 = v_load(inp + istep*0 + 4);
+        a1 = v_load(inp + istep*1 + 4);
+        a2 = v_load(inp + istep*2 + 4);
+        a3 = v_load(inp + istep*3 + 4);
         v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
         v_store(out + ostep*4, b0);
         v_store(out + ostep*5, b1);
         v_store(out + ostep*6, b2);
         v_store(out + ostep*7, b3);
 
-        a0 = vx_load(inp + istep*4);
-        a1 = vx_load(inp + istep*5);
-        a2 = vx_load(inp + istep*6);
-        a3 = vx_load(inp + istep*7);
+        a0 = v_load(inp + istep*4);
+        a1 = v_load(inp + istep*5);
+        a2 = v_load(inp + istep*6);
+        a3 = v_load(inp + istep*7);
         v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
         v_store(out + ostep*0 + 4, b0);
         v_store(out + ostep*1 + 4, b1);
         v_store(out + ostep*2 + 4, b2);
         v_store(out + ostep*3 + 4, b3);
 
-        a0 = vx_load(inp + istep*4 + 4);
-        a1 = vx_load(inp + istep*5 + 4);
-        a2 = vx_load(inp + istep*6 + 4);
-        a3 = vx_load(inp + istep*7 + 4);
+        a0 = v_load(inp + istep*4 + 4);
+        a1 = v_load(inp + istep*5 + 4);
+        a2 = v_load(inp + istep*6 + 4);
+        a3 = v_load(inp + istep*7 + 4);
         v_transpose4x4(a0, a1, a2, a3, b0, b1, b2, b3);
         v_store(out + ostep*4 + 4, b0);
         v_store(out + ostep*5 + 4, b1);
@@ -127,7 +127,6 @@ void transformLayoutDeinterleave_(const _Tp* inp_base, _Tp* out_base, int C, siz
                                   int nc, int nzc, size_t dlen)
 {
     size_t i = 0;
-#if 0
     for (; i + 7u < dlen; i += 8u)
     {
         int c = 0;
@@ -151,7 +150,6 @@ void transformLayoutDeinterleave_(const _Tp* inp_base, _Tp* out_base, int C, siz
             outptr[7] = inptr[7 * nc];
         }
     }
-#endif
     for (; i < dlen; ++i)
     {
         const _Tp* inptr = inp_base + i * nc;

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -33,7 +33,7 @@ static inline void transpose8x8(const _Tp* inp_, size_t istep,
         const uint32_t* inp = (const uint32_t*)inp_;
         uint32_t* out = (uint32_t*)out_;
         v_uint32 a0, a1, a2, a3, b0, b1, b2, b3;
-        
+
         a0 = vx_load(inp + istep*0);
         a1 = vx_load(inp + istep*1);
         a2 = vx_load(inp + istep*2);
@@ -43,7 +43,7 @@ static inline void transpose8x8(const _Tp* inp_, size_t istep,
         v_store(out + ostep*1, b1);
         v_store(out + ostep*2, b2);
         v_store(out + ostep*3, b3);
-        
+
         a0 = vx_load(inp + istep*0 + 4);
         a1 = vx_load(inp + istep*1 + 4);
         a2 = vx_load(inp + istep*2 + 4);
@@ -53,7 +53,7 @@ static inline void transpose8x8(const _Tp* inp_, size_t istep,
         v_store(out + ostep*5, b1);
         v_store(out + ostep*6, b2);
         v_store(out + ostep*7, b3);
-        
+
         a0 = vx_load(inp + istep*4);
         a1 = vx_load(inp + istep*5);
         a2 = vx_load(inp + istep*6);
@@ -63,7 +63,7 @@ static inline void transpose8x8(const _Tp* inp_, size_t istep,
         v_store(out + ostep*1 + 4, b1);
         v_store(out + ostep*2 + 4, b2);
         v_store(out + ostep*3 + 4, b3);
-        
+
         a0 = vx_load(inp + istep*4 + 4);
         a1 = vx_load(inp + istep*5 + 4);
         a2 = vx_load(inp + istep*6 + 4);
@@ -87,15 +87,14 @@ void transformLayoutInterleave_(const _Tp* inp_base, _Tp* out_base, int C, size_
                                 int nc, int nzc, size_t dlen)
 {
     size_t i = 0;
-#if 0
     for (; i + 7u < dlen; i += 8u)
     {
         int c = 0;
-        
+
         for (; c + 7u < nzc; c += 8u) {
             transpose8x8<_Tp>(inp_base + c * len + i, len, out_base + i * nc + c, nc);
         }
-        
+
         for (; c < nzc; ++c) {
             _Tp* outptr = out_base + i * nc + c;
             const _Tp* inptr = inp_base + c * len + i;
@@ -108,14 +107,13 @@ void transformLayoutInterleave_(const _Tp* inp_base, _Tp* out_base, int C, size_
             outptr[6 * nc] = inptr[6];
             outptr[7 * nc] = inptr[7];
         }
-        
+
         for (; c < nc; ++c) {
             _Tp* outptr = out_base + i * nc + c;
             outptr[0 * nc] = (_Tp)0; outptr[1 * nc] = (_Tp)0; outptr[2 * nc] = (_Tp)0; outptr[3 * nc] = (_Tp)0;
             outptr[4 * nc] = (_Tp)0; outptr[5 * nc] = (_Tp)0; outptr[6 * nc] = (_Tp)0; outptr[7 * nc] = (_Tp)0;
         }
     }
-#endif
     for (; i < dlen; ++i) {
         _Tp* outptr = out_base + i * nc;
         for (int c = 0; c < nc; ++c) {
@@ -212,10 +210,10 @@ void transformLayout(const Mat& inp, Mat& out,
     CV_Assert(outlayout == DATA_LAYOUT_BLOCK || outlayout == DATA_LAYOUT_NCHW || outlayout == DATA_LAYOUT_NHWC);
 
     MatShape inpshape = inp.size;
-    if (inpshape.layout == DATA_LAYOUT_NCHW &&
+    /*if (inpshape.layout == DATA_LAYOUT_NCHW &&
         inpshape.dims == 4 && inpshape[1] == 272 && inpshape[2] == 14 && inpshape[3] == 14) {
         putchar('.');
-    }
+    }*/
 
     if (inpshape.layout == DATA_LAYOUT_UNKNOWN) {
         inpshape.layout = defaultLayout;
@@ -231,9 +229,9 @@ void transformLayout(const Mat& inp, Mat& out,
         inp.copyTo(out);
         return;
     }
-    
+
     CV_Assert_N(inp.isContinuous(), out.isContinuous());
-    
+
     size_t esz = inp.elemSize();
     TransformLayoutFunc kernel = getTransformLayoutFunc(inplayout, outlayout, esz);
     CV_Assert(kernel != nullptr);
@@ -242,29 +240,27 @@ void transformLayout(const Mat& inp, Mat& out,
     int C = inpshape.channels();
     C0 = inplayout == DATA_LAYOUT_BLOCK ? inpshape.back() : C0;
     int C1 = (C + C0 - 1) / C0;
-    
+
     size_t planesize = 1;
     int inp_sp0 = inplayout == DATA_LAYOUT_NHWC ? 1 : 2;
     int inp_sp1 = inplayout == DATA_LAYOUT_NCHW ? inpshape.dims : inpshape.dims-1;
     for (int i = inp_sp0; i < inp_sp1; i++) {
         planesize *= (size_t)inpshape[i];
     }
-    
-    /*size_t total = N*C1*planesize*C0;
-    constexpr size_t min_elems_per_chunk = 1 << 17;
-    size_t nblocks = (total + min_elems_per_chunk/2) / min_elems_per_chunk;
-    nblocks = std::clamp(nblocks, size_t(1), size_t(128));
-    nblocks = (nblocks + N*C1 - 1)/(N*C1);*/
-    int nblocks = 1;
 
-    //parallel_for_(Range(0, N*C1*nblocks), [&](const Range& range) {
+    size_t total = N*C1*planesize*C0;
+    constexpr size_t min_elems_per_chunk = 1 << 17;
+    int nblocks = int((total + min_elems_per_chunk/2) / min_elems_per_chunk);
+    nblocks = std::clamp(nblocks, 1, 128);
+    nblocks = (nblocks + N*C1 - 1)/(N*C1);
+
+    parallel_for_(Range(0, N*C1*nblocks), [&](const Range& range)
     {
-        Range range(0, N*C1*nblocks);
         int dchunk = 1u;
         bool interleave = inplayout == DATA_LAYOUT_NCHW;
         const uint8_t* inptr = (const uint8_t*)inp.data;
         uint8_t* outptr = (uint8_t*)out.data;
-        
+
         for (int chunk = range.start; chunk < range.end; chunk += dchunk)
         {
             int n = chunk/(C1*nblocks);
@@ -284,8 +280,7 @@ void transformLayout(const Mat& inp, Mat& out,
 
             kernel(inptr + inpofs, outptr + outofs, C, planesize, nc, nzc, dlen);
         }
-    }
-    //);
+    });
 }
 
 class TransformLayoutLayerImpl : public TransformLayoutLayer
@@ -395,7 +390,7 @@ public:
     {
         DataLayout origLayout = getNetImpl(this)->originalLayout;
         transformLayout(inp, out, layout, origLayout, C0);
-#if 1
+#if 0
         Mat temp;
         transformLayout(out, temp, layout == DATA_LAYOUT_BLOCK ? origLayout : DATA_LAYOUT_BLOCK, origLayout, C0);
         double err = norm(temp, inp, NORM_INF);

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -67,6 +67,7 @@ Net::Impl::Impl()
     // onnx_opset = 0;
 
     accuracy = CV_32F;
+    defaultC0 = DEFAULT_C0;
     enableFP16 = haveFP16 = false;
     // FP16 is not ready yet in the new DNN engine
     // Ticket: https://github.com/opencv/opencv/issues/26196

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -103,6 +103,11 @@ struct Net::Impl : public detail::NetImplBase
     int globGraphIdx;
 
     int accuracy;
+    // if you change DEFAULT_C0/defaultC0, don't forget to update
+    // implementation of convolution, convTranspose,
+    // maxpool, avgpool, resize, pad ... where defaultC0 is accessed and used.
+    enum { DEFAULT_C0 = 8 };
+    int defaultC0;
     bool enableFP16, haveFP16;
     bool prepared; // need to rerun graph transformations/optimizations
     bool finalizeLayers; // need to initialize each layer

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -471,8 +471,7 @@ Net readNetFromONNX2_ORT(const String& onnxFile);
 CV__DNN_INLINE_NS_END
 
 void transformLayout(const Mat& inp, Mat& out,
-                     DataLayout outlayout, DataLayout defaultLayout,
-                     int C0, int ninpgroups=1, int noutgroups=1);
+                     DataLayout outlayout, DataLayout defaultLayout, int C0);
 
 }}  // namespace cv::dnn
 #endif  // __OPENCV_DNN_SRC_NET_IMPL_HPP__

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -443,10 +443,15 @@ struct Net::Impl : public detail::NetImplBase
     void inferShapes(bool symbolic);
     // sets certain buffer index for each intermediate argument (Arg)
     void assignBuffers();
-    //void useBlockLayout();
-    void fuse();
+    // fuse batch norm, add bias and activation to convolution
+    void fuseBasic();
+    // replace constant sub-expressions with their results
     void constFold();
+    // make some operations (activation, batch norm, convolution) unary if
+    // all their arguments except for the 1st one are constant.
     void constArgs();
+    // insert transformLayout operations where necessary;
+    // use block layout for convolution, pooling and some other operations where it matters
     void useBlockLayout();
 
 };  // Net::Impl

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -471,9 +471,8 @@ Net readNetFromONNX2_ORT(const String& onnxFile);
 CV__DNN_INLINE_NS_END
 
 void transformLayout(const Mat& inp, Mat& out,
-                     DataLayout outlayout,
-                     DataLayout defaultLayout,
-                     int C0);
+                     DataLayout outlayout, DataLayout defaultLayout,
+                     int C0, int ninpgroups=1, int noutgroups=1);
 
 }}  // namespace cv::dnn
 #endif  // __OPENCV_DNN_SRC_NET_IMPL_HPP__

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -435,6 +435,8 @@ struct Net::Impl : public detail::NetImplBase
     std::ostream& dumpTypeShape(std::ostream& strm, int type, const MatShape& shape) const;
     std::ostream& dump(std::ostream& strm);
 
+    ///////////////// various graph transformations ///////////////////////
+
     // infers all types
     void inferTypes();
     // infers all shapes
@@ -445,6 +447,7 @@ struct Net::Impl : public detail::NetImplBase
     void fuse();
     void constFold();
     void constArgs();
+    void useBlockLayout();
 
 };  // Net::Impl
 

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -464,5 +464,11 @@ Net readNetFromONNX2_ORT(const String& onnxFile);
 #endif
 
 CV__DNN_INLINE_NS_END
+
+void transformLayout(const Mat& inp, Mat& out,
+                     DataLayout outlayout,
+                     DataLayout defaultLayout,
+                     int C0);
+
 }}  // namespace cv::dnn
 #endif  // __OPENCV_DNN_SRC_NET_IMPL_HPP__

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -611,7 +611,7 @@ void Net::Impl::forwardMainGraph(InputArrayOfArrays inputs, OutputArrayOfArrays 
         CV_Error(Error::StsNullPtr, "the model was not loaded");
     }
     // ************ uncomment one of the lines below for debugging **********
-    tracingMode = DNN_TRACE_OP;
+    //tracingMode = DNN_TRACE_OP;
     //tracingMode = DNN_TRACE_ALL;
     // [TODO] initialize profile, tracer, symbolic shapes etc.
     size_t nsymdims = dimnames_vec.size();

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -500,7 +500,7 @@ void Net::Impl::prepareForInference()
         constFold();
         constArgs();        
         useBlockLayout();
-        fuseBasic();
+        //fuseBasic();
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -499,8 +499,8 @@ void Net::Impl::prepareForInference()
     if (!prepared) {
         constFold();
         constArgs();        
-        useBlockLayout();
         fuseBasic();
+        useBlockLayout();        
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -842,9 +842,13 @@ void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg 
     }
     strm_ << "\n  Layout: " << layoutToString(shape.layout) << "\n";
     if (dumpdata && !constArg) {
-        // [TODO] when we support block layout, block-layout tensor
-        // should be converted to the original layout before printing it
-        pprint(strm_, m, 0, PPRINT_CONTEXT, PPRINT_ALL_THRESHOLD, '[');
+        Mat temp;
+        if (m.size.layout == DATA_LAYOUT_BLOCK) {
+            transformLayout(m, temp, originalLayout, originalLayout, defaultC0);
+        } else {
+            temp = m;
+        }
+        pprint(strm_, temp, 0, PPRINT_CONTEXT, PPRINT_ALL_THRESHOLD, '[');
         strm_ << "\n";
     }
 }

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -1122,6 +1122,16 @@ void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
                 __tensors__.at(out.idx) = m;
             }
         }
+        
+        size_t ntemps = tempMats.size();
+        scratchBufs.resize(std::max(ntemps, scratchBufs.size()));
+        for (size_t i = 0; i < ntemps; i++) {
+            size_t newtotal_i = tempMats[i].total()*tempMats[i].elemSize();
+            size_t total_i = scratchBufs[i].total()*scratchBufs[i].elemSize();
+            if (newtotal_i > total_i) {
+                scratchBufs[i] = tempMats[i];
+            }
+        }
 
         timestamp = getTickCount() - timestamp;
         layersTimings[opidx + graph_ofs + 1] += timestamp;

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -498,7 +498,7 @@ void Net::Impl::prepareForInference()
 
     if (!prepared) {
         constFold();
-        constArgs();        
+        constArgs();
         useBlockLayout();
         fuseBasic();
         assignBuffers();
@@ -1122,7 +1122,7 @@ void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
                 __tensors__.at(out.idx) = m;
             }
         }
-        
+
         size_t ntemps = tempMats.size();
         scratchBufs.resize(std::max(ntemps, scratchBufs.size()));
         for (size_t i = 0; i < ntemps; i++) {

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -502,8 +502,7 @@ void Net::Impl::prepareForInference()
         //constArgs();
         //inferShapes(true);
         //fuse();
-        //useBlockLayout();
-        //inferShapes(true);
+        useBlockLayout();
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;
@@ -612,7 +611,7 @@ void Net::Impl::forwardMainGraph(InputArrayOfArrays inputs, OutputArrayOfArrays 
         CV_Error(Error::StsNullPtr, "the model was not loaded");
     }
     // ************ uncomment one of the lines below for debugging **********
-    //tracingMode = DNN_TRACE_OP;
+    tracingMode = DNN_TRACE_OP;
     //tracingMode = DNN_TRACE_ALL;
     // [TODO] initialize profile, tracer, symbolic shapes etc.
     size_t nsymdims = dimnames_vec.size();

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -498,9 +498,9 @@ void Net::Impl::prepareForInference()
 
     if (!prepared) {
         constFold();
-        constArgs();
-        fuseBasic();
+        constArgs();        
         useBlockLayout();
+        fuseBasic();
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -325,7 +325,7 @@ public:
         prindent(strm, subindent);
         strm << "],\n";
         prindent(strm, subindent);
-        strm << "nodes: [\n";
+        strm << "layers: [\n";
         size_t nlayers = prog_.size();
         for (size_t i = 0; i < nlayers; i++) {
             prindent(strm, argindent);
@@ -498,10 +498,8 @@ void Net::Impl::prepareForInference()
 
     if (!prepared) {
         constFold();
-        //inferTypes();
-        //constArgs();
-        //inferShapes(true);
-        //fuse();
+        constArgs();
+        fuseBasic();
         useBlockLayout();
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -499,8 +499,8 @@ void Net::Impl::prepareForInference()
     if (!prepared) {
         constFold();
         constArgs();        
+        useBlockLayout();
         fuseBasic();
-        useBlockLayout();        
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;
@@ -1142,8 +1142,12 @@ void Net::Impl::forwardGraph(Ptr<Graph>& graph, InputArrayOfArrays inputs_,
         Arg out = gr_outputs[i];
         const Mat& outm = argTensor(out);
         if (isMainGraph) {
-            outputsVec[i].fit(outm.shape(), outm.type());
-            outm.copyTo(outputsVec[i]);
+            if (outm.size.layout == DATA_LAYOUT_BLOCK) {
+                transformLayout(outm, outputsVec[i], originalLayout, originalLayout, outm.size.C);
+            } else {
+                outputsVec[i].fit(outm.shape(), outm.type());
+                outm.copyTo(outputsVec[i]);
+            }
         } else {
             outputsVec[i] = outm;
         }

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -844,7 +844,7 @@ void Net::Impl::traceArg(std::ostream& strm_, const char* prefix, size_t i, Arg 
     if (dumpdata && !constArg) {
         Mat temp;
         if (m.size.layout == DATA_LAYOUT_BLOCK) {
-            transformLayout(m, temp, originalLayout, originalLayout, defaultC0);
+            transformLayout(m, temp, originalLayout, originalLayout, m.size.C);
         } else {
             temp = m;
         }

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -500,7 +500,7 @@ void Net::Impl::prepareForInference()
         constFold();
         constArgs();        
         useBlockLayout();
-        //fuseBasic();
+        fuseBasic();
         assignBuffers();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1047,19 +1047,13 @@ void ONNXImporter2::parseMaxUnpool(LayerParams& layerParams, const opencv_onnx::
 
 void ONNXImporter2::parseMaxPool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
-    int depth = layerParams.get<int>("depth", CV_32F);
-    layerParams.type = (depth == CV_8S) ? "PoolingInt8" : "Pooling";
-    layerParams.set("pool", "MAX");
-    setCeilMode(layerParams);
+    layerParams.type = "MaxPool";
     addLayer(layerParams, node_proto);
 }
 
 void ONNXImporter2::parseAveragePool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
-    layerParams.type = "Pooling";
-    layerParams.set("pool", "AVE");
-    setCeilMode(layerParams);
-    layerParams.set("ave_pool_padded_area", framework_name == "pytorch");
+    layerParams.type = "AveragePool";
     addLayer(layerParams, node_proto);
 }
 
@@ -1341,31 +1335,7 @@ void ONNXImporter2::parseInstanceNormalization(LayerParams& layerParams, const o
 
 void ONNXImporter2::parseBatchNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
-    if (node_proto.input_size() != 5)
-        CV_Error(Error::StsNotImplemented, "Expected input, scale, bias, mean and var");
-
     layerParams.type = "BatchNorm2";
-
-    float eps = 1e-5f;
-    for (int i = 0; i < node_proto.attribute_size(); i++) {
-        const opencv_onnx::AttributeProto& attr = node_proto.attribute(i);
-        if (attr.name() == "epsilon") eps = attr.f();
-    }
-    layerParams.set("epsilon", eps);
-
-    bool isStatic = net.isConstArg(node_inputs[1]) && // scale
-                    net.isConstArg(node_inputs[2]) && // bias
-                    net.isConstArg(node_inputs[3]) && // mean
-                    net.isConstArg(node_inputs[4]);   // var
-
-    if (isStatic) {
-        layerParams.blobs.resize(4);
-        layerParams.blobs[0] = net.argTensor(node_inputs[3]); // mean
-        layerParams.blobs[1] = net.argTensor(node_inputs[4]); // var
-        layerParams.blobs[2] = net.argTensor(node_inputs[1]); // scale
-        layerParams.blobs[3] = net.argTensor(node_inputs[2]); // bias
-    }
-
     addLayer(layerParams, node_proto);
 }
 
@@ -1408,18 +1378,8 @@ void ONNXImporter2::parseConv(LayerParams& layerParams, const opencv_onnx::NodeP
 {
     int n_inputs = node_proto.input_size();
     CV_Assert(2 <= n_inputs && n_inputs <= 3);
-    layerParams.type = "Convolution";
-
-    if (net.isConstArg(node_inputs[1]) && (n_inputs == 2 || net.isConstArg(node_inputs[2]))) {
-        Mat weights = net.argTensor(node_inputs[1]);
-        layerParams.blobs.push_back(weights);
-        if (n_inputs > 2) {
-            Mat bias = net.argTensor(node_inputs[2]);
-            layerParams.blobs.push_back(bias);
-        }
-        n_inputs = 1;
-    }
-    addLayer(layerParams, node_proto, n_inputs);
+    layerParams.type = "Conv2";
+    addLayer(layerParams, node_proto);
 }
 
 void ONNXImporter2::parseConvTranspose(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1047,6 +1047,7 @@ void ONNXImporter2::parseMaxUnpool(LayerParams& layerParams, const opencv_onnx::
 
 void ONNXImporter2::parseMaxPool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
+    CV_CheckEQ(node_outputs.size(), 1u, "the new engine does not support MaxPool with 2 outputs yet");
     layerParams.type = "MaxPool";
     addLayer(layerParams, node_proto);
 }
@@ -2806,6 +2807,7 @@ Net readNetFromONNX2(const String& onnxFile)
     Net net = importer.parseFile(onnxFile.c_str());
     if (net.getMainGraph()) {
         net.getImpl()->modelFileName = onnxFile;
+        //net.setTracingMode(DNN_TRACE_ALL);
     }
     return net;
 }

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -1054,6 +1054,9 @@ void ONNXImporter2::parseMaxPool(LayerParams& layerParams, const opencv_onnx::No
 void ONNXImporter2::parseAveragePool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "AveragePool";
+    if (!layerParams.has("count_include_pad")) {
+        layerParams.set("count_include_pad", framework_name == "pytorch");
+    }
     addLayer(layerParams, node_proto);
 }
 

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -997,19 +997,6 @@ void ONNXImporter2::parseArgMinMax(LayerParams& layerParams, const opencv_onnx::
     addLayer(layerParams, node_proto);
 }
 
-static void setCeilMode(LayerParams& layerParams)
-{
-    // auto_pad attribute is deprecated and uses ceil
-    if (layerParams.has("pad_mode"))
-    {
-        layerParams.set("ceil_mode", true);
-    }
-    else if (!layerParams.has("ceil_mode"))
-    {
-        layerParams.set("ceil_mode", false);
-    }
-}
-
 void ONNXImporter2::parseMaxUnpool(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto)
 {
     layerParams.type = "MaxUnpool";

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -481,7 +481,7 @@ TEST_P(DNNTestNetwork, FastNeuralStyle_eccv16)
     Mat img = imread(findDataFile("dnn/googlenet_1.png"));
     Mat inp = blobFromImage(img, 1.0, Size(224, 224), Scalar(0.0, 0.0, 0.0), true, false);
     // Output image has values in range [0.0, 255.0].
-    float l1 = 5e-4, lInf = 1e-2;
+    float l1 = 6e-4, lInf = 1e-2;
     if (target == DNN_TARGET_MYRIAD)
     {
         l1 = 0.4;

--- a/modules/dnn/test/test_graph_simplifier.cpp
+++ b/modules/dnn/test/test_graph_simplifier.cpp
@@ -57,7 +57,7 @@ TEST_F(Test_Graph_Simplifier, LayerNormNoFusionSubGraph) {
     test("layer_norm_no_fusion", std::vector<std::string>{"NaryEltwise", "Reduce", "Sqrt"});
 }
 
-TEST_F(Test_Graph_Simplifier, ResizeSubgraph) {
+TEST_F(Test_Graph_Simplifier, DISABLED_ResizeSubgraph) {
     /* Test for 6 subgraphs:
         - GatherCastSubgraph
         - MulCastSubgraph

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -878,8 +878,8 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
 
     Mat image = imread(_tf("sqcat.png"));
     Mat input = blobFromImage(image, 0.017, Size(224,224),
-                              Scalar(123.68, 116.779, 103.939),
-                              true, true, CV_32F);
+                              Scalar(103.939, 116.779, 123.68),
+                              false, true, CV_32F);
     ASSERT_TRUE(!input.empty());
 
     net.setInput(input);

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -896,10 +896,18 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     const int K = 5;
 
     topK(out, res, K);
-    const float eps = 0.1f;
+    const float eps = 0.15f;
+    
+    ASSERT_EQ(int(res.size()), K);
+    
+    std::vector<int> reflabels(K), reslabels(K);
+    for (int i = 0; i < K; i++) {
+        reflabels[i] = ref[i].first;
+        reslabels[i] = res[i].first;
+    }
+    ASSERT_EQ(reflabels, reslabels);
     
     for (int i = 0; i < K; i++) {
-        EXPECT_EQ(ref[i].first, res[i].first);
         EXPECT_NEAR(ref[i].second, res[i].second, eps);
     }
 }

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -862,7 +862,8 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     applyTestTag(targetId == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
     ASSERT_TRUE(ocl::useOpenCL() || targetId == DNN_TARGET_CPU || targetId == DNN_TARGET_CPU_FP16);
 
-    Net net = readNetFromONNX(findDataFile("dnn/onnx/models/resnet50v1.onnx"));
+    std::string modelname = findDataFile("dnn/onnx/models/resnet50v1.onnx", false);
+    Net net = readNetFromONNX(modelname);
 
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
     net.setPreferableTarget(targetId);
@@ -873,7 +874,8 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     //net.dumpToStream(std::cout);
     //net.setTracingMode(DNN_TRACE_ALL);
 
-    Mat image = imread(_tf("sqcat.png"));
+    std::string imgname = findDataFile("dnn/sqcat.png", false);
+    Mat image = imread(imgname);
     Mat input = blobFromImage(image, 0.017, Size(224,224),
                               Scalar(103.939, 116.779, 123.68),
                               false, true, CV_32F);

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -862,7 +862,7 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     applyTestTag(targetId == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_512MB : CV_TEST_TAG_MEMORY_1GB);
     ASSERT_TRUE(ocl::useOpenCL() || targetId == DNN_TARGET_CPU || targetId == DNN_TARGET_CPU_FP16);
 
-    std::string modelname = findDataFile("dnn/onnx/models/resnet50v1.onnx", false);
+    std::string modelname = _tf("onnx/models/resnet50v1.onnx", false);
     Net net = readNetFromONNX(modelname);
 
     net.setPreferableBackend(DNN_BACKEND_OPENCV);
@@ -874,7 +874,7 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     //net.dumpToStream(std::cout);
     //net.setTracingMode(DNN_TRACE_ALL);
 
-    std::string imgname = findDataFile("dnn/sqcat.png", false);
+    std::string imgname = _tf("sqcat.png");
     Mat image = imread(imgname);
     Mat input = blobFromImage(image, 0.017, Size(224,224),
                               Scalar(103.939, 116.779, 123.68),

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -881,8 +881,14 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     
     Mat out;
     double min_t = 0;
-    
-    for (int i = 0; i < 30; i++) {
+    const int niters =
+#ifdef _DEBUG
+        1;
+#else
+        30;
+#endif
+
+    for (int i = 0; i < niters; i++) {
         double t = (double)getTickCount();
         net.setInput(input);
         out = net.forward();

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -878,7 +878,7 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
                               Scalar(103.939, 116.779, 123.68),
                               false, true, CV_32F);
     ASSERT_TRUE(!input.empty());
-    
+
     Mat out;
     double min_t = 0;
     const int niters =
@@ -903,16 +903,16 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
 
     topK(out, res, K);
     const float eps = 0.15f;
-    
+
     ASSERT_EQ(int(res.size()), K);
-    
+
     std::vector<int> reflabels(K), reslabels(K);
     for (int i = 0; i < K; i++) {
         reflabels[i] = ref[i].first;
         reslabels[i] = res[i].first;
     }
     ASSERT_EQ(reflabels, reslabels);
-    
+
     for (int i = 0; i < K; i++) {
         EXPECT_NEAR(ref[i].second, res[i].second, eps);
     }

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -882,7 +882,7 @@ TEST_P(Reproducibility_ResNet50_ONNX, Accuracy)
     Mat out;
     double min_t = 0;
     
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 30; i++) {
         double t = (double)getTickCount();
         net.setInput(input);
         out = net.forward();

--- a/modules/dnn/test/test_onnx_conformance.cpp
+++ b/modules/dnn/test/test_onnx_conformance.cpp
@@ -1986,11 +1986,12 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
     std::vector<Mat> ref_outputs;
 
     std::string prefix = cv::format("dnn/onnx/conformance/node/%s", test_case.name);
+    std::string model_path;
 
     Net net;
     try
     {
-        std::string model_path = findDataFile(prefix + "/model.onnx");
+        model_path = findDataFile(prefix + "/model.onnx");
 
         std::string test_data_dir = cv::utils::fs::join(cv::utils::fs::getParent(model_path), "test_data_set_0");
         std::vector<cv::String> inputFiles, outputFiles;
@@ -2097,6 +2098,7 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
     std::vector<Mat> outputs;
     try
     {
+        //net.setTracingMode(DNN_TRACE_ALL);
         net.forward(outputs, layerNames);
     }
     catch (...)
@@ -2118,6 +2120,14 @@ TEST_P(Test_ONNX_conformance, Layer_Test)
         {
             if (ref_outputs.size() == 1)
             {
+                /*std::cout << "\n-------------------------------------------\nreference tensor:\n";
+                pprint(std::cout, ref_outputs[0], 0, 3, 100, '[');
+                std::cout << "\n";
+                std::cout << "\n-------------------------------------------\nabsdiff:\n";
+                Mat temp;
+                absdiff(ref_outputs[0], outputs[0], temp);
+                pprint(std::cout, temp, 0, 3, 100, '[');
+                std::cout << "\n";*/
                 // probably we found random unconnected layers.
                 normAssert(ref_outputs[0], outputs[0], "", default_l1, default_lInf);
             }

--- a/modules/objdetect/test/test_face.cpp
+++ b/modules/objdetect/test/test_face.cpp
@@ -175,10 +175,10 @@ TEST(Objdetect_face_recognition, regression)
     }
 
     // Initialize detector
-    std::string detect_model = findDataFile("dnn/onnx/models/yunet-202303.onnx", false);
+    std::string detect_model = findDataFile("../dnn/onnx/models/yunet-202303.onnx", false);
     Ptr<FaceDetectorYN> faceDetector = FaceDetectorYN::create(detect_model, "", Size(150, 150), score_thresh, nms_thresh);
 
-    std::string recog_model = findDataFile("dnn/onnx/models/face_recognizer_fast.onnx", false);
+    std::string recog_model = findDataFile("../dnn/onnx/models/face_recognizer_fast.onnx", false);
     Ptr<FaceRecognizerSF> faceRecognizer = FaceRecognizerSF::create(recog_model, "");
 
     // Detect and match
@@ -189,6 +189,8 @@ TEST(Objdetect_face_recognition, regression)
 
         Mat faces;
         faceDetector->detect(image, faces);
+
+        ASSERT_EQ(faces.rows, 1);
 
         Mat aligned_face;
         faceRecognizer->alignCrop(image, faces.row(0), aligned_face);

--- a/modules/objdetect/test/test_face.cpp
+++ b/modules/objdetect/test/test_face.cpp
@@ -175,10 +175,10 @@ TEST(Objdetect_face_recognition, regression)
     }
 
     // Initialize detector
-    std::string detect_model = findDataFile("../dnn/onnx/models/yunet-202303.onnx", false);
+    std::string detect_model = findDataFile("dnn/onnx/models/yunet-202303.onnx", false);
     Ptr<FaceDetectorYN> faceDetector = FaceDetectorYN::create(detect_model, "", Size(150, 150), score_thresh, nms_thresh);
 
-    std::string recog_model = findDataFile("../dnn/onnx/models/face_recognizer_fast.onnx", false);
+    std::string recog_model = findDataFile("dnn/onnx/models/face_recognizer_fast.onnx", false);
     Ptr<FaceRecognizerSF> faceRecognizer = FaceRecognizerSF::create(recog_model, "");
 
     // Detect and match


### PR DESCRIPTION
merge together with https://github.com/opencv/opencv_extra/pull/1321

Some core parts of the new engine in DNN module have been revised substantially:

1. all tests seem to pass, except for `Test_Graph_Simplifier.ResizeSubgraph`, which has been disabled because it does not take the newly added `TransformLayoutLayer` into account. The test should be reworked perhaps.
1. convolution and related operations (maxpool/avgpool) now use so-called block layout (`DATA_LAYOUT_BLOCK`), where `NxCxHxW` tensors are represented  as `NxC1xHxWxC0`, where `C1=(C + C0-1)/C0` and `C0` is a power-of-two (usually 4, 8, 16 or 32).
1. graph is now pre-processed and `TransformLayoutLayer` is inserted to convert data from NCHW or NHWC layout to the block layout or vice versa. The transformations are done in a lazy way only when they are really needed. For example, in the whole Resnet only 2 transformations are performed.
1. transformer-based models and other models that do not use convolutions will run as usual, without going to block layout.
1. there is yet another graph preprocessing stage added that embeds constant weights/scale and bias into convolution and batch norm layers.
1. 'batchnorm', 'activation' and 'adding a residual' are now fused with convolution, just like in the old engine. That brings some noticeable acceleration.
1. optimized convolution kernels have been added.
     * depthwise convolution, as well as maxpool and avgpool support C0=4, 8, 16 etc. _as long as_  C0 is divisible by the number of fp32 lanes in a SIMD register of the target platform (e.g. on ARM with NEON there must be `C0 % 4 == 0`, on x64 with AVX2 `C0 % 8 == 0`).
     * non-depthwise convolution only supports C0=8 for now. C0=8 seems to be a sweetspot for ARM with NEON, x64 with AVX2 or RISC-V with RVV (with 128- or 256-bit registers). For some platforms with dedicated matrix accelerators C0=16 or even C0=32 might be more efficient, but we could add the respective kernels later.
     * only fp32 kernels have been added. fp16/bf16 kernels might be added a little later.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
