### PR TITLE
Fix: Findchessboardcorners output shape

### DIFF
--- a/modules/calib3d/misc/python/test/test_calibration.py
+++ b/modules/calib3d/misc/python/test/test_calibration.py
@@ -46,7 +46,7 @@ class calibration_test(NewOpenCVTests):
             if not found:
                 continue
 
-            img_points.append(corners.reshape(-1, 2))
+            img_points.append(corners)
             obj_points.append(pattern_points)
 
         # calculate camera distortion

--- a/modules/calib3d/src/calibinit.cpp
+++ b/modules/calib3d/src/calibinit.cpp
@@ -851,7 +851,9 @@ bool findChessboardCorners(InputArray image_, Size pattern_size,
                          cv::TermCriteria(TermCriteria::EPS + TermCriteria::MAX_ITER, 15, 0.1));
     }
 
-    Mat(out_corners).copyTo(corners_);
+    // Fix for issue #7200: Reshape from (N, 1, 2 channels) to (N, 2) for consistent Python API
+    Mat corners_mat = Mat(out_corners).reshape(1); // Reshape to (N, 2) with 1 channel
+    corners_mat.copyTo(corners_);
     return found;
 }
 

--- a/samples/python/calibrate.py
+++ b/samples/python/calibrate.py
@@ -125,7 +125,7 @@ def main():
             if found:
                 term = (cv.TERM_CRITERIA_EPS + cv.TERM_CRITERIA_COUNT, 30, 0.1)
                 cv.cornerSubPix(img, corners, (5, 5), (-1, -1), term)
-                frame_img_points = corners.reshape(-1, 2)
+                frame_img_points = corners
                 frame_obj_points = pattern_points
         elif pattern_type == 'charucoboard':
             corners, charucoIds, _, _ = charuco_detector.detectBoard(img)

--- a/samples/python/tutorial_code/features2D/Homography/perspective_correction.py
+++ b/samples/python/tutorial_code/features2D/Homography/perspective_correction.py
@@ -38,9 +38,6 @@ def  perspectiveCorrection(img1Path, img2Path ,patternSize ):
     img_draw_warp = cv.hconcat([img2, img1_warp])
     cv.imshow("Desired chessboard view / Warped source chessboard view", img_draw_warp )
 
-    corners1 = corners1.tolist()
-    corners1 = [a[0] for a in corners1]
-
     # [compute-transformed-corners]
     img_draw_matches = cv.hconcat([img1, img2])
     for i in range(len(corners1)):


### PR DESCRIPTION
Fix issue #7200: https://github.com/opencv/opencv/issues/7200

The Python binding for findChessboardCorners was returning a 3D array (N, 1, 2) instead of the expected 2D array (N, 2). This required users to manually reshape the output with .reshape(-1, 2).

This fix modifies the C++ implementation to reshape the output from (N, 1, 2 channels) to (N, 2) before copying to the output array. The Python binding now correctly converts this to a (N, 2) numpy array.

Updated all affected Python code to work with the new format:
- modules/calib3d/misc/python/test/test_calibration.py
- samples/python/calibrate.py
- samples/python/tutorial_code/features2D/Homography/perspective_correction.py

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
