### PR TITLE
Allow applyColorMap for 1d arrays

### DIFF
--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -735,7 +735,7 @@ namespace colormap
         if(src.type() != CV_8UC1  &&  src.type() != CV_8UC3)
             CV_Error(Error::StsBadArg, "cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3");
 
-        CV_CheckEQ(src.dims, 2, "Not supported");
+        CV_CheckLE(src.dims, 2, "Not supported");
 
         CV_Assert(_lut.isContinuous());
         const int lut_type = _lut.type();

--- a/modules/imgproc/test/test_color.cpp
+++ b/modules/imgproc/test/test_color.cpp
@@ -3296,4 +3296,17 @@ TEST(ImgProc_cvtColor_InvalidNumOfChannels, regression_25971)
     }
 }
 
+TEST(ImgProc_applyColorMap, dimensions)
+{
+    cv::Mat1b src({0, 128, 255});
+    cv::Mat3b gt = (cv::Mat3b(1, 3) << cv::Vec3b(128, 0, 0), cv::Vec3b(126, 255, 130), cv::Vec3b(0, 0, 128));
+    cv::Mat3b dst;
+    cv::applyColorMap(src, dst, cv::COLORMAP_JET);
+    ASSERT_EQ(cv::norm(dst, gt, NORM_L1), 0);
+    src = src.t();
+    gt = gt.t();
+    cv::applyColorMap(src, dst, cv::COLORMAP_JET);
+    ASSERT_EQ(cv::norm(dst, gt, NORM_L1), 0);
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
