### PR TITLE
videoio(dshow): fix crash in videoInput::start() when pVih is NULL

### DIFF
--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2756,8 +2756,7 @@ int videoInput::start(int deviceID, videoDevice *VD){
     }
 
     VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
-    
-    // Some legacy or virtual cameras (e.g., Microsoft Ball filter) return S_OK 
+    // Some legacy or virtual cameras (e.g., Microsoft Ball filter) return S_OK
     // but leave pbFormat as NULL. We check for NULL here to avoid a crash.
     // https://github.com/opencv/opencv/issues/28904
     if (pVih == NULL) {

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2760,6 +2760,7 @@ int videoInput::start(int deviceID, videoDevice *VD){
     // but leave pbFormat as NULL. We check for NULL here to avoid a crash.
     // https://github.com/opencv/opencv/issues/28904
     if (pVih == NULL) {
+        DebugPrintOut("ERROR: pbFormat field is not set!\n");
         return false;
     }
     int currentWidth    =  HEADER(pVih)->biWidth;

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2756,6 +2756,10 @@ int videoInput::start(int deviceID, videoDevice *VD){
     }
 
     VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
+    
+    // Some legacy or virtual cameras (e.g., Microsoft Ball filter) return S_OK 
+    // but leave pbFormat as NULL. We check for NULL here to avoid a crash.
+    // https://github.com/opencv/opencv/issues/28904
     if (pVih == NULL) {
         return false;
     }

--- a/modules/videoio/src/cap_dshow.cpp
+++ b/modules/videoio/src/cap_dshow.cpp
@@ -2756,7 +2756,9 @@ int videoInput::start(int deviceID, videoDevice *VD){
     }
 
     VIDEOINFOHEADER *pVih =  reinterpret_cast<VIDEOINFOHEADER*>(VD->pAmMediaType->pbFormat);
-    CV_Assert(pVih);
+    if (pVih == NULL) {
+        return false;
+    }
     int currentWidth    =  HEADER(pVih)->biWidth;
     int currentHeight    =  HEADER(pVih)->biHeight;
 


### PR DESCRIPTION
### Summary
This PR fixes a critical application crash in the DirectShow backend when encountering certain legacy or virtual cameras (e.g., Microsoft's DirectShow "Ball" Sample).

### The Problem
In `modules/videoio/src/cap_dshow.cpp`, the function `videoInput::start()` calls `pConfig->GetConnectedMediaType(&mt)`. 
- In some edge cases, this call returns `S_OK`, indicating success.
- However, the associated format block `mt.pbFormat` (which `pVih` points to) can still be `NULL`.
- The current implementation uses `CV_Assert(pVih)`, which triggers a hard crash of the entire application when this occurs.

### The Fix
I have replaced the `CV_Assert(pVih)` with a null-pointer check. If `pVih` is `NULL`, the function now returns `false`. This allows the high-level `cv::VideoCapture` to handle the failure (e.g., by returning `false` from `.open()`) instead of crashing the process.

### Engineering Rationale
- Execution Path Consistency: For devices providing valid format headers, `pVih` remains non-NULL. In these cases, the conditional check is skipped, and the execution path is identical to the original implementation.
- Process Stability: Replacing `CV_Assert` prevents immediate process termination (SIGABRT) when a DirectShow filter provides an invalid or empty format block. 
- Error Propagation: Returning `false` in `videoInput::start()` allows the initialization failure to propagate through the call stack. This ensures that `cv::VideoCapture::open()` returns `false`, enabling the caller to detect the issue via the standard API (e.g., `isOpened()`) instead of the process being terminated.

### Evidence
I have manually reproduced this crash using the Microsoft DirectShow Ball Sample filter on Windows. As shown in the attached debugger screenshot:
- `deviceID` is 2 (the virtual camera).
- `hr` is `S_OK`.
- `pVih` is `NULL`.

<img width="773" height="1413" alt="dshow_null_pvih_debug_evidence" src="https://github.com/user-attachments/assets/5bc454b4-4a0b-4703-825d-0d5fd23cba28" />

Fixes #28904

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
