### PR TITLE
Make sure j < maxRow in smooth functions

### DIFF
--- a/modules/imgproc/src/smooth.simd.hpp
+++ b/modules/imgproc/src/smooth.simd.hpp
@@ -620,6 +620,8 @@ void inline smooth3N121Impl(const ET* src,  int cn, ET *dst, int ito, int idst, 
     int len = (width - offset) * cn;
     int x = offset * cn;
     int maxRow = min((ito - vOffset),height-vOffset);
+    if (v >= maxRow) return;
+
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     VFT v_8 = vx_setall((WET)8);
     const int VECSZ = VTraits<VET>::vlanes();
@@ -713,6 +715,7 @@ void inline smooth5N14641Impl(const ET* src, int cn, ET* dst, int ito, int idst,
     int len = (width - offset) * cn;
     int x = offset * cn;
     int maxRow = min((ito - vOffset),height-vOffset);
+    if (v >= maxRow) return;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     VFT v_6 = vx_setall((WET)6);


### PR DESCRIPTION
Otherwise some values out of memory can be read.
This was found with ASAN.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
