### PR TITLE
Restored IPP in cv::compare 

### DIFF
--- a/modules/core/src/arithm_ipp.hpp
+++ b/modules/core/src/arithm_ipp.hpp
@@ -283,40 +283,24 @@ inline IppCmpOp arithm_ipp_convert_cmp(int cmpop)
 inline int arithm_ipp_cmp8u(const uchar* src1, size_t step1, const uchar* src2, size_t step2,
                             uchar* dst, size_t step, int width, int height, int cmpop)
 {
-    // perf regression with AVX512: https://github.com/opencv/opencv/issues/28251
-    if (ippCPUID_AVX512F&cv::ipp::getIppFeatures())
-        return 0;
-
     ARITHM_IPP_CMP(ippiCompare_8u_C1R, src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(width, height));
 }
 
 inline int arithm_ipp_cmp16u(const ushort* src1, size_t step1, const ushort* src2, size_t step2,
                             uchar* dst, size_t step, int width, int height, int cmpop)
 {
-    // perf regression with AVX512: https://github.com/opencv/opencv/issues/28251
-    if (ippCPUID_AVX512F&cv::ipp::getIppFeatures())
-        return 0;
-
     ARITHM_IPP_CMP(ippiCompare_16u_C1R, src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(width, height));
 }
 
 inline int arithm_ipp_cmp16s(const short* src1, size_t step1, const short* src2, size_t step2,
                              uchar* dst, size_t step, int width, int height, int cmpop)
 {
-    // perf regression with AVX512: https://github.com/opencv/opencv/issues/28251
-    if (ippCPUID_AVX512F&cv::ipp::getIppFeatures())
-        return 0;
-
     ARITHM_IPP_CMP(ippiCompare_16s_C1R, src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(width, height));
 }
 
 inline int arithm_ipp_cmp32f(const float* src1, size_t step1, const float* src2, size_t step2,
                              uchar* dst, size_t step, int width, int height, int cmpop)
 {
-    // perf regression with AVX512: https://github.com/opencv/opencv/issues/28251
-    if (ippCPUID_AVX512F&cv::ipp::getIppFeatures())
-        return 0;
-
     ARITHM_IPP_CMP(ippiCompare_32f_C1R, src1, (int)step1, src2, (int)step2, dst, (int)step, ippiSize(width, height));
 }
 


### PR DESCRIPTION
Integration was disabled for AVX512 platforms because of performance regression. #28251 And was disabled by #28311
Issue was fixed with update of ICV package #28292

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
