### PR TITLE
Disable FFmpeg tests that need FFmpeg wrapper rebuild on Windows.

### DIFF
--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -845,6 +845,8 @@ TEST(videoio_ffmpeg, create_with_property_badarg)
     EXPECT_FALSE(cap.isOpened());
 }
 
+// requires FFmpeg wrapper rebuild on Windows
+#ifndef _WIN32
 TEST(videoio_ffmpeg, open_with_format_cv8uc3)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -860,6 +862,7 @@ TEST(videoio_ffmpeg, open_with_format_cv8uc3)
     ASSERT_TRUE(cap.read(frame));
     EXPECT_EQ(frame.channels(), 3);
 }
+#endif
 
 // related issue: https://github.com/opencv/opencv/issues/16821
 TEST(videoio_ffmpeg, DISABLED_open_from_web)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
