### PR TITLE
Fix #22056: Remove redundant self-copy in Cloning::illuminationChange()

### DIFF
--- a/modules/photo/src/seamless_cloning_impl.cpp
+++ b/modules/photo/src/seamless_cloning_impl.cpp
@@ -428,10 +428,6 @@ void Cloning::illuminationChange(Mat &I, Mat &mask, Mat &wmask, Mat &cloned, flo
     multiply(multY,multy_temp,patchGradientY);
     patchNaNs(patchGradientY);
 
-    Mat zeroMask = (patchGradientX != 0);
-
-    patchGradientX.copyTo(patchGradientX, zeroMask);
-    patchGradientY.copyTo(patchGradientY, zeroMask);
 
     evaluate(I,wmask,cloned);
 }


### PR DESCRIPTION
Fix #22056

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
