### PR TITLE
highgui(qt): preserve UTF-8 window names in fallback paths

### DIFF
--- a/modules/highgui/src/window_QT.cpp
+++ b/modules/highgui/src/window_QT.cpp
@@ -238,8 +238,8 @@ void setWindowTitle_QT(const String& winname, const String& title)
     QMetaObject::invokeMethod(guiMainThread,
         "setWindowTitle",
         autoBlockingConnection(),
-        Q_ARG(QString, QString(winname.c_str())),
-        Q_ARG(QString, QString(title.c_str())));
+        Q_ARG(QString, QString::fromUtf8(winname.c_str())),
+        Q_ARG(QString, QString::fromUtf8(title.c_str())));
 }
 
 
@@ -562,10 +562,10 @@ CV_IMPL int cvNamedWindow(const char* name, int flags)
         QMetaObject::invokeMethod(guiMainThread,
         "createWindow",
         Qt::BlockingQueuedConnection,  // block so that we can do useful stuff once we confirm it is created
-        Q_ARG(QString, QString(name)),
+        Q_ARG(QString, QString::fromUtf8(name)),
         Q_ARG(int, flags));
      } else {
-        guiMainThread->createWindow(QString(name), flags);
+        guiMainThread->createWindow(QString::fromUtf8(name), flags);
      }
 
     return 1; //Dummy value - probably should return the result of the invocation.
@@ -766,11 +766,11 @@ CV_IMPL void cvShowImage(const char* name, const CvArr* arr)
         QMetaObject::invokeMethod(guiMainThread,
             "showImage",
              autoBlockingConnection(),
-             Q_ARG(QString, QString(name)),
+             Q_ARG(QString, QString::fromUtf8(name)),
              Q_ARG(void*, (void*)arr)
         );
      } else {
-        guiMainThread->showImage(QString(name), (void*)arr);
+        guiMainThread->showImage(QString::fromUtf8(name), (void*)arr);
      }
 }
 
@@ -942,7 +942,7 @@ double GuiReceiver::getRatioWindow(QString name)
 
 void GuiReceiver::setRatioWindow(QString name, double arg2)
 {
-    QPointer<CvWindow> w = icvFindWindowByName( name.toLatin1().data() );
+    QPointer<CvWindow> w = icvFindWindowByName(name);
 
     if (!w)
         return;
@@ -992,7 +992,7 @@ void GuiReceiver::setWindowTitle(QString name, QString title)
 
     if (!w)
     {
-        cvNamedWindow(name.toLatin1().data());
+        cvNamedWindow(name.toUtf8().constData());
         w = icvFindWindowByName(name);
     }
 
@@ -1042,7 +1042,7 @@ void GuiReceiver::createWindow(QString name, int flags)
         CV_Error(cv::Error::StsNullPtr, "NULL session handler" );
 
     // Check the name in the storage
-    if (icvFindWindowByName(name.toLatin1().data()))
+    if (icvFindWindowByName(name))
     {
         return;
     }
@@ -1083,7 +1083,7 @@ void GuiReceiver::showImage(QString name, void* arr)
 
     if (!w) //as observed in the previous implementation (W32, GTK), create a new window is the pointer returned is null
     {
-        cvNamedWindow(name.toLatin1().data());
+        cvNamedWindow(name.toUtf8().constData());
         w = icvFindWindowByName(name);
     }
 


### PR DESCRIPTION
Fixes non-ASCII Qt HighGUI window-title handling by removing lossy Latin-1 conversions in fallback create/lookup paths and by using explicit UTF-8 conversion for Qt string entry points in cvNamedWindow/cvShowImage/setWindowTitle_QT. This prevents mismatched window names that can cause silent update failures with Unicode titles. Closes #27262.