### PR TITLE
core: fix signed integer overflow in cubeRoot() via unsigned cast

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -138,7 +138,7 @@ float  cubeRoot( float value )
     /* fr *= 2^ex * sign */
     m.f = value;
     v.f = fr;
-    v.i = (v.i + (ex << 23) + s) & (m.i*2 != 0 ? -1 : 0);
+    v.i = (v.i + (ex << 23) + s) & ((unsigned)m.i*2 != 0 ? -1 : 0);
     return v.f;
 }
 


### PR DESCRIPTION
## Summary

`cv::cubeRoot(float)` triggers a signed integer overflow (UB) at `mathfuncs.cpp:141` for any input with `|value| >= 2.0f`, which covers the vast majority of practical float values.

## Root Cause

`Cv32suf` is a union `{ int i; unsigned u; float f; }`. Line 141 applies a zero-mask to return `0.0f` when `value == ±0.0f`:

```cpp
// mathfuncs.cpp:141 (before fix)
v.i = (v.i + (ex << 23) + s) & (m.i*2 != 0 ? -1 : 0);
```

`m.i*2` is intended to detect both `+0.0f` (bit pattern `0x00000000`) and `-0.0f` (bit pattern `0x80000000`) by multiplying out the sign bit. However, `m.i` is a **signed `int`**. For any `|value| >= 2.0f`, `m.i >= 0x40000000 = 1073741824`, so `1073741824 * 2 > INT_MAX` — **signed integer overflow, undefined behaviour** per the C++ standard. UBSan reliably detects and aborts on this.

## Fix

Cast `m.i` to `unsigned` before multiplication. Unsigned wraparound is well-defined: `(unsigned)0x80000000u * 2 == 0` still correctly detects `-0.0f`.

```diff
-    v.i = (v.i + (ex << 23) + s) & (m.i*2 != 0 ? -1 : 0);
+    v.i = (v.i + (ex << 23) + s) & ((unsigned)m.i*2 != 0 ? -1 : 0);
```

One-character change. No logic change for any value; purely eliminates the UB.

## Minimal Reproducer

```cpp
#include <opencv2/core.hpp>
int main() {
    cv::cubeRoot(2.0f);  // any float with |value| >= 2.0f
    return 0;
}
```

```
mathfuncs.cpp:141:40: runtime error: signed integer overflow: 1073741824 * 2 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior mathfuncs.cpp:141:40
```

## Tested

- Built OpenCV with `-fsanitize=address,undefined` (clang++ 21.1.8)
- PoC exits 0 (no UBSan report) after the fix
- All values including `±0.0f`, `2.0f`, `3.14f`, `-100.0f` produce correct cube roots

Signed-off-by: FuzzAnything \<fuzzanything@gmail.com\>