### PR TITLE
imgproc: migrate cv::moments<ushort> SIMD to universal/scalable intrinsics

### DIFF
--- a/modules/imgproc/src/moments.cpp
+++ b/modules/imgproc/src/moments.cpp
@@ -255,56 +255,65 @@ struct MomentsInTile_SIMD<uchar, int, int>
     }
 };
 
+#endif // CV_SIMD128
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+
+namespace {
+template <typename T, int N>
+struct IotaInit {
+    T CV_DECL_ALIGNED(CV_SIMD_WIDTH) data[N];
+    IotaInit() { for (int i = 0; i < N; i++) data[i] = (T)i; }
+};
+static const IotaInit<int, VTraits<v_int32>::max_nlanes> g_ix0_init;
+}
+
 template <>
 struct MomentsInTile_SIMD<ushort, int, int64>
 {
-    MomentsInTile_SIMD()
-    {
-        // nothing
-    }
+    MomentsInTile_SIMD() {}
 
     int operator() (const ushort * ptr, int len, int & x0, int & x1, int & x2, int64 & x3)
     {
         int x = 0;
+        const int vlanes32 = VTraits<v_int32>::vlanes();
 
+        v_int32  v_delta = vx_setall_s32(vlanes32);
+        v_int32  v_ix0   = vx_load(g_ix0_init.data);
+        v_uint32 z       = vx_setzero_u32();
+        v_uint32 v_x0 = z, v_x1 = z, v_x2 = z;
+        v_uint64 v_x3    = vx_setzero_u64();
+
+        for ( ; x <= len - vlanes32; x += vlanes32 )
         {
-            v_int32x4 v_delta = v_setall_s32(4), v_ix0 = v_int32x4(0, 1, 2, 3);
-            v_uint32x4 z = v_setzero_u32(), v_x0 = z, v_x1 = z, v_x2 = z;
-            v_uint64x2 v_x3 = v_reinterpret_as_u64(z);
+            v_int32 v_src = v_reinterpret_as_s32(vx_load_expand(ptr + x));
 
-            for( ; x <= len - 4; x += 4 )
-            {
-                v_int32x4 v_src = v_reinterpret_as_s32(v_load_expand(ptr + x));
+            v_x0 = v_add(v_x0, v_reinterpret_as_u32(v_src));
+            v_x1 = v_add(v_x1, v_reinterpret_as_u32(v_mul(v_src, v_ix0)));
 
-                v_x0 = v_add(v_x0, v_reinterpret_as_u32(v_src));
-                v_x1 = v_add(v_x1, v_reinterpret_as_u32(v_mul(v_src, v_ix0)));
+            v_int32 v_ix1 = v_mul(v_ix0, v_ix0);
+            v_x2 = v_add(v_x2, v_reinterpret_as_u32(v_mul(v_src, v_ix1)));
 
-                v_int32x4 v_ix1 = v_mul(v_ix0, v_ix0);
-                v_x2 = v_add(v_x2, v_reinterpret_as_u32(v_mul(v_src, v_ix1)));
+            v_ix1 = v_mul(v_ix0, v_ix1);
+            v_src = v_mul(v_src, v_ix1);
+            v_uint64 v_lo, v_hi;
+            v_expand(v_reinterpret_as_u32(v_src), v_lo, v_hi);
+            v_x3 = v_add(v_x3, v_add(v_lo, v_hi));
 
-                v_ix1 = v_mul(v_ix0, v_ix1);
-                v_src = v_mul(v_src, v_ix1);
-                v_uint64x2 v_lo, v_hi;
-                v_expand(v_reinterpret_as_u32(v_src), v_lo, v_hi);
-                v_x3 = v_add(v_x3, v_add(v_lo, v_hi));
-
-                v_ix0 = v_add(v_ix0, v_delta);
-            }
-
-            x0 = v_reduce_sum(v_x0);
-            x1 = v_reduce_sum(v_x1);
-            x2 = v_reduce_sum(v_x2);
-            v_store_aligned(buf64, v_reinterpret_as_s64(v_x3));
-            x3 = buf64[0] + buf64[1];
+            v_ix0 = v_add(v_ix0, v_delta);
         }
 
+        x0 = v_reduce_sum(v_x0);
+        x1 = v_reduce_sum(v_x1);
+        x2 = v_reduce_sum(v_x2);
+        x3 = (int64)v_reduce_sum(v_x3);
+
+        vx_cleanup();
         return x;
     }
-
-    int64 CV_DECL_ALIGNED(16) buf64[2];
 };
 
-#endif
+#endif // CV_SIMD || CV_SIMD_SCALABLE
 
 template<typename T, typename WT, typename MT>
 #if defined __GNUC__ && __GNUC__ == 4 && __GNUC_MINOR__ >= 5 && __GNUC_MINOR__ < 9


### PR DESCRIPTION
### Pull Request

Migrate `MomentsInTile_SIMD<ushort>` from fixed-width `CV_SIMD128` to
`(CV_SIMD || CV_SIMD_SCALABLE)`, enabling AVX2/AVX512 wider lanes on x86
and RVV VLA on RISC-V.

`MomentsInTile_SIMD<uchar>` is left at `CV_SIMD128`. The initial migration
regressed on RVV (Muse Pi v3.0, 0.77~0.85x — see comment thread above):
when `vlanes16 == TILE_SIZE == 32`, the inner SIMD loop collapses to a
single iteration and per-tile setup (vsetvl + vx_load + vx_setall +
vx_setzero) dominates over the dotprod work. ushort uses `v_int32` lanes
where `vlanes32 == 16 < TILE_SIZE`, so the SIMD loop runs twice and the
overhead is amortized — RVV measured at +14~37% on the same board. uchar
will be revisited in a follow-up once that overhead can be addressed.

#### Changes

- replace `v_int32x4`/`v_uint32x4`/`v_uint64x2` with scalable `v_int32`/`v_uint32`/`v_uint64`
- iota vector stored in a static const initialized once at program load,
  sized by `VTraits<v_int32>::max_nlanes` (compile-time upper bound)
- drop `buf64`; use `v_reduce_sum(v_uint64)` directly (defined on every
  backend including AVX512 via `OPENCV_HAL_IMPL_AVX512_REDUCE_8` macro)
- `vx_cleanup()` at `operator()` tail for RVV vsetvl hygiene

#### Lane counts after migration (ushort path)

| 128-bit | AVX2 256-bit | AVX512 512-bit | RVV (VLEN ≤ 1024) |
|---|---|---|---|
| 4 | 8 | 16 | up to 64 |

#### Testing

Apple Silicon NEON (local):
- `opencv_test_imgproc --gtest_filter="Imgproc_Moments*:Imgproc_HuMoments*"` — 3/3 PASSED
- `opencv_perf_imgproc --gtest_filter="*Moments1*" --perf_force_samples=100` — 32/32 PASSED, no regression

ARM (asmorkalov, without KleidiCV) — first push: no regression on Moments1, OCL_Moments.
RVV Muse Pi v3.0 (asmorkalov) — first push: ushort +14~37%, uchar -15~23% (uchar reverted in this commit).
AVX2 / AVX512: validated via CI.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or an incompatible license
- [x] The PR is proposed to the proper branch (4.x)
