### PR TITLE
Get rid of redundant C++ optional.

### DIFF
--- a/modules/dnn/src/tokenizer/core_bpe.cpp
+++ b/modules/dnn/src/tokenizer/core_bpe.cpp
@@ -141,7 +141,7 @@ CoreBPE::CoreBPE(ByteVecRankMap encoder,
     std::sort(sortedTokenBytes_.begin(), sortedTokenBytes_.end());
 }
 
-std::optional<std::vector<std::uint8_t>>
+std::vector<std::uint8_t>
 CoreBPE::decodeBytes(const std::vector<std::uint32_t>& tokens) const {
     std::vector<std::uint8_t> out;
     out.reserve(tokens.size() * 2);
@@ -157,7 +157,7 @@ CoreBPE::decodeBytes(const std::vector<std::uint32_t>& tokens) const {
             if (sit != specialDecoder_.end()) {
                 tokenBytes = &sit->second;
             } else {
-                return std::nullopt;
+                return std::vector<std::uint8_t>();
             }
         }
         out.insert(out.end(), tokenBytes->begin(), tokenBytes->end());

--- a/modules/dnn/src/tokenizer/core_bpe.hpp
+++ b/modules/dnn/src/tokenizer/core_bpe.hpp
@@ -45,7 +45,6 @@
 #include <vector>
 #include <unordered_map>
 #include <unordered_set>
-#include <optional>
 #include <string>
 #include <cstdint>
 
@@ -148,7 +147,7 @@ public:
      * @param tokens  Token ids.
      * @return Decoded bytes on success, or @c std::nullopt if any id is unknown.
      */
-    std::optional<std::vector<std::uint8_t>> decodeBytes(const std::vector<std::uint32_t>& tokens) const;
+    std::vector<std::uint8_t> decodeBytes(const std::vector<std::uint32_t>& tokens) const;
 
 private:
     ByteVecRankMap encoder_;

--- a/modules/dnn/src/tokenizer/tokenizer.cpp
+++ b/modules/dnn/src/tokenizer/tokenizer.cpp
@@ -47,11 +47,10 @@ struct BpeTokenizerImpl : public Tokenizer::Impl {
     std::string decode(const std::vector<int>& tokens) override {
         CV_Assert(coreBPE);
         std::vector<uint32_t> t32(tokens.begin(), tokens.end());
-        auto opt_bytes = coreBPE->decodeBytes(t32);
-        if (!opt_bytes)
+        const std::vector<std::uint8_t> opt_bytes = coreBPE->decodeBytes(t32);
+        if (opt_bytes.empty())
             CV_Error(cv::Error::StsError, "Invalid decode.");
-        const auto& bytes = *opt_bytes;
-        return std::string(reinterpret_cast<const char*>(bytes.data()), bytes.size());
+        return std::string(reinterpret_cast<const char*>(opt_bytes.data()), opt_bytes.size());
     }
 };
 


### PR DESCRIPTION
It helps to some old compilers to build the code.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
