### PR TITLE
core(hal): fix misaligned int64_t dereference in v_lut_pairs(const int*)

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -3144,7 +3144,10 @@ inline v_int32x4 v_lut(const int* tab, const int* idx)
 }
 inline v_int32x4 v_lut_pairs(const int* tab, const int* idx)
 {
-    return v_int32x4(_mm_set_epi64x(*(const int64_t*)(tab + idx[1]), *(const int64_t*)(tab + idx[0])));
+    int64_t lo, hi;
+    memcpy(&lo, tab + idx[0], sizeof(int64_t));
+    memcpy(&hi, tab + idx[1], sizeof(int64_t));
+    return v_int32x4(_mm_set_epi64x(hi, lo));
 }
 inline v_int32x4 v_lut_quads(const int* tab, const int* idx)
 {


### PR DESCRIPTION
The SSE2 overload of v_lut_pairs(const int* tab, const int* idx) reads two consecutive int values as a single int64_t via a C-style pointer cast:

    *(const int64_t*)(tab + idx[0])

tab is only guaranteed to be 4-byte aligned (it is an int array).  When idx[0] is odd (e.g. 11), the resulting address is 4-byte aligned but NOT 8-byte aligned, making the int64_t dereference undefined behaviour per C++ [basic.align].

On x86/x86_64 hardware this is silently tolerated, but:
 - UBSan flags it immediately and injects UD1, crashing with SIGILL.
 - On ARM / RISC-V the CPU raises SIGBUS unconditionally.
 - Even on x86, the compiler may exploit the alignment assumption under -O2/-O3 to produce wrong results.

The identical bug was previously reported and closed as "won't fix" under the false assumption that memcpy would be slower. A fixed-size memcpy of 8 bytes is lowered to a single movq instruction by every modern compiler at -O1 or higher — there is no performance difference.

Fix: replace the type-pun cast with memcpy, the standard-defined way to express an unaligned load.

Reproducer: call cv::imread(path, IMREAD_REDUCED_GRAYSCALE_8) on any non-JPEG image (PNG, TIFF, …). The internal INTER_LINEAR_EXACT downscale triggered by imread reaches hlineResizeCn<uint8_t,…,4> → vx_lut_pairs → v_lut_pairs(const int*,…) with an odd index, hitting this UB.

Tested: UBSan reports no error with the fix; the result is bit-identical to the expected value. Without the fix UBSan fires at intrin_sse.hpp:3147.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
