### PR TITLE
imgproc: remove redundant fabs() in fitEllipseDirect

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -750,7 +750,7 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         M(2,1) = (DM(0,1) + (DM(0,3)*TM(0,1) + DM(0,4)*TM(1,1) + DM(0,5)*TM(2,1))/Ts)/2.;
         M(2,2) = (DM(0,2) + (DM(0,3)*TM(0,2) + DM(0,4)*TM(1,2) + DM(0,5)*TM(2,2))/Ts)/2.;
 
-        double det = fabs(cv::determinant(M));
+        double det = cv::determinant(M);
         if (fabs(det) > 1.0e-10)
             break;
         eps = (float)(s/(n*2)*1e-2);


### PR DESCRIPTION
## Problem

In `fitEllipseDirect` (shapedescr.cpp, line ~753), the determinant is computed as:

```cpp
double det = fabs(cv::determinant(M));
if (fabs(det) > 1.0e-10)
    break;
```

The `fabs()` wrapping `cv::determinant(M)` is redundant because the next line already
applies `fabs(det)` in the comparison. Since `fabs(fabs(x)) == fabs(x)`, this has no
behavioral impact, but the redundant call obscures the code's intent.

## Fix

Changed `double det = fabs(cv::determinant(M))` to `double det = cv::determinant(M)`.
The subsequent `if (fabs(det) > 1.0e-10)` correctly handles both positive and negative
determinant values.

## Tests

No test changes required — this is a no-op refactor (`fabs(fabs(x)) == fabs(x)`).
Existing tests continue to pass.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
