### PR TITLE
ONNX-Runtime warnings supression via ocv_warnings_disable

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -186,6 +186,8 @@ if(WITH_ONNXRUNTIME)
 
   if(HAVE_ONNX)
     set(HAVE_ONNXRUNTIME 1 CACHE INTERNAL "ONNX Runtime availability")
+    # Suppress warnings from ONNX Runtime headers
+    ocv_warnings_disable(CMAKE_CXX_FLAGS -Wsuggest-override -Wsign-promo)
 
     if(ONNXRUNTIME_PREFER_STATIC)
       set(_ort_static_lib "")


### PR DESCRIPTION
Add suppress ORT-triggered warnings via ocv_warnings_disable

Resolving  : https://github.com/opencv/ci-gha-workflow/pull/296#discussion_r2964178325

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
