### PR TITLE
Rewrite getBitsFromByteList to avoid harmless buffer overflow

### DIFF
--- a/modules/objdetect/src/aruco/aruco_dictionary.cpp
+++ b/modules/objdetect/src/aruco/aruco_dictionary.cpp
@@ -235,34 +235,30 @@ Mat Dictionary::getBitsFromByteList(const Mat &byteList, int markerSize, int rot
     CV_Assert(byteList.channels() >= 4);
     CV_Assert(rotationId >= 0 && rotationId < 4);
 
-    Mat bits(markerSize, markerSize, CV_8UC1, Scalar::all(0));
-
-    unsigned char base2List[] = { 128, 64, 32, 16, 8, 4, 2, 1 };
+    Mat bits = Mat::zeros(markerSize, markerSize, CV_8UC1);
+    unsigned char *bitsPtr = bits.ptr();
 
     // Use a base offset for the selected rotation
     int nbytes = (bits.cols * bits.rows + 8 - 1) / 8; // integer ceil
     int base = rotationId * nbytes;
-    int currentByteIdx = 0;
-    unsigned char currentByte = byteList.ptr()[base + currentByteIdx];
-    int currentBit = 0;
+    const unsigned char *currentBytePtr = byteList.ptr() + base;
+    const unsigned char *currentBytePtrEnd = currentBytePtr + bits.total() / 8;
 
-    for(int row = 0; row < bits.rows; row++) {
-        for(int col = 0; col < bits.cols; col++) {
-            if(currentByte >= base2List[currentBit]) {
-                bits.at<unsigned char>(row, col) = 1;
-                currentByte -= base2List[currentBit];
-            }
-            currentBit++;
-            if(currentBit == 8) {
-                currentByteIdx++;
-                currentByte = byteList.ptr()[base + currentByteIdx];
-                // if not enough bits for one more byte, we are in the end
-                // update bit position accordingly
-                if(8 * (currentByteIdx + 1) > (int)bits.total())
-                    currentBit = 8 * (currentByteIdx + 1) - (int)bits.total();
-                else
-                    currentBit = 0; // ok, bits enough for next byte
-            }
+    for(;currentBytePtr < currentBytePtrEnd; ++currentBytePtr) {
+        unsigned char currentByte = *currentBytePtr;
+        for(int mask = 1 << 7; mask != 0; mask >>= 1) {
+            if (currentByte & mask) *bitsPtr = 1;
+            ++bitsPtr;
+        }
+    }
+    // if not enough bits for one more byte, we are in the end
+    // update bit position accordingly
+    if (bits.total() % 8 != 0) {
+        unsigned char currentByte = *currentBytePtrEnd;
+        int mask = 1 << ((bits.total() % 8) - 1);
+        for(; mask != 0; mask >>= 1) {
+            if (currentByte & mask) *bitsPtr = 1;
+            ++bitsPtr;
         }
     }
     return bits;


### PR DESCRIPTION
At the end, currentByte = byteList.ptr()[base + currentByteIdx]; could be out of bound though never used.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
