### PR TITLE
imgproc: fix putText extremely slow with large coordinates

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1646,16 +1646,21 @@ ThickLine( Mat& img, Point2l p0, Point2l p1, const void* color,
 {
     static const double INV_XY_ONE = 1./static_cast<double>(XY_ONE);
 
-    Rect_<int64> boundingRect(Point2l(0, 0), (Size2l)img.size());
-    if( (thickness > 1) && (shift == 0) && ( !boundingRect.contains(p0) || !boundingRect.contains(p1) ) )
+    if( thickness > 1 )
     {
-        const int margin = thickness;
-        const Point2l offset(margin, margin);
-        p0 += offset;
-        p1 += offset;
-        clipLine(Size2l(boundingRect.width+2*margin, boundingRect.height+2*margin), p0, p1);
-        p0 -= offset;
-        p1 -= offset;
+        // Convert coordinates and margin to the same fixed-point space for clipping
+        int64 scale = (int64)1 << shift;
+        Rect_<int64> boundingRect(Point2l(0, 0), Size2l((int64)img.cols * scale, (int64)img.rows * scale));
+        if( !boundingRect.contains(p0) || !boundingRect.contains(p1) )
+        {
+            const int64 margin = (int64)thickness * scale;
+            const Point2l offset(margin, margin);
+            p0 += offset;
+            p1 += offset;
+            clipLine(Size2l(boundingRect.width+2*margin, boundingRect.height+2*margin), p0, p1);
+            p0 -= offset;
+            p1 -= offset;
+        }
     }
 
     p0.x <<= XY_SHIFT - shift;


### PR DESCRIPTION
## Summary
Fixes #28613

`cv::putText` with coordinates near `INT32_MAX` and high thickness (>=8) takes minutes because `ThickLine`'s early clipping was gated on `shift == 0`. Since `putText` calls `PolyLine`/`ThickLine` with `shift = XY_SHIFT`, the clipping was bypassed entirely, causing `FillConvexPoly` and `EllipseEx` to attempt rasterizing enormous shapes.

## Changes
- Removed the `shift == 0` condition from `ThickLine`'s early clipping check
- Scale the bounding rect and margin into the input's fixed-point coordinate space so clipping works correctly for any shift value

## Testing
- Verify the reproducer from #28613 completes in <1ms instead of minutes:
  ```python
  import cv2, numpy as np
  img = np.zeros((240,320,3), dtype=np.uint8)
  img = cv2.putText(img, "Hello", (2147483647, -2147483648), fontFace=cv2.FONT_HERSHEY_SIMPLEX, fontScale=1, thickness=10, color=(255, 255, 255), lineType=cv2.LINE_AA)
  ```
- Verify normal putText rendering is unaffected

This contribution was developed with AI assistance (Claude Code).