### PR TITLE
imgproc: fix fitEllipseDirect/AMS determinant threshold for near-circular data

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -579,7 +579,9 @@ cv::RotatedRect cv::fitEllipseAMS( InputArray _points )
         M(4,3)=DM(3,4);
         M(4,4)=DM(4,4);
 
-        if (fabs(cv::determinant(M)) > 1.0e-10) {
+        double npow = (double)n * (double)n;
+        npow = npow * npow * (double)n;  // n^5
+        if (fabs(cv::determinant(M)) > 1.0e-10 / npow) {
             break;
         }
 
@@ -703,6 +705,8 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
     Matx<double, 3, 1> pVec;
 
     double x0, y0, a, b, theta, Ts;
+    Mat eVal, eVec;
+    double cond[3];
     double s = 0;
 
     for( i = 0; i < n; i++ )
@@ -763,6 +767,11 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         Ts=(-(DM(3,5)*DM(4,4)*DM(5,3)) + DM(3,4)*DM(4,5)*DM(5,3) + DM(3,5)*DM(4,3)*DM(5,4) - \
               DM(3,3)*DM(4,5)*DM(5,4)  - DM(3,4)*DM(4,3)*DM(5,5) + DM(3,3)*DM(4,4)*DM(5,5));
 
+        if (fabs(Ts) < DBL_EPSILON) {
+            eps = (float)(s/(n*2)*1e-2);
+            continue;
+        }
+
         M(0,0) = (DM(2,0) + (DM(2,3)*TM(0,0) + DM(2,4)*TM(1,0) + DM(2,5)*TM(2,0))/Ts)/2.;
         M(0,1) = (DM(2,1) + (DM(2,3)*TM(0,1) + DM(2,4)*TM(1,1) + DM(2,5)*TM(2,1))/Ts)/2.;
         M(0,2) = (DM(2,2) + (DM(2,3)*TM(0,2) + DM(2,4)*TM(1,2) + DM(2,5)*TM(2,2))/Ts)/2.;
@@ -773,18 +782,9 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         M(2,1) = (DM(0,1) + (DM(0,3)*TM(0,1) + DM(0,4)*TM(1,1) + DM(0,5)*TM(2,1))/Ts)/2.;
         M(2,2) = (DM(0,2) + (DM(0,3)*TM(0,2) + DM(0,4)*TM(1,2) + DM(0,5)*TM(2,2))/Ts)/2.;
 
-        double det = cv::determinant(M);
-        if (fabs(det) > 1.0e-10)
-            break;
-        eps = (float)(s/(n*2)*1e-2);
-    }
-
-    if( iter < 2 ) {
-        Mat eVal, eVec;
         eigenNonSymmetric(M, eVal, eVec);
 
         // Select the eigen vector {a,b,c} which satisfies 4ac-b^2 > 0
-        double cond[3];
         cond[0]=(4.0 * eVec.at<double>(0,0) * eVec.at<double>(0,2) - eVec.at<double>(0,1) * eVec.at<double>(0,1));
         cond[1]=(4.0 * eVec.at<double>(1,0) * eVec.at<double>(1,2) - eVec.at<double>(1,1) * eVec.at<double>(1,1));
         cond[2]=(4.0 * eVec.at<double>(2,0) * eVec.at<double>(2,2) - eVec.at<double>(2,1) * eVec.at<double>(2,1));
@@ -793,6 +793,18 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         } else {
             i = (cond[0]<cond[2]) ? 2 : 0;
         }
+        // Check that the ellipse condition 4ac-b^2 is meaningfully positive
+        // (not just positive due to floating-point noise from complex eigenvalues)
+        {
+            double v0 = eVec.at<double>(i,0), v1 = eVec.at<double>(i,1), v2 = eVec.at<double>(i,2);
+            double vnorm2 = v0*v0 + v1*v1 + v2*v2;
+            if (cond[i] > 1e-6 * vnorm2)
+                break;
+        }
+        eps = (float)(s/(n*2)*1e-2);
+    }
+
+    if( iter < 2 ) {
         double norm = std::sqrt(eVec.at<double>(i,0)*eVec.at<double>(i,0) + eVec.at<double>(i,1)*eVec.at<double>(i,1) + eVec.at<double>(i,2)*eVec.at<double>(i,2));
         if (((eVec.at<double>(i,0)<0.0  ? -1 : 1) * (eVec.at<double>(i,1)<0.0  ? -1 : 1) * (eVec.at<double>(i,2)<0.0  ? -1 : 1)) <= 0.0) {
                 norm=-1.0*norm;

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -337,6 +337,26 @@ TEST(Imgproc_FitEllipseAMS_Issue_7, accuracy) {
     EXPECT_TRUE(checkEllipse(ellipseAMSTest, ellipseAMSTrue, tol));
 }
 
+TEST(Imgproc_FitEllipseAMS_NearCircular, accuracy)
+{
+    std::vector<cv::Point2f> points;
+    double cx = 27.0, cy = 27.0, a = 17.0, b = 16.5;
+    for (int i = 0; i < 360; i++) {
+        double theta = 2.0 * CV_PI * i / 360.0;
+        points.push_back(cv::Point2f(
+            (float)(cx + a * cos(theta)),
+            (float)(cy + b * sin(theta))));
+    }
+
+    cv::RotatedRect ams = cv::fitEllipseAMS(points);
+
+    // AMS should produce a valid result close to ground truth
+    EXPECT_NEAR(ams.center.x, 27.0, 0.5);
+    EXPECT_NEAR(ams.center.y, 27.0, 0.5);
+    EXPECT_NEAR(std::max(ams.size.width, ams.size.height), 34.0, 1.0);
+    EXPECT_NEAR(std::min(ams.size.width, ams.size.height), 33.0, 1.0);
+}
+
 TEST(Imgproc_FitEllipseAMS_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseAMS(pts);

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -337,6 +337,28 @@ TEST(Imgproc_FitEllipseDirect_Issue_7, accuracy) {
     EXPECT_TRUE(checkEllipse(ellipseDirectTest, ellipseDirectTrue, tol));
 }
 
+TEST(Imgproc_FitEllipseDirect_NearCircular, accuracy)
+{
+    // 360 points on a near-circular ellipse (a=17, b=16.5)
+    // This data previously triggered unnecessary fallback to fitEllipseNoDirect
+    std::vector<cv::Point2f> points;
+    double cx = 27.0, cy = 27.0, a = 17.0, b = 16.5;
+    for (int i = 0; i < 360; i++) {
+        double theta = 2.0 * CV_PI * i / 360.0;
+        points.push_back(cv::Point2f(
+            (float)(cx + a * cos(theta)),
+            (float)(cy + b * sin(theta))));
+    }
+
+    cv::RotatedRect direct = cv::fitEllipseDirect(points);
+
+    // Direct should produce a valid result close to ground truth
+    EXPECT_NEAR(direct.center.x, 27.0, 0.1);
+    EXPECT_NEAR(direct.center.y, 27.0, 0.1);
+    EXPECT_NEAR(std::max(direct.size.width, direct.size.height), 34.0, 0.5);
+    EXPECT_NEAR(std::min(direct.size.width, direct.size.height), 33.0, 0.5);
+}
+
 TEST(Imgproc_FitEllipseDirect_HorizontalLine, accuracy) {
     vector<Point2f> pts({{-300, 100}, {-200, 100}, {-100, 100}, {0, 100}, {100, 100}, {200, 100}, {300, 100}});
     const RotatedRect el = fitEllipseDirect(pts);


### PR DESCRIPTION
Closes #28627 

## Problem

`fitEllipseDirect` and `fitEllipseAMS` silently fail on near-circular ellipse data when the
number of points exceeds approximately 100. Both functions normalize the design matrix `DM`
by `1/n`, which causes the determinant of the reduced matrix `M` to scale down as a power of
`n`. The fixed threshold `1e-10` then falsely detects the matrix as singular, triggering
unnecessary fallback to `fitEllipseNoDirect` (in Direct) or noise perturbation (in AMS).

## Fix

**`fitEllipseDirect`:**
- **Kept `DM *= (1.0/n)` normalization** — it is needed for numerical stability.
- **Removed `det(M) > 1e-10` threshold check** and replaced it with eigenvector quality
  validation. The old threshold was the direct cause of false singular-matrix detection.
- **Added `Ts ≈ 0` guard:** When `Ts` (the determinant of the lower-right 3×3 block) is
  near zero, the Schur complement `M` involves division by `Ts` — skip and retry with
  perturbation instead of computing garbage values.
- **Moved `eigenNonSymmetric` inside the perturbation loop** so that eigenvector quality
  can be evaluated on each iteration.
- **Added eigenvector quality check `4ac - b² > 1e-6 * ||v||²`:** When the 3×3 matrix `M`
  has complex eigenvalues (which happens for near-circular data with the scaled-down `DM`),
  `eigenNonSymmetric` returns real parts that are garbage. The condition `4ac - b² > 0`
  may be trivially satisfied by these garbage vectors. The relative threshold filters them
  out, ensuring only genuine ellipse eigenvectors are accepted.

**Why different approaches?**

Both functions share the same root cause — `DM *= (1.0/n)` normalization shrinks `det(M)`
below the fixed `1e-10` threshold as `n` grows. However, the fix differs because the two
algorithms have different failure modes:

- **`fitEllipseDirect`** uses a 3×3 non-symmetric eigenproblem where scaled-down matrices
  produce complex eigenvalues. The `det(M)` threshold is replaced entirely by eigenvector
  quality validation (`4ac - b² > 1e-6 * ||v||²`), which directly checks whether the
  solution is a valid ellipse regardless of matrix scale.
- **`fitEllipseAMS`** uses a 5×5 symmetric eigenproblem where scaling only affects the
  determinant magnitude. The threshold is simply scaled to match: `1e-10 / n^5`.

**`fitEllipseAMS`:**
- **Kept `DM *= (1.0/n)` normalization** because the AMS method's non-uniform matrix structure
  (mixing `DM` subblocks in a non-homogeneous way) requires consistent scaling for numerical
  stability.
- **Scaled the threshold by `1/n^5`:** Since the 5×5 matrix `M` in AMS is built from the
  normalized `DM`, its determinant scales as `O(1/n^5)`. The threshold is now
  `1.0e-10 / n^5`, correctly tracking the expected magnitude of `det(M)`.

## Tests

Added regression test:
- `Imgproc_FitEllipseDirect_NearCircular` — 360-point near-circular ellipse (a=17, b=16.5),
  verifies center and size accuracy against ground truth.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
