### PR TITLE
Force step to be ptrdiff_t in resize

### DIFF
--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -1030,7 +1030,7 @@ void Mat::resize(size_t nelems)
         reserve(nelems);
 
     size.p[0] = (int)nelems;
-    dataend += (size.p[0] - saveRows)*step.p[0];
+    dataend += (size.p[0] - saveRows)*(ptrdiff_t)step.p[0];
 
     //updateContinuityFlag(*this);
 }


### PR DESCRIPTION
Otherwise, ASAN could return an error:
"runtime error: addition of unsigned offset"

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
