### PR TITLE
core: fix Unicode temp path handling on Windows (fix #21960)

### DIFF
--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1118,12 +1118,19 @@ String tempfile( const char* suffix )
 #else
     // Use GUID-based naming to avoid race condition with GetTempFileNameA
     // See issue #19648
-    char temp_dir2[MAX_PATH] = { 0 };
+    wchar_t temp_dir2_w[MAX_PATH] = { 0 };
 
     if (temp_dir.empty())
     {
-        ::GetTempPathA(sizeof(temp_dir2), temp_dir2);
-        temp_dir = std::string(temp_dir2);
+        ::GetTempPathW(sizeof(temp_dir2_w)/sizeof(wchar_t), temp_dir2_w);
+        // Convert from UTF-16 to UTF-8 to support Unicode paths
+        int len = WideCharToMultiByte(CP_UTF8, 0, temp_dir2_w, -1, NULL, 0, NULL, NULL);
+        if (len > 0)
+        {
+            std::vector<char> utf8_buf(len);
+            WideCharToMultiByte(CP_UTF8, 0, temp_dir2_w, -1, utf8_buf.data(), len, NULL, NULL);
+            temp_dir = std::string(utf8_buf.data());
+        }
     }
 
     GUID g;

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -438,64 +438,19 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
     {
         cv::String default_cache_path;
 #ifdef _WIN32
-        char tmp_path_buf[MAX_PATH+1] = {0};
-        DWORD res = GetTempPath(MAX_PATH, tmp_path_buf);
+        wchar_t tmp_path_buf_w[MAX_PATH+1] = {0};
+        DWORD res = GetTempPathW(MAX_PATH, tmp_path_buf_w);
         if (res > 0 && res <= MAX_PATH)
         {
-            default_cache_path = tmp_path_buf;
-        }
-#elif defined __ANDROID__
-        // no defaults
-#elif defined __APPLE__
-        const std::string tmpdir_env = utils::getConfigurationParameterString("TMPDIR");
-        if (!tmpdir_env.empty() && utils::fs::isDirectory(tmpdir_env))
-        {
-            default_cache_path = tmpdir_env;
-        }
-        else
-        {
-            default_cache_path = "/tmp/";
-            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-        }
-#elif defined __linux__ || defined __HAIKU__ || defined __FreeBSD__ || defined __GNU__
-        // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-        if (default_cache_path.empty())
-        {
-            const std::string xdg_cache_env = utils::getConfigurationParameterString("XDG_CACHE_HOME");
-            if (!xdg_cache_env.empty() && utils::fs::isDirectory(xdg_cache_env))
+            // Convert from UTF-16 to UTF-8 to support Unicode paths
+            int len = WideCharToMultiByte(CP_UTF8, 0, tmp_path_buf_w, -1, NULL, 0, NULL, NULL);
+            if (len > 0)
             {
-                default_cache_path = xdg_cache_env;
+                std::vector<char> utf8_buf(len);
+                WideCharToMultiByte(CP_UTF8, 0, tmp_path_buf_w, -1, utf8_buf.data(), len, NULL, NULL);
+                default_cache_path = std::string(utf8_buf.data());
             }
         }
-        if (default_cache_path.empty())
-        {
-            const std::string home_env = utils::getConfigurationParameterString("HOME");
-            if (!home_env.empty() && utils::fs::isDirectory(home_env))
-            {
-                cv::String home_path = home_env;
-                cv::String home_cache_path = utils::fs::join(home_path, ".cache/");
-                if (utils::fs::isDirectory(home_cache_path))
-                {
-                    default_cache_path = home_cache_path;
-                }
-            }
-        }
-        if (default_cache_path.empty())
-        {
-            const char* temp_path = "/var/tmp/";
-            if (utils::fs::isDirectory(temp_path))
-            {
-                default_cache_path = temp_path;
-                CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-            }
-        }
-        if (default_cache_path.empty())
-        {
-            default_cache_path = "/tmp/";
-            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-        }
-#else
-        // no defaults
 #endif
         CV_LOG_VERBOSE(NULL, 0, "default_cache_path = " << default_cache_path);
         if (!default_cache_path.empty())

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -451,6 +451,58 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
                 default_cache_path = std::string(utf8_buf.data());
             }
         }
+#elif defined __ANDROID__
+        // no defaults
+#elif defined __APPLE__
+        const std::string tmpdir_env = utils::getConfigurationParameterString("TMPDIR");
+        if (!tmpdir_env.empty() && utils::fs::isDirectory(tmpdir_env))
+        {
+            default_cache_path = tmpdir_env;
+        }
+        else
+        {
+            default_cache_path = "/tmp/";
+            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+        }
+#elif defined __linux__ || defined __HAIKU__ || defined __FreeBSD__ || defined __GNU__
+        // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+        if (default_cache_path.empty())
+        {
+            const std::string xdg_cache_env = utils::getConfigurationParameterString("XDG_CACHE_HOME");
+            if (!xdg_cache_env.empty() && utils::fs::isDirectory(xdg_cache_env))
+            {
+                default_cache_path = xdg_cache_env;
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            const std::string home_env = utils::getConfigurationParameterString("HOME");
+            if (!home_env.empty() && utils::fs::isDirectory(home_env))
+            {
+                cv::String home_path = home_env;
+                cv::String home_cache_path = utils::fs::join(home_path, ".cache/");
+                if (utils::fs::isDirectory(home_cache_path))
+                {
+                    default_cache_path = home_cache_path;
+                }
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            const char* temp_path = "/var/tmp/";
+            if (utils::fs::isDirectory(temp_path))
+            {
+                default_cache_path = temp_path;
+                CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            default_cache_path = "/tmp/";
+            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+        }
+#else
+        // no defaults
 #endif
         CV_LOG_VERBOSE(NULL, 0, "default_cache_path = " << default_cache_path);
         if (!default_cache_path.empty())

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10483,6 +10483,8 @@ class CapturedStream {
         }
         // Create file and get fd for redirect
         captured_fd = _open(temp_file_path.c_str(), _O_CREAT | _O_WRONLY | _O_TRUNC, _S_IREAD | _S_IWRITE);
+        GTEST_CHECK_(captured_fd != -1) << "Unable to open temporary file "
+        << temp_file_path;
         filename_ = temp_file_path;
     }
 # else

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10471,6 +10471,7 @@ class CapturedStream {
                                             temp_file_path_w);
     // Convert filename back to UTF-8
     std::string temp_file_path;
+    int captured_fd = -1;
     if (success != 0)
     {
         len = WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, NULL, 0, NULL, NULL);
@@ -10480,6 +10481,9 @@ class CapturedStream {
             WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, utf8_buf.data(), len, NULL, NULL);
             temp_file_path = std::string(utf8_buf.data());
         }
+        // Create file and get fd for redirect
+        captured_fd = _open(temp_file_path.c_str(), _O_CREAT | _O_WRONLY | _O_TRUNC, _S_IREAD | _S_IWRITE);
+        filename_ = temp_file_path;
     }
 # else
     // There's no guarantee that a test has write access to the current

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10452,20 +10452,35 @@ class CapturedStream {
   // The ctor redirects the stream to a temporary file.
   explicit CapturedStream(int fd) : fd_(fd), uncaptured_fd_(dup(fd)) {
 # if GTEST_OS_WINDOWS
-    char temp_dir_path[MAX_PATH + 1] = { '\0' };  // NOLINT
-    char temp_file_path[MAX_PATH + 1] = { '\0' };  // NOLINT
+    wchar_t temp_dir_path_w[MAX_PATH + 1] = { L'\0' };
+    wchar_t temp_file_path_w[MAX_PATH + 1] = { L'\0' };
 
-    ::GetTempPathA(sizeof(temp_dir_path), temp_dir_path);
-    const UINT success = ::GetTempFileNameA(temp_dir_path,
-                                            "gtest_redir",
+    ::GetTempPathW(sizeof(temp_dir_path_w)/sizeof(wchar_t), temp_dir_path_w);
+    // Convert to UTF-8 to support Unicode paths
+    int len = WideCharToMultiByte(CP_UTF8, 0, temp_dir_path_w, -1, NULL, 0, NULL, NULL);
+    std::string temp_dir_path;
+    if (len > 0)
+    {
+        std::vector<char> utf8_buf(len);
+        WideCharToMultiByte(CP_UTF8, 0, temp_dir_path_w, -1, utf8_buf.data(), len, NULL, NULL);
+        temp_dir_path = std::string(utf8_buf.data());
+    }
+    const UINT success = ::GetTempFileNameW(temp_dir_path_w,
+                                            L"gtest_redir",
                                             0,  // Generate unique file name.
-                                            temp_file_path);
-    GTEST_CHECK_(success != 0)
-        << "Unable to create a temporary file in " << temp_dir_path;
-    const int captured_fd = creat(temp_file_path, _S_IREAD | _S_IWRITE);
-    GTEST_CHECK_(captured_fd != -1) << "Unable to open temporary file "
-                                    << temp_file_path;
-    filename_ = temp_file_path;
+                                            temp_file_path_w);
+    // Convert filename back to UTF-8
+    std::string temp_file_path;
+    if (success != 0)
+    {
+        len = WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, NULL, 0, NULL, NULL);
+        if (len > 0)
+        {
+            std::vector<char> utf8_buf(len);
+            WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, utf8_buf.data(), len, NULL, NULL);
+            temp_file_path = std::string(utf8_buf.data());
+        }
+    }
 # else
     // There's no guarantee that a test has write access to the current
     // directory, so we create the temporary file in the /tmp directory


### PR DESCRIPTION
## Summary

Fixes getCacheDirectoryForDownloads and related temp file functions failing when the user home directory contains Unicode characters like C:\\Users\\テスト\\AppData\\Local\\Temp.

## Root Cause

On Windows, OpenCV was using ANSI versions of GetTempPath and GetTempFileName which fail with Unicode paths.

## Fix

Replace with wide-character GetTempPathW plus UTF-8 conversion:

- modules/core/src/utils/filesystem.cpp - getCacheDirectory for cache paths
- modules/core/src/system.cpp - temporary file creation  
- modules/ts/src/ts_gtest.cpp - test stream capture

## Testing

The fix has been verified compiles. Manual testing on Windows with Unicode username required.

## Risk

Low: Uses same output format, just different encoding path. Existing ASCII functionality preserved.

---
Fixes opencv/opencv#21960