### PR TITLE
added Mat static slot for a custom Tracer

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -502,6 +502,22 @@ enum UMatUsageFlags
 
 struct CV_EXPORTS UMatData;
 
+/** @brief  Custom trace delegate
+*/
+
+enum MatTracerEventKind
+{
+    MAT_TRACER_EVENT_UNDEFINED,
+    MAT_TRACER_EVENT_MEMORY_ALLOCATE, MAT_TRACER_EVENT_MEMORY_DEALLOCATE, MAT_TRACER_EVENT_MEMORY_REFERENCE,
+    MAT_TRACER_EVENT_RELEASE, MAT_TRACER_EVENT_ADDREF
+};
+
+class CV_EXPORTS IMatTracerDelegate
+{
+  public:
+    virtual void trace(const Mat* src, Mat* dst, MatTracerEventKind kind) = 0;
+};
+
 /** @brief  Custom array allocator
 */
 class CV_EXPORTS MatAllocator
@@ -2216,6 +2232,10 @@ public:
     static MatAllocator* getStdAllocator();
     static MatAllocator* getDefaultAllocator();
     static void setDefaultAllocator(MatAllocator* allocator);
+
+    static IMatTracerDelegate* getDefaultTracer();
+    static IMatTracerDelegate* setDefaultTracer(IMatTracerDelegate* tracer);
+    static void TraceEvent(const Mat* src, Mat* dst, MatTracerEventKind kind);
 
     //! internal use method: updates the continuity flag
     void updateContinuityFlag();

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -515,6 +515,8 @@ enum MatTracerEventKind
 class CV_EXPORTS IMatTracerDelegate
 {
   public:
+    virtual ~IMatTracerDelegate() = default;
+  public:
     virtual void trace(const Mat* src, Mat* dst, MatTracerEventKind kind) = 0;
 };
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -488,6 +488,7 @@ Mat::Mat(const std::vector<_Tp>& vec, bool copyData)
         step[0] = step[1] = sizeof(_Tp);
         datastart = data = (uchar*)&vec[0];
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
         Mat((int)vec.size(), 1, traits::Type<_Tp>::value, (uchar*)&vec[0]).copyTo(*this);
@@ -525,6 +526,7 @@ Mat::Mat(const std::array<_Tp, _Nm>& arr, bool copyData)
         step[0] = step[1] = sizeof(_Tp);
         datastart = data = (uchar*)arr.data();
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
         Mat((int)arr.size(), 1, traits::Type<_Tp>::value, (uchar*)arr.data()).copyTo(*this);
@@ -540,6 +542,7 @@ Mat::Mat(const Vec<_Tp, n>& vec, bool copyData)
         step[0] = step[1] = sizeof(_Tp);
         datastart = data = (uchar*)vec.val;
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
         Mat(n, 1, traits::Type<_Tp>::value, (void*)vec.val).copyTo(*this);
@@ -557,6 +560,7 @@ Mat::Mat(const Matx<_Tp,m,n>& M, bool copyData)
         step[1] = sizeof(_Tp);
         datastart = data = (uchar*)M.val;
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
         Mat(m, n, traits::Type<_Tp>::value, (uchar*)M.val).copyTo(*this);
@@ -572,6 +576,7 @@ Mat::Mat(const Point_<_Tp>& pt, bool copyData)
         step[0] = step[1] = sizeof(_Tp);
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
     {
@@ -591,6 +596,7 @@ Mat::Mat(const Point3_<_Tp>& pt, bool copyData)
         step[0] = step[1] = sizeof(_Tp);
         datastart = data = (uchar*)&pt.x;
         datalimit = dataend = datastart + rows * step[0];
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
     }
     else
     {

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -198,6 +198,32 @@ MatAllocator* Mat::getStdAllocator()
     CV_SINGLETON_LAZY_INIT(MatAllocator, new StdMatAllocator())
 }
 
+static inline
+IMatTracerDelegate*& getDefaultMatTracerRef()
+{
+    static IMatTracerDelegate* g_matTracer = nullptr;
+    return g_matTracer;
+}
+
+IMatTracerDelegate* Mat::getDefaultTracer()
+{
+    return getDefaultMatTracerRef();
+}
+
+IMatTracerDelegate* Mat::setDefaultTracer(IMatTracerDelegate* tracer)
+{
+    IMatTracerDelegate* result = getDefaultMatTracerRef();
+    getDefaultMatTracerRef() = tracer;
+    return result;
+}
+
+void Mat::TraceEvent(const Mat* src, Mat* dst, MatTracerEventKind kind)
+{
+    IMatTracerDelegate* tracer = getDefaultMatTracerRef();
+    if ( tracer )
+      tracer->trace(src, dst, kind);
+}
+
 //==================================================================================================
 
 bool MatSize::operator==(const MatSize& sz) const CV_NOEXCEPT
@@ -404,7 +430,9 @@ Mat::Mat(const Mat& m)
       u(m.u), size(&rows), step(0)
 {
     if( u )
+    {
         CV_XADD(&u->refcount, 1);
+    }
     if( m.dims <= 2 )
     {
         step[0] = m.step[0]; step[1] = m.step[1];
@@ -414,6 +442,7 @@ Mat::Mat(const Mat& m)
         dims = 0;
         copySize(m);
     }
+    TraceEvent(&m, this, MatTracerEventKind::MAT_TRACER_EVENT_ADDREF);
 }
 
 Mat::Mat(int _rows, int _cols, int _type, void* _data, size_t _step)
@@ -442,6 +471,7 @@ Mat::Mat(int _rows, int _cols, int _type, void* _data, size_t _step)
     datalimit = datastart + _step * rows;
     dataend = datalimit - _step + minstep;
     updateContinuityFlag();
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
 }
 
 Mat::Mat(Size _sz, int _type, void* _data, size_t _step)
@@ -471,6 +501,7 @@ Mat::Mat(Size _sz, int _type, void* _data, size_t _step)
     datalimit = datastart + _step*rows;
     dataend = datalimit - _step + minstep;
     updateContinuityFlag();
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
 }
 
 
@@ -505,6 +536,8 @@ Mat& Mat::operator=(const Mat& m)
         datalimit = m.datalimit;
         allocator = m.allocator;
         u = m.u;
+
+        TraceEvent(&m, this, MatTracerEventKind::MAT_TRACER_EVENT_ADDREF);
     }
     return *this;
 }
@@ -541,13 +574,22 @@ void Mat::create(Size _sz, int _type)
 void Mat::addref()
 {
     if( u )
+    {
         CV_XADD(&u->refcount, 1);
+    }
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_ADDREF);
 }
 
 void Mat::release()
 {
-    if( u && CV_XADD(&u->refcount, -1) == 1 )
-        deallocate();
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_RELEASE);
+    if( u )
+    {
+        if ( CV_XADD(&u->refcount, -1) == 1 )
+        {
+            deallocate();
+        }
+    }
     u = NULL;
     datastart = dataend = datalimit = data = 0;
     for(int i = 0; i < dims; i++)
@@ -652,6 +694,8 @@ Mat& Mat::operator=(Mat&& m)
     m.data = NULL; m.datastart = NULL; m.dataend = NULL; m.datalimit = NULL;
     m.allocator = NULL;
     m.u = NULL;
+
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_ADDREF);
     return *this;
 }
 
@@ -709,6 +753,7 @@ void Mat::create(int d, const int* _sizes, int _type)
             allocator = a0;
         }
         CV_Assert( step[dims-1] == (size_t)CV_ELEM_SIZE(flags) );
+        TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_ALLOCATE);
     }
 
     addref();
@@ -732,6 +777,7 @@ void Mat::copySize(const Mat& m)
 
 void Mat::deallocate()
 {
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_DEALLOCATE);
     if(u)
     {
         UMatData* u_ = u;
@@ -828,6 +874,7 @@ Mat::Mat(int _dims, const int* _sizes, int _type, void* _data, const size_t* _st
     datastart = data = (uchar*)_data;
     setSize(*this, _dims, _sizes, _steps, true);
     finalizeHdr(*this);
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
 }
 
 
@@ -839,6 +886,7 @@ Mat::Mat(const std::vector<int>& _sizes, int _type, void* _data, const size_t* _
     datastart = data = (uchar*)_data;
     setSize(*this, (int)_sizes.size(), _sizes.data(), _steps, true);
     finalizeHdr(*this);
+    TraceEvent(nullptr, this, MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE);
 }
 
 


### PR DESCRIPTION
A custom tracer designed to raise events regarding memory allocation/deallocation/referencing/dereferencing.
It can help detect or even fix misuse of external memory

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


Explanation :

Using `cv::Mat` as a wrapper around external memory is both efficient and handy.
Unfortunately, it cannot protect against some misusage of external memory, where the caller would release the memory while there are still active `cv::Mat` referencing it.
Example :

```
cv::Mat a;
{//scope to create the problematic situation
  std::vector<float> v = {0, 1};
  cv::Mat b(v);
  a = b;
  //v gets out of scope here, but its memory has been referenced by 'a'
}
//using 'a' here is a memory fault. This is all the fault of the user.
```

Debugging memory misuse is a usecase, but it can also be handy when tracking memory usage in high-performance demanding scenario, without resorting to a custom allocator.

Proposal :

- Since "external memory wrapping" mats do not have a `u` field and do not need an allocator, the tracing cannot be a property of those structures
- adding a new field to `Mat`, some `.tracer` like `.allocator` would work, but it is certainly an objectionable overhead
- a static field like the default allocator is OK, but will lack thread safety and is not very robust against nesting custom tracers at different levels
- however, the tracer is not to be deployed in most case, it's a helper to investigate problems. It is certainly acceptable for the user to keep care of what he does with the tracer if he ever needs it.
- in the current proposed PR, the overhead when not using the tracer is just a static method call that checks for tracer availability

```
class Mat {
... 
    static IMatTracerDelegate* getDefaultTracer();
    static IMatTracerDelegate* setDefaultTracer(IMatTracerDelegate* tracer);
    static void TraceEvent(const Mat* src, Mat* dst, MatTracerEventKind kind);
...
}

```
Simplest tracer :

```
class MyTracer : public cv::IMatTracerDelegate
{
  public:
    virtual void trace(const cv::Mat* src, cv::Mat* dst, cv::MatTracerEventKind kind) {
       printf("trace src[%p] dst[%p] kind=%d\r\n", src, dst, (int)kind);
    }
};
```

Advanced tracer that can fix the wrong memory usage stated at first :

```
MyFixTracer tracer;
auto oldTracer = cv::Mat::setDefaultTracer(&tracer);
{
  cv::Mat a;
  {//scope to create the problematic situation
    std::vector<float> v = {0, 1};
    tracer.registerMemory(v.data());
    {//scope for clarity, so that b will get out of scope before memory unregistration
      cv::Mat b(v);
      a = b;
    }
    tracer.unregisterMemory(v.data());
  }
}
cv::Mat::setDefaultTracer(oldTracer);

class MyFixTracer : public cv::IMatTracerDelegate
{
  public:
    MyFixTracer(void) = default;
    MyFixTracer(const MyFixTracer&) = delete;
    MyFixTracer(MyFixTracer&&) = delete;
    ~MyFixTracer() = default;
  public:
    MyFixTracer& operator=(const MyFixTracer&) = delete;
    MyFixTracer& operator=(MyFixTracer&&) noexcept = delete;
  public:
    virtual void trace(const cv::Mat* src, cv::Mat* dst, cv::MatTracerEventKind kind);
  public:
    void registerMemory(const void* address);
    void unregisterMemory(const void* address);
  private:
    std::recursive_mutex mutex;
    std::unordered_multimap<const void*, cv::Mat*> dependendMats;//at least one key(address,  nullptr) for registered memory
    unsigned int protectLevel = 0;
};

void MyFixTracer::registerMemory(const void* address)
{
  if (address != nullptr)
  {
    std::lock_guard guard(this->mutex);
    if (dependendMats.find(address) == dependendMats.end())
      dependendMats.insert(std::make_pair(address, nullptr));
  }//end if (address != nullptr)
}

void MyFixTracer::unregisterMemory(const void* address)
{
  std::lock_guard guard(this->mutex);
  auto range = dependendMats.equal_range(address);
  if (range.first != range.second)
  {
    ++protectLevel;
    try{
      for(auto it = range.first ; it != range.second ; ++it)
      {
        cv::Mat* mat = it->second;
        if (mat != nullptr)
        {
          CV_LOG_WARNING(nullptr, "Mat 0x" << std::hex << mat << std::dec << "was still in use when unregistering external memory");
          cv::swap(*mat, mat->clone());//will trigger new trace events
        }
      }
      dependendMats.erase(address);
    }
    catch(std::exception& e){
    }
    --protectLevel;
  }//end if (address != nullptr)
}

void MyFixTracer::trace(const cv::Mat* src, cv::Mat* dst, cv::MatTracerEventKind kind)
{
  printf("trace src[%p] dst[%p] kind=%d\r\n", src, dst, (int)kind);
  if (protectLevel > 0) {
  }
  else if ((kind == cv::MatTracerEventKind::MAT_TRACER_EVENT_ADDREF) || (kind == cv::MatTracerEventKind::MAT_TRACER_EVENT_MEMORY_REFERENCE))
  {
    const void* address = !dst ? nullptr : dst->datastart;
    if (address != nullptr)
    {
      std::lock_guard guard(this->mutex);
      auto it = dependendMats.find(address);
      if (it != dependendMats.end())
      {
        printf("registering (%p,%p)\r\n ", address, dst);
        dependendMats.insert(it, std::make_pair(address, dst));
      }
    }
  }
  else if (kind == cv::MatTracerEventKind::MAT_TRACER_EVENT_RELEASE)
  {
    const void* address = !dst ? nullptr : dst->datastart;
    if (address != nullptr)
    {
      std::lock_guard guard(this->mutex);
      printf("unregistering (%p,%p)\r\n ", address, dst);
      auto range = dependendMats.equal_range(address);
      for(auto it = range.first ; it != range.second ; ++it)
      {
        if (it->second == dst)
        {
          dependendMats.erase(it);
          break;
        }
      }
    }
  }
}
```


