### PR TITLE
imgproc: add SIMD support for distance transform function

### DIFF
--- a/modules/imgproc/src/distransform.cpp
+++ b/modules/imgproc/src/distransform.cpp
@@ -332,12 +332,14 @@ distanceTransform_5x5( const Mat& _src, Mat& _temp, Mat& _dist, const float* met
             t1p2_0 = v_add(t1p2_0, v_long);
 
             v_uint32 m0 = v_min(t2m1_0, t2p1_0);
-            m0 = v_min(m0, t1m2_0);
-            m0 = v_min(m0, t1m1_0);
-            m0 = v_min(m0, t1_0);
-            m0 = v_min(m0, t1p1_0);
-            m0 = v_min(m0, t1p2_0);
+            v_uint32 m0_1 = v_min(t1m2_0, t1m1_0);
+            v_uint32 m0_2 = v_min(t1p1_0, t1p2_0);
+            m0 = v_min(m0, m0_1);
+            m0_2 = v_min(m0_2, t1_0);
+            m0 = v_min(m0, m0_2);
             m0 = v_min(m0, v_max);
+
+            v_store(cur + j,     m0);
 
             v_uint32 t2m1_1 = vx_load(top2 + j + 3);
             v_uint32 t2p1_1 = vx_load(top2 + j + 5);
@@ -356,14 +358,13 @@ distanceTransform_5x5( const Mat& _src, Mat& _temp, Mat& _dist, const float* met
             t1p2_1 = v_add(t1p2_1, v_long);
 
             v_uint32 m1 = v_min(t2m1_1, t2p1_1);
-            m1 = v_min(m1, t1m2_1);
-            m1 = v_min(m1, t1m1_1);
-            m1 = v_min(m1, t1_1);
-            m1 = v_min(m1, t1p1_1);
-            m1 = v_min(m1, t1p2_1);
+            v_uint32 m1_1 = v_min(t1m2_1, t1m1_1);
+            v_uint32 m1_2 = v_min(t1p1_1, t1p2_1);
+            m1 = v_min(m1, m1_1);
+            m1_2 = v_min(m1_2, t1_1);
+            m1 = v_min(m1, m1_2);
             m1 = v_min(m1, v_max);
 
-            v_store(cur + j,     m0);
             v_store(cur + j + 4, m1);
 
             for (int k = 0; k < BLOCK; k++)


### PR DESCRIPTION
- This PR adds OpenCV SIMD intrinsics-based optimizations to the distance transform functions for improved performance.
- The optimized implementation uses vectorized operations to accelerate the forward and backward passes of distance computation.
- In x64 architecture, distance transform function benefit from IPP-based optimized implementations. However, on ARM64 platforms, the execution falls back to scalar implementation, which results in lower performance.
- After introducing these changes, the distance transform functions showed noticeable performance improvements on Windows-ARM64.
<img width="800" height="706" alt="image" src="https://github.com/user-attachments/assets/9786606a-9d92-489d-a5ea-d2e57453ef02" />

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
