### PR TITLE
doc: modernize Doxygen comments to support for v1.15.0

### DIFF
--- a/doc/tutorials/calib3d/real_time_pose/real_time_pose.markdown
+++ b/doc/tutorials/calib3d/real_time_pose/real_time_pose.markdown
@@ -105,7 +105,7 @@ The tutorial consists of two main programs:
     Using the found matches along with @ref cv::solvePnPRansac function the `R` and `t` of
     the camera are computed. Finally, a KalmanFilter is applied in order to reject bad poses.
 
-    In the case that you compiled OpenCV with the samples, you can find it in opencv/build/bin/cpp-tutorial-pnp_detection`.
+    In the case that you compiled OpenCV with the samples, you can find it in `opencv/build/bin/cpp-tutorial-pnp_detection`.
     Then you can run the application and change some parameters:
     @code{.cpp}
     This program shows how to detect an object given its 3D textured model. You can choose to use a recorded video or the webcam.
@@ -252,8 +252,8 @@ Here is explained in detail the code for the real time application:
     The next step is to detect the scene features and extract it descriptors. For this task I
     implemented a *class* **RobustMatcher** which has a function for keypoints detection and features
     extraction. You can find it in
-    `samples/cpp/tutorial_code/calib3d/real_time_pose_estimation/src/RobusMatcher.cpp`. In your
-    *RobusMatch* object you can use any of the 2D features detectors of OpenCV. In this case I used
+    `samples/cpp/tutorial_code/calib3d/real_time_pose_estimation/src/RobustMatcher.cpp`. In your
+    *RobustMatch* object you can use any of the 2D features detectors of OpenCV. In this case I used
     @ref cv::ORB features because is based on @ref cv::FAST to detect the keypoints and cv::xfeatures2d::BriefDescriptorExtractor
     to extract the descriptors which means that is fast and robust to rotations. You can find more
     detailed information about *ORB* in the documentation.

--- a/modules/calib3d/include/opencv2/calib3d.hpp
+++ b/modules/calib3d/include/opencv2/calib3d.hpp
@@ -4171,7 +4171,7 @@ namespace fisheye
         which are dimensionless coordinates in the camera's focal plane, independent of intrinsic parameters.
 
     @note **Fisheye vs. Standard Model:**
-    Use this function (#fisheye::undistortPoints) for fisheye cameras (wide-angle lenses).
+    Use this function (#cv::fisheye::undistortPoints) for fisheye cameras (wide-angle lenses).
     For standard pinhole cameras, use #undistortPoints instead. The fisheye model uses a different distortion
     parameterization (4 coefficients) compared to the standard model (4-14 coefficients).
 
@@ -4220,14 +4220,14 @@ namespace fisheye
 
     The function transforms an image to compensate radial lens distortion.
 
-    The function is simply a combination of #fisheye::initUndistortRectifyMap (with unity R ) and #remap
+    The function is simply a combination of #cv::fisheye::initUndistortRectifyMap (with unity R ) and #remap
     (with bilinear interpolation). See the former function for details of the transformation being
     performed.
 
     See below the results of undistortImage.
        -   a\) result of undistort of perspective camera model (all possible coefficients (k_1, k_2, k_3,
             k_4, k_5, k_6) of distortion were optimized under calibration)
-        -   b\) result of #fisheye::undistortImage of fisheye camera model (all possible coefficients (k_1, k_2,
+        -   b\) result of #cv::fisheye::undistortImage of fisheye camera model (all possible coefficients (k_1, k_2,
             k_3, k_4) of fisheye distortion were optimized under calibration)
         -   c\) original image was captured with fisheye lens
 

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -490,7 +490,7 @@ message in the Exception constructor.
 |`const char*`|`%s`|
 |`char`|`%c`|
 |`float` / `double`|`%f`,`%g`|
-|`int`, `long`, `long long`|`%d`, `%ld`, ``%lld`|
+|`int`, `long`, `long long`|`%d`, `%ld`, `%lld`|
 |`unsigned`, `unsigned long`, `unsigned long long`|`%u`, `%lu`, `%llu`|
 |`uint64` -> `uintmax_t`, `int64` -> `intmax_t`|`%ju`, `%jd`|
 |`size_t`|`%zu`|

--- a/modules/flann/include/opencv2/flann/all_indices.h
+++ b/modules/flann/include/opencv2/flann/all_indices.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/allocator.h
+++ b/modules/flann/include/opencv2/flann/allocator.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/autotuned_index.h
+++ b/modules/flann/include/opencv2/flann/autotuned_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/composite_index.h
+++ b/modules/flann/include/opencv2/flann/composite_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/config.h
+++ b/modules/flann/include/opencv2/flann/config.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/defines.h
+++ b/modules/flann/include/opencv2/flann/defines.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/dist.h
+++ b/modules/flann/include/opencv2/flann/dist.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/dynamic_bitset.h
+++ b/modules/flann/include/opencv2/flann/dynamic_bitset.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/flann_base.hpp
+++ b/modules/flann/include/opencv2/flann/flann_base.hpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/general.h
+++ b/modules/flann/include/opencv2/flann/general.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/ground_truth.h
+++ b/modules/flann/include/opencv2/flann/ground_truth.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/heap.h
+++ b/modules/flann/include/opencv2/flann/heap.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
+++ b/modules/flann/include/opencv2/flann/hierarchical_clustering_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/index_testing.h
+++ b/modules/flann/include/opencv2/flann/index_testing.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/kdtree_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/kdtree_single_index.h
+++ b/modules/flann/include/opencv2/flann/kdtree_single_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/kmeans_index.h
+++ b/modules/flann/include/opencv2/flann/kmeans_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/linear_index.h
+++ b/modules/flann/include/opencv2/flann/linear_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/logger.h
+++ b/modules/flann/include/opencv2/flann/logger.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/lsh_index.h
+++ b/modules/flann/include/opencv2/flann/lsh_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/lsh_table.h
+++ b/modules/flann/include/opencv2/flann/lsh_table.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/matrix.h
+++ b/modules/flann/include/opencv2/flann/matrix.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/nn_index.h
+++ b/modules/flann/include/opencv2/flann/nn_index.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/object_factory.h
+++ b/modules/flann/include/opencv2/flann/object_factory.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/params.h
+++ b/modules/flann/include/opencv2/flann/params.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2011  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/random.h
+++ b/modules/flann/include/opencv2/flann/random.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/result_set.h
+++ b/modules/flann/include/opencv2/flann/result_set.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/sampling.h
+++ b/modules/flann/include/opencv2/flann/sampling.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/saving.h
+++ b/modules/flann/include/opencv2/flann/saving.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/simplex_downhill.h
+++ b/modules/flann/include/opencv2/flann/simplex_downhill.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/include/opencv2/flann/timer.h
+++ b/modules/flann/include/opencv2/flann/timer.h
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.

--- a/modules/flann/src/flann.cpp
+++ b/modules/flann/src/flann.cpp
@@ -1,4 +1,4 @@
-/***********************************************************************
+/*M*********************************************************************
  * Software License Agreement (BSD License)
  *
  * Copyright 2008-2009  Marius Muja (mariusm@cs.ubc.ca). All rights reserved.


### PR DESCRIPTION
This PR addresses several documentation build failures encountered with modern Doxygen versions, particularly v1.15.0 (shipped with Ubuntu 26.04).

- flann module: Updated license headers from /**** to /*M****. This prevents Doxygen from misinterpreting the license text (specifically the unclosed backticks in ``AS IS'') as documentation blocks, which previously caused "Reached end of file" errors.
- core module: Fixed a typo in operations.hpp where a doubled backtick (``) caused parsing to fail.
- tutorials: Fixed a missing backtick in real_time_pose.markdown (around line 108) and corrected typos in the RobustMatcher class name.
- Links: Resolved explicit link request failures in calib3d.hpp by ensuring proper namespace resolution.

These fixes ensure that the documentation can be generated without errors on the latest toolchains.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
