### PR TITLE
python: preload stdlib typing before loader path changes

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -129,6 +129,11 @@ def bootstrap():
             if DEBUG: print('OpenCV loader: exception during checking workaround for sys.path[0]')
             pass  # applySysPathWorkaround is False
 
+    # Keep stdlib typing in sys.modules before cv2/typing can become
+    # visible as a top-level package while loading the native extension.
+    if sys.version_info[0] >= 3:
+        import typing as _opencv_loader_typing  # noqa: F401
+
     for p in reversed(l_vars['PYTHON_EXTENSIONS_PATHS']):
         sys.path.insert(1 if not applySysPathWorkaround else 0, p)
 


### PR DESCRIPTION
Fixes #28766.

The Python loader temporarily adds extension paths to `sys.path` before importing the native `cv2` extension. Those paths can expose `cv2/typing` as a top-level `typing` package while bootstrap-time imports are still running.

Preload the standard-library `typing` module before mutating `sys.path`, so any later bare `import typing` during native extension loading resolves through `sys.modules` to the stdlib module.

### Test

- `python3 -m py_compile modules/python/package/cv2/__init__.py`
- `git diff --check`
- Local Python import-path simulation confirming that preloading stdlib `typing` prevents a `cv2/typing` directory at the front of `sys.path` from shadowing it.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
