### PR TITLE
calib3d: unify behavior of findHomography and estimateAffine2d

### DIFF
--- a/modules/calib3d/src/fundam.cpp
+++ b/modules/calib3d/src/fundam.cpp
@@ -387,7 +387,7 @@ cv::Mat cv::findHomography( InputArray _points1, InputArray _points2,
         }
         // Need at least 4 point correspondences to calculate Homography
         if( npoints < 4 )
-            CV_Error(Error::StsVecLengthErr , "The input arrays should have at least 4 corresponding point sets to calculate Homography");
+            return Mat(); // Return empty matrix instead of throwing an error to align with estimateAffine2d behavior
         p.reshape(2, npoints).convertTo(m, CV_32F);
     }
 

--- a/modules/calib3d/test/test_homography.cpp
+++ b/modules/calib3d/test/test_homography.cpp
@@ -763,4 +763,15 @@ TEST(Calib3d_Homography, Refine)
     }
 }
 
+// Test for Issue #22746: findHomography should return an empty matrix instead of crashing when given less than 4 points
+TEST(Calib3d_Homography, issue_22746_not_enough_points)
+{
+    std::vector<cv::Point2f> src = {cv::Point2f(0, 0), cv::Point2f(1, 0), cv::Point2f(0, 1)};
+    std::vector<cv::Point2f> dst = {cv::Point2f(1, 1), cv::Point2f(2, 1), cv::Point2f(1, 2)};
+    
+    cv::Mat H;
+    EXPECT_NO_THROW(H = cv::findHomography(src, dst));
+    EXPECT_TRUE(H.empty());
+}
+
 }} // namespace


### PR DESCRIPTION
This PR addresses the inconsistency reported in Issue #22746.

### Changes:
- Modified `findHomography` in `modules/calib3d/src/fundam.cpp` to return an empty `cv::Mat()` instead of throwing a `CV_Error` when `npoints < 4`.
- Added a regression test in `modules/calib3d/test/test_homography.cpp` to ensure the function safely handles inputs with fewer than 4 points.

### Regarding homogenization (RFC):
I agree with the RFC that unifying the behavior is necessary for consistency across the `calib3d` module. Between the two existing approaches, returning an empty `cv::Mat()` (as `estimateAffine2d` does) is generally safer for continuous data pipelines. It allows the caller to gracefully check `.empty()` and handle the failure, whereas aggressively throwing a `CV_Error` can cause unexpected hard crashes if not strictly caught. Therefore, I updated `findHomography` to match `estimateAffine2d`.

Fixes #22746

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
