### PR TITLE
Fix JPEG chroma configuration & Standardize component settings

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -829,6 +829,8 @@ bool JpegEncoder::write( const Mat& img, const std::vector<int>& params )
             cinfo.comp_info[0].h_samp_factor = (sampling_factor >> 20 ) & 0xF;
             cinfo.comp_info[1].v_samp_factor = 1;
             cinfo.comp_info[1].h_samp_factor = 1;
+            cinfo.comp_info[2].v_samp_factor = 1;
+            cinfo.comp_info[2].h_samp_factor = 1;
         }
 
         if (luma_quality >= 0 && chroma_quality >= 0)
@@ -843,6 +845,8 @@ bool JpegEncoder::write( const Mat& img, const std::vector<int>& params )
                 cinfo.comp_info[0].h_samp_factor = 1;
                 cinfo.comp_info[1].v_samp_factor = 1;
                 cinfo.comp_info[1].h_samp_factor = 1;
+                cinfo.comp_info[2].v_samp_factor = 1;
+                cinfo.comp_info[2].h_samp_factor = 1;
             }
             jpeg_default_qtables( &cinfo, TRUE );
 #else

--- a/modules/imgcodecs/src/grfmt_jpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg.cpp
@@ -825,12 +825,12 @@ bool JpegEncoder::write( const Mat& img, const std::vector<int>& params )
 
         if( (channels > 1) && ( sampling_factor != 0 ) )
         {
-            cinfo.comp_info[0].v_samp_factor = (sampling_factor >> 16 ) & 0xF;
             cinfo.comp_info[0].h_samp_factor = (sampling_factor >> 20 ) & 0xF;
-            cinfo.comp_info[1].v_samp_factor = 1;
-            cinfo.comp_info[1].h_samp_factor = 1;
-            cinfo.comp_info[2].v_samp_factor = 1;
-            cinfo.comp_info[2].h_samp_factor = 1;
+            cinfo.comp_info[0].v_samp_factor = (sampling_factor >> 16 ) & 0xF;
+            cinfo.comp_info[1].h_samp_factor = (sampling_factor >> 12 ) & 0xF;
+            cinfo.comp_info[1].v_samp_factor = (sampling_factor >> 8 ) & 0xF;
+            cinfo.comp_info[2].h_samp_factor = (sampling_factor >> 4 ) & 0xF;
+            cinfo.comp_info[2].v_samp_factor = (sampling_factor >> 0 ) & 0xF;
         }
 
         if (luma_quality >= 0 && chroma_quality >= 0)


### PR DESCRIPTION
### Problem
Incorrectly treated Chroma as a single channel. In $YC_bC_r$, chroma must be set in both separate channels ($C_b$ and $C_r$).
### Fix
- Explicit Setup: Configured all three components ($Y$, $C_b$, $C_r$) individually.
- Standardization: Removed reliance on library defaults to prevent undefined behavior.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
