### PR TITLE
objdetect: Fix INT8 casting in FaceDetectorYN

### DIFF
--- a/modules/objdetect/src/face_detect.cpp
+++ b/modules/objdetect/src/face_detect.cpp
@@ -171,11 +171,19 @@ private:
             Mat bbox = output_blobs[i + strides.size() * 2];
             Mat kps = output_blobs[i + strides.size() * 3];
 
+            // Ensure tensors are in floating-point format (CV_32F) to prevent raw pointer casting errors.
+            // cv::Mat::convertTo safely casts quantized outputs (e.g., CV_8S) and is a no-op for CV_32F.
+            Mat cls_float, obj_float, bbox_float, kps_float;
+            cls.convertTo(cls_float, CV_32F);
+            obj.convertTo(obj_float, CV_32F);
+            bbox.convertTo(bbox_float, CV_32F);
+            kps.convertTo(kps_float, CV_32F);
+
             // Decode from predictions
-            float* cls_v = (float*)(cls.data);
-            float* obj_v = (float*)(obj.data);
-            float* bbox_v = (float*)(bbox.data);
-            float* kps_v = (float*)(kps.data);
+            float* cls_v = (float*)(cls_float.data);
+            float* obj_v = (float*)(obj_float.data);
+            float* bbox_v = (float*)(bbox_float.data);
+            float* kps_v = (float*)(kps_float.data);
 
             // (tl_x, tl_y, w, h, re_x, re_y, le_x, le_y, nt_x, nt_y, rcm_x, rcm_y, lcm_x, lcm_y, score)
             // 'tl': top left point of the bounding box

--- a/modules/objdetect/test/test_face.cpp
+++ b/modules/objdetect/test/test_face.cpp
@@ -144,6 +144,89 @@ TEST(Objdetect_face_detection, regression)
     }
 }
 
+TEST(Objdetect_face_detection_int8, regression)
+{
+    // Pre-set params
+    float scoreThreshold = 0.7f;
+    float matchThreshold = 0.7f;
+    float l2disThreshold = 15.0f;
+    int numLM = 5;
+    int numCoords = 4 + 2 * numLM;
+
+    // Load ground truth labels
+    std::map<std::string, Mat> gt = blobFromTXT(findDataFile("dnn_face/detection/cascades_labels.txt"), numCoords);
+
+    // Initialize detector with INT8 model
+    std::string model = findDataFile("dnn/onnx/models/face_detection_yunet_2023mar_int8.onnx", false);
+    Ptr<FaceDetectorYN> faceDetector = FaceDetectorYN::create(model, "", Size(300, 300));
+    faceDetector->setScoreThreshold(0.7f);
+
+    // Detect and match
+    for (auto item: gt)
+    {
+        std::string imagePath = findDataFile("cascadeandhog/images/" + item.first);
+        Mat image = imread(imagePath);
+
+        // Set input size
+        faceDetector->setInputSize(image.size());
+
+        // Run detection
+        Mat faces;
+        faceDetector->detect(image, faces);
+        // std::cout << item.first << " " << item.second.rows << " " << faces.rows << std::endl;
+
+        // Match bboxes and landmarks
+        std::vector<bool> matchedItem(item.second.rows, false);
+        for (int i = 0; i < faces.rows; i++)
+        {
+            if (faces.at<float>(i, numCoords) < scoreThreshold)
+                continue;
+
+            bool boxMatched = false;
+            std::vector<bool> lmMatched(numLM, false);
+            cv::Rect2f resBox(faces.at<float>(i, 0), faces.at<float>(i, 1), faces.at<float>(i, 2), faces.at<float>(i, 3));
+            for (int j = 0; j < item.second.rows && !boxMatched; j++)
+            {
+                if (matchedItem[j])
+                    continue;
+
+                // Retrieve bbox and compare IoU
+                cv::Rect2f gtBox(item.second.at<float>(j, 0), item.second.at<float>(j, 1), item.second.at<float>(j, 2), item.second.at<float>(j, 3));
+                double interArea = (resBox & gtBox).area();
+                double iou = interArea / (resBox.area() + gtBox.area() - interArea);
+                if (iou >= matchThreshold)
+                {
+                    boxMatched = true;
+                    matchedItem[j] = true;
+                }
+
+                // Match landmarks if bbox is matched
+                if (!boxMatched)
+                    continue;
+                for (int lmIdx = 0; lmIdx < numLM; lmIdx++)
+                {
+                    float gtX = item.second.at<float>(j, 4 + 2 * lmIdx);
+                    float gtY = item.second.at<float>(j, 4 + 2 * lmIdx + 1);
+                    float resX = faces.at<float>(i, 4 + 2 * lmIdx);
+                    float resY = faces.at<float>(i, 4 + 2 * lmIdx + 1);
+                    float l2dis = cv::sqrt((gtX - resX) * (gtX - resX) + (gtY - resY) * (gtY - resY));
+
+                    if (l2dis <= l2disThreshold)
+                    {
+                        lmMatched[lmIdx] = true;
+                    }
+                }
+                break;
+            }
+            EXPECT_TRUE(boxMatched) << "In image " << item.first << ", cannot match resBox " << resBox << " with any ground truth.";
+            if (boxMatched)
+            {
+                EXPECT_TRUE(std::all_of(lmMatched.begin(), lmMatched.end(), [](bool v) { return v; })) << "In image " << item.first << ", resBox " << resBox << " matched but its landmarks failed to match.";
+            }
+        }
+    }
+}
+
 TEST(Objdetect_face_recognition, regression)
 {
     // Pre-set params


### PR DESCRIPTION
### Description
This PR fixes a bug where `FaceDetectorYN` fails to detect any faces when using INT8 quantized models (specifically `face_detection_yunet_2023mar_int8.onnx`). 

**Root Cause:**
In `modules/objdetect/src/face_detect.cpp`, the `postProcess` function extracts output blobs and immediately casts their data to `float*`. For INT8 models, these blobs are of type `CV_8S`. Casting a 1-byte integer array directly to a 4-byte float pointer results in memory misinterpretation (garbage values), causing all bounding box scores to drop near zero and fail the `scoreThreshold` check.

**Solution:**
Added a step to safely cast the extracted tensors to `CV_32F` using `cv::Mat::convertTo` before applying the `float*` read. This acts as a safe cast for quantized models and is practically a no-op for models that already output `CV_32F`.

### Related Issue
Fixes #28798  

### Checklist
- [x] I agree to contribute my code under OpenCV (Apache 2.0) license.
- [x] I have tested this code locally with both FP32 and INT8 models using the Python script.
- [x] The code matches the Coding Style Guide of the project.
- [x] I have checked for and removed any trailing whitespaces.
- [x] This PR contains a single, clean commit.