### PR TITLE
photo:fixed saturation bug in icvTeleaInpaintFMM function

### DIFF
--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -340,7 +340,7 @@ icvTeleaInpaintFMM(Mat &f, Mat &t, Mat &out, int range, CvPriorityQueueFloat *He
                                     gradI.y=0;
                                  }
                               }
-                              Ia[color] += (float)w * (float)(out.at<PixelT>(k-1,l-1)[color]);
+                              Ia[color] += (float)w * (float)(out.at<PixelT>(km,lm)[color]);
                               Jx[color] -= (float)w * (float)(gradI.x*r.x);
                               Jy[color] -= (float)w * (float)(gradI.y*r.y);
                               s[color]  += w;

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -183,4 +183,38 @@ TEST_P(Photo_InpaintSmallBorders, regression)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintSmallBorders,  Values(CV_8UC1, CV_8UC3));
 
+TEST(Photo_Inpaint_TELEA, no_saturation)
+{
+    Mat image(25, 25, CV_8UC3, Scalar(255, 0, 255));
+
+    std::vector<Point> holes = {
+        {0, 0}, {24, 0}, {1, 1}, {23, 1},
+        {1, 23}, {23, 23}, {0, 24}, {24, 24}
+    };
+
+    for (const auto& pt : holes)
+        image.at<Vec3b>(pt.y, pt.x) = Vec3b(0, 0, 0);
+
+    Mat1b inpaintMask = Mat1b::zeros(25, 25);
+    for (const auto& pt : holes)
+        inpaintMask(pt.y, pt.x) = 255;
+
+    Mat res;
+    inpaint(image, inpaintMask, res, 5, INPAINT_TELEA);
+
+    struct PixelCheck { int y, x, maxVal; };
+    const std::vector<PixelCheck> checks = {
+        {0, 0, 200},   
+        {1, 1, 200}, 
+    };
+
+    for (const auto& c : checks)
+    {
+        Vec3b result = res.at<Vec3b>(c.y, c.x);
+        ASSERT_EQ((int)result[1], 0);
+        ASSERT_LT((int)result[0], c.maxVal);
+        ASSERT_LT((int)result[2], c.maxVal);
+    }
+}
+
 }} // namespace

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -183,38 +183,4 @@ TEST_P(Photo_InpaintSmallBorders, regression)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintSmallBorders,  Values(CV_8UC1, CV_8UC3));
 
-TEST(Photo_Inpaint_TELEA, no_saturation)
-{
-    Mat image(25, 25, CV_8UC3, Scalar(255, 0, 255));
-
-    std::vector<Point> holes = {
-        {0, 0}, {24, 0}, {1, 1}, {23, 1},
-        {1, 23}, {23, 23}, {0, 24}, {24, 24}
-    };
-
-    for (const auto& pt : holes)
-        image.at<Vec3b>(pt.y, pt.x) = Vec3b(0, 0, 0);
-
-    Mat1b inpaintMask = Mat1b::zeros(25, 25);
-    for (const auto& pt : holes)
-        inpaintMask(pt.y, pt.x) = 255;
-
-    Mat res;
-    inpaint(image, inpaintMask, res, 5, INPAINT_TELEA);
-
-    struct PixelCheck { int y, x, maxVal; };
-    const std::vector<PixelCheck> checks = {
-        {0, 0, 200},   
-        {1, 1, 200}, 
-    };
-
-    for (const auto& c : checks)
-    {
-        Vec3b result = res.at<Vec3b>(c.y, c.x);
-        ASSERT_EQ((int)result[1], 0);
-        ASSERT_LT((int)result[0], c.maxVal);
-        ASSERT_LT((int)result[2], c.maxVal);
-    }
-}
-
 }} // namespace

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -183,4 +183,34 @@ TEST_P(Photo_InpaintSmallBorders, regression)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintSmallBorders,  Values(CV_8UC1, CV_8UC3));
 
+struct PixelCheck { int y, x, maxVal; };
+
+typedef testing::TestWithParam<PixelCheck> Photo_InpaintTeleaNoSaturation;
+
+TEST_P(Photo_InpaintTeleaNoSaturation, regression)
+{
+    Mat image(25, 25, CV_8UC3, Scalar(255, 0, 255));
+
+    std::vector<Point> holes = {{0, 0}, {24, 0}, {1, 1}, {23, 1}, {1, 23}};
+
+    for (const auto& pt : holes)
+        image.at<Vec3b>(pt.y, pt.x) = Vec3b(0, 0, 0);
+
+    Mat1b inpaintMask = Mat1b::zeros(25, 25);
+    for (const auto& pt : holes)
+        inpaintMask(pt.y, pt.x) = 255;
+
+    Mat res;
+    inpaint(image, inpaintMask, res, 5, INPAINT_TELEA);
+
+    const PixelCheck c = GetParam();
+    Vec3b result = res.at<Vec3b>(c.y, c.x);
+    ASSERT_EQ((int)result[1], 0);
+    ASSERT_LT((int)result[0], c.maxVal);
+    ASSERT_LT((int)result[2], c.maxVal);
+}
+
+INSTANTIATE_TEST_CASE_P(Photo_Inpaint_TELEA, Photo_InpaintTeleaNoSaturation,
+    Values(PixelCheck{0, 0, 200}, PixelCheck{1, 1, 200}));
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description 

Fixes #28648 

the saturated values were produced by using improper raw limits `(k-1, l-1)`  instead of precalculated safe limits `(km,lm)` in the  `icvTeleaInpaintFMM` function in ` inpaint.cpp`

**Earlier (with Bug) -**
    `Ia[color] += (float)w * (float)(out.at<PixelT>(k-1,l-1)[color]);`

>           OUTPUT ( Saturated )-
>           ( 0, 0): [  0,  0,  0] -> [255,  0,255]
>           ( 0,24): [  0,  0,  0] -> [255,  0,255]
>           ( 1, 1): [  0,  0,  0] -> [255,  0,255]
>           ( 1,23): [  0,  0,  0] -> [255,  0,255]
>           (23, 1): [  0,  0,  0] -> [255,  0,255]
>           (23,23): [  0,  0,  0] -> [255,  0,255]
>           (24, 0): [  0,  0,  0] -> [255,  0,255]
>           (24,24): [  0,  0,  0] -> [255,  0,255]

  **Fixed -** 
    `Ia[color] += (float)w * (float)(out.at<PixelT>(km,lm)[color]);`
    
>           OUTPUT -
>           ( 0, 0): [  0,  0,  0] -> [118,  0,118]
>           ( 0,24): [  0,  0,  0] -> [236,  0,236]
>           ( 1, 1): [  0,  0,  0] -> [144,  0,144]
>           ( 1,23): [  0,  0,  0] -> [208,  0,208]
>           (23, 1): [  0,  0,  0] -> [208,  0,208]
>           (23,23): [  0,  0,  0] -> [255,  0,255]
>           (24, 0): [  0,  0,  0] -> [236,  0,236]
>           (24,24): [  0,  0,  0] -> [255,  0,255]
