### PR TITLE
Add static integer casting for cvMixChannels, safer

### DIFF
--- a/modules/core/src/convert_c.cpp
+++ b/modules/core/src/convert_c.cpp
@@ -83,7 +83,9 @@ cvMixChannels( const CvArr** src, int src_count,
                CvArr** dst, int dst_count,
                const int* from_to, int pair_count )
 {
-    cv::AutoBuffer<cv::Mat> buf(src_count + dst_count);
+    CV_Assert(src_count >= 0 && dst_count >= 0);
+    size_t buf_size = static_cast<size_t>(src_count) + static_cast<size_t>(dst_count);
+    cv::AutoBuffer<cv::Mat> buf(buf_size);
 
     int i;
     for( i = 0; i < src_count; i++ )


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
* [x] The PR is proposed to the proper branch (`4.x`).
* [x] There is a reference to the original bug report and related work (`#28631`).
* [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable.
  Patch to opencv_extra has the same branch name.
* [ ] The feature is well documented and sample code can be built with the project CMake.

Fixes #28631

This patch adds explicit non-negative validation and safe `size_t` conversion in `cvMixChannels` before constructing `AutoBuffer<cv::Mat>`.

Previously, `src_count + dst_count` was evaluated in signed arithmetic and then passed to `AutoBuffer`, which could trigger `-Walloc-size-larger-than` warnings because GCC could not exclude a negative path leading to `SIZE_MAX`.
