### PR TITLE
photo: fix corner pixel saturation in TELEA inpainting

### DIFF
--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -293,7 +293,7 @@ icvTeleaInpaintFMM(Mat &f, Mat &t, Mat &out, int range, CvPriorityQueueFloat *He
                float Jx[3] = {0,0,0};
                float Jy[3] = {0,0,0};
                float Ia[3] = {0,0,0};
-               float s[3] = {1.0e-20f,1.0e-20f,1.0e-20f};
+               float s[3] = {0,0,0};
                float w,dst,lev,dir,sat;
 
                for (k=i-range; k<=i+range; k++) {
@@ -340,18 +340,24 @@ icvTeleaInpaintFMM(Mat &f, Mat &t, Mat &out, int range, CvPriorityQueueFloat *He
                                     gradI.y=0;
                                  }
                               }
-                              Ia[color] += (float)w * (float)(out.at<PixelT>(k-1,l-1)[color]);
-                              Jx[color] -= (float)w * (float)(gradI.x*r.x);
-                              Jy[color] -= (float)w * (float)(gradI.y*r.y);
-                              s[color]  += w;
+                              if (k-1 >= 0 && l-1 >= 0 && k-1 < out.rows && l-1 < out.cols) {
+                                 Ia[color] += (float)w * (float)(out.at<PixelT>(k-1,l-1)[color]);
+                                 Jx[color] -= (float)w * (float)(gradI.x*r.x);
+                                 Jy[color] -= (float)w * (float)(gradI.y*r.y);
+                                 s[color]  += w;
+                              }
                            }
                         }
                      }
                   }
                }
                for (color=0; color<=2; color++) {
-                  sat = (float)(Ia[color]/s[color]+(Jx[color]+Jy[color])/(sqrt(Jx[color]*Jx[color]+Jy[color]*Jy[color])+1.0e-20f));
-                  out.at<PixelT>(i-1,j-1)[color] = round_cast<uchar>(sat);
+                  if (s[color] <= FLT_EPSILON) {
+                     out.at<PixelT>(i-1,j-1)[color] = out.at<PixelT>(ii-1,jj-1)[color];
+                  } else {
+                     sat = (float)(Ia[color]/s[color]+(Jx[color]+Jy[color])/(sqrt(Jx[color]*Jx[color]+Jy[color]*Jy[color])+1.0e-20f));
+                     out.at<PixelT>(i-1,j-1)[color] = round_cast<uchar>(sat);
+                  }
                }
 
                f.at<uchar>(i,j) = BAND;
@@ -381,7 +387,7 @@ icvTeleaInpaintFMM(Mat &f, Mat &t, Mat &out, int range, CvPriorityQueueFloat *He
 
                for (color=0; color<=0; color++) {
                   cv::Point2f gradI,gradT,r;
-                  float Ia=0,Jx=0,Jy=0,s=1.0e-20f,w,dst,lev,dir,sat;
+                  float Ia=0,Jx=0,Jy=0,s=0,w,dst,lev,dir,sat;
 
                   if (f.at<uchar>(i,j+1)!=INSIDE) {
                      if (f.at<uchar>(i,j-1)!=INSIDE) {
@@ -452,17 +458,21 @@ icvTeleaInpaintFMM(Mat &f, Mat &t, Mat &out, int range, CvPriorityQueueFloat *He
                                     gradI.y=0;
                                  }
                               }
-                              Ia += (float)w * (float)(out.at<data_type>(k-1,l-1));
-                              Jx -= (float)w * (float)(gradI.x*r.x);
-                              Jy -= (float)w * (float)(gradI.y*r.y);
-                              s  += w;
+                              if (k-1 >= 0 && l-1 >= 0 && k-1 < out.rows && l-1 < out.cols) {
+                                 Ia += (float)w * (float)(out.at<data_type>(k-1,l-1));
+                                 Jx -= (float)w * (float)(gradI.x*r.x);
+                                 Jy -= (float)w * (float)(gradI.y*r.y);
+                                 s  += w;
+                              }
                            }
                         }
                      }
                   }
-                  sat = (float)(Ia/s+(Jx+Jy)/(sqrt(Jx*Jx+Jy*Jy)+1.0e-20f));
-                  {
-                  out.at<data_type>(i-1,j-1) = round_cast<data_type>(sat);
+                  if (s <= FLT_EPSILON) {
+                     out.at<data_type>(i-1,j-1) = out.at<data_type>(ii-1,jj-1);
+                  } else {
+                     sat = (float)(Ia/s+(Jx+Jy)/(sqrt(Jx*Jx+Jy*Jy)+1.0e-20f));
+                     out.at<data_type>(i-1,j-1) = round_cast<data_type>(sat);
                   }
                }
 

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -183,4 +183,56 @@ TEST_P(Photo_InpaintSmallBorders, regression)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintSmallBorders,  Values(CV_8UC1, CV_8UC3));
 
+typedef testing::TestWithParam<tuple<perf::MatType>> Photo_Inpaint_TELEA_CornerSaturation;
+
+TEST_P(Photo_Inpaint_TELEA_CornerSaturation, regression)
+{
+    int type = get<0>(GetParam());
+    const int width = 25;
+    const int height = 25;
+    const uchar bg_val = 120;
+
+    Mat image(height, width, type, Scalar::all(bg_val));
+    if (type == CV_8UC3)
+    {
+        image.setTo(Scalar(bg_val, 0, bg_val));
+    }
+    Mat mask = Mat::zeros(image.size(), CV_8U);
+
+    std::vector<Point> holes = {
+        {0, 0}, {24, 0}, {1, 1}, {23, 1},
+        {1, 23}, {23, 23}, {0, 24}, {24, 24}
+    };
+
+    for (const auto& pt : holes)
+    {
+        mask.at<uchar>(pt.y, pt.x) = 255;
+        if (type == CV_8UC3)
+            image.at<Vec3b>(pt.y, pt.x) = Vec3b(0, 0, 0);
+        else
+            image.at<uchar>(pt.y, pt.x) = 0;
+    }
+
+    Mat result;
+    inpaint(image, mask, result, 5, INPAINT_TELEA);
+
+    for (const auto& pt : holes)
+    {
+        if (type == CV_8UC3)
+        {
+            Vec3b val = result.at<Vec3b>(pt.y, pt.x);
+            ASSERT_EQ((int)val[1], 0);
+            ASSERT_NEAR((double)val[0], (double)bg_val, 50.0);
+            ASSERT_NEAR((double)val[2], (double)bg_val, 50.0);
+        }
+        else
+        {
+            uchar val = result.at<uchar>(pt.y, pt.x);
+            ASSERT_NEAR((double)val, (double)bg_val, 50.0);
+        }
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_Inpaint_TELEA_CornerSaturation, Values(CV_8UC1, CV_8UC3));
+
 }} // namespace


### PR DESCRIPTION
This PR fixes a regression in INPAINT_TELEA (introduced in OpenCV 4.10.0) where 1-pixel holes at image boundaries produced saturated artifacts (Issue #28648).

Key Changes:

Kept Geometry: Kept the (k-1, l-1) sampling geometry insteand of clamping.
Safety Guards: Added boundary checks to prevent out-of-bounds memory access at image corners.
Numerical Stability: Initialized weight s=0 with an explicit FLT_EPSILON guard. If no neighbors contribute (at isolated corners), the algorithm now copies the nearest known pixel value instead of dividing by zero.
Testing: Added a parameterized regression test Photo_Inpaint_TELEA_CornerSaturation (8UC1/8UC3) using the #28648 reproduction case.
Fixes: #28648

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
