### PR TITLE
imgproc: fix fitEllipseDirect/fitEllipseAMS singularity check for large n

### DIFF
--- a/modules/imgproc/src/shapedescr.cpp
+++ b/modules/imgproc/src/shapedescr.cpp
@@ -579,7 +579,9 @@ cv::RotatedRect cv::fitEllipseAMS( InputArray _points )
         M(4,3)=DM(3,4);
         M(4,4)=DM(4,4);
 
-        if (fabs(cv::determinant(M)) > 1.0e-10) {
+        double detAMS = cv::determinant(M);
+        double normMAMS = cv::norm(M, NORM_INF);
+        if (fabs(detAMS) > 1.0e-10 * normMAMS * normMAMS * normMAMS * normMAMS * normMAMS) {
             break;
         }
 
@@ -587,6 +589,12 @@ cv::RotatedRect cv::fitEllipseAMS( InputArray _points )
     }
 
     if (iter < 2) {
+            // Normalize M to prevent precision loss when matrix entries are very small
+            // (which occurs with large point counts due to the 1/n scaling of DM)
+            double mScale = cv::norm(M, NORM_INF);
+            if (mScale > DBL_EPSILON)
+                M *= (1.0 / mScale);
+
             Mat eVal, eVec;
             eigenNonSymmetric(M, eVal, eVec);
 
@@ -774,12 +782,19 @@ cv::RotatedRect cv::fitEllipseDirect( InputArray _points )
         M(2,2) = (DM(0,2) + (DM(0,3)*TM(0,2) + DM(0,4)*TM(1,2) + DM(0,5)*TM(2,2))/Ts)/2.;
 
         double det = cv::determinant(M);
-        if (fabs(det) > 1.0e-10)
+        double normM = cv::norm(M, NORM_INF);
+        if (fabs(det) > 1.0e-10 * normM * normM * normM)
             break;
         eps = (float)(s/(n*2)*1e-2);
     }
 
     if( iter < 2 ) {
+        // Normalize M to prevent precision loss when matrix entries are very small
+        // (which occurs with large point counts due to the 1/n scaling of DM)
+        double mScale = cv::norm(M, NORM_INF);
+        if (mScale > DBL_EPSILON)
+            M *= (1.0 / mScale);
+
         Mat eVal, eVec;
         eigenNonSymmetric(M, eVal, eVec);
 

--- a/modules/imgproc/test/test_fitellipse_ams.cpp
+++ b/modules/imgproc/test/test_fitellipse_ams.cpp
@@ -348,4 +348,28 @@ TEST(Imgproc_FitEllipseAMS_HorizontalLine, accuracy) {
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 
+// Regression test for https://github.com/opencv/opencv/issues/28627
+// fitEllipseAMS should handle near-circular ellipses with many points correctly.
+// Previously, the singularity threshold did not account for the 1/n scaling of the
+// design matrix, causing false singular-matrix detection for large n.
+TEST(Imgproc_FitEllipseAMS_NearCircularLargeN, accuracy) {
+    const double cx = 27.0, cy = 27.0, a = 17.0, b = 16.5;
+    const float tol = 2.0f;
+
+    for (int n : {200, 360, 1000}) {
+        std::vector<Point2f> pts;
+        for (int i = 0; i < n; i++) {
+            double theta = 2.0 * CV_PI * i / n;
+            pts.push_back(Point2f(
+                (float)(cx + a * std::cos(theta)),
+                (float)(cy + b * std::sin(theta))));
+        }
+        const RotatedRect el = fitEllipseAMS(pts);
+        EXPECT_FALSE(std::isnan(el.center.x)) << "n=" << n;
+        EXPECT_FALSE(std::isnan(el.center.y)) << "n=" << n;
+        EXPECT_NEAR(el.center.x, cx, tol) << "n=" << n;
+        EXPECT_NEAR(el.center.y, cy, tol) << "n=" << n;
+    }
+}
+
 }} // namespace

--- a/modules/imgproc/test/test_fitellipse_direct.cpp
+++ b/modules/imgproc/test/test_fitellipse_direct.cpp
@@ -348,4 +348,28 @@ TEST(Imgproc_FitEllipseDirect_HorizontalLine, accuracy) {
     EXPECT_NEAR(el.angle, 90, 0.1);
 }
 
+// Regression test for https://github.com/opencv/opencv/issues/28627
+// fitEllipseDirect should handle near-circular ellipses with many points correctly.
+// Previously, the singularity threshold did not account for the 1/n scaling of the
+// design matrix, causing false singular-matrix detection for large n.
+TEST(Imgproc_FitEllipseDirect_NearCircularLargeN, accuracy) {
+    const double cx = 27.0, cy = 27.0, a = 17.0, b = 16.5;
+    const float tol = 2.0f;
+
+    for (int n : {200, 360, 1000}) {
+        std::vector<Point2f> pts;
+        for (int i = 0; i < n; i++) {
+            double theta = 2.0 * CV_PI * i / n;
+            pts.push_back(Point2f(
+                (float)(cx + a * std::cos(theta)),
+                (float)(cy + b * std::sin(theta))));
+        }
+        const RotatedRect el = fitEllipseDirect(pts);
+        EXPECT_FALSE(std::isnan(el.center.x)) << "n=" << n;
+        EXPECT_FALSE(std::isnan(el.center.y)) << "n=" << n;
+        EXPECT_NEAR(el.center.x, cx, tol) << "n=" << n;
+        EXPECT_NEAR(el.center.y, cy, tol) << "n=" << n;
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
### What's the problem

Both `fitEllipseDirect` and `fitEllipseAMS` fall back to `fitEllipseNoDirect` — or produce degraded results from noise perturbation — when given near-circular ellipse data with more than ~100 points. Reported in #28627.

### Why it happens

The scale factor for point coordinates is computed as `100 / sum(|p - center|)`. Since the sum grows linearly with n, the scale shrinks as O(1/n), causing scaled coordinates to be O(1/n). This flows through the design matrix DM, making the matrix M entries O(1/n^k). Specifically:

- In `fitEllipseDirect` (3×3 M): `det(M) ~ O(1/n^6)`
- In `fitEllipseAMS` (5×5 M): entries scale similarly

The hardcoded threshold `1e-10` does not track this scaling, so for large n even a well-conditioned M looks singular. The algorithm then enters the noise-perturbation iteration, and for sufficiently large n that iteration also fails, triggering a full fallback to `fitEllipseNoDirect`.

### Minimal reproduction

```cpp
double cx = 27, cy = 27, a = 17, b = 16.5;
for (int n : {100, 360, 1000}) {
    std::vector<cv::Point2f> pts;
    for (int i = 0; i < n; i++) {
        double t = 2.0 * CV_PI * i / n;
        pts.push_back({(float)(cx + a*cos(t)), (float)(cy + b*sin(t))});
    }
    auto el = cv::fitEllipseDirect(pts);  // returns NoDirect result for n >= ~150
    auto am = cv::fitEllipseAMS(pts);     // noise-perturbed result for n ~50-150
}
```

### Fix

Two changes to `modules/imgproc/src/shapedescr.cpp`:

**1. Scale-relative singularity threshold**

Replace the absolute threshold with one that tracks the matrix scale:

```cpp
// Before:
if (fabs(det) > 1.0e-10)

// After (fitEllipseDirect, 3×3 M):
double normM = cv::norm(M, NORM_INF);
if (fabs(det) > 1.0e-10 * normM * normM * normM)

// After (fitEllipseAMS, 5×5 M):
double normM = cv::norm(M, NORM_INF);
if (fabs(det) > 1.0e-10 * normM * normM * normM * normM * normM)
```

This keeps the threshold proportional to the expected determinant magnitude for a well-conditioned matrix, independent of n. Genuinely singular matrices (collinear points etc.) still trigger the fallback because their relative det/||M||^k ratio is near machine epsilon.

**2. Normalize M before eigendecomposition**

For very large n (e.g. n=5000), M entries can be O(1e-9) or smaller. At that scale, `eigenNonSymmetric` returns NaN. Dividing M by its infinity norm before the eigenvector computation fixes this without affecting the result: eigenvectors are scale-invariant, and the eigenvalue ordering (used for eigenvector selection in `fitEllipseAMS`) is preserved under uniform scaling.

### Tests added

- `Imgproc_FitEllipseDirect_NearCircularLargeN` in `test_fitellipse_direct.cpp`
- `Imgproc_FitEllipseAMS_NearCircularLargeN` in `test_fitellipse_ams.cpp`

Both verify that center and size are correct for n = 200, 360, 1000 on a near-circular ellipse (a=17, b=16.5).

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable