### PR TITLE
dnn: fix int8 AvgPool crash with OpenVINO backend

### DIFF
--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -181,9 +181,9 @@ void Net::Impl::setPreferableBackend(Net& net, int backendId)
         backendId = DNN_BACKEND_OPENCV;
     }
 #ifdef HAVE_DNN_NGRAPH
-    if (netWasQuantized && backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH && INF_ENGINE_VER_MAJOR_LT(INF_ENGINE_RELEASE_2023_0))
+    if (netWasQuantized && backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
     {
-        CV_LOG_WARNING(NULL, "DNN: OpenVINO 2023.0 and higher is required to supports quantized networks");
+        CV_LOG_WARNING(NULL, "DNN: quantized networks on OpenVINO backend currently fail to evaluate; falling back to OpenCV");
         backendId = DNN_BACKEND_OPENCV;
     }
 #endif


### PR DESCRIPTION
Newer OpenVINO versions fail to compile a FakeQuantize-->AvgPool-->FakeQuantize subgraph for the CPU plugin, throwing "Supported primitive descriptors list is empty" and crashing the test instead of falling back gracefully.

The fix makes `supportBackend` return false for int8 AvgPool and ReduceSum when the OpenVINO backend is selected, so those ops fall through to the CPU implementation. MaxPool is unaffected and continues to run on OpenVINO. Fixes #28659.