### PR TITLE
Added AVX_VNNI function to core module

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -274,6 +274,7 @@ namespace cv {
 #define CV_CPU_AVX_512VPOPCNTDQ 25
 #define CV_CPU_AVX_5124VNNIW    26
 #define CV_CPU_AVX_5124FMAPS    27
+#define CV_CPU_AVX_VNNI         28
 
 #define CV_CPU_NEON             100
 #define CV_CPU_NEON_DOTPROD     101
@@ -337,6 +338,7 @@ enum CpuFeatures {
     CPU_AVX_512VPOPCNTDQ= 25,
     CPU_AVX_5124VNNIW   = 26,
     CPU_AVX_5124FMAPS   = 27,
+    CPU_AVX_VNNI        = 28,
 
     CPU_NEON            = 100,
     CPU_NEON_DOTPROD    = 101,

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -423,6 +423,7 @@ struct HWFeatures
         g_hwFeatureNames[CPU_AVX_512VPOPCNTDQ] = "AVX512VPOPCNTDQ";
         g_hwFeatureNames[CPU_AVX_5124VNNIW] = "AVX5124VNNIW";
         g_hwFeatureNames[CPU_AVX_5124FMAPS] = "AVX5124FMAPS";
+        g_hwFeatureNames[CPU_AVX_VNNI] = "AVX_VNNI";
 
         g_hwFeatureNames[CPU_NEON] = "NEON";
         g_hwFeatureNames[CPU_NEON_DOTPROD] = "NEON_DOTPROD";
@@ -503,6 +504,11 @@ struct HWFeatures
             have[CV_CPU_AVX_5124VNNIW]    = (cpuid_data_ex[3] & (1<<2))  != 0;
             have[CV_CPU_AVX_5124FMAPS]    = (cpuid_data_ex[3] & (1<<3))  != 0;
 
+            // CPUID leaf 7, subleaf 1 for AVX-VNNI
+            int cpuid_data_ex1[4] = { 0, 0, 0, 0 };
+            CV_CPUID_X86(cpuid_data_ex1, 7, 1);
+            have[CV_CPU_AVX_VNNI]         = (cpuid_data_ex1[0] & (1<<4))  != 0;
+
             bool have_AVX_OS_support = true;
             bool have_AVX512_OS_support = true;
             if (!(cpuid_data[2] & (1<<27)))
@@ -527,6 +533,7 @@ struct HWFeatures
                 have[CV_CPU_FP16] = false;
                 have[CV_CPU_AVX2] = false;
                 have[CV_CPU_FMA3] = false;
+                have[CV_CPU_AVX_VNNI] = false;
             }
             if (!have_AVX_OS_support || !have_AVX512_OS_support)
             {


### PR DESCRIPTION
Backport of #28668

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
