### PR TITLE
videoio: fix C4576 build error with older ffmpeg versions

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -526,14 +526,17 @@ inline static std::string _opencv_ffmpeg_get_error_string(int error_code)
 
 static inline int64_t to_avtb(int64_t ts, AVRational tb)
 {
-    return av_rescale_q(ts, tb, AV_TIME_BASE_Q);
+    // Replace AV_TIME_BASE_Q with av_make_q(1, AV_TIME_BASE) to fix 
+    // MSVC C4576 error caused by C99 compound literal in strict C++17 mode
+    return av_rescale_q(ts, tb, av_make_q(1, AV_TIME_BASE));
 }
 
 static inline int64_t from_avtb(int64_t ts_avtb, AVRational tb)
 {
-    return av_rescale_q(ts_avtb, AV_TIME_BASE_Q, tb);
+    // Replace AV_TIME_BASE_Q with av_make_q(1, AV_TIME_BASE) to fix 
+    // MSVC C4576 error caused by C99 compound literal in strict C++17 mode
+    return av_rescale_q(ts_avtb, av_make_q(1, AV_TIME_BASE), tb);
 }
-
 
 struct CvCapture_FFMPEG
 {

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -526,15 +526,11 @@ inline static std::string _opencv_ffmpeg_get_error_string(int error_code)
 
 static inline int64_t to_avtb(int64_t ts, AVRational tb)
 {
-    // Replace AV_TIME_BASE_Q with av_make_q(1, AV_TIME_BASE) to fix 
-    // MSVC C4576 error caused by C99 compound literal in strict C++17 mode
     return av_rescale_q(ts, tb, av_make_q(1, AV_TIME_BASE));
 }
 
 static inline int64_t from_avtb(int64_t ts_avtb, AVRational tb)
 {
-    // Replace AV_TIME_BASE_Q with av_make_q(1, AV_TIME_BASE) to fix 
-    // MSVC C4576 error caused by C99 compound literal in strict C++17 mode
     return av_rescale_q(ts_avtb, av_make_q(1, AV_TIME_BASE), tb);
 }
 


### PR DESCRIPTION
Fixes #28875

### Description
This PR fixes a build failure (`error C4576`) that occurs when building the `videoio` module with older FFmpeg versions (e.g., 4.4.4) using MSVC under strict C++17 mode.

**Root Cause:**
In older FFmpeg headers, the `AV_TIME_BASE_Q` macro is defined using a C99 compound literal `(AVRational){1, AV_TIME_BASE}`. This syntax is non-standard in C++ and is strictly rejected by MSVC when `/std:c++17` is enabled.

**Solution:**
Replaced the `AV_TIME_BASE_Q` macro with FFmpeg's standard `av_make_q(1, AV_TIME_BASE)` function. This resolves the C4576 compiler error and ensures modern C++ compatibility. 

*(Note: `av_make_q` is already smoothly polyfilled in `cap_ffmpeg_impl.hpp` for extremely old FFmpeg versions, making this a highly safe, consistent, and zero-overhead replacement.)*
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
