### PR TITLE
DNN: Fix OpenVINO 2026 build failure due to ov::Tensor::data() const change

### DIFF
--- a/modules/dnn/src/op_inf_engine.cpp
+++ b/modules/dnn/src/op_inf_engine.cpp
@@ -53,9 +53,6 @@ Mat infEngineBlobToMat(const ov::Tensor& blob)
         default:
             CV_Error(Error::StsNotImplemented, "Unsupported blob precision");
     }
-    // OpenVINO 2026 changed Tensor::data() to return const void*.
-    // Tensor memory for input/output blobs remains mutable.
-    // Cast is required to preserve zero-copy semantics.
     return Mat(size, type, const_cast<void*>(blob.data()));
 }
 


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/issues/28586

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### PR Description

OpenVINO 2026 changed ov::Tensor::data() to return `const void*`
instead of `void*`. This causes a build error in
modules/dnn/src/op_inf_engine.cpp when constructing a cv::Mat
wrapper over Tensor memory.

Tensor memory for input/output blobs remains mutable, but the API
now enforces const-correct access. This patch casts away const with
an explicit comment to preserve existing zero-copy semantics and
restore compatibility with OpenVINO 2026.
Preserves existing zero-copy semantics of the OpenVINO backend without altering runtime behavior.


Tested by building OpenCV 4.x against OpenVINO 2026.0.0 on Ubuntu 24.04.