### PR TITLE
dnn: fix BatchNorm bias blob index in validation and add test

### DIFF
--- a/modules/dnn/src/layers/batch_norm_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm_layer.cpp
@@ -84,7 +84,7 @@ public:
         if( hasBias )
         {
             CV_Assert((size_t)biasBlobIndex < blobs.size());
-            const Mat& b = blobs[weightsBlobIndex];
+            const Mat& b = blobs[biasBlobIndex];
             CV_Assert(b.isContinuous() && b.type() == CV_32F && b.total() == (size_t)n);
         }
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2356,6 +2356,37 @@ TEST_P(Layer_Test_BatchNorm, fusion)
     }
 }
 
+TEST_P(Layer_Test_BatchNorm, bias_blob_validation)
+{
+    // Regression test for PR #28701: the constructor validated
+    // blobs[weightsBlobIndex] instead of blobs[biasBlobIndex] when hasBias was true.
+    // Providing a CV_64F bias blob must trigger the type assertion on the actual
+    // bias blob. Before the fix the weights blob (CV_32F) was checked instead,
+    // so the wrong type went undetected.
+    if (get<0>(GetParam()) != DNN_BACKEND_OPENCV || get<1>(GetParam()) != DNN_TARGET_CPU)
+        return;
+
+    const int ch = 3;
+    Net net;
+    {
+        LayerParams lp;
+        lp.type = "BatchNorm";
+        lp.name = "bn";
+        lp.set("has_weight", true);
+        lp.set("has_bias", true);
+        lp.blobs.push_back(Mat(1, ch, CV_32F, Scalar(0)));   // mean
+        lp.blobs.push_back(Mat(1, ch, CV_32F, Scalar(1)));   // var
+        lp.blobs.push_back(Mat(1, ch, CV_32F, Scalar(1)));   // weights (CV_32F, correct)
+        lp.blobs.push_back(Mat(1, ch, CV_64F, Scalar(0)));   // bias    (CV_64F, wrong)
+        net.addLayerToPrev(lp.name, lp.type, lp);
+    }
+
+    net.setPreferableBackend(DNN_BACKEND_OPENCV);
+    net.setPreferableTarget(DNN_TARGET_CPU);
+    net.setInput(blobFromImage(Mat(2, 2, CV_32FC(ch), Scalar::all(1.f))));
+    ASSERT_ANY_THROW(net.forward());
+}
+
 INSTANTIATE_TEST_CASE_P(/**/, Layer_Test_BatchNorm, dnnBackendsAndTargets());
 
 class TestLayerFusion : public DNNTestLayer {


### PR DESCRIPTION
Fix the bias blob validation in BatchNormLayerImpl constructor: the hasBias block incorrectly referenced blobs[weightsBlobIndex] instead of blobs[biasBlobIndex], so the type/shape assertion checked the weights blob rather than the actual bias blob.

Add a regression test that provides a CV_64F bias blob (should be CV_32F). Before the fix the assertion silently passed because it checked the correct-typed weights blob; after the fix it properly catches the type mismatch and throws.

 Related to #28701

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
