### PR TITLE
[bug] core: fix signed integer overflow in cv::Point_<int>::dot()

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1242,7 +1242,7 @@ Point_<_Tp>::operator Vec<_Tp, 2>() const
 template<typename _Tp> inline
 _Tp Point_<_Tp>::dot(const Point_& pt) const
 {
-    return saturate_cast<_Tp>(x*pt.x + y*pt.y);
+    return saturate_cast<_Tp>((double)x*pt.x + (double)y*pt.y);
 }
 
 template<typename _Tp> inline


### PR DESCRIPTION
## Summary

Fixes a signed integer overflow (undefined behavior) in `cv::Point_<int>::dot()` where the intermediate multiplication `x*pt.x` is evaluated in the `int` domain before `saturate_cast` is applied. For large-magnitude integer coordinates the product overflows `INT_MAX`, triggering UBSan.

## Root Cause

The vulnerable line in `modules/core/include/opencv2/core/types.hpp:1245`:

```cpp
// Before: intermediate multiplication occurs in int — UB for large coordinates
return saturate_cast<_Tp>(x*pt.x + y*pt.y);
```

The `saturate_cast` has no effect on UB that already occurred during the multiplication. The same file's `ddot()` and `cross()` already correctly promote operands to `double` before multiplying.

Additionally, `normL2Sqr<int>(const Point_<int>&)` at line 1447 calls `dot()` internally, making this overflow reachable from library-internal code as well.

## Fix

Promote operands to `double` before multiplying, consistent with `ddot()` and `cross()`:

```diff
-    return saturate_cast<_Tp>(x*pt.x + y*pt.y);
+    return saturate_cast<_Tp>((double)x*pt.x + (double)y*pt.y);
```

## Reproduction

```cpp
#include <opencv2/core.hpp>

extern "C" int LLVMFuzzerTestOneInput(uint8_t *data, int size) {
    cv::Point pt1(-512594060, -211847581);
    cv::Point pt2(-295341969, -1355019714);
    pt1.dot(pt2);  // -512594060 * -295341969 overflows int
    return 0;
}
```

```
$ UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 ./poc
opencv2/core/types.hpp:1245:32: runtime error: signed integer overflow:
    -512594060 * -295341969 cannot be represented in type 'int'
```

Discovered via libFuzzer + UBSan fuzzing campaign on OpenCV 4.13.0-150-gc7732e1043.

---
> Signed-off-by: FuzzAnything <fuzzanything@gmail.com>