### PR TITLE
core,objdetects,dnn,features2d: fix build warnings with GCC 16

### DIFF
--- a/apps/visualisation/opencv_visualisation.cpp
+++ b/apps/visualisation/opencv_visualisation.cpp
@@ -155,13 +155,12 @@ int main( int argc, const char** argv )
     vector< vector<int> > stage_features;
     FileNode stages = cascade["stages"];
     FileNodeIterator it_stages = stages.begin(), it_stages_end = stages.end();
-    int idx = 0;
-    for( ; it_stages != it_stages_end; it_stages++, idx++ ){
+    for( ; it_stages != it_stages_end; it_stages++ ){
         vector<int> current_feature_indexes;
         FileNode weak_classifiers = (*it_stages)["weakClassifiers"];
         FileNodeIterator it_weak = weak_classifiers.begin(), it_weak_end = weak_classifiers.end();
         vector<int> values;
-        for(int idy = 0; it_weak != it_weak_end; it_weak++, idy++ ){
+        for( ; it_weak != it_weak_end; it_weak++ ){
             (*it_weak)["internalNodes"] >> values;
             current_feature_indexes.push_back( (int)values[2] );
         }
@@ -192,7 +191,7 @@ int main( int argc, const char** argv )
         FileNode features = cascade["features"];
         vector< vector< rect_data > > feature_data;
         FileNodeIterator it_features = features.begin(), it_features_end = features.end();
-        for(int idf = 0; it_features != it_features_end; it_features++, idf++ ){
+        for( ; it_features != it_features_end; it_features++ ){
             vector< rect_data > current_feature_rectangles;
             FileNode rectangles = (*it_features)["rects"];
             int nrects = (int)rectangles.size();
@@ -278,7 +277,7 @@ int main( int argc, const char** argv )
         FileNode features = cascade["features"];
         vector<Rect> feature_data;
         FileNodeIterator it_features = features.begin(), it_features_end = features.end();
-        for(int idf = 0; it_features != it_features_end; it_features++, idf++ ){
+        for( ; it_features != it_features_end; it_features++ ){
             FileNode rectangle = (*it_features)["rect"];
             Rect current_feature ((int)rectangle[0], (int)rectangle[1], (int)rectangle[2], (int)rectangle[3]);
             feature_data.push_back(current_feature);

--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -522,7 +522,6 @@ bool FileStorage::Impl::open(const char *filename_or_buf, int _flags, const char
     bool write_base64 = (write_mode || append) && (_flags & FileStorage::BASE64) != 0;
 
     bool isGZ = false;
-    size_t fnamelen = 0;
 
     std::vector<std::string> params;
     //if ( !mem_mode )
@@ -556,7 +555,7 @@ bool FileStorage::Impl::open(const char *filename_or_buf, int _flags, const char
             isGZ = true;
             compression = dot_pos[3];
             if (compression)
-                dot_pos[3] = '\0', fnamelen--;
+                dot_pos[3] = '\0';
         }
 
         if (!isGZ) {

--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -1511,9 +1511,15 @@ void runFastConv(InputArray _input, OutputArray _output, const Ptr<FastConv>& co
 
                             char *wptr = weights + (k0_block * DkHkWkCg + c0 * CONV_MR) * esz;
                             float *cptr = cbuf_task + stripe * CONV_NR;
+#ifdef CONV_ARM_FP16
                             hfloat* cptr_f16 = (hfloat*)cbuf_task + stripe*CONV_NR;
+#endif // CONV_ARM_FP16
                             for (int k = k0_block; k < k1_block; k += CONV_MR,
-                                    wptr += DkHkWkCg * CONV_MR * esz, cptr += CONV_MR * ldc, cptr_f16 += CONV_MR * ldc)
+                                    wptr += DkHkWkCg * CONV_MR * esz,
+#ifdef CONV_ARM_FP16
+                                    cptr_f16 += CONV_MR * ldc,
+#endif // CONV_ARM_FP16
+                                    cptr += CONV_MR * ldc)
                             {
 #if CV_TRY_AVX2
                                 if (conv->useAVX2)
@@ -1547,12 +1553,18 @@ void runFastConv(InputArray _input, OutputArray _output, const Ptr<FastConv>& co
 
                     size_t outofs = ((n * ngroups + g) * Kg + k0_block) * out_planesize + zyx0;
                     const float *cptr = cbuf_task;
+#ifdef CONV_ARM_FP16
                     const hfloat *cptr_fp16 = (const hfloat *)cbuf_task;
+#endif // CONV_ARM_FP16
                     float *outptr = out + outofs;
                     const float *pbptr = fusedAddPtr0 ? fusedAddPtr0 + outofs : 0;
 
                     for (int k = k0_block; k < k1_block; k++,
-                            cptr += ldc, cptr_fp16 += ldc, outptr += out_planesize,
+                            cptr += ldc,
+#ifdef CONV_ARM_FP16
+                            cptr_fp16 += ldc,
+#endif // CONV_ARM_FP16
+                            outptr += out_planesize,
                             pbptr += (pbptr ? out_planesize : 0))
                     {
                         float biasval = biasptr[k];

--- a/modules/features2d/src/evaluation.cpp
+++ b/modules/features2d/src/evaluation.cpp
@@ -230,7 +230,7 @@ static void filterEllipticKeyPointsByImageSize( std::vector<EllipticKeyPoint>& k
         std::vector<EllipticKeyPoint> filtered;
         filtered.reserve(keypoints.size());
         std::vector<EllipticKeyPoint>::const_iterator it = keypoints.begin();
-        for( int i = 0; it != keypoints.end(); ++it, i++ )
+        for( ; it != keypoints.end(); ++it )
         {
             if( it->center.x + it->boundingBox.width < imgSize.width &&
                 it->center.x - it->boundingBox.width > 0 &&

--- a/modules/imgproc/src/contours_link.cpp
+++ b/modules/imgproc/src/contours_link.cpp
@@ -111,8 +111,7 @@ public:
 void LinkRunner::convertLinks(int& first, int& prev, bool isHole)
 {
     const vector<int>& contours = isHole ? int_rns : ext_rns;
-    int count = 0;
-    for (int j = 0; j < (int)contours.size(); j++, count++)
+    for (int j = 0; j < (int)contours.size(); j++)
     {
         int start = contours[j];
         int cur = start;

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -204,12 +204,13 @@ void CV_DetectorTest::run( int )
 
         // write image filenames
         validationFS << IMAGE_FILENAMES << "[";
-        vector<string>::const_iterator it = imageFilenames.begin();
-        for( int ii = 0; it != imageFilenames.end(); ++it, ii++ )
+        // int ii = 0;
+        for( const auto& filename : imageFilenames )
         {
             //String buf = cv::format("img_%d", ii);
             //cvWriteComment( validationFS.fs, buf, 0 );
-            validationFS << *it;
+            validationFS << filename;
+            //ii++;
         }
         validationFS << "]"; // IMAGE_FILENAMES
 


### PR DESCRIPTION
Fix -Wunused-but-set-variable build warnings for GCC 16 on Ubuntu 26.04 LTS.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
