### PR TITLE
docs: fix unsafe imread in py_canny tutorial

### DIFF
--- a/doc/py_tutorials/py_imgproc/py_canny/py_canny.markdown
+++ b/doc/py_tutorials/py_imgproc/py_canny/py_canny.markdown
@@ -83,7 +83,7 @@ import numpy as np
 import cv2 as cv
 from matplotlib import pyplot as plt
 
-img = cv.imread('messi5.jpg', cv.IMREAD_GRAYSCALE)
+img = cv.imread(cv.samples.findFile('starry_night.jpg'), cv.IMREAD_GRAYSCALE)
 assert img is not None, "file could not be read, check with os.path.exists()"
 edges = cv.Canny(img,100,200)
 


### PR DESCRIPTION
- Replace legacy `messi5.jpg` with `starry_night.jpg` in the Canny edge detection tutorial
- Use `cv.samples.findFile()` for robust file loading so the tutorial works regardless of working directory
- Related to #28449

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
