### PR TITLE
imgproc(warpAffine): fix signed integer overflow in scalar blockline loops

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2299,8 +2299,8 @@ void warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, 
 #endif
     for (; x1 < bw; x1++)
     {
-        const int X = (X0 + adelta[x1]) >> AB_BITS;
-        const int Y = (Y0 + bdelta[x1]) >> AB_BITS;
+        const int X = (int)(((int64_t)X0 + adelta[x1]) >> AB_BITS);
+        const int Y = (int)(((int64_t)Y0 + bdelta[x1]) >> AB_BITS);
         xy[x1 * 2] = saturate_cast<short>(X);
         xy[x1 * 2 + 1] = saturate_cast<short>(Y);
     }
@@ -2348,8 +2348,8 @@ void warpAffineBlockline(int *adelta, int *bdelta, short* xy, short* alpha, int 
         #endif
         for( ; x1 < bw; x1++ )
         {
-            int X = (X0 + adelta[x1]) >> (AB_BITS - INTER_BITS);
-            int Y = (Y0 + bdelta[x1]) >> (AB_BITS - INTER_BITS);
+            int X = (int)(((int64_t)X0 + adelta[x1]) >> (AB_BITS - INTER_BITS));
+            int Y = (int)(((int64_t)Y0 + bdelta[x1]) >> (AB_BITS - INTER_BITS));
             xy[x1*2] = saturate_cast<short>(X >> INTER_BITS);
             xy[x1*2+1] = saturate_cast<short>(Y >> INTER_BITS);
             alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +


### PR DESCRIPTION
### Summary

A signed integer overflow (undefined behavior) occurs in the scalar fallback loops of `cv::hal::warpAffineBlocklineNN` (line 2302) and `cv::hal::warpAffineBlockline` (line 2351) when the affine transformation matrix contains extreme values.

Both `X0` and `adelta[x1]` can independently saturate to `INT_MIN` via `saturate_cast<int>`. Their subsequent C++ `int` addition then overflows, triggering undefined behavior — a `SIGILL` trap under UBSan / `-fsanitize=undefined`.

### Root Cause

```cpp
// BEFORE (UB)
int X = (X0 + adelta[x1]) >> (AB_BITS - INTER_BITS);
```

Both operands are safe individually (clamped by `saturate_cast<int>`), but their **sum** is not guarded against overflow.

### Fix

Promote the addition to `int64_t` before performing it, then cast the shifted result back to `int`:

```cpp
// AFTER
int X = (int)(((int64_t)X0 + adelta[x1]) >> (AB_BITS - INTER_BITS));
```

This matches the intent of the surrounding SIMD paths which naturally use wrapping 32-bit intrinsics (`v_add` / `_mm256_add_epi32`).

### Affected paths

| Function | File | Line |
|---|---|---|
| `warpAffineBlocklineNN` scalar tail | `modules/imgproc/src/imgwarp.cpp` | 2302 |
| `warpAffineBlockline` scalar tail | `modules/imgproc/src/imgwarp.cpp` | 2351 |

### Minimal reproducer

```cpp
#include <opencv4/opencv2/core.hpp>
#include <opencv4/opencv2/imgproc.hpp>
int main() {
    cv::Mat src(1, 1, CV_16SC1, cv::Scalar(0));
    double M_data[] = { -2097152.0, 0.0, -2097152.0, 0.0, 1.0, 0.0 };
    cv::Mat M(2, 3, CV_64F, M_data);
    cv::Mat dst;
    cv::warpAffine(src, dst, M, cv::Size(2, 1),
                   cv::INTER_CUBIC | cv::WARP_INVERSE_MAP,
                   cv::BORDER_CONSTANT);
    return 0;
}
```

**Crash** (without fix, compiled with `-fsanitize=address,undefined`):
```
modules/imgproc/src/imgwarp.cpp:2351:21: runtime error: signed integer overflow:
  -2147483632 + -2147483648 cannot be represented in type 'int'
```

### Testing

- Verified the original scalar computation triggers `SIGILL` under `-fsanitize-trap=undefined`.
- Verified the patched computation runs cleanly with the same inputs.
- Note: SIMD paths are unaffected (they use wrapping integer intrinsics).
