### PR TITLE
core: fix meanStdDev bug by using separate variables v2, v3 in sumsqr_

### DIFF
--- a/modules/core/src/mean.simd.hpp
+++ b/modules/core/src/mean.simd.hpp
@@ -224,9 +224,10 @@ static int sumsqr_(const T* src0, const uchar* mask, ST* sum, SQT* sqsum, int le
                 v0 = src[0], v1 = src[1];
                 s0 += v0; sq0 += (SQT)v0*v0;
                 s1 += v1; sq1 += (SQT)v1*v1;
-                v0 = src[2], v1 = src[3];
-                s2 += v0; sq2 += (SQT)v0*v0;
-                s3 += v1; sq3 += (SQT)v1*v1;
+                T v2, v3;
+                v2 = src[2], v3 = src[3];
+                s2 += v2; sq2 += (SQT)v2*v2;
+                s3 += v3; sq3 += (SQT)v3*v3;
             }
             sum[k] = s0; sum[k+1] = s1;
             sum[k+2] = s2; sum[k+3] = s3;


### PR DESCRIPTION
- This PR fixes a failing accuracy test on Windows 11 from the core module by addressing a variable reuse issue in the sumsqr_ function.
- **Failing Test :** Core_MeanStdDev/ElemWiseTest.accuracy/0
- The current implementation reuses variables v0 and v1 for both the first pair (src[0], src[1]) and the second pair (src[2], src[3]) of source values within the same loop iteration in mean.simd.hpp
- This reuse of v0 and v1 leads to incorrect values being used in the s2, sq2, s3, sq3 accumulators, producing statistically incorrect mean/stddev results on Windows 11.
- **Fix :**
  - Introduces separate variables v2 and v3 for src[2] and src[3]
  - Eliminates variable reuse that was leading to incorrect accumulation.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
