### PR TITLE
imgproc: replace signed left-shift with multiplication in FillConvexPoly

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1117,11 +1117,12 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
     else
         delta1 = XY_ONE - 1, delta2 = 0;
 
-    p0 = v[npts - 1];
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
-
     CV_Assert( 0 <= shift && shift <= XY_SHIFT );
+    const int64 xy_scale = 1LL << (XY_SHIFT - shift);
+
+    p0 = v[npts - 1];
+    p0.x *= xy_scale;
+    p0.y *= xy_scale;
     xmin = xmax = v[0].x;
     ymin = ymax = v[0].y;
 
@@ -1138,8 +1139,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         xmax = std::max( xmax, p.x );
         xmin = MIN( xmin, p.x );
 
-        p.x <<= XY_SHIFT - shift;
-        p.y <<= XY_SHIFT - shift;
+        p.x *= xy_scale;
+        p.y *= xy_scale;
 
         if( line_type <= 8 )
         {
@@ -1202,8 +1203,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
                             int64 xe = v[idx].x;
                             if (shift != XY_SHIFT)
                             {
-                                xs <<= XY_SHIFT - shift;
-                                xe <<= XY_SHIFT - shift;
+                                xs *= xy_scale;
+                                xe *= xy_scale;
                             }
 
                             edge[i].ye = ty;

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -1128,4 +1128,30 @@ TEST(Drawing, line_connectivity_regression_26413)
     EXPECT_GT(count4, 15) << "LINE_4 diagonal should have significantly more pixels due to staircase";
 }
 
+
+// Negative coordinates are valid for shapes extending beyond image boundaries.
+// FillConvexPoly must handle them without undefined behavior during
+// fixed-point coordinate scaling.
+TEST(Drawing, fillconvexpoly_negative_coord_scaling)
+{
+    Mat img(64, 64, CV_8UC3, Scalar::all(255));
+    Scalar color(0, 0, 255);
+
+    // filled rectangle with negative origin goes through FillConvexPoly
+    rectangle(img, Rect(-10, -10, 20, 20), color, -1);
+
+    // fillConvexPoly directly with negative vertices
+    std::vector<Point> pts;
+    pts.push_back(Point(-10, -10));
+    pts.push_back(Point(10, -10));
+    pts.push_back(Point(10, 10));
+    pts.push_back(Point(-10, 10));
+    fillConvexPoly(img, pts, color);
+
+    // verify something was actually drawn
+    Mat ref(64, 64, CV_8UC3, Scalar::all(255));
+    EXPECT_GT(countNonZero(img.reshape(1) != ref.reshape(1)), 0)
+        << "Drawing with negative coordinates should produce visible output";
+}
+
 }} // namespace


### PR DESCRIPTION
Resolves #28598.

`FillConvexPoly` scales coordinates with `p.x <<= XY_SHIFT - shift`, which is undefined behavior when `p.x` is negative (C++ [expr.shift]). This happens for shapes that extend beyond image boundaries, e.g. `cv::rectangle(img, Rect(-10, -10, 20, 20), color, -1)` produces clipped coordinates of `-1` which are then shifted left by 16.

This patch computes the scale factor once as `const int64 xy_scale = 1LL << (XY_SHIFT - shift)` and replaces all 6 `<<=` sites in `FillConvexPoly` with `*= xy_scale`. Same arithmetic result, no UB for negative operands, and the repeated `XY_SHIFT - shift` expression is computed once. Also moves the `CV_Assert(0 <= shift && shift <= XY_SHIFT)` before its first use.

Scope is limited to `FillConvexPoly`. Similar patterns in other drawing functions can follow if this approach is acceptable.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake