### PR TITLE
photo: enable 16-bit image support for fastNlm denoising

### DIFF
--- a/modules/photo/include/opencv2/photo/cuda.hpp
+++ b/modules/photo/include/opencv2/photo/cuda.hpp
@@ -114,20 +114,6 @@ CV_WRAP inline void fastNlMeansDenoising(const GpuMat& src, CV_OUT GpuMat& dst,
 {
     fastNlMeansDenoising(InputArray(src), OutputArray(dst), h, search_window, block_size, stream);
 }
-
-CV_EXPORTS void fastNlMeansDenoising_16(InputArray src, OutputArray dst,
-                                    float h,
-                                    int search_window = 21,
-                                    int block_size = 7,
-                                    Stream& stream = Stream::Null());
-CV_WRAP inline void fastNlMeansDenoising_16(const GpuMat& src, CV_OUT GpuMat& dst,
-                                    float h,
-                                    int search_window = 21,
-                                    int block_size = 7,
-                                    Stream& stream = Stream::Null())
-{
-    fastNlMeansDenoising_16(InputArray(src), OutputArray(dst), h, search_window, block_size, stream);
-}
 /** @brief Modification of fastNlMeansDenoising function for colored images
 
 @param src Input 8-bit 3-channel image.

--- a/modules/photo/include/opencv2/photo/cuda.hpp
+++ b/modules/photo/include/opencv2/photo/cuda.hpp
@@ -115,6 +115,19 @@ CV_WRAP inline void fastNlMeansDenoising(const GpuMat& src, CV_OUT GpuMat& dst,
     fastNlMeansDenoising(InputArray(src), OutputArray(dst), h, search_window, block_size, stream);
 }
 
+CV_EXPORTS void fastNlMeansDenoising_16(InputArray src, OutputArray dst,
+                                    float h,
+                                    int search_window = 21,
+                                    int block_size = 7,
+                                    Stream& stream = Stream::Null());
+CV_WRAP inline void fastNlMeansDenoising_16(const GpuMat& src, CV_OUT GpuMat& dst,
+                                    float h,
+                                    int search_window = 21,
+                                    int block_size = 7,
+                                    Stream& stream = Stream::Null())
+{
+    fastNlMeansDenoising_16(InputArray(src), OutputArray(dst), h, search_window, block_size, stream);
+}
 /** @brief Modification of fastNlMeansDenoising function for colored images
 
 @param src Input 8-bit 3-channel image.

--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -506,13 +506,13 @@ namespace cv { namespace cuda { namespace device
                 search_window(search_window_),
                 block_window(block_window_),
                 minus_h2_inv(-1.f / (h * h)) {
-            }   // tek kanal: VecTraits cn=1
+            }   // One Channel: VecTraits cn=1
 
             PtrStep<ushort> src;
             mutable PtrStepf buffer;                  // float buffer (int yerine)
 
-            // calcDist — float döndürür, int overflow olmaz
-            // 65535² = 4.29×10⁹ > INT_MAX olduğu için float zorunlu
+            // calcDist — returns float
+            // 65535² = 4.29×10⁹ > INT_MAX, must return float
             __device__ __forceinline__ float calcDist_16(ushort a, ushort b) const
             {
                 float diff = float(a) - float(b);
@@ -521,8 +521,8 @@ namespace cv { namespace cuda { namespace device
 
             __device__ __forceinline__ void initSums_BruteForce(
                 int i, int j,
-                float* dist_sums,          // float[] — orijinalde int[]
-                PtrStepf& col_sums,        // PtrStepf — orijinalde PtrStepi
+                float* dist_sums,
+                PtrStepf& col_sums,
                 PtrStepf& up_col_sums) const
             {
                 for (int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
@@ -664,7 +664,7 @@ namespace cv { namespace cuda { namespace device
                     + blockIdx.y * search_window * search_window;
                 up_col_sums.step = buffer.step;
 
-                extern __shared__ float dist_sums_16[];   // float — orijinalde int
+                extern __shared__ float dist_sums_16[];
 
                 int first = 0;
 

--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -171,6 +171,7 @@ namespace cv { namespace cuda { namespace device
         template void nlm_bruteforce_gpu<uchar>(const PtrStepSzb&, PtrStepSzb, int, int, float, int, cudaStream_t);
         template void nlm_bruteforce_gpu<uchar2>(const PtrStepSzb&, PtrStepSzb, int, int, float, int, cudaStream_t);
         template void nlm_bruteforce_gpu<uchar3>(const PtrStepSzb&, PtrStepSzb, int, int, float, int, cudaStream_t);
+        template void nlm_bruteforce_gpu<ushort>(const PtrStepSzb&, PtrStepSzb, int, int, float, int, cudaStream_t);
     }
 }}}
 
@@ -263,6 +264,7 @@ namespace cv { namespace cuda { namespace device
         __device__ __forceinline__ int calcDist(const uchar&  a, const uchar&  b) { return (a-b)*(a-b); }
         __device__ __forceinline__ int calcDist(const uchar2& a, const uchar2& b) { return (a.x-b.x)*(a.x-b.x) + (a.y-b.y)*(a.y-b.y); }
         __device__ __forceinline__ int calcDist(const uchar3& a, const uchar3& b) { return (a.x-b.x)*(a.x-b.x) + (a.y-b.y)*(a.y-b.y) + (a.z-b.z)*(a.z-b.z); }
+        __device__ __forceinline__ int calcDist(const ushort& a, const ushort& b) { int diff = int(a) - int(b); return diff * diff; }
 
         template <class T> struct FastNonLocalMeans
         {
@@ -474,7 +476,223 @@ namespace cv { namespace cuda { namespace device
             }
 
         };
+        struct FastNonLocalMeans_16
+        {
+            enum
+            {
+                CTA_SIZE = 128,
+                TILE_COLS = 128,
+                TILE_ROWS = 32,
+                STRIDE = CTA_SIZE
+            };
 
+            struct plus
+            {
+                __device__ __forceinline__ float operator()(float v1, float v2) const
+                {
+                    return v1 + v2;
+                }
+            };
+
+            int   search_radius;
+            int   block_radius;
+            int   search_window;
+            int   block_window;
+            float minus_h2_inv;
+
+            FastNonLocalMeans_16(int search_window_, int block_window_, float h)
+                : search_radius(search_window_ / 2),
+                block_radius(block_window_ / 2),
+                search_window(search_window_),
+                block_window(block_window_),
+                minus_h2_inv(-1.f / (h * h)) {
+            }   // tek kanal: VecTraits cn=1
+
+            PtrStep<ushort> src;
+            mutable PtrStepf buffer;                  // float buffer (int yerine)
+
+            // calcDist — float döndürür, int overflow olmaz
+            // 65535² = 4.29×10⁹ > INT_MAX olduğu için float zorunlu
+            __device__ __forceinline__ float calcDist_16(ushort a, ushort b) const
+            {
+                float diff = float(a) - float(b);
+                return diff * diff;
+            }
+
+            __device__ __forceinline__ void initSums_BruteForce(
+                int i, int j,
+                float* dist_sums,          // float[] — orijinalde int[]
+                PtrStepf& col_sums,        // PtrStepf — orijinalde PtrStepi
+                PtrStepf& up_col_sums) const
+            {
+                for (int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
+                {
+                    dist_sums[index] = 0.f;
+
+                    for (int tx = 0; tx < block_window; ++tx)
+                        col_sums(tx, index) = 0.f;
+
+                    int y = index / search_window;
+                    int x = index - y * search_window;
+
+                    int ay = i, ax = j;
+                    int by = i + y - search_radius;
+                    int bx = j + x - search_radius;
+
+                    for (int tx = -block_radius; tx <= block_radius; ++tx)
+                    {
+                        float col_sum = 0.f;
+                        for (int ty = -block_radius; ty <= block_radius; ++ty)
+                        {
+                            float dist = calcDist_16(src(ay + ty, ax + tx),
+                                src(by + ty, bx + tx));
+                            dist_sums[index] += dist;
+                            col_sum += dist;
+                        }
+                        col_sums(tx + block_radius, index) = col_sum;
+                    }
+                    up_col_sums(j, index) = col_sums(block_window - 1, index);
+                }
+            }
+
+            __device__ __forceinline__ void shiftRight_FirstRow(
+                int i, int j, int first,
+                float* dist_sums,
+                PtrStepf& col_sums,
+                PtrStepf& up_col_sums) const
+            {
+                for (int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
+                {
+                    int y = index / search_window;
+                    int x = index - y * search_window;
+
+                    int ay = i, ax = j + block_radius;
+                    int by = i + y - search_radius;
+                    int bx = j + x - search_radius + block_radius;
+
+                    float col_sum = 0.f;
+                    for (int ty = -block_radius; ty <= block_radius; ++ty)
+                        col_sum += calcDist_16(src(ay + ty, ax), src(by + ty, bx));
+
+                    dist_sums[index] += col_sum - col_sums(first, index);
+                    col_sums(first, index) = col_sum;
+                    up_col_sums(j, index) = col_sum;
+                }
+            }
+
+            __device__ __forceinline__ void shiftRight_UpSums(
+                int i, int j, int first,
+                float* dist_sums,
+                PtrStepf& col_sums,
+                PtrStepf& up_col_sums) const
+            {
+                int ay = i, ax = j + block_radius;
+
+                ushort a_up = src(ay - block_radius - 1, ax);
+                ushort a_down = src(ay + block_radius, ax);
+
+                for (int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
+                {
+                    int y = index / search_window;
+                    int x = index - y * search_window;
+
+                    int by = i + y - search_radius;
+                    int bx = j + x - search_radius + block_radius;
+
+                    ushort b_up = src(by - block_radius - 1, bx);
+                    ushort b_down = src(by + block_radius, bx);
+
+                    float col_sum = up_col_sums(j, index)
+                        + calcDist_16(a_down, b_down)
+                        - calcDist_16(a_up, b_up);
+
+                    dist_sums[index] += col_sum - col_sums(first, index);
+                    col_sums(first, index) = col_sum;
+                    up_col_sums(j, index) = col_sum;
+                }
+            }
+
+            __device__ __forceinline__ void convolve_window(
+                int i, int j,
+                const float* dist_sums,
+                ushort& dst) const
+            {
+                float weights_sum = 0.f;
+                float sum = 0.f;
+                float bw2_inv = 1.f / (block_window * block_window);
+
+                int sx = j - search_radius;
+                int sy = i - search_radius;
+
+                for (int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
+                {
+                    int   y = index / search_window;
+                    int   x = index - y * search_window;
+                    float avg_dist = dist_sums[index] * bw2_inv;
+                    float weight = __expf(avg_dist * minus_h2_inv);
+
+                    weights_sum += weight;
+                    sum += weight * float(src(sy + y, sx + x));
+                }
+
+                __shared__ float cta_buffer[CTA_SIZE * 2];  // cn=1 → 2 slot
+
+                reduce<CTA_SIZE>(
+                    cv::cuda::device::smem_tuple(cta_buffer, cta_buffer + CTA_SIZE),
+                    thrust::tie(weights_sum, sum),
+                    threadIdx.x,
+                    thrust::make_tuple(plus(), plus()));
+
+                if (threadIdx.x == 0)
+                    dst = saturate_cast<ushort>(sum / weights_sum);
+            }
+
+            __device__ __forceinline__ void operator()(PtrStepSz<ushort>& dst) const
+            {
+                int tbx = blockIdx.x * TILE_COLS;
+                int tby = blockIdx.y * TILE_ROWS;
+                int tex = ::min(tbx + TILE_COLS, dst.cols);
+                int tey = ::min(tby + TILE_ROWS, dst.rows);
+
+                PtrStepf col_sums;
+                col_sums.data = (float*)buffer.ptr(dst.cols + blockIdx.x * block_window)
+                    + blockIdx.y * search_window * search_window;
+                col_sums.step = buffer.step;
+
+                PtrStepf up_col_sums;
+                up_col_sums.data = (float*)buffer.data
+                    + blockIdx.y * search_window * search_window;
+                up_col_sums.step = buffer.step;
+
+                extern __shared__ float dist_sums_16[];   // float — orijinalde int
+
+                int first = 0;
+
+                for (int i = tby; i < tey; ++i)
+                    for (int j = tbx; j < tex; ++j)
+                    {
+                        __syncthreads();
+
+                        if (j == tbx)
+                        {
+                            initSums_BruteForce(i, j, dist_sums_16, col_sums, up_col_sums);
+                            first = 0;
+                        }
+                        else
+                        {
+                            if (i == tby)
+                                shiftRight_FirstRow(i, j, first, dist_sums_16, col_sums, up_col_sums);
+                            else
+                                shiftRight_UpSums(i, j, first, dist_sums_16, col_sums, up_col_sums);
+
+                            first = (first + 1) % block_window;
+                        }
+
+                        __syncthreads();
+                        convolve_window(i, j, dist_sums_16, dst(i, j));
+                    }
+            }
+        };
         template<typename T>
         __global__ void fast_nlm_kernel(const FastNonLocalMeans<T> fnlm, PtrStepSz<T> dst) { fnlm(dst); }
 
@@ -511,7 +729,29 @@ namespace cv { namespace cuda { namespace device
         template void nlm_fast_gpu<uchar>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float,  cudaStream_t);
         template void nlm_fast_gpu<uchar2>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
         template void nlm_fast_gpu<uchar3>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        //template void nlm_fast_gpu<ushort>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        __global__ void fast_nlm_kernel_16(const FastNonLocalMeans_16 fnlm, PtrStepSz<ushort> dst)
+        {
+            fnlm(dst);
+        }
+        void nlm_fast_gpu_16u(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSzf buffer,
+            int search_window, int block_window, float h, cudaStream_t stream)
+        {
+            FastNonLocalMeans_16 fnlm(search_window, block_window, h);
+            fnlm.src = (PtrStepSz<ushort>)src;
+            fnlm.buffer = buffer;
 
+            dim3 block(FastNonLocalMeans_16::CTA_SIZE, 1);
+            dim3 grid(divUp(src.cols, FastNonLocalMeans_16::TILE_COLS),
+                divUp(src.rows, FastNonLocalMeans_16::TILE_ROWS));
+
+            int smem = search_window * search_window * sizeof(float); // float — int değil
+
+            fast_nlm_kernel_16 << <grid, block, smem >> > (fnlm, (PtrStepSz<ushort>)dst);
+            cudaSafeCall(cudaGetLastError());
+            if (stream == 0)
+                cudaSafeCall(cudaDeviceSynchronize());
+        }
 
 
         __global__ void fnlm_split_kernel(const PtrStepSz<uchar3> lab, PtrStepb l, PtrStep<uchar2> ab)

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -67,8 +67,6 @@ using namespace cv::cuda;
 
 void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoising(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
-void cv::cuda::fastNlMeansDenoising_16(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
-void cv::cuda::fastNlMeansDenoisingColored(InputArray, OutputArray, float, float, int, int, Stream&) { throw_no_cuda(); }
 
 #else
 
@@ -129,7 +127,7 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
 {
     const GpuMat src = _src.getGpuMat();
 
-    CV_Assert(src.depth() == CV_8U && src.channels() < 4);
+    CV_Assert((src.depth() == CV_8U && src.channels() < 4) || (src.depth() == CV_16UC1));
 
     int border_size = search_window/2 + block_window/2;
     Size esize = src.size() + Size(border_size, border_size) * 2;
@@ -146,43 +144,28 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
 
     using namespace cv::cuda::device::imgproc;
     typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
-    static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar>, nlm_fast_gpu<uchar2>, nlm_fast_gpu<uchar3>, 0};
+    if(src.depth() == CV_8U)
+    {
+        // Use 8-bit functions
+        static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar>, nlm_fast_gpu<uchar2>, nlm_fast_gpu<uchar3>, 0};
 
-    _dst.create(src.size(), src.type());
-    GpuMat dst = _dst.getGpuMat();
+        _dst.create(src.size(), src.type());
+        GpuMat dst = _dst.getGpuMat();
 
-    funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
-}
+        funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
+    }
+    else
+    {
+        // Use 16-bit function
+        static const nlm_fast_t func = nlm_fast_gpu<ushort>;
 
-void cv::cuda::fastNlMeansDenoising_16(InputArray _src, OutputArray _dst, float h, int search_window, int block_window, Stream& stream)
-{
-    const GpuMat src = _src.getGpuMat();
-    //
-    CV_Assert(src.depth() == CV_16UC1);
-    //Sadece tek kanal 16-bit
-    int border_size = search_window/2 + block_window/2;
-    Size esize = src.size() + Size(border_size, border_size) * 2;
+        _dst.create(src.size(), src.type());
+        GpuMat dst = _dst.getGpuMat();
 
-    BufferPool pool(stream);
-
-    GpuMat extended_src = pool.getBuffer(esize, src.type());
-    cv::cuda::copyMakeBorder(src, extended_src, border_size, border_size, border_size, border_size, cv::BORDER_DEFAULT, Scalar(), stream);
-    GpuMat src_hdr = extended_src(Rect(Point2i(border_size, border_size), src.size()));
-
-    int bcols, brows;
-    device::imgproc::nln_fast_get_buffer_size(src_hdr, search_window, block_window, bcols, brows);
-    GpuMat buffer = pool.getBuffer(brows, bcols, CV_32S);
-
-    using namespace cv::cuda::device::imgproc;
-    typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
-    static const nlm_fast_t func = nlm_fast_gpu<ushort>;
-
-    _dst.create(src.size(), src.type());
-    GpuMat dst = _dst.getGpuMat();
-
-    device::imgproc::nlm_fast_gpu_16u(src_hdr, dst, buffer,
-                                      search_window, block_window,
-                                      h, StreamAccessor::getStream(stream));
+        device::imgproc::nlm_fast_gpu_16u(src_hdr, dst, buffer,
+                                        search_window, block_window,
+                                        h, StreamAccessor::getStream(stream));
+    }
 }
 
 void cv::cuda::fastNlMeansDenoisingColored(InputArray _src, OutputArray _dst, float h_luminance, float h_color, int search_window, int block_window, Stream& stream)

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -67,6 +67,7 @@ using namespace cv::cuda;
 
 void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoising(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
+void cv::cuda::fastNlMeansDenoising_16(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoisingColored(InputArray, OutputArray, float, float, int, int, Stream&) { throw_no_cuda(); }
 
 #else
@@ -116,6 +117,9 @@ namespace cv { namespace cuda { namespace device
         void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepi buffer,
                           int search_window, int block_window, float h, cudaStream_t stream);
 
+        void nlm_fast_gpu_16u(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSzf buffer,
+            int search_window, int block_window, float h, cudaStream_t stream);
+
         void fnlm_split_channels(const PtrStepSz<uchar3>& lab, PtrStepb l, PtrStep<uchar2> ab, cudaStream_t stream);
         void fnlm_merge_channels(const PtrStepb& l, const PtrStep<uchar2>& ab, PtrStepSz<uchar3> lab, cudaStream_t stream);
      }
@@ -148,6 +152,37 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
     GpuMat dst = _dst.getGpuMat();
 
     funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
+}
+
+void cv::cuda::fastNlMeansDenoising_16(InputArray _src, OutputArray _dst, float h, int search_window, int block_window, Stream& stream)
+{
+    const GpuMat src = _src.getGpuMat();
+    //
+    CV_Assert(src.depth() == CV_16UC1);
+    //Sadece tek kanal 16-bit
+    int border_size = search_window/2 + block_window/2;
+    Size esize = src.size() + Size(border_size, border_size) * 2;
+
+    BufferPool pool(stream);
+
+    GpuMat extended_src = pool.getBuffer(esize, src.type());
+    cv::cuda::copyMakeBorder(src, extended_src, border_size, border_size, border_size, border_size, cv::BORDER_DEFAULT, Scalar(), stream);
+    GpuMat src_hdr = extended_src(Rect(Point2i(border_size, border_size), src.size()));
+
+    int bcols, brows;
+    device::imgproc::nln_fast_get_buffer_size(src_hdr, search_window, block_window, bcols, brows);
+    GpuMat buffer = pool.getBuffer(brows, bcols, CV_32S);
+
+    using namespace cv::cuda::device::imgproc;
+    typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+    static const nlm_fast_t func = nlm_fast_gpu<ushort>;
+
+    _dst.create(src.size(), src.type());
+    GpuMat dst = _dst.getGpuMat();
+
+    device::imgproc::nlm_fast_gpu_16u(src_hdr, dst, buffer,
+                                      search_window, block_window,
+                                      h, StreamAccessor::getStream(stream));
 }
 
 void cv::cuda::fastNlMeansDenoisingColored(InputArray _src, OutputArray _dst, float h_luminance, float h_color, int search_window, int block_window, Stream& stream)

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -67,7 +67,7 @@ using namespace cv::cuda;
 
 void cv::cuda::nonLocalMeans(InputArray, OutputArray, float, int, int, int, Stream&) { throw_no_cuda(); }
 void cv::cuda::fastNlMeansDenoising(InputArray, OutputArray, float, int, int, Stream&) { throw_no_cuda(); }
-
+void cv::cuda::fastNlMeansDenoisingColored(InputArray, OutputArray, float, float, int, int, Stream&) { throw_no_cuda(); }
 #else
 
 //////////////////////////////////////////////////////////////////////////////////

--- a/modules/photo/test/test_denoising.cuda.cpp
+++ b/modules/photo/test/test_denoising.cuda.cpp
@@ -133,7 +133,7 @@ TEST(CUDA_Photo_FastNlMeans, regression_16u)
 
     // 3. Execute the function and ensure it does not throw any exceptions
     EXPECT_NO_THROW({
-        cv::cuda::fastNlMeansDenoising_16(src_device, dst_device, h, search_window, block_size);
+        cv::cuda::fastNlMeansDenoising(src_device, dst_device, h, search_window, block_size);
     });
 
     ASSERT_FALSE(dst_device.empty()) << "Error: GPU output matrix should not be empty!";
@@ -164,27 +164,27 @@ TEST(CUDA_Photo_FastNlMeans, accuracy_16u)
 
     // 2. Convert the 8-bit image to 16-bit and scale it to the full range (0-255 becomes 0-65280)
     Mat src_host;
-    img_8u.convertTo(src_host, CV_16U, 256.0); 
+    img_8u.convertTo(src_host, CV_16U, 256.0);
 
     // 3. Add synthetic Gaussian noise safely
     Mat noise(src_host.size(), CV_16S);
     randn(noise, 0, 1500); // Standard deviation suitable for 16-bit scale
-    
+
     Mat noisy_host;
     // cv::add automatically handles clamping between 0-65535 for CV_16U
-    cv::add(src_host, noise, noisy_host, noArray(), CV_16U); 
+    cv::add(src_host, noise, noisy_host, noArray(), CV_16U);
 
     // 4. Upload data to the GPU
     cuda::GpuMat d_noisy, d_dst;
     d_noisy.upload(noisy_host);
 
     // 5. Execute the 16-bit NLM algorithm
-    float h = 3000.0f; 
+    float h = 3000.0f;
     int search_window = 21;
     int block_size = 7;
 
     EXPECT_NO_THROW({
-        cuda::fastNlMeansDenoising_16(d_noisy, d_dst, h, search_window, block_size);
+        cuda::fastNlMeansDenoising(d_noisy, d_dst, h, search_window, block_size);
     });
 
     Mat dst_host;
@@ -196,11 +196,11 @@ TEST(CUDA_Photo_FastNlMeans, accuracy_16u)
     double psnr_denoised = cv::PSNR(src_host, dst_host, max_val_16u);
 
     // The PSNR of the denoised image must be HIGHER than the noisy image (Higher = Better quality)
-    EXPECT_GT(psnr_denoised, psnr_noisy) 
+    EXPECT_GT(psnr_denoised, psnr_noisy)
         << "Accuracy Failed: Denoised image quality is worse than the noisy input!";
-    
+
     // Logical minimum threshold for PSNR
-    EXPECT_GT(psnr_denoised, 30.0) 
+    EXPECT_GT(psnr_denoised, 30.0)
         << "Accuracy Failed: PSNR is too low, check accumulator types or scaling!";
 }
 

--- a/modules/photo/test/test_denoising.cuda.cpp
+++ b/modules/photo/test/test_denoising.cuda.cpp
@@ -116,5 +116,43 @@ TEST(CUDA_FastNonLocalMeans, Regression)
     EXPECT_MAT_NEAR(gray_gold, dgray, 1);
 }
 
+TEST(CUDA_Photo_FastNlMeans, regression_16u)
+{
+    // 1. Generate random 16-bit data on the CPU (512x512 is sufficient for testing)
+    cv::Mat src_host(512, 512, CV_16U);
+    cv::randu(src_host, Scalar::all(0), Scalar::all(16));
+
+    // 2. Upload data to the GPU
+    cv::cuda::GpuMat src_device;
+    src_device.upload(src_host);
+    cv::cuda::GpuMat dst_device;
+
+    float h = 3.0f;
+    int search_window = 21;
+    int block_size = 7;
+
+    // 3. Execute the function and ensure it does not throw any exceptions
+    EXPECT_NO_THROW({
+        cv::cuda::fastNlMeansDenoising_16(src_device, dst_device, h, search_window, block_size);
+    });
+
+    ASSERT_FALSE(dst_device.empty()) << "Error: GPU output matrix should not be empty!";
+
+    // 4. Download data back to the CPU for analysis
+    cv::Mat dst_host;
+    dst_device.download(dst_host);
+
+    // CHECK 1: Did the output become completely zero? (Black image check)
+    double minVal, maxVal;
+    cv::minMaxLoc(dst_host, &minVal, &maxVal);
+    EXPECT_GT(maxVal, 0) << "Error: Maximum value in the output image is 0 (Completely black)!";
+
+    // CHECK 2: Did the algorithm actually modify the image?
+    cv::Mat diff;
+    cv::absdiff(src_host, dst_host, diff); // Get the absolute difference between input and output
+    int changed_pixels = cv::countNonZero(diff);
+    EXPECT_GT(changed_pixels, 0) << "Error: The algorithm did not change the image at all!";
+}
+
 }} // namespace
 #endif // HAVE_CUDA

--- a/modules/photo/test/test_denoising.cuda.cpp
+++ b/modules/photo/test/test_denoising.cuda.cpp
@@ -154,5 +154,55 @@ TEST(CUDA_Photo_FastNlMeans, regression_16u)
     EXPECT_GT(changed_pixels, 0) << "Error: The algorithm did not change the image at all!";
 }
 
+TEST(CUDA_Photo_FastNlMeans, accuracy_16u)
+{
+    // 1. Load the standard OpenCV test image from opencv_extra
+    std::string path = "shared/lena.png";
+    string img_path = cvtest::findDataFile(path);
+    Mat img_8u = imread(img_path, IMREAD_GRAYSCALE);
+    ASSERT_FALSE(img_8u.empty()) << "Test image not found!";
+
+    // 2. Convert the 8-bit image to 16-bit and scale it to the full range (0-255 becomes 0-65280)
+    Mat src_host;
+    img_8u.convertTo(src_host, CV_16U, 256.0); 
+
+    // 3. Add synthetic Gaussian noise safely
+    Mat noise(src_host.size(), CV_16S);
+    randn(noise, 0, 1500); // Standard deviation suitable for 16-bit scale
+    
+    Mat noisy_host;
+    // cv::add automatically handles clamping between 0-65535 for CV_16U
+    cv::add(src_host, noise, noisy_host, noArray(), CV_16U); 
+
+    // 4. Upload data to the GPU
+    cuda::GpuMat d_noisy, d_dst;
+    d_noisy.upload(noisy_host);
+
+    // 5. Execute the 16-bit NLM algorithm
+    float h = 3000.0f; 
+    int search_window = 21;
+    int block_size = 7;
+
+    EXPECT_NO_THROW({
+        cuda::fastNlMeansDenoising_16(d_noisy, d_dst, h, search_window, block_size);
+    });
+
+    Mat dst_host;
+    d_dst.download(dst_host);
+
+    // 6. Accuracy Check (PSNR) - IMPORTANT: Max value must be explicitly set to 65535.0 for 16-bit!
+    double max_val_16u = 65535.0;
+    double psnr_noisy = cv::PSNR(src_host, noisy_host, max_val_16u);
+    double psnr_denoised = cv::PSNR(src_host, dst_host, max_val_16u);
+
+    // The PSNR of the denoised image must be HIGHER than the noisy image (Higher = Better quality)
+    EXPECT_GT(psnr_denoised, psnr_noisy) 
+        << "Accuracy Failed: Denoised image quality is worse than the noisy input!";
+    
+    // Logical minimum threshold for PSNR
+    EXPECT_GT(psnr_denoised, 30.0) 
+        << "Accuracy Failed: PSNR is too low, check accumulator types or scaling!";
+}
+
 }} // namespace
 #endif // HAVE_CUDA


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


Summary
This PR extends the fastNlmDenoising algorithm to support 16-bit (CV_16U) input images. Currently, the implementation is primarily optimized for 8-bit images, which limits its application in high-dynamic-range (HDR) imaging, medical imaging (DICOM), and scientific data processing.

Key Changes
Template Extension: Extend the core kernels of the fastNLM algorithm to handle ushort (16-bit) depth alongside the existing uchar (8-bit) implementation.

Precision Handling: Adjusted internal accumulator types to prevent overflow during the calculation of weighted averages in 16-bit space.

Interface Update: Ensured that the dispatch logic correctly identifies CV_16U and routes it to the appropriate optimized path.

Impact
Users can now apply Non-Local Means denoising directly to 16-bit grayscale images without pre-scaling them down to 8-bit, preserving significant bit-depth information.

The performance remains optimized as the core logic still utilizes the "integral image" based fast approach.

Testing Done

Verified with a 16-bit input image: CV_16U type is correctly processed.

Performed a visual check on denoising results using a 16-bit grayscale sensor raw output.

Fixes #28962