### PR TITLE
calib3d: fix reprojection error RMSE calculation in Python tutorial

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
+++ b/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
@@ -206,17 +206,17 @@ Re-projection Error
 
 Re-projection error gives a good estimation of just how exact the found parameters are. The closer the re-projection error is to zero, the more accurate the parameters we found are. Given the intrinsic, distortion, rotation and translation matrices,
 we must first transform the object point to image point using **cv.projectPoints()**. Then, we can calculate
-the absolute norm between what we got with our transformation and the corner finding algorithm. To
-find the average error, we calculate the arithmetical mean of the errors calculated for all the
-calibration images.
+the norm between what we got with our transformation and the corner finding algorithm. To find the
+RMSE (root mean squared error), we average the squared errors over all points and images, then take
+the square root.
 @code{.py}
 mean_error = 0
 for i in range(len(objpoints)):
     imgpoints2, _ = cv.projectPoints(objpoints[i], rvecs[i], tvecs[i], mtx, dist)
-    error = cv.norm(imgpoints[i], imgpoints2, cv.NORM_L2)/len(imgpoints2)
+    error = cv.norm(imgpoints[i], imgpoints2, cv.NORM_L2SQR) / len(imgpoints2)
     mean_error += error
 
-print( "total error: {}".format(mean_error/len(objpoints)) )
+print( "total error: {}".format(np.sqrt(mean_error/len(objpoints))) )
 @endcode
 
 Exercises


### PR DESCRIPTION
## Summary

The camera calibration Python tutorial computes reprojection error incorrectly. It uses `cv.NORM_L2` (which already takes a square root) and then averages those values, which is not a proper RMSE calculation.

**Fix:** Use `cv.NORM_L2SQR` to get squared errors, average them across all points and images, then take the square root at the end - the standard RMSE formula.

Also updated the explanatory text to say "RMSE (root mean squared error)" instead of "arithmetical mean."

Fixes #28651

This contribution was developed with AI assistance (Claude Code).