### PR TITLE
add CV_64S type support to modules/dnn/src/layers/gatherND.cpp

### DIFF
--- a/modules/dnn/src/layers/gatherND.cpp
+++ b/modules/dnn/src/layers/gatherND.cpp
@@ -112,6 +112,7 @@ public:
                     case CV_16F: forward_impl<int64_t, int16_t>(data, indices, out); break;
                     case CV_32F: forward_impl<int64_t, float>(data, indices, out); break;
                     case CV_64F: forward_impl<int64_t, double>(data, indices, out); break;
+                    case CV_64S: forward_impl<int64_t, int64_t>(data, indices, out); break;
                     default: CV_Error(Error::StsNotImplemented, "Unsupported data type");
                 }
             } break;


### PR DESCRIPTION
###Description
Issue: unable to run simplified superpoint onnx model due to unsupported missing support for the CV_64S data types in **gatherND.cpp**



Fix: add CV_64S type support to *modules/dnn/src/layers/gatherND.cpp*

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
