### PR TITLE
Replace System.exit(-1) with exceptions in HighGui.java (#28696)

### DIFF
--- a/modules/highgui/misc/java/src/java/highgui+HighGui.java
+++ b/modules/highgui/misc/java/src/java/highgui+HighGui.java
@@ -154,6 +154,7 @@ public final class HighGui {
                 latch.await(delay, TimeUnit.MILLISECONDS);
             }
         } catch (InterruptedException e) {
+            e.printStackTrace();
             Thread.currentThread().interrupt();
         }
 


### PR DESCRIPTION
## Summary

Library code should never call System.exit() as it kills the entire JVM. Replaced all 3 instances with appropriate exceptions.

Closes #28696

## Changes

- `imshow()` with empty image: `System.exit(-1)` -> `throw new IllegalArgumentException("Image is empty")`
- `waitKey()` with no windows: `System.exit(-1)` -> `throw new IllegalStateException("No windows created. Call imshow() first")`
- `waitKey()` with null window image: `System.exit(-1)` -> `throw new IllegalStateException("No image set for window: ... Call imshow() first")`
- `InterruptedException` catch: `printStackTrace()` -> `Thread.currentThread().interrupt()`