### PR TITLE
Do not use AVX options on Windows ARM in libwebp.

### DIFF
--- a/3rdparty/libwebp/CMakeLists.txt
+++ b/3rdparty/libwebp/CMakeLists.txt
@@ -21,7 +21,7 @@ if(ANDROID AND ARMEABI_V7A AND NOT NEON)
   endforeach()
 endif()
 
-if(WIN32)
+if(WIN32 AND (X86_64 OR X86))
   foreach(file ${lib_srcs})
     if("${file}" MATCHES "_avx2.c")
       if(MSVC)


### PR DESCRIPTION
Fixes MS Visual Studio warning:
```
Warning: cl : command line  warning D9002: ignoring unknown option '/arch:AVX' [C:\a\ci-gha-workflow\ci-gha-workflow\build\3rdparty\libwebp\libwebp.vcxproj]
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
