### PR TITLE
Fix Python bindings when optional modules are disabled

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -26,7 +26,7 @@ def __load_extra_py_code_for_module(base, name, enable_debug_print=False):
     native_module = sys.modules.pop(module_name, None)
     try:
         py_module = importlib.import_module(module_name)
-    except ImportError as err:
+    except (ImportError, AttributeError) as err:
         if enable_debug_print:
             print("Can't load Python code for module:", module_name,
                   ". Reason:", err)

--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -708,7 +708,7 @@ def _generate_typing_module(root: NamespaceNode, output_path: Path) -> None:
     """
 
     def has_all_required_modules(type_node: TypeNode) -> bool:
-        return all(em in root.namespaces for em in node.required_modules)
+        return all(em in root.namespaces for em in type_node.required_modules)
 
     def register_alias_links_from_aggregated_type(type_node: TypeNode) -> None:
         assert isinstance(type_node, AggregatedTypeNode), \


### PR DESCRIPTION
## Summary

Fixes two issues that cause `import cv2` to fail when building OpenCV with `-DBUILD_opencv_gapi=OFF -DWITH_GAPI=OFF`.

PR #26633 added `required_modules` filtering to the typing stubs generator, which addressed the main problem. However, two issues remain:

### 1. Wrong variable in `has_all_required_modules()` (`generation.py`)

The function parameter is named `type_node` but the body uses `node` — the loop variable from the enclosing scope:

```python
def has_all_required_modules(type_node: TypeNode) -> bool:
    return all(em in root.namespaces for em in node.required_modules)
    #                                          ^^^^ should be type_node
```

This works by accident because the function is only called as `has_all_required_modules(node)`, so the closure variable `node` happens to equal the argument. Fixed by using `type_node.required_modules`.

### 2. `__load_extra_py_code_for_module()` only catches `ImportError` (`cv2/__init__.py`)

When a stale `gapi/` submodule directory persists from a previous build (e.g., in incremental builds), the runtime loader discovers it and attempts to import it. The `gapi/__init__.py` calls `cv.gapi_GNetPackage(...)` at import time, which raises `AttributeError` when the gapi C++ bindings are absent. The loader only catches `ImportError`, so the `AttributeError` propagates and crashes `import cv2`.

Fixed by catching `(ImportError, AttributeError)`.

## Files Changed

- `modules/python/src2/typing_stubs_generation/generation.py` — use function parameter instead of closure variable
- `modules/python/package/cv2/__init__.py` — catch `AttributeError` in addition to `ImportError`

## Testing

Verified with OpenCV 4.11.0 built with `-DBUILD_opencv_gapi=OFF -DWITH_GAPI=OFF`:
- `import cv2` succeeds without manual post-install cleanup
- No regression with gapi enabled

Resolves #26098