### PR TITLE
Add wasm support for int64

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_wasm.hpp
@@ -1238,17 +1238,14 @@ OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_uint16x8, u16x8, i16x8)
 OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_int16x8, i16x8, i16x8)
 OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_uint32x4, u32x4, i32x4)
 OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_int32x4, i32x4, i32x4)
+OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_int64x2, i64x2, i64x2)
 OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_float32x4, f32x4, f32x4)
 OPENCV_HAL_IMPL_WASM_INIT_CMP_OP(v_float64x2, f64x2, f64x2)
 
-#define OPENCV_HAL_IMPL_WASM_64BIT_CMP_OP(_Tpvec, cast) \
-inline _Tpvec v_eq(const _Tpvec& a, const _Tpvec& b) \
-{ return cast(v_eq(v_reinterpret_as_f64(a), v_reinterpret_as_f64(b))); } \
-inline _Tpvec v_ne(const _Tpvec& a, const _Tpvec& b) \
-{ return cast(v_ne(v_reinterpret_as_f64(a), v_reinterpret_as_f64(b))); }
-
-OPENCV_HAL_IMPL_WASM_64BIT_CMP_OP(v_uint64x2, v_reinterpret_as_u64)
-OPENCV_HAL_IMPL_WASM_64BIT_CMP_OP(v_int64x2, v_reinterpret_as_s64)
+inline v_uint64x2 v_eq(const v_uint64x2& a, const v_uint64x2& b)
+{ return v_reinterpret_as_u64(v_eq(v_reinterpret_as_f64(a), v_reinterpret_as_f64(b))); }
+inline v_uint64x2 v_ne(const v_uint64x2& a, const v_uint64x2& b)
+{ return v_reinterpret_as_u64(v_ne(v_reinterpret_as_f64(a), v_reinterpret_as_f64(b))); }
 
 inline v_float32x4 v_not_nan(const v_float32x4& a)
 {


### PR DESCRIPTION
This has been around since 2021 and is part of the wasm spec: https://github.com/llvm/llvm-project/commit/502f54049d17f5a107f833596fb2c31297a99773 This makes 5.x compile for wasm because convertTo needs it at: https://github.com/opencv/opencv/blob/6751304b3556082cc79b63624024419ee15c1ed4/modules/core/src/convert.hpp#L204

This could be backported to 4.x though there is no need for it yet there.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
