### PR TITLE
objdetect: fix FaceDetectorYN dynamic input size for ONNX Runtime backend

### DIFF
--- a/modules/objdetect/src/face_detect.cpp
+++ b/modules/objdetect/src/face_detect.cpp
@@ -43,6 +43,9 @@ public:
         padW = (int((inputW - 1) / divisor) + 1) * divisor;
         padH = (int((inputH - 1) / divisor) + 1) * divisor;
 
+        if (!net.getMainGraph())
+            net.setInputShape("input", MatShape({1, 3, padH, padW}));
+
         scoreThreshold = score_threshold;
         nmsThreshold = nms_threshold;
         topK = top_k;
@@ -72,6 +75,9 @@ public:
         padW = (int((inputW - 1) / divisor) + 1) * divisor;
         padH = (int((inputH - 1) / divisor) + 1) * divisor;
 
+        if (!net.getMainGraph())
+            net.setInputShape("input", MatShape({1, 3, padH, padW}));
+
         scoreThreshold = score_threshold;
         nmsThreshold = nms_threshold;
         topK = top_k;
@@ -83,6 +89,8 @@ public:
         inputH = input_size.height;
         padW = ((inputW - 1) / divisor + 1) * divisor;
         padH = ((inputH - 1) / divisor + 1) * divisor;
+        if (!net.getMainGraph())
+            net.setInputShape("input", MatShape({1, 3, padH, padW}));
     }
 
     Size getInputSize() override

--- a/samples/dnn/face_detect.cpp
+++ b/samples/dnn/face_detect.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         "{image2 i2         |            | Path to the input image2. When image1 and image2 parameters given then the program try to find a face on both images and runs face recognition algorithm}"
         "{video v           | 0          | Path to the input video}"
         "{scale sc          | 1.0        | Scale factor used to resize input video frames}"
-        "{fd_model fd       | face_detection_yunet_2021dec.onnx| Path to the model. Download yunet.onnx in https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet}"
+        "{fd_model fd       | face_detection_yunet_2023mar.onnx| Path to the model. Download yunet.onnx in https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet}"
         "{fr_model fr       | face_recognition_sface_2021dec.onnx | Path to the face recognition model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface}"
         "{score_threshold   | 0.9        | Filter out faces of score < score_threshold}"
         "{nms_threshold     | 0.3        | Suppress bounding boxes of iou >= nms_threshold}"

--- a/samples/dnn/face_detect.py
+++ b/samples/dnn/face_detect.py
@@ -16,7 +16,7 @@ parser.add_argument('--image1', '-i1', type=str, help='Path to the input image1.
 parser.add_argument('--image2', '-i2', type=str, help='Path to the input image2. When image1 and image2 parameters given then the program try to find a face on both images and runs face recognition algorithm.')
 parser.add_argument('--video', '-v', type=str, help='Path to the input video.')
 parser.add_argument('--scale', '-sc', type=float, default=1.0, help='Scale factor used to resize input video frames.')
-parser.add_argument('--face_detection_model', '-fd', type=str, default='face_detection_yunet_2021dec.onnx', help='Path to the face detection model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet')
+parser.add_argument('--face_detection_model', '-fd', type=str, default='face_detection_yunet_2023mar.onnx', help='Path to the face detection model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet')
 parser.add_argument('--face_recognition_model', '-fr', type=str, default='face_recognition_sface_2021dec.onnx', help='Path to the face recognition model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface')
 parser.add_argument('--score_threshold', type=float, default=0.9, help='Filtering out faces of score < score_threshold.')
 parser.add_argument('--nms_threshold', type=float, default=0.3, help='Suppress bounding boxes of iou >= nms_threshold.')


### PR DESCRIPTION
When using ONNX Runtime as the DNN engine, the backend enforces the model's static input shape at inference time and rejects blobs of any other size, breaking the existing `setInputSize()` workflow that works fine with the default OpenCV DNN backend.

This change calls `net.setInputShape()` whenever the input dimensions are set, both in the constructors and in `setInputSize()`, so ONNX Runtime receives the concrete shape before the forward pass, enabling proper use with a dynamic-input model. Sample defaults are also bumped from the 2021dec model to 2023mar. Fixes #28769.