### PR TITLE
Fix reprojection error calculation in camera calibration tutorial

### DIFF
--- a/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
+++ b/doc/py_tutorials/py_calib3d/py_calibration/py_calibration.markdown
@@ -210,13 +210,15 @@ the absolute norm between what we got with our transformation and the corner fin
 find the average error, we calculate the arithmetical mean of the errors calculated for all the
 calibration images.
 @code{.py}
-mean_error = 0
+total_error = 0
+total_points = 0
 for i in range(len(objpoints)):
     imgpoints2, _ = cv.projectPoints(objpoints[i], rvecs[i], tvecs[i], mtx, dist)
-    error = cv.norm(imgpoints[i], imgpoints2, cv.NORM_L2)/len(imgpoints2)
-    mean_error += error
+    error = cv.norm(imgpoints[i], imgpoints2, cv.NORM_L2SQR)
+    total_error += error
+    total_points += len(imgpoints2)
 
-print( "total error: {}".format(mean_error/len(objpoints)) )
+print( "RMSE: {}".format(np.sqrt(total_error/total_points)) )
 @endcode
 
 Exercises


### PR DESCRIPTION
The previous code incorrectly calculated the mean over NORM_L2 values (which already include a square root). The correct RMSE calculation requires computing the mean of squared errors first, then taking the square root.

Fixes #28651

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
