### PR TITLE
Fix calibration sample when the board is not a Charuco

### DIFF
--- a/samples/cpp/calibration.cpp
+++ b/samples/cpp/calibration.cpp
@@ -540,9 +540,14 @@ int main( int argc, char** argv )
         dictionary.readDictionary(fn);
     }
 
-    cv::aruco::CharucoBoard ch_board(boardSize, squareSize, markerSize, dictionary);
+    cv::Ptr<cv::aruco::CharucoBoard> ch_board;
     std::vector<int> markerIds;
-    cv::aruco::CharucoDetector ch_detector(ch_board);
+    cv::Ptr<cv::aruco::CharucoDetector> ch_detector;
+    if (pattern == CHARUCOBOARD) {
+        ch_board = cv::makePtr<cv::aruco::CharucoBoard>(boardSize, squareSize, markerSize, dictionary);
+        ch_detector = cv::makePtr<cv::aruco::CharucoDetector>(cv::aruco::CharucoDetector(*ch_board));
+    }
+
 
     if( !inputFilename.empty() )
     {
@@ -563,7 +568,7 @@ int main( int argc, char** argv )
     if( capture.isOpened() )
         printf( "%s", liveCaptureHelp );
 
-    namedWindow( "Image View", 1 );
+    namedWindow( "Image View", cv::WINDOW_AUTOSIZE );
 
     for(i = 0;;i++)
     {
@@ -612,7 +617,7 @@ int main( int argc, char** argv )
                 break;
             case CHARUCOBOARD:
             {
-                ch_detector.detectBoard(view, pointbuf, markerIds);
+                ch_detector->detectBoard(view, pointbuf, markerIds);
                 found = pointbuf.size() == (size_t)(boardSize.width-1)*(boardSize.height-1);
                 break;
             }


### PR DESCRIPTION
When using a chessboard, running the calibration exe gives the following error:

> opencv/modules/objdetect/src/aruco/aruco_board.cpp:543: error: (-215:Assertion failed) size.width > 1 && size.height > 1 && markerLength > 0 && squareLength > markerLength in function 'CharucoBoard'

To reproduce the issue:
- git clone this repo: https://github.com/jhbrito/CameraCalibrationDataset (or any chessboard images data)
- create the list of images: `./example_cpp_imagelist_creator CameraCalibrationDataset/imagelist_canon_6D_35mm.yml "CameraCalibrationDataset/Cannon 6D Lens Cannon 35mm/"*.JPG`
- run the calibration, e.g.: `./example_cpp_calibration -w=9 -h=6 -s=0.026 -o=calibration_canon_6D_35mm.yml -op -oe -enable-k3=1 -imshow-scale=4 imagelist_canon_6D_35mm.yml`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
