### PR TITLE
imgcodecs(tiff): set TIFFTAG_EXTRASAMPLES for 4-channel images

### DIFF
--- a/modules/imgcodecs/src/grfmt_tiff.cpp
+++ b/modules/imgcodecs/src/grfmt_tiff.cpp
@@ -1494,6 +1494,13 @@ bool TiffEncoder::writeLibTiff( const std::vector<Mat>& img_vec, const std::vect
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_PLANARCONFIG, PLANARCONFIG_CONTIG));
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_ROWSPERSTRIP, rowsPerStrip));
 
+        if(channels == 4)
+        {
+            uint16_t extra_samples_num = 1;
+            uint16_t extra_samples[] = {EXTRASAMPLE_UNASSALPHA};
+            CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_EXTRASAMPLES, extra_samples_num, extra_samples));
+        }
+
         CV_TIFF_CHECK_CALL(TIFFSetField(tif, TIFFTAG_SAMPLEFORMAT, sample_format));
 
         if (page_compression == COMPRESSION_LZW || page_compression == COMPRESSION_ADOBE_DEFLATE || page_compression == COMPRESSION_DEFLATE)


### PR DESCRIPTION
This specifies EXTRASAMPLE_UNASSALPHA for 4-channel (RGBA) images to resolve libtiff warnings regarding mismatched SamplesPerPixel.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
