### PR TITLE
Fix UB: left shift of negative value in FillConvexPoly

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1118,8 +1118,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         delta1 = XY_ONE - 1, delta2 = 0;
 
     p0 = v[npts - 1];
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
+    p0.x = (int64)(((uint64)p0.x) << (XY_SHIFT - shift));
+    p0.y = (int64)(((uint64)p0.y) << (XY_SHIFT - shift));
 
     CV_Assert( 0 <= shift && shift <= XY_SHIFT );
     xmin = xmax = v[0].x;
@@ -1138,8 +1138,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         xmax = std::max( xmax, p.x );
         xmin = MIN( xmin, p.x );
 
-        p.x <<= XY_SHIFT - shift;
-        p.y <<= XY_SHIFT - shift;
+        p.x = (int64)(((uint64)p.x) << (XY_SHIFT - shift));
+        p.y = (int64)(((uint64)p.y) << (XY_SHIFT - shift));
 
         if( line_type <= 8 )
         {


### PR DESCRIPTION
## Fix undefined behavior: left shift of negative value in FillConvexPoly

### Problem
Calling `cv::rectangle()` with coordinates extending beyond image bounds (e.g., `cv::Rect(-10, -10, 20, 20)`) causes the `FillConvexPoly` function to perform left shift on negative `int64` values, which is undefined behavior per the C++ standard (§5.8).

**UBSan output:**
```
drawing.cpp:1121:10: runtime error: left shift of negative value -1
```

### Fix
Cast `int64` values to `uint64` before left shifting, then cast back to `int64`. This preserves the same bit-level result while eliminating undefined behavior.

**Before:**
```cpp
p0.x <<= XY_SHIFT - shift;
```

**After:**
```cpp
p0.x = (int64)(((uint64)p0.x) << (XY_SHIFT - shift));
```

Applied to all 4 occurrences in the `FillConvexPoly` function (`p0.x`, `p0.y`, `p.x`, `p.y`).

Fixes #28598