### PR TITLE
better_minSideLengthCanonicalImg

### DIFF
--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -57,7 +57,7 @@ struct CV_EXPORTS_W_SIMPLE DetectorParameters {
         aprilTagDeglitch = 0;
         detectInvertedMarker = false;
         useAruco3Detection = false;
-        minSideLengthCanonicalImg = 32;
+        minSideLengthCanonicalImg = 12;
         minMarkerLengthRatioOriginalImg = 0.0;
         validBitIdThreshold = DEFAULT_VALID_BIT_ID_THRESHOLD;
     }

--- a/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_detector.hpp
@@ -57,7 +57,7 @@ struct CV_EXPORTS_W_SIMPLE DetectorParameters {
         aprilTagDeglitch = 0;
         detectInvertedMarker = false;
         useAruco3Detection = false;
-        minSideLengthCanonicalImg = 12;
+        minSideLengthCanonicalImg = 21;
         minMarkerLengthRatioOriginalImg = 0.0;
         validBitIdThreshold = DEFAULT_VALID_BIT_ID_THRESHOLD;
     }


### PR DESCRIPTION
## Summary
Change the default value of `minSideLengthCanonicalImg` in ArUco3 detector from **32** to **12**.

## Motivation
The current default (32) is overly restrictive and causes smaller markers to be missed during detection. As noted in the algorithm design: *"if minSideLengthCanonicalImg is set too large, smaller markers may be missed during detection."*

Our evaluation shows that 12 provides a better balance—significantly improving detection efficiency (35%–300%) with negligible impact on runtime and without introducing noticeable false positives.

## Experimental Evidence
- **Datasets:** 3 self-constructed datasets with USB camera (1080p), varying marker density (1/5/14), inclination angle, and resolution (480p/600p/720p)
- **Parameter range tested:** 5 to 40
- **Optimal value:** 12
- **Detection efficiency:** 35%–300% improvement vs. default 32
- **Runtime:** Negligible change (see report Figure 7)

## Reference
Detailed dataset and experiment here:
https://drive.google.com/file/d/1CYQ59nt8fcqf3CEdY7wRqawSURedEQBF/view