### PR TITLE
Benchmark cv::mean instead of cvtest::mean

### DIFF
--- a/modules/core/perf/perf_stat.cpp
+++ b/modules/core/perf/perf_stat.cpp
@@ -29,7 +29,7 @@ PERF_TEST_P(Size_MatType, mean, TYPICAL_MATS)
 
     declare.in(src, WARMUP_RNG).out(s);
 
-    TEST_CYCLE() s = mean(src);
+    TEST_CYCLE() s = cv::mean(src);
 
     SANITY_CHECK(s, 1e-5);
 }
@@ -45,7 +45,7 @@ PERF_TEST_P(Size_MatType, mean_mask, TYPICAL_MATS)
 
     declare.in(src, WARMUP_RNG).in(mask).out(s);
 
-    TEST_CYCLE() s = mean(src, mask);
+    TEST_CYCLE() s = cv::mean(src, mask);
 
     SANITY_CHECK(s, 5e-5);
 }


### PR DESCRIPTION
The mean performance tests actually call the `mean` function in namespace `cvtest` which are just used for accuracy tests. We want to benchmark the actual OpenCV function. This replaces #28720.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
