### PR TITLE
Better AutoBuffer API

### DIFF
--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -107,6 +107,7 @@ public:
     AutoBuffer();
     //! constructor taking the real buffer size
     explicit AutoBuffer(size_t _size);
+    AutoBuffer(size_t _size, const _Tp& value);
 
     //! the copy constructor
     AutoBuffer(const AutoBuffer<_Tp, fixed_size>& buf);
@@ -140,7 +141,13 @@ public:
     //! returns a reference to the element at specified location. No bounds checking is performed in Release builds.
     inline const _Tp& operator[] (size_t i) const { CV_DbgCheckLT(i, sz, "out of range"); return ptr[i]; }
 #endif
-
+public:
+    inline _Tp* begin() { return data(); }
+    inline const _Tp* begin() const { return data(); }
+    inline const _Tp* cbegin() const { return begin(); }
+    inline _Tp* end() { return data()+size(); }
+    inline const _Tp* end() const { return data()+size(); }
+    inline const _Tp* cend() const { return end(); }
 protected:
     //! pointer to the real buffer, can point to buf if the buffer is small enough
     _Tp* ptr;
@@ -1052,6 +1059,13 @@ AutoBuffer<_Tp, fixed_size>::AutoBuffer(size_t _size)
     ptr = buf;
     sz = fixed_size;
     allocate(_size);
+}
+
+template<typename _Tp, size_t fixed_size> inline
+AutoBuffer<_Tp, fixed_size>::AutoBuffer(size_t _size, const _Tp& value)
+                            :AutoBuffer(size)
+{
+    std::fill(begin(), end(), value);
 }
 
 template<typename _Tp, size_t fixed_size> inline

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -102,6 +102,12 @@ template<typename _Tp, size_t fixed_size = 1024/sizeof(_Tp)+8> class AutoBuffer
 {
 public:
     typedef _Tp value_type;
+    typedef  std::size_t size_type;
+    typedef  std::ptrdiff_t difference_type;
+    typedef const _Tp* const_iterator;
+    typedef _Tp* iterator;
+    typedef const _Tp& const_reference;
+    typedef _Tp& reference;
 
     //! the default constructor
     AutoBuffer();
@@ -142,12 +148,24 @@ public:
     inline const _Tp& operator[] (size_t i) const { CV_DbgCheckLT(i, sz, "out of range"); return ptr[i]; }
 #endif
 public:
-    inline _Tp* begin() { return data(); }
-    inline const _Tp* begin() const { return data(); }
-    inline const _Tp* cbegin() const { return begin(); }
-    inline _Tp* end() { return data()+size(); }
-    inline const _Tp* end() const { return data()+size(); }
-    inline const _Tp* cend() const { return end(); }
+    inline iterator begin() { return data(); }
+    inline const_iterator begin() const { return data(); }
+    inline const_iterator cbegin() const { return begin(); }
+    inline iterator end() { return data()+size(); }
+    inline const_iterator end() const { return data()+size(); }
+    inline const_iterator cend() const { return end(); }
+public:
+    inline bool empty() const { return !size(); }
+    inline void clear() {resize(0);}
+    inline const_reference front() const { return (*this)[0] ;}
+    inline reference front() { return (*this)[0] ;}
+    inline const_reference back() const { CV_DbgCheckGT(sz, 0, "out of range"); return (*this)[size()-1] ;}
+    inline reference back() { CV_DbgCheckGT(sz, 0, "out of range"); return (*this)[size()-1] ;}
+public:
+    inline void push_back( const _Tp& value ) {resize(size()+1); back() = value;}
+    inline void push_back( _Tp&& value ) {resize(size()+1); back() = std::move(value);}
+    inline void emplace_back( _Tp&& value ) {push_back(value);}
+    inline void pop_back() {CV_DbgCheckGT(sz, 0, "out of range"); resize(size()-1);}
 protected:
     //! pointer to the real buffer, can point to buf if the buffer is small enough
     _Tp* ptr;

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -1081,7 +1081,7 @@ AutoBuffer<_Tp, fixed_size>::AutoBuffer(size_t _size)
 
 template<typename _Tp, size_t fixed_size> inline
 AutoBuffer<_Tp, fixed_size>::AutoBuffer(size_t _size, const _Tp& value)
-                            :AutoBuffer(size)
+                            :AutoBuffer<_Tp, fixed_size>(_size)
 {
     std::fill(begin(), end(), value);
 }

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -159,13 +159,13 @@ public:
     inline void clear() {resize(0);}
     inline const_reference front() const { return (*this)[0] ;}
     inline reference front() { return (*this)[0] ;}
-    inline const_reference back() const { CV_DbgCheckGT(sz, 0, "out of range"); return (*this)[size()-1] ;}
-    inline reference back() { CV_DbgCheckGT(sz, 0, "out of range"); return (*this)[size()-1] ;}
+    inline const_reference back() const { CV_DbgCheckGT(sz, (size_t)0, "out of range"); return (*this)[size()-1] ;}
+    inline reference back() { CV_DbgCheckGT(sz, (size_t)0, "out of range"); return (*this)[size()-1] ;}
 public:
     inline void push_back( const _Tp& value ) {resize(size()+1); back() = value;}
     inline void push_back( _Tp&& value ) {resize(size()+1); back() = std::move(value);}
     inline void emplace_back( _Tp&& value ) {push_back(value);}
-    inline void pop_back() {CV_DbgCheckGT(sz, 0, "out of range"); resize(size()-1);}
+    inline void pop_back() {CV_DbgCheckGT(sz, (size_t)0, "out of range"); resize(size()-1);}
 protected:
     //! pointer to the real buffer, can point to buf if the buffer is small enough
     _Tp* ptr;


### PR DESCRIPTION
Mimic std::vector<> to help replacing std::vector<T> by cv::AutoBuffer<T> when possible

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
