### PR TITLE
Perf test for gemm

### DIFF
--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -6,24 +6,29 @@ using namespace perf;
 
 CV_FLAGS(GemmFlag, 0, GEMM_1_T, GEMM_2_T, GEMM_3_T)
 
-#define GEMM_BODY()                                                             \
-    int M = get<0>(get<0>(GetParam()));                                         \
-    int N = get<1>(get<0>(GetParam()));                                         \
-    int K = get<2>(get<0>(GetParam()));                                         \
-    int type = get<1>(GetParam());                                              \
-    int flags = get<2>(GetParam());                                             \
-                                                                                \
-    Size aSize = (flags & GEMM_1_T) ? Size(M, K) : Size(K, M);                  \
-    Size bSize = (flags & GEMM_2_T) ? Size(K, N) : Size(N, K);                  \
-                                                                                \
-    Mat src1(aSize, type), src2(bSize, type), src3(M, N, type), dst(M, N, type);\
-    declare.in(src1, src2, src3, WARMUP_RNG).out(dst);                          \
-                                                                                \
-    TEST_CYCLE() cv::gemm(src1, src2, 1.0, src3, 1.0, dst, flags);              \
-                                                                                \
-    SANITY_CHECK(dst, 1e-3);
+typedef tuple<tuple<int, int, int>, MatType, GemmFlag> GemmTestParams_t;
+class GemmTest : public perf::TestBaseWithParam<GemmTestParams_t>
+{
+    public:
+    void runGemmTest(const GemmTestParams_t& params)
+    {
+        int M = get<0>(get<0>(params));
+        int N = get<1>(get<0>(params));
+        int K = get<2>(get<0>(params));
+        int type = get<1>(params);
+        int flags = get<2>(params);
 
-using GemmTest = perf::TestBaseWithParam<tuple<tuple<int, int, int>, MatType, GemmFlag>>;
+        Size aSize = (flags & GEMM_1_T) ? Size(M, K) : Size(K, M);
+        Size bSize = (flags & GEMM_2_T) ? Size(K, N) : Size(N, K);
+
+        Mat src1(aSize, type), src2(bSize, type), src3(M, N, type), dst(M, N, type);
+        declare.in(src1, src2, src3, WARMUP_RNG).out(dst);
+
+        TEST_CYCLE() cv::gemm(src1, src2, 1.0, src3, 1.0, dst, flags);
+
+        SANITY_CHECK(dst, 1e-3);
+    };
+};
 
 PERF_TEST_P(GemmTest, gemmTiny,
             testing::Combine(
@@ -37,7 +42,7 @@ PERF_TEST_P(GemmTest, gemmTiny,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
 
 PERF_TEST_P(GemmTest, gemmSmall,
@@ -56,7 +61,7 @@ PERF_TEST_P(GemmTest, gemmSmall,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
 
 PERF_TEST_P(GemmTest, gemmSquare,
@@ -71,7 +76,7 @@ PERF_TEST_P(GemmTest, gemmSquare,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
 
 PERF_TEST_P(GemmTest, gemmRect,
@@ -79,8 +84,12 @@ PERF_TEST_P(GemmTest, gemmRect,
                 testing::Values(
                     // Tall output (M >> N)
                     make_tuple(1024, 64, 256),
+                    make_tuple(1024, 256, 512),
                     make_tuple(512, 32, 512),
+                    make_tuple(512, 128, 256),
                     // Wide output (N >> M)
+                    make_tuple(256, 1024, 512),
+                    make_tuple(128, 512, 256),
                     make_tuple(64, 1024, 256),
                     make_tuple(32, 512, 512)
                 ),
@@ -89,7 +98,7 @@ PERF_TEST_P(GemmTest, gemmRect,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
 
 PERF_TEST_P(GemmTest, gemmM1,
@@ -104,7 +113,7 @@ PERF_TEST_P(GemmTest, gemmM1,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
 
 PERF_TEST_P(GemmTest, gemmN1,
@@ -118,9 +127,7 @@ PERF_TEST_P(GemmTest, gemmN1,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
 {
-    GEMM_BODY();
+    GemmTest::runGemmTest(GetParam());
 }
-
-#undef GEMM_BODY
 
 } // namespace

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -106,7 +106,7 @@ PERF_TEST_P(GemmTest, gemmM1,
                 testing::Values(
                     make_tuple(1, 20, 2500),
                     make_tuple(1, 64, 2500),
-                    make_tuple(1, 80, 10000)
+                    make_tuple(1, 80, 2500)
                 ),
                 testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
                 testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -1,0 +1,126 @@
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+using namespace perf;
+
+CV_FLAGS(GemmFlag, 0, GEMM_1_T, GEMM_2_T, GEMM_3_T)
+
+#define GEMM_BODY()                                                             \
+    int M = get<0>(get<0>(GetParam()));                                         \
+    int N = get<1>(get<0>(GetParam()));                                         \
+    int K = get<2>(get<0>(GetParam()));                                         \
+    int type = get<1>(GetParam());                                              \
+    int flags = get<2>(GetParam());                                             \
+                                                                                \
+    Size aSize = (flags & GEMM_1_T) ? Size(M, K) : Size(K, M);                  \
+    Size bSize = (flags & GEMM_2_T) ? Size(K, N) : Size(N, K);                  \
+                                                                                \
+    Mat src1(aSize, type), src2(bSize, type), src3(M, N, type), dst(M, N, type);\
+    declare.in(src1, src2, src3, WARMUP_RNG).out(dst);                          \
+                                                                                \
+    TEST_CYCLE() cv::gemm(src1, src2, 1.0, src3, 1.0, dst, flags);              \
+                                                                                \
+    SANITY_CHECK(dst, 1e-3);
+
+using GemmTest = perf::TestBaseWithParam<tuple<tuple<int, int, int>, MatType, GemmFlag>>;
+
+PERF_TEST_P(GemmTest, gemmTiny,
+            testing::Combine(
+                testing::Values(
+                    make_tuple(2, 2, 2),
+                    make_tuple(3, 3, 3),
+                    make_tuple(4, 4, 4)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+PERF_TEST_P(GemmTest, gemmSmall,
+            testing::Combine(
+                testing::Values(
+                    make_tuple(4, 8, 16),
+                    make_tuple(8, 8, 8),
+                    make_tuple(8, 16, 32),
+                    make_tuple(16, 16, 16),
+                    make_tuple(32, 32, 32),
+                    make_tuple(64, 64, 64),
+                    make_tuple(128, 128, 128)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+PERF_TEST_P(GemmTest, gemmSquare,
+            testing::Combine(
+                testing::Values(
+                    make_tuple(256, 256, 256),
+                    make_tuple(512, 512, 512),
+                    make_tuple(1024, 1024, 1024)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+PERF_TEST_P(GemmTest, gemmRect,
+            testing::Combine(
+                testing::Values(
+                    // Tall output (M >> N)
+                    make_tuple(1024, 64, 256),
+                    make_tuple(512, 32, 512),
+                    // Wide output (N >> M)
+                    make_tuple(64, 1024, 256),
+                    make_tuple(32, 512, 512)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+PERF_TEST_P(GemmTest, gemmM1,
+            testing::Combine(
+                testing::Values(
+                    make_tuple(1, 20, 2500),
+                    make_tuple(1, 64, 2500),
+                    make_tuple(1, 80, 10000)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+PERF_TEST_P(GemmTest, gemmN1,
+            testing::Combine(
+                testing::Values(
+                    make_tuple(256, 1, 256),
+                    make_tuple(1024, 1, 1024)
+                ),
+                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
+                                (int)(GEMM_1_T | GEMM_2_T))
+            ))
+{
+    GEMM_BODY();
+}
+
+#undef GEMM_BODY
+
+} // namespace

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -26,7 +26,7 @@ class GemmTest : public perf::TestBaseWithParam<GemmTestParams_t>
 
         TEST_CYCLE() cv::gemm(src1, src2, 1.0, src3, 1.0, dst, flags);
 
-        SANITY_CHECK(dst, 1e-3);
+        SANITY_CHECK(dst, 0.01);
     };
 };
 

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -26,7 +26,10 @@ class GemmTest : public perf::TestBaseWithParam<GemmTestParams_t>
 
         TEST_CYCLE() cv::gemm(src1, src2, 1.0, src3, 1.0, dst, flags);
 
-        SANITY_CHECK(dst, 0.01);
+        if (dst.total() * dst.channels() < 26)
+            SANITY_CHECK_NOTHING();
+        else
+            SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
     };
 };
 

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -33,14 +33,15 @@ class GemmTest : public perf::TestBaseWithParam<GemmTestParams_t>
     };
 };
 
+// Sparse coverage: exercise tiny/small/rectangular shapes and m=1/n=1 edge cases.
+// Large square sizes (640+) are covered by opencl/perf_gemm.cpp on the CPU perf tool.
 PERF_TEST_P(GemmTest, gemmTiny,
             testing::Combine(
                 testing::Values(
                     make_tuple(2, 2, 2),
-                    make_tuple(3, 3, 3),
-                    make_tuple(4, 4, 4)
+                    make_tuple(3, 3, 3)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
+                testing::Values(CV_32FC1, CV_64FC1),
                 testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
                                 (int)(GEMM_1_T | GEMM_2_T))
             ))
@@ -51,17 +52,13 @@ PERF_TEST_P(GemmTest, gemmTiny,
 PERF_TEST_P(GemmTest, gemmSmall,
             testing::Combine(
                 testing::Values(
-                    make_tuple(4, 8, 16),
                     make_tuple(8, 8, 8),
-                    make_tuple(8, 16, 32),
-                    make_tuple(16, 16, 16),
                     make_tuple(32, 32, 32),
                     make_tuple(64, 64, 64),
-                    make_tuple(128, 128, 128)
+                    make_tuple(8, 16, 32)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
-                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
-                                (int)(GEMM_1_T | GEMM_2_T))
+                testing::Values(CV_32FC1),
+                testing::Values(0, (int)GEMM_2_T)
             ))
 {
     GemmTest::runGemmTest(GetParam());
@@ -71,12 +68,10 @@ PERF_TEST_P(GemmTest, gemmSquare,
             testing::Combine(
                 testing::Values(
                     make_tuple(256, 256, 256),
-                    make_tuple(512, 512, 512),
-                    make_tuple(1024, 1024, 1024)
+                    make_tuple(512, 512, 512)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
-                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
-                                (int)(GEMM_1_T | GEMM_2_T))
+                testing::Values(CV_32FC1),
+                testing::Values(0)
             ))
 {
     GemmTest::runGemmTest(GetParam());
@@ -85,20 +80,11 @@ PERF_TEST_P(GemmTest, gemmSquare,
 PERF_TEST_P(GemmTest, gemmRect,
             testing::Combine(
                 testing::Values(
-                    // Tall output (M >> N)
                     make_tuple(1024, 64, 256),
-                    make_tuple(1024, 256, 512),
-                    make_tuple(512, 32, 512),
-                    make_tuple(512, 128, 256),
-                    // Wide output (N >> M)
-                    make_tuple(256, 1024, 512),
-                    make_tuple(128, 512, 256),
-                    make_tuple(64, 1024, 256),
-                    make_tuple(32, 512, 512)
+                    make_tuple(256, 1024, 512)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
-                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
-                                (int)(GEMM_1_T | GEMM_2_T))
+                testing::Values(CV_32FC1),
+                testing::Values(0)
             ))
 {
     GemmTest::runGemmTest(GetParam());
@@ -107,13 +93,10 @@ PERF_TEST_P(GemmTest, gemmRect,
 PERF_TEST_P(GemmTest, gemmM1,
             testing::Combine(
                 testing::Values(
-                    make_tuple(1, 20, 2500),
-                    make_tuple(1, 64, 2500),
-                    make_tuple(1, 80, 2500)
+                    make_tuple(1, 64, 2500)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
-                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
-                                (int)(GEMM_1_T | GEMM_2_T))
+                testing::Values(CV_32FC1),
+                testing::Values(0, (int)GEMM_1_T)
             ))
 {
     GemmTest::runGemmTest(GetParam());
@@ -122,12 +105,10 @@ PERF_TEST_P(GemmTest, gemmM1,
 PERF_TEST_P(GemmTest, gemmN1,
             testing::Combine(
                 testing::Values(
-                    make_tuple(256, 1, 256),
-                    make_tuple(1024, 1, 1024)
+                    make_tuple(256, 1, 256)
                 ),
-                testing::Values(CV_32FC1, CV_64FC1, CV_32FC2, CV_64FC2),
-                testing::Values(0, (int)GEMM_1_T, (int)GEMM_2_T,
-                                (int)(GEMM_1_T | GEMM_2_T))
+                testing::Values(CV_32FC1),
+                testing::Values(0)
             ))
 {
     GemmTest::runGemmTest(GetParam());

--- a/modules/core/perf/perf_gemm.cpp
+++ b/modules/core/perf/perf_gemm.cpp
@@ -29,7 +29,7 @@ class GemmTest : public perf::TestBaseWithParam<GemmTestParams_t>
         if (dst.total() * dst.channels() < 26)
             SANITY_CHECK_NOTHING();
         else
-            SANITY_CHECK(dst, 1e-6, ERROR_RELATIVE);
+            SANITY_CHECK(dst, (CV_MAT_DEPTH(type) == CV_32F) ? 1e-4 : 1e-6, ERROR_RELATIVE);
     };
 };
 


### PR DESCRIPTION
OpenCV Extra: https://github.com/opencv/opencv_extra/pull/1336

- Added perf test to verify gemm performance.
- small sizes, square & rectangular matrix shapes are added.
- special case of n=1 and m=1 are added.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
