### PR TITLE
photo: remove redundant code in illuminationChange

### DIFF
--- a/modules/photo/src/seamless_cloning_impl.cpp
+++ b/modules/photo/src/seamless_cloning_impl.cpp
@@ -428,11 +428,6 @@ void Cloning::illuminationChange(Mat &I, Mat &mask, Mat &wmask, Mat &cloned, flo
     multiply(multY,multy_temp,patchGradientY);
     patchNaNs(patchGradientY);
 
-    Mat zeroMask = (patchGradientX != 0);
-
-    patchGradientX.copyTo(patchGradientX, zeroMask);
-    patchGradientY.copyTo(patchGradientY, zeroMask);
-
     evaluate(I,wmask,cloned);
 }
 


### PR DESCRIPTION
This PR removes duplicate and redundant `copyTo` operations found in `Cloning::illuminationChange()`, where `patchGradientX` and `patchGradientY` were being unnecessarily copied onto themselves via a mask.
As reported in the issue, this has zero effect on the output but cleans up the logic properly.
Resolves #22056.
### Testing
- Existing test suite (no functional logic modifications introduced).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
