### PR TITLE
imgproc: fix UB left shift of negative value in drawing functions

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1118,8 +1118,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         delta1 = XY_ONE - 1, delta2 = 0;
 
     p0 = v[npts - 1];
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
+    p0.x = (int64)(((uint64)p0.x) << (XY_SHIFT - shift));
+    p0.y = (int64)(((uint64)p0.y) << (XY_SHIFT - shift));
 
     CV_Assert( 0 <= shift && shift <= XY_SHIFT );
     xmin = xmax = v[0].x;
@@ -1138,8 +1138,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         xmax = std::max( xmax, p.x );
         xmin = MIN( xmin, p.x );
 
-        p.x <<= XY_SHIFT - shift;
-        p.y <<= XY_SHIFT - shift;
+        p.x = (int64)(((uint64)p.x) << (XY_SHIFT - shift));
+        p.y = (int64)(((uint64)p.y) << (XY_SHIFT - shift));
 
         if( line_type <= 8 )
         {
@@ -1202,8 +1202,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
                             int64 xe = v[idx].x;
                             if (shift != XY_SHIFT)
                             {
-                                xs <<= XY_SHIFT - shift;
-                                xe <<= XY_SHIFT - shift;
+                                xs = (int64)(((uint64)xs) << (XY_SHIFT - shift));
+                                xe = (int64)(((uint64)xe) << (XY_SHIFT - shift));
                             }
 
                             edge[i].ye = ty;
@@ -1658,10 +1658,10 @@ ThickLine( Mat& img, Point2l p0, Point2l p1, const void* color,
         p1 -= offset;
     }
 
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
-    p1.x <<= XY_SHIFT - shift;
-    p1.y <<= XY_SHIFT - shift;
+    p0.x = (int64)(((uint64)p0.x) << (XY_SHIFT - shift));
+    p0.y = (int64)(((uint64)p0.y) << (XY_SHIFT - shift));
+    p1.x = (int64)(((uint64)p1.x) << (XY_SHIFT - shift));
+    p1.y = (int64)(((uint64)p1.y) << (XY_SHIFT - shift));
 
     if( thickness <= 1 )
     {
@@ -1931,8 +1931,8 @@ void circle( InputOutputArray _img, Point center, int radius,
     {
         Point2l _center(center);
         int64 _radius(radius);
-        _center.x <<= XY_SHIFT - shift;
-        _center.y <<= XY_SHIFT - shift;
+        _center.x = (int64)(((uint64)_center.x) << (XY_SHIFT - shift));
+        _center.y = (int64)(((uint64)_center.y) << (XY_SHIFT - shift));
         _radius <<= XY_SHIFT - shift;
         EllipseEx( img, _center, Size2l(_radius, _radius),
                    0, 0, 360, buf, thickness, line_type );
@@ -1964,8 +1964,8 @@ void ellipse( InputOutputArray _img, Point center, Size axes,
     int _end_angle = cvRound(end_angle);
     Point2l _center(center);
     Size2l _axes(axes);
-    _center.x <<= XY_SHIFT - shift;
-    _center.y <<= XY_SHIFT - shift;
+    _center.x = (int64)(((uint64)_center.x) << (XY_SHIFT - shift));
+    _center.y = (int64)(((uint64)_center.y) << (XY_SHIFT - shift));
     _axes.width <<= XY_SHIFT - shift;
     _axes.height <<= XY_SHIFT - shift;
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

Fixes https://github.com/opencv/opencv/issues/28598

Left-shifting a negative integer is undefined behavior in C/C++. This fixes all coordinate left-shift operations in `drawing.cpp` that can have negative values by casting to unsigned before shifting, then casting back:

```cpp
// Before (UB when p.x < 0):
p.x <<= XY_SHIFT - shift;

// After:
p.x = (int64)(((uint64)p.x) << (XY_SHIFT - shift));
```

**Functions fixed:**
- `FillConvexPoly` - p0.x/y, p.x/y, xs, xe
- `ThickLine` - p0.x/y, p1.x/y
- `circle` - _center.x/y
- `ellipse` - _center.x/y

Values that are always non-negative (size.width/height, thickness, _radius, _axes) were left unchanged.

This contribution was developed with AI assistance (Claude Code).