### PR TITLE
objdetect: add CHARUCO_2 board type with charuco2 detection backend

### DIFF
--- a/apps/interactive-calibration/calibCommon.hpp
+++ b/apps/interactive-calibration/calibCommon.hpp
@@ -84,6 +84,7 @@ namespace calib
         cv::Size boardSizeUnits; // board size in squares, circles, etc.
         int charucoDictName;
         std::string charucoDictFile;
+        int charucoBoardType;
         int calibrationStep;
         float charucoSquareLength, charucoMarkerSize;
         float captureDelay;

--- a/apps/interactive-calibration/frameProcessor.cpp
+++ b/apps/interactive-calibration/frameProcessor.cpp
@@ -289,7 +289,8 @@ CalibProcessor::CalibProcessor(cv::Ptr<calibrationData> data, captureParameters 
             mArucoDictionary = cv::aruco::getPredefinedDictionary(cv::aruco::PredefinedDictionaryType(capParams.charucoDictName));
         }
         mCharucoBoard = cv::makePtr<cv::aruco::CharucoBoard>(cv::Size(mBoardSizeUnits.width, mBoardSizeUnits.height), capParams.charucoSquareLength,
-                                capParams.charucoMarkerSize, mArucoDictionary);
+                                capParams.charucoMarkerSize, mArucoDictionary, cv::noArray(),
+                                static_cast<cv::aruco::CharucoBoardType>(capParams.charucoBoardType));
         detector = cv::makePtr<cv::aruco::CharucoDetector>(cv::aruco::CharucoDetector(*mCharucoBoard, charucoParameters));
         break;
     case CirclesGrid:

--- a/apps/interactive-calibration/main.cpp
+++ b/apps/interactive-calibration/main.cpp
@@ -43,7 +43,7 @@ const char* keys  =
         "{ci       | 0       | Camera id }"
         "{vb       |         | Video I/O back-end. One of: %s }"
         "{flip     | false   | Vertical flip of input frames }"
-        "{t        | circles | Template for calibration (circles, chessboard, dualCircles, charuco, symcircles) }"
+        "{t        | circles | Template for calibration (circles, chessboard, dualCircles, charuco, charuco2, symcircles) }"
         "{sz       | 16.3    | Distance between two nearest centers of circles or squares on calibration board}"
         "{dst      | 295     | Distance between white and black parts of daulCircles template}"
         "{w        |         | Width of template (in corners or circles)}"

--- a/apps/interactive-calibration/parametersController.cpp
+++ b/apps/interactive-calibration/parametersController.cpp
@@ -4,6 +4,7 @@
 
 #include "parametersController.hpp"
 #include <opencv2/objdetect/aruco_dictionary.hpp>
+#include <opencv2/objdetect/aruco_board.hpp>
 #include <opencv2/videoio/registry.hpp>
 #include <iostream>
 
@@ -150,6 +151,7 @@ bool calib::parametersController::loadFromParser(cv::CommandLineParser &parser)
     }
     else if(templateType.find("charuco", 0) == 0) {
         mCapParams.board = ChArUco;
+        mCapParams.charucoBoardType = (templateType == "charuco2") ? cv::aruco::CHARUCO_2 : cv::aruco::CHARUCO_1;
         mCapParams.boardSizeUnits = cv::Size(5, 7);
         mCapParams.charucoDictFile = parser.get<std::string>("fad");
         std::string arucoDictName = parser.get<std::string>("ad");
@@ -180,7 +182,7 @@ bool calib::parametersController::loadFromParser(cv::CommandLineParser &parser)
             return false;
         }
         mCapParams.charucoSquareLength = 200;
-        mCapParams.charucoMarkerSize = 100;
+        mCapParams.charucoMarkerSize = (templateType == "charuco2") ? 200 : 100;
     }
     else {
         std::cerr << "Wrong template name\n";

--- a/modules/objdetect/doc/objdetect.bib
+++ b/modules/objdetect/doc/objdetect.bib
@@ -1,3 +1,11 @@
+@article{charuco2_2026,
+  author  = {R. Mu{\~n}oz-Salinas and F.J. Romero-Ramirez and S. Garrido-Jurado},
+  title   = {{ChArUco2}: Enhanced Calibration Boards with Dual Black-and-White Marker Detection},
+  journal = {SoftwareX},
+  year    = {2026},
+  note    = {Under review}
+}
+
 @article{Aruco2014,
   author = {S. Garrido-Jurado and R. Mu\~noz-Salinas and F.J. Madrid-Cuevas and M.J. Mar\'in-Jim\'enez}
   title = {Automatic generation and detection of highly reliable fiducial markers under occlusion},

--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -136,6 +136,7 @@ public:
  *   squareLength). A size=(W,H) board has W*H markers and (W+1)*(H+1) corner intersections
  *   including border corners. The board origin is at the physical top-left corner of the
  *   top-left marker. Provides better corner detection than CHARUCO_1.
+ *   See @cite charuco2_2026 for the full description of the CHARUCO_2 algorithm.
  *
  * The two types are not interchangeable: they differ in corner count, corner positions, and
  * the coordinate origin, so object points from matchImagePoints() are not directly comparable.
@@ -150,7 +151,7 @@ enum CharucoBoardType{
  *
  * Two layout types are supported, selected via CharucoBoardType:
  * - CHARUCO_1 (default): classic layout, markers inside the white squares.
- * - CHARUCO_2: full-cell layout, each square is entirely a marker.
+ * - CHARUCO_2: full-cell layout, each square is entirely a marker. See @cite charuco2_2026.
  *
  * The benefits of ChArUco boards is that they provide both, ArUco markers versatility and chessboard corner precision,
  * which is important for calibration and pose estimation. The board image can be drawn using generateImage() method.

--- a/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/aruco_board.hpp
@@ -125,33 +125,70 @@ public:
     CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     GridBoard();
 };
+/** @brief Type of ChArUco board layout.
+ *
+ * - **CHARUCO_1** (classic): markers are placed inside the white squares of a chessboard.
+ *   markerLength < squareLength. A size=(W,H) board has W*H squares, (W-1)*(H-1) interior
+ *   chessboard corner intersections, and the board origin is at the outer top-left corner of
+ *   the top-left square (i.e. the first interior corner is at (squareLength, squareLength)).
+ *
+ * - **CHARUCO_2** (full-cell): each square is entirely covered by a marker (markerLength ==
+ *   squareLength). A size=(W,H) board has W*H markers and (W+1)*(H+1) corner intersections
+ *   including border corners. The board origin is at the physical top-left corner of the
+ *   top-left marker. Provides better corner detection than CHARUCO_1.
+ *
+ * The two types are not interchangeable: they differ in corner count, corner positions, and
+ * the coordinate origin, so object points from matchImagePoints() are not directly comparable.
+ */
+enum CharucoBoardType{
+    CHARUCO_1=0,
+    CHARUCO_2=1
+};
 
 /**
- * @brief ChArUco board is a planar chessboard where the markers are placed inside the white squares of a chessboard.
+ * @brief ChArUco board: a chessboard with ArUco markers embedded in its squares.
+ *
+ * Two layout types are supported, selected via CharucoBoardType:
+ * - CHARUCO_1 (default): classic layout, markers inside the white squares.
+ * - CHARUCO_2: full-cell layout, each square is entirely a marker.
  *
  * The benefits of ChArUco boards is that they provide both, ArUco markers versatility and chessboard corner precision,
  * which is important for calibration and pose estimation. The board image can be drawn using generateImage() method.
  */
 class CV_EXPORTS_W_SIMPLE CharucoBoard : public Board {
+    CharucoBoardType type_=CHARUCO_1;//type of board. By default, the original
 public:
     /** @brief CharucoBoard constructor
      *
      * @param size number of chessboard squares in x and y directions
-     * @param squareLength squareLength chessboard square side length (normally in meters)
-     * @param markerLength marker side length (same unit than squareLength)
+     * @param squareLength chessboard square side length (normally in meters)
+     * @param markerLength marker side length (same unit as squareLength). For CHARUCO_1 must be
+     *        less than squareLength. For CHARUCO_2 this parameter is ignored (markerLength == squareLength).
      * @param dictionary dictionary of markers indicating the type of markers
-     * @param ids array of id used markers
-     * The first markers in the dictionary are used to fill the white chessboard squares.
+     * @param ids array of marker ids to use; if empty, the first size.width*size.height ids are used
+     * @param type board layout: CHARUCO_1 (classic, default) or CHARUCO_2 (full-cell).
+     *        See CharucoBoardType for a description of both layouts.
      */
     CV_WRAP CharucoBoard(const Size& size, float squareLength, float markerLength,
-                         const Dictionary &dictionary, InputArray ids = noArray());
+                         const Dictionary &dictionary, InputArray ids = noArray(), CharucoBoardType type=CHARUCO_1);
 
-    /** @brief set legacy chessboard pattern.
+    /** @brief CharucoBoard constructor for CHARUCO_2 layout.
+     *
+     * Convenience constructor that creates a CHARUCO_2 board (full-cell markers, markerLength == squareLength).
+     *
+     * @param size number of chessboard squares in x and y directions
+     * @param squareLength chessboard square side length (normally in meters); equals the marker side length
+     * @param dictionary dictionary of markers indicating the type of markers
+     */
+    CV_WRAP CharucoBoard(const Size& size, float squareLength, const Dictionary &dictionary);
+
+    /** @brief set legacy chessboard pattern (CHARUCO_1 only).
      *
      * Legacy setting creates chessboard patterns starting with a white box in the upper left corner
      * if there is an even row count of chessboard boxes, otherwise it starts with a black box.
      * This setting ensures compatibility to patterns created with OpenCV versions prior OpenCV 4.6.0.
      * See https://github.com/opencv/opencv/issues/23152.
+     * Not supported for CHARUCO_2 boards; calling on a CHARUCO_2 board throws cv::Error::StsNotImplemented.
      *
      * Default value: false.
      */
@@ -162,15 +199,24 @@ public:
     CV_WRAP float getSquareLength() const;
     CV_WRAP float getMarkerLength() const;
 
-    /** @brief get CharucoBoard::chessboardCorners
+    /** @brief get the 3D positions of the chessboard corner intersections.
+     *
+     * For CHARUCO_1: returns the (squaresX-1)*(squaresY-1) interior corners, origin at the
+     * outer top-left corner of the board, Y increasing downward.
+     *
+     * For CHARUCO_2: returns the (squaresX+1)*(squaresY+1) corner intersections including
+     * border corners, origin at the physical top-left corner of the top-left marker, Y
+     * increasing downward.
      */
     CV_WRAP std::vector<Point3f> getChessboardCorners() const;
 
-    /** @brief get CharucoBoard::nearestMarkerIdx, for each charuco corner, nearest marker index in ids array
+    /** @brief get CharucoBoard::nearestMarkerIdx, for each charuco corner, nearest marker index in ids array.
+     * Only meaningful for CHARUCO_1 boards; returns an empty vector for CHARUCO_2.
      */
     CV_PROP std::vector<std::vector<int> > getNearestMarkerIdx() const;
 
-    /** @brief get CharucoBoard::nearestMarkerCorners, for each charuco corner, nearest marker corner id of each marker
+    /** @brief get CharucoBoard::nearestMarkerCorners, for each charuco corner, nearest marker corner id of each marker.
+     * Only meaningful for CHARUCO_1 boards; returns an empty vector for CHARUCO_2.
      */
     CV_PROP std::vector<std::vector<int> > getNearestMarkerCorners() const;
 
@@ -186,6 +232,12 @@ public:
      * for number of charucoIDs <= 2,the function returns true.
      */
     CV_WRAP bool checkCharucoCornersCollinear(InputArray charucoIds) const;
+
+
+    /**
+     * @brief getType indicates the type of board
+     */
+    CV_WRAP CharucoBoardType getType()const;
 
     CV_DEPRECATED_EXTERNAL  // avoid using in C++ code, will be moved to "protected" (need to fix bindings first)
     CharucoBoard();

--- a/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
@@ -39,9 +39,9 @@ public:
     /** @brief Basic CharucoDetector constructor
      *
      * @param board ChAruco board
-     * @param charucoParams charuco detection parameters
-     * @param detectorParams marker detection parameters
-     * @param refineParams marker refine detection parameters
+     * @param charucoParams charuco detection parameters (used only for CHARUCO_1; ignored for CHARUCO_2)
+     * @param detectorParams marker detection parameters (used only for CHARUCO_1; ignored for CHARUCO_2)
+     * @param refineParams marker refine detection parameters (used only for CHARUCO_1; ignored for CHARUCO_2)
      */
     CV_WRAP CharucoDetector(const CharucoBoard& board,
                             const CharucoParameters& charucoParams = CharucoParameters(),
@@ -61,24 +61,23 @@ public:
     CV_WRAP void setRefineParameters(const RefineParameters& refineParameters);
 
     /**
-     * @brief detect aruco markers and interpolate position of ChArUco board corners
-     * @param image input image necessary for corner refinement. Note that markers are not detected and
-     * should be sent in corners and ids parameters.
+     * @brief detect ArUco markers and interpolate position of ChArUco board corners
+     * @param image input image.
      * @param charucoCorners interpolated chessboard corners.
      * @param charucoIds interpolated chessboard corners identifiers.
      * @param markerCorners vector of already detected markers corners. For each marker, its four
      * corners are provided, (e.g std::vector<std::vector<cv::Point2f> > ). For N detected markers, the
      * dimensions of this array should be Nx4. The order of the corners should be clockwise.
-     * If markerCorners and markerCorners are empty, the function detect aruco markers and ids.
+     * Used only for CHARUCO_1; for CHARUCO_2 all markers are always detected internally and this
+     * parameter is ignored. If empty (CHARUCO_1 only), the function detects aruco markers automatically.
      * @param markerIds list of identifiers for each marker in corners.
-     *  If markerCorners and markerCorners are empty, the function detect aruco markers and ids.
+     * Used only for CHARUCO_1; ignored for CHARUCO_2.
+     * If empty (CHARUCO_1 only), the function detects aruco markers automatically.
      *
-     * This function receives the detected markers and returns the 2D position of the chessboard corners
-     * from a ChArUco board using the detected Aruco markers.
-     *
-     * If markerCorners and markerCorners are empty, the detectMarkers() will run and detect aruco markers and ids.
-     *
-     * If camera parameters are provided, the process is based in an approximated pose estimation, else it is based on local homography.
+     * This function returns the 2D position of the chessboard corners from a ChArUco board.
+     * For CHARUCO_1, detection can optionally be seeded with pre-detected marker corners; if camera
+     * parameters are provided the process uses an approximated pose estimation, otherwise local
+     * homography. For CHARUCO_2, markers are always detected internally from the image.
      * Only visible corners are returned. For each corner, its corresponding identifier is also returned in charucoIds.
      * @sa findChessboardCorners
      * @note After OpenCV 4.6.0, there was an incompatible change in the ChArUco pattern generation algorithm for even row counts.
@@ -93,28 +92,34 @@ public:
      * @brief Detect ChArUco Diamond markers
      *
      * @param image input image necessary for corner subpixel.
-     * @param diamondCorners output list of detected diamond corners (4 corners per diamond). The order
-     * is the same than in marker corners: top left, top right, bottom right and bottom left. Similar
-     * format than the corners returned by detectMarkers (e.g std::vector<std::vector<cv::Point2f> > ).
-     * @param diamondIds ids of the diamonds in diamondCorners. The id of each diamond is in fact of
-     * type Vec4i, so each diamond has 4 ids, which are the ids of the aruco markers composing the
-     * diamond.
-     * @param markerCorners list of detected marker corners from detectMarkers function.
-     * If markerCorners and markerCorners are empty, the function detect aruco markers and ids.
-     * @param markerIds list of marker ids in markerCorners.
-     * If markerCorners and markerCorners are empty, the function detect aruco markers and ids.
+     * @param diamondCorners output list of detected diamond corners per diamond. The format depends
+     * on the board type:
+     * - CHARUCO_1: 4 corners per diamond (the interior chessboard intersections), ordered
+     *   top-left, top-right, bottom-right, bottom-left.
+     * - CHARUCO_2: 9 corners per diamond (the full 3x3 grid of corner intersections of the
+     *   2x2 marker board), in row-major order from top-left to bottom-right.
+     * @param diamondIds ids of the diamonds in diamondCorners. The id of each diamond is of
+     * type Vec4i, containing the ids of the four ArUco markers composing the diamond.
+     * @param markerCorners list of detected marker corners. Used only for CHARUCO_1; for CHARUCO_2
+     * all markers are always detected internally and this parameter is ignored.
+     * If empty (CHARUCO_1 only), the function detects aruco markers automatically.
+     * @param markerIds list of marker ids in markerCorners. Used only for CHARUCO_1; ignored for CHARUCO_2.
+     * If empty (CHARUCO_1 only), the function detects aruco markers automatically.
      *
-     * This function detects Diamond markers from the previous detected ArUco markers. The diamonds
-     * are returned in the diamondCorners and diamondIds parameters. If camera calibration parameters
-     * are provided, the diamond search is based on reprojection. If not, diamond search is based on
-     * homography. Homography is faster than reprojection, but less accurate.
+     * This function detects Diamond markers. For CHARUCO_1, the detector board must be of size (3,3)
+     * and detection can be seeded with pre-detected marker corners. For CHARUCO_2, a 2x2 board is
+     * used and all markers are detected internally from the image.
+     * The two types produce different corner counts and coordinate origins; see CharucoBoardType.
      */
     CV_WRAP void detectDiamonds(InputArray image, OutputArrayOfArrays diamondCorners, OutputArray diamondIds,
                                 InputOutputArrayOfArrays markerCorners = noArray(),
                                 InputOutputArray markerIds = noArray()) const;
 protected:
-    struct CharucoDetectorImpl;
-    Ptr<CharucoDetectorImpl> charucoDetectorImpl;
+    struct CharucoBaseDetectorImpl;
+    Ptr<CharucoBaseDetectorImpl> charucoDetectorImpl;
+    friend struct Charuco1DetectorImpl;
+    friend struct Charuco2DetectorImpl;
+
 };
 
 /**
@@ -137,8 +142,8 @@ CV_EXPORTS_W void drawDetectedCornersCharuco(InputOutputArray image, InputArray 
  * @param image input/output image. It must have 1 or 3 channels. The number of channels is not
  * altered.
  * @param diamondCorners positions of diamond corners in the same format returned by
- * detectCharucoDiamond(). (e.g std::vector<std::vector<cv::Point2f> > ). For N detected markers,
- * the dimensions of this array should be Nx4. The order of the corners should be clockwise.
+ * detectDiamonds(). (e.g std::vector<std::vector<cv::Point2f> > ). For N detected diamonds,
+ * each entry has 4 corners (CHARUCO_1) or 9 corners (CHARUCO_2).
  * @param diamondIds vector of identifiers for diamonds in diamondCorners, in the same format
  * returned by detectCharucoDiamond() (e.g. std::vector<Vec4i>).
  * Optional, if not provided, ids are not painted.

--- a/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/charuco_detector.hpp
@@ -34,6 +34,11 @@ struct CV_EXPORTS_W_SIMPLE CharucoParameters {
     CV_PROP_RW bool checkMarkers;
 };
 
+/** @brief Detects ChArUco board corners and diamond markers.
+ *
+ * Supports both CHARUCO_1 (classic) and CHARUCO_2 (full-cell) board layouts.
+ * For the CHARUCO_2 detection algorithm see @cite charuco2_2026.
+ */
 class CV_EXPORTS_W CharucoDetector : public Algorithm {
 public:
     /** @brief Basic CharucoDetector constructor

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -8,7 +8,7 @@
 
 #include <opencv2/objdetect/aruco_dictionary.hpp>
 #include <numeric>
-
+#include "charuco2.h"
 namespace cv {
 namespace aruco {
 using namespace std;
@@ -290,16 +290,12 @@ float GridBoard::getMarkerSeparation() const {
     CV_Assert(impl);
     return static_pointer_cast<GridBoardImpl>(impl)->markerSeparation;
 }
+struct CharucoBoardBaseImpl : Board::Impl {
 
-struct CharucoBoardImpl : Board::Impl {
-    CharucoBoardImpl(const Dictionary& _dictionary, const Size& _size, float _squareLength, float _markerLength):
-        Board::Impl(_dictionary),
+   explicit CharucoBoardBaseImpl(const Dictionary& _dictionary, const Size& _size, float _squareLength, float _markerLength):  Board::Impl(_dictionary),
         size(_size),
         squareLength(_squareLength),
-        markerLength(_markerLength),
-        legacyPattern(false)
-    {}
-
+        markerLength(_markerLength) {}
     // chessboard size
     Size size;
 
@@ -309,18 +305,30 @@ struct CharucoBoardImpl : Board::Impl {
     // Physical marker side length (normally in meters)
     float markerLength;
 
+    // vector of chessboard 3D corners precalculated
+    std::vector<Point3f> chessboardCorners;
+
+    virtual void createCharucoBoard(){}
+
+};
+struct CharucoBoard1Impl : CharucoBoardBaseImpl {
+    CharucoBoard1Impl(const Dictionary& _dictionary, const Size& _size, float _squareLength, float _markerLength):
+        CharucoBoardBaseImpl(_dictionary, _size, _squareLength, _markerLength),
+        legacyPattern(false)
+    {}
+
+
+
     // set pre4.6.0 chessboard pattern behavior (even row count patterns have a white box in the upper left corner)
     bool legacyPattern;
 
-    // vector of chessboard 3D corners precalculated
-    std::vector<Point3f> chessboardCorners;
 
     // for each charuco corner, nearest marker index in ids array
     std::vector<std::vector<int> > nearestMarkerIdx;
     // for each charuco corner, nearest marker corner id of each marker
     std::vector<std::vector<int> > nearestMarkerCorners;
 
-    void createCharucoBoard();
+    void createCharucoBoard()override;
     void calcNearestMarkerCorners();
 
     void matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
@@ -329,7 +337,8 @@ struct CharucoBoardImpl : Board::Impl {
     void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const override;
 };
 
-void CharucoBoardImpl::createCharucoBoard() {
+
+void CharucoBoard1Impl::createCharucoBoard() {
     float diffSquareMarkerLength = (squareLength - markerLength) / 2;
     int totalMarkers = (int)(ids.size());
     // calculate Board objPoints
@@ -376,7 +385,7 @@ void CharucoBoardImpl::createCharucoBoard() {
 }
 
 /** Fill nearestMarkerIdx and nearestMarkerCorners arrays */
-void CharucoBoardImpl::calcNearestMarkerCorners() {
+void CharucoBoard1Impl::calcNearestMarkerCorners() {
     nearestMarkerIdx.clear();
     nearestMarkerCorners.clear();
     nearestMarkerIdx.resize(chessboardCorners.size());
@@ -426,7 +435,7 @@ void CharucoBoardImpl::calcNearestMarkerCorners() {
     }
 }
 
-void CharucoBoardImpl::matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
+void CharucoBoard1Impl::matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
                                         OutputArray outObjPoints, OutputArray outImgPoints) const {
     CV_CheckEQ(detectedIds.total(), detectedCharuco.total(), "Number of corners and ids must be equal");
     CV_Assert(detectedIds.total() > 0ull);
@@ -464,7 +473,7 @@ void CharucoBoardImpl::matchImagePoints(InputArrayOfArrays detectedCharuco, Inpu
     Mat(imgPnts).copyTo(outImgPoints);
 }
 
-void CharucoBoardImpl::generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const {
+void CharucoBoard1Impl::generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const {
     CV_Assert(!outSize.empty());
     CV_Assert(marginSize >= 0);
 
@@ -533,52 +542,120 @@ void CharucoBoardImpl::generateImage(Size outSize, OutputArray img, int marginSi
         }
     }
 }
+struct CharucoBoard2Impl : CharucoBoardBaseImpl {
+    CharucoBoard2 board2;
 
+    CharucoBoard2Impl(const Dictionary& _dictionary, const Size& _size, float _squareLength, float _markerLength):
+        CharucoBoardBaseImpl(_dictionary, _size, _squareLength, _markerLength)
+    {}
+
+    void createCharucoBoard() override;
+    void matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
+                          OutputArray objPoints, OutputArray imgPoints) const override;
+    void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const override;
+};
+
+void CharucoBoard2Impl::createCharucoBoard() {
+    if (ids.empty())
+        board2 = CharucoBoard2(size, squareLength, 0.f, dictionary);
+    else
+        board2 = CharucoBoard2(size, squareLength, 0.f, dictionary, cv::Mat(ids));
+    ids = board2.ids;
+
+    chessboardCorners.clear();
+    for (int row = 0; row <= size.height; row++)
+        for (int col = 0; col <= size.width; col++)
+            chessboardCorners.push_back(Point3f(col * squareLength, row * squareLength, 0.f));
+
+    objPoints.clear();
+    for (int row = 0; row < size.height; row++) {
+        for (int col = 0; col < size.width; col++) {
+            vector<Point3f> corners(4);
+            corners[0] = Point3f(col * squareLength,       row * squareLength,       0.f);
+            corners[1] = corners[0] + Point3f(squareLength, 0.f,          0.f);
+            corners[2] = corners[0] + Point3f(squareLength, squareLength, 0.f);
+            corners[3] = corners[0] + Point3f(0.f,          squareLength, 0.f);
+            objPoints.push_back(corners);
+        }
+    }
+    rightBottomBorder = Point3f(size.width * squareLength, size.height * squareLength, 0.f);
+}
+
+void CharucoBoard2Impl::matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
+                                         OutputArray objPoints, OutputArray imgPoints) const {
+    board2.matchImagePoints(detectedCharuco, detectedIds, objPoints, imgPoints);
+}
+
+void CharucoBoard2Impl::generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const {
+    cv::Mat mat;
+    board2.generateImage(outSize, mat, marginSize, borderBits);
+    mat.copyTo(img);
+}
 CharucoBoard::CharucoBoard(){}
 
 CharucoBoard::CharucoBoard(const Size& size, float squareLength, float markerLength,
-                           const Dictionary &dictionary, InputArray ids):
-    Board(new CharucoBoardImpl(dictionary, size, squareLength, markerLength)) {
+                           const Dictionary &dictionary, InputArray ids,CharucoBoardType type):
+    Board(  (type==CHARUCO_1? static_cast<Board::Impl*>(new CharucoBoard1Impl(dictionary, size, squareLength, markerLength)):
+                static_cast<Board::Impl*>(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength))) ){
 
-    CV_Assert(size.width > 1 && size.height > 1 && markerLength > 0 && squareLength > markerLength);
-    float onePin = markerLength / ((float)(dictionary.markerSize+2));
-    float markerSeparation = (squareLength - markerLength)/2.f;
-    if (markerSeparation < onePin*.7f) {
-        CV_LOG_WARNING(NULL, "Marker border " << markerSeparation << " is less than 70% of ArUco pin size "
-            << onePin <<". Please increase markerSeparation or decrease markerLength for stable board detection");
+    type_=type;
+    CV_Assert(size.width > 1 && size.height > 1 );
+    if(type==CHARUCO_1)
+        CV_Assert(markerLength > 0  && squareLength > markerLength);
+
+    if(type==CHARUCO_1) {
+        float onePin = markerLength / ((float)(dictionary.markerSize+2));
+        float markerSeparation = (squareLength - markerLength)/2.f;
+        if (markerSeparation < onePin*.7f) {
+            CV_LOG_WARNING(NULL, "Marker border " << markerSeparation << " is less than 70% of ArUco pin size "
+                << onePin <<". Please increase markerSeparation or decrease markerLength for stable board detection");
+        }
     }
     ids.copyTo(impl->ids);
 
-    static_pointer_cast<CharucoBoardImpl>(impl)->createCharucoBoard();
+    static_pointer_cast<CharucoBoardBaseImpl>(impl)->createCharucoBoard();
+}
+
+CharucoBoard::CharucoBoard(const Size& size, float squareLength,
+                           const Dictionary &dictionary):
+    Board(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength) ){
+
+    CV_Assert(size.width > 1 && size.height > 1 );
+    type_=CHARUCO_2;
+    static_pointer_cast<CharucoBoardBaseImpl>(impl)->createCharucoBoard();
 }
 
 Size CharucoBoard::getChessboardSize() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->size;
+    return static_pointer_cast<CharucoBoardBaseImpl>(impl)->size;
 }
 
 float CharucoBoard::getSquareLength() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->squareLength;
+    return static_pointer_cast<CharucoBoardBaseImpl>(impl)->squareLength;
 }
 
 float CharucoBoard::getMarkerLength() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->markerLength;
+    return static_pointer_cast<CharucoBoardBaseImpl>(impl)->markerLength;
 }
 
 void CharucoBoard::setLegacyPattern(bool legacyPattern) {
     CV_Assert(impl);
-    if (static_pointer_cast<CharucoBoardImpl>(impl)->legacyPattern != legacyPattern)
+    if (type_ != CHARUCO_1)
+        CV_Error(cv::Error::StsNotImplemented, "setLegacyPattern is only supported for CHARUCO_1 boards");
+    if (static_pointer_cast<CharucoBoard1Impl>(impl)->legacyPattern != legacyPattern)
     {
-        static_pointer_cast<CharucoBoardImpl>(impl)->legacyPattern = legacyPattern;
-        static_pointer_cast<CharucoBoardImpl>(impl)->createCharucoBoard();
+        static_pointer_cast<CharucoBoard1Impl>(impl)->legacyPattern = legacyPattern;
+        static_pointer_cast<CharucoBoard1Impl>(impl)->createCharucoBoard();
     }
 }
 
 bool CharucoBoard::getLegacyPattern() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->legacyPattern;
+    if (type_ != CHARUCO_1)
+        CV_Error(cv::Error::StsNotImplemented, "getLegacyPattern is only supported for CHARUCO_1 boards");
+    return static_pointer_cast<CharucoBoard1Impl>(impl)->legacyPattern;
 }
 
 bool CharucoBoard::checkCharucoCornersCollinear(InputArray charucoIds) const {
@@ -590,7 +667,7 @@ bool CharucoBoard::checkCharucoCornersCollinear(InputArray charucoIds) const {
         return true;
 
     // only test if there are 3 or more corners
-    auto board = static_pointer_cast<CharucoBoardImpl>(impl);
+    auto board = static_pointer_cast<CharucoBoardBaseImpl>(impl);
     CV_Assert(board->chessboardCorners.size() >= charucoIdsMat.total());
 
     Vec<double, 3> point0(board->chessboardCorners[charucoIdsMat.at<int>(0)].x,
@@ -625,19 +702,28 @@ bool CharucoBoard::checkCharucoCornersCollinear(InputArray charucoIds) const {
     return true;
 }
 
+CharucoBoardType CharucoBoard::getType() const
+{
+    return type_;
+}
+
 std::vector<Point3f> CharucoBoard::getChessboardCorners() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->chessboardCorners;
+    return static_pointer_cast<CharucoBoardBaseImpl>(impl)->chessboardCorners;
 }
 
 std::vector<std::vector<int> > CharucoBoard::getNearestMarkerIdx() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerIdx;
+    if (type_ != CHARUCO_1)
+        return {};
+    return static_pointer_cast<CharucoBoard1Impl>(impl)->nearestMarkerIdx;
 }
 
 std::vector<std::vector<int> > CharucoBoard::getNearestMarkerCorners() const {
     CV_Assert(impl);
-    return static_pointer_cast<CharucoBoardImpl>(impl)->nearestMarkerCorners;
+    if (type_ != CHARUCO_1)
+        return {};
+    return static_pointer_cast<CharucoBoard1Impl>(impl)->nearestMarkerCorners;
 }
 
 }

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -328,13 +328,13 @@ struct CharucoBoard1Impl : CharucoBoardBaseImpl {
     // for each charuco corner, nearest marker corner id of each marker
     std::vector<std::vector<int> > nearestMarkerCorners;
 
-    void createCharucoBoard()override;
+    void createCharucoBoard() CV_OVERRIDE;
     void calcNearestMarkerCorners();
 
     void matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
-                          OutputArray objPoints, OutputArray imgPoints) const override;
+                          OutputArray objPoints, OutputArray imgPoints) const CV_OVERRIDE;
 
-    void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const override;
+    void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const CV_OVERRIDE;
 };
 
 
@@ -549,10 +549,10 @@ struct CharucoBoard2Impl : CharucoBoardBaseImpl {
         CharucoBoardBaseImpl(_dictionary, _size, _squareLength, _markerLength)
     {}
 
-    void createCharucoBoard() override;
+    void createCharucoBoard() CV_OVERRIDE;
     void matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
-                          OutputArray objPoints, OutputArray imgPoints) const override;
-    void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const override;
+                          OutputArray objPoints, OutputArray imgPoints) const CV_OVERRIDE;
+    void generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const CV_OVERRIDE;
 };
 
 void CharucoBoard2Impl::createCharucoBoard() {
@@ -591,14 +591,15 @@ void CharucoBoard2Impl::generateImage(Size outSize, OutputArray img, int marginS
     board2.generateImage(outSize, mat, marginSize, borderBits);
     mat.copyTo(img);
 }
-CharucoBoard::CharucoBoard(){}
+CharucoBoard::CharucoBoard() : type_(CHARUCO_1) {}
 
 CharucoBoard::CharucoBoard(const Size& size, float squareLength, float markerLength,
-                           const Dictionary &dictionary, InputArray ids,CharucoBoardType type):
+                           const Dictionary &dictionary, InputArray ids, CharucoBoardType type):
     Board(  (type==CHARUCO_1? static_cast<Board::Impl*>(new CharucoBoard1Impl(dictionary, size, squareLength, markerLength)):
-                static_cast<Board::Impl*>(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength))) ){
+                static_cast<Board::Impl*>(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength))) ),
+    type_(type)
+{
 
-    type_=type;
     CV_Assert(size.width > 1 && size.height > 1 );
     if(type==CHARUCO_1)
         CV_Assert(markerLength > 0  && squareLength > markerLength);
@@ -618,10 +619,11 @@ CharucoBoard::CharucoBoard(const Size& size, float squareLength, float markerLen
 
 CharucoBoard::CharucoBoard(const Size& size, float squareLength,
                            const Dictionary &dictionary):
-    Board(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength) ){
+    Board(new CharucoBoard2Impl(dictionary, size, squareLength, squareLength) ),
+    type_(CHARUCO_2)
+{
 
     CV_Assert(size.width > 1 && size.height > 1 );
-    type_=CHARUCO_2;
     static_pointer_cast<CharucoBoardBaseImpl>(impl)->createCharucoBoard();
 }
 

--- a/modules/objdetect/src/aruco/aruco_board.cpp
+++ b/modules/objdetect/src/aruco/aruco_board.cpp
@@ -581,9 +581,9 @@ void CharucoBoard2Impl::createCharucoBoard() {
     rightBottomBorder = Point3f(size.width * squareLength, size.height * squareLength, 0.f);
 }
 
-void CharucoBoard2Impl::matchImagePoints(InputArrayOfArrays detectedCharuco, InputArray detectedIds,
-                                         OutputArray objPoints, OutputArray imgPoints) const {
-    board2.matchImagePoints(detectedCharuco, detectedIds, objPoints, imgPoints);
+void CharucoBoard2Impl::matchImagePoints(InputArrayOfArrays detectedCharuco_, InputArray detectedIds_,
+                                         OutputArray objPoints_, OutputArray imgPoints_) const {
+    board2.matchImagePoints(detectedCharuco_, detectedIds_, objPoints_, imgPoints_);
 }
 
 void CharucoBoard2Impl::generateImage(Size outSize, OutputArray img, int marginSize, int borderBits) const {

--- a/modules/objdetect/src/aruco/charuco2.cpp
+++ b/modules/objdetect/src/aruco/charuco2.cpp
@@ -1,0 +1,1344 @@
+#include "charuco2.h"
+#include "opencv2/core/hal/intrin.hpp"
+#include "opencv2/core/utils/logger.hpp"
+#include "opencv2/imgproc.hpp"
+#include "opencv2/flann.hpp"
+#include <map>
+#include <queue>
+
+namespace     {
+/**
+ * @brief The Marker class is a marker detectable by the library
+ * It is a vector where each corner is a corner of the detected marker
+ */
+class Marker : public std::vector<cv::Point2f>
+{
+public:
+    // id of  the marker
+    int id=-1;
+    //id of the dict
+    int dict=-1;
+    //max distance between any two similar corners
+    int cornerMaxDistance(const Marker &m2);
+};
+struct DetectorParameters {
+    int boxFilterSize=15,thres=3; //values for adaptive thresholding
+    int minSize=10;//minimum size of a contour side to be considered as a marker candidate
+    int maxAttemptsPerCandidate=5;//number of attempts to identify a candidate by slightly altering the corners
+    std::vector<cv::aruco::Dictionary> dicts= {cv::aruco::getPredefinedDictionary(cv::aruco::DICT_ARUCO_MIP_36h12)};
+    // [0,1] ; maximum number of times a contour can revisit any of its pixels (1 is the minimum which is the starting point)
+    //if you set a high value (std::numeric_limits<int>::max()) the algorithm behaves as the normal moore contour tracer
+    float maxTimesRevisited=0.05; //1 equals tradional algo,
+    /// number of bits of the marker border, i.e. marker border width (default 1).
+    float  markerBorderBits=1; //i do not see this useful. all dicts have 1 border bit but its used in opencv  aruco and I keep it here
+    double errorCorrectionRate=0;//The default 0.6 value in aruco opencv is very dangerous. It causes many false positives.
+    double maxErroneousBitsInBorderRate=0;//maximum rate of erroneous bits in the border. Default 0 means no error allowed.
+    bool detectInvertedMarker=false;//if the markers are printed in white over black background
+};
+/** @brief The MarkerDetector class is detecting the markers in the image passed */
+class MarkerDetector{
+public:
+    // The only function you need to call
+    static inline std::vector<Marker> detect(const cv::Mat &img, const DetectorParameters &params=DetectorParameters(),std::vector<Marker> *candidatesOut=nullptr,cv::Mat thresImage=cv::Mat());
+private:
+    static inline Marker sort( const  Marker &marker);
+    static inline float  getSubpixelValue(const cv::Mat &im_grey,const cv::Point2f &p);
+    static inline int   getMarkerId(  cv::Mat  candidateBits,int &idx, int &nrotations, const DetectorParameters &params,int dictIndex);
+    static inline int isInto(const std::vector<cv::Point2f> &a, const std::vector<cv::Point2f> &b) ;
+    static std::vector<std::vector<cv::Point>> visitedAwareTracingContour(cv::Mat &padded, size_t minSize = 1,float maxRevisited=0.1) ;
+    static int getBorderErrors(const cv::Mat &bits, int markerSize, int borderSize) ;
+    static void thres255Adaptive(cv::Mat &in,cv::Mat &out,int off=2,int thres=5);
+    static bool isAInnerMarker(const cv::Mat &grey,const Marker &m);
+};
+struct Homographer{
+    Homographer(const std::vector<cv::Point2f> & out ){
+        std::vector<cv::Point2f>  in={cv::Point2f(0,0),cv::Point2f(1,0),cv::Point2f(1,1),cv::Point2f(0,1)};
+        H=cv::getPerspectiveTransform(in, out);
+    }
+    cv::Point2f operator()(const cv::Point2f &p){
+        double *m=H.ptr<double>(0);
+        double c=m[6]*p.x+m[7]*p.y+m[8];
+        return cv::Point2f((m[0]*p.x+m[1]*p.y+m[2])/c,(m[3]*p.x+m[4]*p.y+m[5])/c);
+    }
+    cv::Mat H;
+};
+
+int Marker::cornerMaxDistance(const Marker &m2)
+{
+    int md=0;
+    for(int i=0;i<4;i++){
+        int d=int(((*this)[i].x-m2[i].x)*((*this)[i].x-m2[i].x)+((*this)[i].y-m2[i].y)*((*this)[i].y-m2[i].y));
+        if(d>md) md=d;
+    }
+    return md;
+}
+
+
+//Marker intersection. Tells the marker with most corners into another. 0 if no intersection or tie
+int MarkerDetector::isInto(const std::vector<cv::Point2f> &a, const std::vector<cv::Point2f> &b) {
+    // Lambda for point-in-polygon test (Ray Casting)
+    auto countInside = [](const std::vector<cv::Point2f>& source, const std::vector<cv::Point2f>& target) -> int {
+        int count = 0;
+        for (const auto& pt : source) {
+            bool inside = false;
+            // Fixed 4-side loop logic
+            for (int i = 0, j = 3; i < 4; j = i++) {
+                if (((target[i].y > pt.y) != (target[j].y > pt.y)) &&
+                    (pt.x < (target[j].x - target[i].x) * (pt.y - target[i].y) / (target[j].y - target[i].y) + target[i].x)) {
+                    inside = !inside;
+                }
+            }
+            if (inside) count++;
+        }
+        return count;
+    };
+    // Count how many corners of A are in B
+    int aInB = countInside(a, b);
+    // Count how many corners of B are in A
+    int bInA = countInside(b, a);
+    // Rule 1: Must contain at least one corner
+    if (aInB == 0 && bInA == 0) return 0;
+    // Rule 2: Compare counts
+    if (aInB > bInA) return 1;
+    if (bInA > aInB) return 2;
+    // Default: Tie or no relative dominance
+    return 0;
+}
+
+std::vector<Marker>  MarkerDetector::detect(const cv::Mat &img, const DetectorParameters &params,std::vector<Marker> *candidatesOut,cv::Mat ThresImIn){
+    cv::Mat greyimage,thresImage;
+    std::vector<Marker> DetectedMarkers;
+    //first, convert to bw
+    if(img.channels()==3)
+        cv::cvtColor(img,greyimage,cv::COLOR_BGR2GRAY);
+    else greyimage=img;
+    /////////////////// Adaptive Threshold to detect border
+    //this method achieves a ~1.5 speed up
+    if(ThresImIn.empty()){
+        cv::boxFilter( greyimage, thresImage, greyimage.type(), cv::Size(params.boxFilterSize, params.boxFilterSize),cv::Point(-1,-1), true, cv::BORDER_REPLICATE|cv::BORDER_ISOLATED );
+        thresImage=thresImage-greyimage;
+        cv::threshold(thresImage, thresImage, params.thres, 255, cv::THRESH_BINARY);
+    }
+    else{
+        thresImage=ThresImIn;
+    }
+    /////////////////// compute marker candidates by detecting contours
+    std::vector<std::vector<cv::Point>> contours;
+    std::vector<cv::Point> approxCurve;
+    cv::RNG rand;
+    int  minSizeSq=params.minSize*params.minSize,minSize4=4*params.minSize;
+    contours=visitedAwareTracingContour(thresImage,minSize4,params.maxTimesRevisited);
+
+    //decide where to store the candidates. If candidatesOut is not null, store there, otherwise use a local variable
+    std::vector<Marker> candidateslocal;
+    if(candidatesOut!=nullptr) {
+        candidatesOut->clear();
+    }
+    else{
+        candidatesOut=&candidateslocal;
+    }
+    ///////////////// for each contour, approx to a rectangle
+    for (unsigned int i = 0; i < contours.size(); i++)
+    {
+        // can approximate to a convex rect?
+        cv::approxPolyDP(contours[i], approxCurve, double(contours[i].size()) * 0.03, true);
+        if (approxCurve.size() != 4 || !cv::isContourConvex(approxCurve)) continue;
+        //check distance  between corners at least minSize pix
+        if(  ((approxCurve[0].x-approxCurve[1].x)*(approxCurve[0].x-approxCurve[1].x) + (approxCurve[0].y-approxCurve[1].y)*(approxCurve[0].y-approxCurve[1].y))<minSizeSq) continue;
+        if(  ((approxCurve[1].x-approxCurve[2].x)*(approxCurve[1].x-approxCurve[2].x) + (approxCurve[1].y-approxCurve[2].y)*(approxCurve[1].y-approxCurve[2].y))<minSizeSq) continue;
+        if(  ((approxCurve[2].x-approxCurve[3].x)*(approxCurve[2].x-approxCurve[3].x) + (approxCurve[2].y-approxCurve[3].y)*(approxCurve[2].y-approxCurve[3].y))<minSizeSq) continue;
+        if(  ((approxCurve[3].x-approxCurve[0].x)*(approxCurve[3].x-approxCurve[0].x) + (approxCurve[3].y-approxCurve[0].y)*(approxCurve[3].y-approxCurve[0].y))<minSizeSq) continue;
+        // add the points
+        Marker marker;marker.reserve(4);
+        for (int j = 0; j < 4; j++)
+            marker.emplace_back( cv::Point2f( approxCurve[j].x,approxCurve[j].y));
+        //sort corner in clockwise direction
+        marker=sort(marker);
+        //check no point is too close to the border (which may cause error in corner subpix), leave at least 11 pixs
+        bool discardBcTooCloseToBorder=false;
+        for(auto p:marker){
+            if(p.x<11 || p.y<11 || p.x>greyimage.cols-11 || p.y>greyimage.rows-11) {discardBcTooCloseToBorder=true;break;}
+        }
+        if(discardBcTooCloseToBorder) continue;
+        candidatesOut->push_back(marker);
+    }
+    //now, for each candidate check bits inside
+    int dictIndex=-1;
+    for(const auto &dict:params.dicts){
+        std::vector<Marker> currDirMarkerDetected;
+        dictIndex++;
+        cv::Mat bits(dict.markerSize+2,dict.markerSize+2,CV_8UC1),bitadaptive(dict.markerSize+2,dict.markerSize+2,CV_8UC1);
+
+        for(auto it=candidatesOut->begin();it!=candidatesOut->end();){
+            auto marker=*it;
+
+            ////// extract the code. Obtain the intensities of the bits using  homography
+            for(int i=0;i<int(params.maxAttemptsPerCandidate) && marker.id==-1;i++){
+                //if not first attempt, we may wanna produce small random alteration of the corners
+                auto marker2=marker;
+                if( i!=0) for(int c=0;c<4;c++) {marker2[c].x+=rand.gaussian(0.75);marker2[c].y+=rand.gaussian(0.75);}//if not first, alter corner location
+                Homographer hom(marker2);
+                for(int r=0;r<bits.rows;r++){
+                    for(int c=0;c<bits.cols;c++){
+                        bits.at<uchar>(r,c)=uchar(0.5+getSubpixelValue(greyimage,hom(cv::Point2f(  float(c+0.5) / float(bits.cols) ,  float(r+0.5) / float(bits.rows)  ))));
+                    }
+                }
+                if(i==2){ // if not working the first time, try this time adaptive threshold into the bits to improve robustness to lighting
+                    thres255Adaptive(bits,bitadaptive);
+                    bitadaptive.copyTo(bits);
+                }
+                else{
+                    cv::threshold(bits,bits,0,255,cv::THRESH_OTSU);
+                }
+                //now, analyze the inner code to see it if is a marker. If so, rotate to have the points properly sorted
+                int nrotations=0;
+                if(getMarkerId(bits,marker.id,nrotations,params,dictIndex)==0) continue;
+                std::rotate(marker.begin(),marker.begin() + 4 - nrotations,marker.end());
+            }
+            if(marker.id!=-1) {
+                marker.dict=dictIndex;
+                currDirMarkerDetected.push_back(marker);
+                //remove from candidate list
+                it=candidatesOut->erase(it);
+            }
+            else it++;//go to next
+        }
+
+        /// REMOVAL OF INNER DUPLICATED DETECTIONS OF THE SAME MARKER(INNER AND OUTER BORDER)
+        std::sort(currDirMarkerDetected.begin(), currDirMarkerDetected.end(),[](const Marker &a,const Marker &b){return a.id<b.id;});
+        {
+            std::vector<bool> toRemove(currDirMarkerDetected.size(), false);
+            for (int i = 0; i < int(currDirMarkerDetected.size()) - 1; i++)
+            {
+                for (int j = i + 1; j < int(currDirMarkerDetected.size()) && !toRemove[i]; j++)
+                {
+                    if (currDirMarkerDetected[i].id == currDirMarkerDetected[j].id )
+                    {
+                        auto res=isInto(currDirMarkerDetected[i],currDirMarkerDetected[j]);
+                        if( res==1)toRemove[i]=true;
+                        else if( res==2)toRemove[j]=true;
+
+                    }
+                }
+            }
+            //now move to DetectedMarkers these not marked for removal
+            for (unsigned int i = 0; i < currDirMarkerDetected.size(); i++)
+                if (!toRemove[i]) DetectedMarkers.push_back(currDirMarkerDetected[i]);
+        }
+    }
+
+    //we want to remove the markers that are detected only with inner border, and thus are wrong
+    //for that, we will analyze points on both sides along the line between the corners, and remove these for which the
+    // color diff between them is below a threshold
+    for(size_t i=0;i<DetectedMarkers.size();i++){
+        if( isAInnerMarker(greyimage,DetectedMarkers[i])){
+            //swap it with the last one (if not this) and resize
+            if(i!=DetectedMarkers.size()-1) std::swap(DetectedMarkers[i],DetectedMarkers.back());
+            DetectedMarkers.pop_back();
+            i--;//stay in the same index to analyze the swapped one
+
+        }
+    }
+    //no corner subpixel here
+    return DetectedMarkers;//DONE
+}
+/**
+ * @brief Tries to identify one candidate given the dictionary
+ * @return candidate typ. zero if the candidate is not valid,
+ *                           1 if the candidate is a black candidate (default candidate)
+ *                           2 if the candidate is a white candidate
+ */
+int MarkerDetector:: getMarkerId(cv::Mat candidateBits, int &idx, int &nrotations, const DetectorParameters &params,int dictIndex){
+    uint8_t typ=1;
+
+    if(params.detectInvertedMarker ) candidateBits=~candidateBits;
+    // analyze border bits
+    int maximumErrorsInBorder =int(params.dicts[dictIndex].markerSize * params.dicts[dictIndex].markerSize * params.maxErroneousBitsInBorderRate);
+    int borderErrors =getBorderErrors(candidateBits, params.dicts[dictIndex].markerSize, params.markerBorderBits);
+    if(borderErrors > maximumErrorsInBorder) return 0; // border is wrong
+    // take only inner bits
+    int borderBits = static_cast<int>(params.markerBorderBits);
+    cv::Mat onlyBits = candidateBits.rowRange(borderBits, candidateBits.rows - borderBits).colRange(borderBits, candidateBits.cols - borderBits);
+    onlyBits/=255;
+    // try to indentify the marker
+    if(!params.dicts[dictIndex].identify(onlyBits, idx, nrotations, params.errorCorrectionRate))
+        return 0;
+    return typ;
+}
+/**
+  * @brief Return number of erroneous bits in border, i.e. number of white bits in border.
+  */
+int MarkerDetector::getBorderErrors(const cv::Mat &bits, int markerSize, int borderSize) {
+    int sizeWithBorders = markerSize + 2 * borderSize;
+    int totalErrors = 0;
+    for(int y = 0; y < sizeWithBorders; y++) {
+        for(int k = 0; k < borderSize; k++) {
+            if(bits.ptr<unsigned char>(y)[k] != 0) totalErrors++;
+            if(bits.ptr<unsigned char>(y)[sizeWithBorders - 1 - k] != 0) totalErrors++;
+        }
+    }
+    for(int x = borderSize; x < sizeWithBorders - borderSize; x++) {
+        for(int k = 0; k < borderSize; k++) {
+            if(bits.ptr<unsigned char>(k)[x] != 0) totalErrors++;
+            if(bits.ptr<unsigned char>(sizeWithBorders - 1 - k)[x] != 0) totalErrors++;
+        }
+    }
+    return totalErrors;
+}
+float MarkerDetector::getSubpixelValue(const cv::Mat &im_grey, const cv::Point2f &p) {
+    // 1. Get integer coordinates
+    const int ix = static_cast<int>(p.x);
+    const int iy = static_cast<int>(p.y);
+
+
+    //   Boundary Check: Ensure the 2x2 patch is within limits
+    // We check ix+1 and iy+1 because the interpolation looks at the next pixel over.
+    if (ix < 0 || iy < 0 || ix >= im_grey.cols - 1 || iy >= im_grey.rows - 1) {
+        // Option A: Return a default value
+        // Option B: Clamp the point to the nearest valid boundary
+        return 0.0f;
+    }
+
+    // 2. Get fractional parts
+    const float dx = p.x - ix;
+    const float dy = p.y - iy;
+    // 3. Optimized Pointer Access
+    const uchar* ptr = im_grey.ptr<uchar>(iy) + ix;
+    const size_t step = im_grey.step;
+    // 4. Fetch the four pixels immediately as floats
+    const float p00 = static_cast<float>(ptr[0]);        // Top-Left
+    const float p01 = static_cast<float>(ptr[1]);        // Top-Right
+    const float p10 = static_cast<float>(ptr[step]);     // Bottom-Left
+    const float p11 = static_cast<float>(ptr[step + 1]); // Bottom-Right
+    // 5. Separable Interpolation (3 Multiplications total)
+    const float top = p00 + dx * (p01 - p00);// Interpolate Top Row Horizontally
+    const float bot = p10 + dx * (p11 - p10);    // Interpolate Bottom Row Horizontallys
+    // Interpolate Vertically between Top and Bottom results
+    return top + dy * (bot - top);
+}
+Marker  MarkerDetector::sort( const  Marker &marker){
+    Marker res_marker=marker;
+    /// sort the points in anti-clockwise order
+    double dx1 = res_marker[1].x - res_marker[0].x;
+    double dy1 = res_marker[1].y - res_marker[0].y;
+    double dx2 = res_marker[2].x - res_marker[0].x;
+    double dy2 = res_marker[2].y - res_marker[0].y;
+    double o = (dx1 * dy2) - (dy1 * dx2);
+    // if the third point is in the left side, then sort in anti-clockwise order
+    if (o < 0.0)  std::swap(res_marker[1], res_marker[3]);
+    return res_marker;
+}
+/**
+ * @brief Traces the contours of a binary image using our visited aware Tracing algorithm.
+ *
+ * This function scans a binary image (foreground as 255, background as 0) and
+ * finds the external boundaries of all distinct objects.
+ */
+std::vector<std::vector<cv::Point>> MarkerDetector::visitedAwareTracingContour(cv::Mat &padded, size_t minSize, float maxRevisited ) {
+    if (padded.empty() || padded.type() != CV_8UC1) return {};
+    // 1. Fast Initialization and Padding
+    int rows = padded.rows;
+    int cols = padded.cols;
+    int32_t step = padded.step;
+    uchar* data = padded.data;
+    // Fast clear of top and bottom rows
+    memset(data, 0, cols);
+    memset(data + (rows - 1) * step, 0, cols);
+    // Fast clear of left and right columns
+    for (int r = 1; r < rows - 1; ++r) {
+        uchar* row_ptr = data + r * step;
+        row_ptr[0] = 0;
+        row_ptr[cols - 1] = 0;
+    }
+    // 2. Precompute Neighbor Offsets based on image stride This removes the need for Point arithmetic in the loop
+    const int offsets[16]={-1,-step-1,-step,-step+1,1,step+1,step,step-1, -1,-step-1,-step,-step+1,1,step+1,step,step-1, };
+    // Use static tables to avoid initialization overhead on every call // 8-connectivity offsets relative to center (0,0) // Order: W, NW, N, NE, E, SE, S, SW
+    const int dx[8] = { -1, -1,  0,  1, 1, 1, 0, -1 }, dy[8] = {  0, -1, -1, -1, 0, 1, 1,  1 };
+    // Pre-allocate results
+    std::vector<std::vector<cv::Point>> contours;contours.reserve(2048);
+    std::vector<cv::Point> buffer;buffer.reserve(2048);
+    const uchar FOREGROUND = 255, BACKGROUND = 0,VISITED = 100;
+    // 3. Scanning Loop
+    // We iterate using raw pointers for maximum speed
+    int rowStep=1;//std::max(1,int(minSize/6));
+    for (int r = 1; r < rows - 1; r+=rowStep) {
+        uchar* row_ptr = data + r * step;
+        for (int c = 1; c < cols - 1;  ) {
+            ////findStartContourPoint
+            {
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+                cv::v_uint8 v_zero = cv::vx_setzero_u8();
+                for (; c <= cols - cv::VTraits<cv::v_uint8>::vlanes(); c+= cv::VTraits<cv::v_uint8>::vlanes())
+                {
+                    cv::v_uint8 vmask = (cv::v_ne(cv::vx_load((uchar*)(row_ptr + c)), v_zero));
+                    if (v_check_any(vmask))
+                    {
+                        c += v_scan_forward(vmask);
+                        break;
+                    }
+                }
+#endif
+                //process last tail
+                for (; c < cols && !row_ptr[c]; ++c) ;//last tail
+            }
+            if( c==cols) break;//reached end of row
+            if (row_ptr[c] == FOREGROUND ) {// --- 4. Tracing Loop  if is foreground
+                buffer.clear();
+                int curr_x = c, curr_y = r,search_idx = 1 ;
+                uchar* curr_ptr = row_ptr + c,*start_ptr=curr_ptr;
+                size_t ntimesRevisited=0;
+                do {
+                    buffer.emplace_back(curr_x, curr_y);// Add point
+                    *curr_ptr = VISITED;// Mark as visited
+                    //showImage(padded);
+                    // Search for next foreground pixel. We search 8 neighbors starting from search_idx
+                    for (int i = 0; i < 8; ++i) {
+                        int idx = search_idx + i; // index into offsets (0..15)
+                        uchar* neighbor = curr_ptr + offsets[idx]; // Fast pointer arithmetic
+                        if (*neighbor != BACKGROUND) {
+                            // Found next boundary pixel
+                            curr_ptr = neighbor;
+                            int dir = (idx & 7);                             // Update Integer Coordinates using the small static tables(Use modulo 8 to get the distinct direction 0-7)
+                            int next_x=curr_x+dx[dir], next_y=curr_y+dy[dir];
+                            ntimesRevisited+= int(*neighbor == VISITED);
+                            curr_x = next_x;curr_y = next_y;
+                            search_idx = (dir + 5) & 7;
+                            break;
+                        }
+                    }
+                } while (curr_ptr != start_ptr );
+                size_t bufsize=buffer.size();
+                if (ntimesRevisited<= float(bufsize)*maxRevisited && bufsize >= minSize) {
+                    contours.push_back(buffer);
+                }
+            }
+            c++;//move to next pixel
+            ////findEndContourPoint
+            if ( row_ptr[c]){
+                {
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+
+                    cv::v_uint8 v_zero = cv::vx_setzero_u8();
+                    for (; c <=  cols - cv::VTraits<cv::v_uint8>::vlanes(); c += cv::VTraits<cv::v_uint8>::vlanes())
+                    {
+                        cv::v_uint8 vmask = (cv::v_eq(cv::vx_load((uchar*)(row_ptr + c)), v_zero));
+                        if (cv::v_check_any(vmask))
+                        {
+                            c += cv::v_scan_forward(vmask);
+                            break;
+                        }
+                    }
+#endif
+                }
+                for (; c < cols && row_ptr[c]; ++c) ;//last tail
+            }
+        }
+    }
+    return contours;
+}
+bool MarkerDetector::isAInnerMarker(const cv::Mat &grey,const Marker &marker)
+{
+    // --- tunable parameters ---
+    const int   nSamplesPerEdge = 5;     // pairs along each edge
+    const float perpOffset      = 2.0f;  // pixels perpendicular to the edge
+    const float colorThreshold  = 30.0f; // mean |L-R| below this => inner marker
+    // --------------------------
+
+    // NOTE: replace `grey` with whatever member of MarkerDetector
+    // holds the grayscale input image (e.g. _grey, grayImage, ...).
+    const cv::Mat &img = grey;
+    if (img.empty() || img.type() != CV_8UC1) return false;
+
+
+    float totalDiff   = 0.f;
+    int   validPairs  = 0;
+
+    for (int i = 0; i < 4; ++i) {
+        const cv::Point2f &p1 = marker[i];
+        const cv::Point2f &p2 = marker[(i + 1) % 4];
+
+        cv::Point2f edge = p2 - p1;
+        float edgeLen = cv::norm(edge);
+        if (edgeLen < 1e-6f) continue;
+
+        cv::Point2f edgeDir = edge / edgeLen;
+        // perpendicular (rotate 90°): one side will be "outside",
+        // the other "inside" the polygon — we don't actually need
+        // to know which is which, only the magnitude of the difference.
+        cv::Point2f perp(-edgeDir.y, edgeDir.x);
+
+        for (int j = 1; j <= nSamplesPerEdge; ++j) {
+            // t in (0,1) — skip exact corners to avoid noise there
+            float t = float(j) / float(nSamplesPerEdge + 1);
+            cv::Point2f midPt = p1 + t * edge;
+
+            cv::Point2f leftPt  = midPt + perp * perpOffset;
+            cv::Point2f rightPt = midPt - perp * perpOffset;
+
+            float cL = getSubpixelValue(grey,leftPt);
+            float cR = getSubpixelValue(grey,rightPt);
+            if (cL < 0.f || cR < 0.f) continue; // out of image
+
+            totalDiff += std::fabs(cL - cR);
+            ++validPairs;
+        }
+    }
+
+    if (validPairs == 0) return false;
+
+    float avgDiff = totalDiff / validPairs;
+    return avgDiff < colorThreshold; // low contrast across the line => inner marker
+}
+
+
+void MarkerDetector::thres255Adaptive(cv::Mat &in,cv::Mat &out,int off,int thres){
+    cv::boxFilter( in, out, in.type(), cv::Size(off*2+1, off*2+1),
+                  cv::Point(-1,-1), true, 4 );
+
+    for(int i = 0; i < in.rows; i++ )
+    {
+        const uchar* sdata = in.ptr(i);
+        uchar* ddata = out.ptr(i);
+        for(int j = 0; j < in.cols; j++ )
+            ddata[j] = ((int)ddata[j] - thres < (int)sdata[j]) ? 255 : 0;
+    }
+
+}
+void copyVector2Output(std::vector<Marker> &vec, cv::OutputArrayOfArrays out )   {
+    out.create((int)vec.size(), 1, CV_32FC2);
+    if(out.isMatVector()) {
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create(4, 1, CV_32FC2, i);
+            cv::Mat &m = out.getMatRef(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else if(out.isUMatVector()) {
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create(4, 1, CV_32FC2, i);
+            cv::UMat &m = out.getUMatRef(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else if(out.kind() == cv::_OutputArray::STD_VECTOR_VECTOR){
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create(4, 1, CV_32FC2, i);
+            cv::Mat m = out.getMat(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else {
+        CV_Error(cv::Error::StsNotImplemented,
+                 "Only Mat vector, UMat vector, and vector<vector> OutputArrays are currently supported.");
+    }
+}
+
+
+void copyVector2Output(std::vector<std::vector<cv::Point2f> > &vec, cv::OutputArrayOfArrays out )   {
+    out.create((int)vec.size(), 1, CV_32FC2);
+    if(out.isMatVector()) {
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create((int)vec[i].size(), 1, CV_32FC2, i);
+            cv::Mat &m = out.getMatRef(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else if(out.isUMatVector()) {
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create((int)vec[i].size(), 1, CV_32FC2, i);
+            cv::UMat &m = out.getUMatRef(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else if(out.kind() == cv::_OutputArray::STD_VECTOR_VECTOR){
+        for (unsigned int i = 0; i < vec.size(); i++) {
+            out.create(vec[i].size(), 1, CV_32FC2, i);
+            cv::Mat m = out.getMat(i);
+            cv::Mat(cv::Mat(vec[i]).t()).copyTo(m);
+        }
+    }
+    else {
+        CV_Error(cv::Error::StsNotImplemented,
+                 "Only Mat vector, UMat vector, and vector<vector> OutputArrays are currently supported.");
+    }
+}
+
+std::vector<Marker> detect(cv::aruco::Dictionary dict, cv::Mat & src_gray,cv::Mat & thresImage,   int erosionIt){
+
+    cv::Mat kernel = cv::getStructuringElement(cv::MORPH_CROSS, cv::Size(3, 3));
+    cv::erode(thresImage, thresImage, kernel,{-1,-1},erosionIt);
+    DetectorParameters params;
+    //params.expansionDueToErosion=erosionIt;
+    params.dicts.push_back(dict);
+    return MarkerDetector::detect(src_gray,params,nullptr,thresImage);
+
+
+}
+std::vector<std::vector<int>> getConnectedComponents(cv::Mat graph_8uc1) {
+    int n = graph_8uc1.rows;
+    std::vector<bool> visited(n, false);
+    std::vector<std::vector<int>> components;
+
+    // Ensure the matrix is square
+    if (n != graph_8uc1.cols) {
+        return components;
+    }
+
+    for (int i = 0; i < n; ++i) {
+        if (!visited[i]) {
+            // Start of a new connected component
+            std::vector<int> currentComponent;
+            std::queue<int> q;
+
+            q.push(i);
+            visited[i] = true;
+
+            while (!q.empty()) {
+                int u = q.front();
+                q.pop();
+                currentComponent.push_back(u);
+
+                // Check the row in the adjacency matrix for neighbors
+                // Using ptr<uchar> for faster row access than .at<uchar>
+                const uchar* rowPtr = graph_8uc1.ptr<uchar>(u);
+                for (int v = 0; v < n; ++v) {
+                    if (rowPtr[v] != 0 && !visited[v]) {
+                        visited[v] = true;
+                        q.push(v);
+                    }
+                }
+            }
+            components.push_back(currentComponent);
+        }
+    }
+
+    return components;
+}
+
+std::shared_ptr<cv::flann::Index> buildFlannIndex(const std::vector<Marker> &markers) {
+    //create a vector with all corners
+    std::vector<cv::Point2f> corners;
+    corners.reserve(markers.size()*4);
+    for(const auto &m:markers){
+        for(const auto &c:m){
+            corners.push_back(c);
+        }
+    }
+    //now, create a flann index with these corners
+    cv::flann::KDTreeIndexParams indexParams(1);
+    cv::Mat data = cv::Mat(corners).reshape(1, static_cast<int>(corners.size()));
+    return std::make_shared<cv::flann::Index>(data, indexParams);
+}
+//returns a set of markers that are connected, i.e. that have at least one corner closer than a threshold.
+std::vector<std::vector<Marker>> connectedComponents(const std::vector<Marker> &markers){
+    //create a vector with all corners
+    //now, create a flann index with these corners
+    auto flannIndex=buildFlannIndex(markers);
+
+    cv::Mat  graph(markers.size(), markers.size(), CV_8UC1, cv::Scalar(0));
+
+    //now, for each corner, find the neighbors closer than a threshold
+    const float threshold=10.0f;
+    for(size_t m=0;m<markers.size();m++){
+        for(int i=0;i<4;i++){
+            std::vector<int> indices;
+            std::vector<float> dists;
+            cv::Mat query = (cv::Mat_<float>(1, 2) << markers[m][i].x, markers[m][i].y); // Single 2D query point
+            int n=flannIndex->radiusSearch(query, indices, dists, threshold*threshold, 4*markers.size());
+            for(int x=0;x<n;x++){
+                int idx=indices[x];
+                graph.at<uchar>(m,idx/4)=1;
+                graph.at<uchar>(idx/4,m)=1;
+            }
+        }
+    }
+
+    //std::cout<<"Graph:\n"<<graph<<std::endl;
+    //obtain the different connected components available
+    auto ccomps=getConnectedComponents(graph);
+
+
+    //now, for each component, obtain the corresponding markers
+    std::vector<std::vector<Marker>> res;
+    for(const auto &comp:ccomps){
+        res.push_back({});
+        for(auto idx:comp){
+            res.back().push_back(markers[idx]);
+        }
+    }
+    return res;
+}
+
+
+std::vector<Marker> detectBWMarkers(const cv::aruco::CharucoBoard2 &board,cv::Mat &src_gray){
+
+
+     std::vector<Marker>  markers_black,markers_white;
+    cv::Mat thresImage;
+
+    //BLACK MARKERS
+    cv::boxFilter( src_gray, thresImage, src_gray.type(), cv::Size(25,25),cv::Point(-1,-1), true, cv::BORDER_REPLICATE|cv::BORDER_ISOLATED );
+    thresImage=thresImage-src_gray;
+    cv::threshold(thresImage, thresImage, 3, 255, cv::THRESH_BINARY);
+    //determine how many erosion iterations we will do, depending on the size of the image
+    int maxErodeIterations= std::max(2, int( (2.*src_gray.cols/2000.)+0.5));
+    std::vector<std::vector<Marker>  > markers_blackv(maxErodeIterations);
+    cv::Range range(1, maxErodeIterations);
+
+   cv::parallel_for_(range, [&](const cv::Range& r) {
+       for(int i=r.start;i<r.end;i++){
+         cv::Mat thres=thresImage.clone();
+            markers_blackv[i]=detect(board.dictionary,src_gray,thres,i);//black markers
+            //because we have shrink the borders for black markers, we will expand the corners a bit from the center
+            for(auto & marker:markers_blackv[i]){
+                std::vector<cv::Point2f> newPoints;
+                for(int j=0;j<4;j++){
+                    int idx0=j;
+                    int idx1=(j+2) % 4;
+                    auto dif=marker[idx0]-marker[idx1];
+                    auto norm=cv::norm(dif);
+                    auto p= marker[idx1]+  ((dif)/norm)*(norm+ 2+i   );
+                    newPoints.push_back(p);
+                }
+                //replace the points by the new ones
+                for(int j=0;j<4;j++){
+                    marker[j]=newPoints[j];
+                }
+            }
+        }
+    });
+
+    //merge them all into markers_black
+    for(const auto &v:markers_blackv){
+        for(const auto &m:v){
+            markers_black.push_back(m);
+        }
+    }
+    //now, we need to merge the different markers
+    if(markers_blackv.size()>1){
+
+        std::vector<Marker> unduplicated;
+        /// REMOVAL OF INNER DUPLICATED DETECTIONS OF THE SAME MARKER(INNER AND OUTER BORDER)
+        std::sort(markers_black.begin(), markers_black.end(),[](const Marker &a,const Marker &b){return a.id<b.id;});
+        std::vector<bool> toRemove(markers_black.size(), false);
+        for (int i = 0; i < int(markers_black.size()) - 1; i++)
+        {
+            for (int j = i + 1; j < int(markers_black.size()) && !toRemove[i]; j++)
+            {
+                if (markers_black[i].id == markers_black[j].id )
+                {
+                    if( markers_black[i].cornerMaxDistance(markers_black[j])<100)
+                        toRemove[i]=true;
+                }
+            }
+        }
+        //now move to DetectedMarkers these not marked for removal
+        for (unsigned int i = 0; i < markers_black.size(); i++)
+            if (!toRemove[i]) unduplicated.push_back(markers_black[i]);
+        markers_black=unduplicated;
+    }
+
+
+//    markers_black=detect(board.dictionary,src_gray,thresImage,erodeIterations);//black markers
+
+
+
+
+
+    ///WHITE MARKERS
+    cv::boxFilter( src_gray, thresImage, src_gray.type(), cv::Size(15,15),cv::Point(-1,-1), true, cv::BORDER_REPLICATE|cv::BORDER_ISOLATED );
+    thresImage=thresImage-src_gray;
+    cv::threshold(thresImage, thresImage, 3, 255, cv::THRESH_BINARY);
+
+
+    //draw a line between opposite corners to break the continous contour of the white markers, which will help to detect them.
+    for(auto m:markers_black){
+        auto n02=m[2]-m[0];
+        auto n02norm=cv::norm(n02);
+        auto p0=m[0]-(n02/n02norm)* (n02norm/8);
+        auto p1=m[0]+(n02/n02norm)* (n02norm/8);
+        cv::line(thresImage,p0,p1,cv::Scalar::all(255),2);
+        p0=m[2]-(n02/n02norm)* (n02norm/8);
+        p1=m[2]+(n02/n02norm)* (n02norm/8);
+        cv::line(thresImage,p0,p1,cv::Scalar::all(255),2);
+
+        //same for the other diagonal
+        auto n13=m[3]-m[1];
+        auto n13norm=cv::norm(n13);
+        p0=m[1]-(n13/n13norm)* (n13norm/8);
+        p1=m[1]+(n13/n13norm)* (n13norm/8);
+        cv::line(thresImage,p0,p1,cv::Scalar::all(255),2);
+        p0=m[3]-(n13/n13norm)* (n13norm/8);
+        p1=m[3]+(n13/n13norm)* (n13norm/8);
+        cv::line(thresImage,p0,p1,cv::Scalar::all(255),2);
+    }
+    thresImage=255-thresImage;
+    cv::Mat src_gray_inv = 255 - src_gray;
+    markers_white = detect(board.dictionary, src_gray_inv, thresImage, 1); // white markers
+
+
+    // Combine results from both
+    std::vector<Marker> allMarkers;
+    allMarkers.reserve(markers_black.size() + markers_white.size());
+    allMarkers.insert(allMarkers.end(), markers_black.begin(), markers_black.end());
+    allMarkers.insert(allMarkers.end(), markers_white.begin(), markers_white.end());
+
+
+
+
+
+      return allMarkers;
+}
+
+
+//given a marker id and one of its corners, return the global corner id of that corner, which is a unique id for that corner in the whole board,
+
+    int getGlobalCornerID(int marker_id, int corner_id,const  cv::aruco::CharucoBoard2 &Board)
+{
+    //obtain the row, col of the marker_id
+    auto row_col=Board.getIdPos(marker_id);
+    if(corner_id<=1){
+        return (Board.bSize.width+1) *row_col.first +  row_col.second+  corner_id;
+    }
+    else if(corner_id==2){
+        return (Board.bSize.width+1) *(row_col.first+1) +  row_col.second+ 1;
+    }
+    else  {
+        return (Board.bSize.width+1) *(row_col.first+1) +  row_col.second;
+
+    }
+}
+//opposite of getGlobalCornerID, given a global corner id, return the marker ids and corner ids of that corner
+
+std::vector<std::pair<int,int>> getMarkerCornersFromGlobalCornerID( int gid,const  cv::aruco::CharucoBoard2 &Board)
+{
+    std::vector<std::pair<int,int>> result;
+    const int W = Board.bSize.width;
+
+    // Decompose gid into (cr, cc) in the (H+1) x (W+1) corner grid.
+    // Inverse of  gid = (W+1) * cr + cc  used in getGlobalCornerID.
+    const int cr = gid / (W + 1);
+    const int cc = gid % (W + 1);
+
+    // Up to 4 markers share a global corner. Sort order: 0=TL, 1=TR, 2=BR, 3=BL.
+    // Board.getId() returns -1 for out-of-range (row,col), so it doubles as a bounds check.
+    int id;
+
+    // Marker at (cr, cc) sees this point as its top-left (0)
+    id = Board.getId(cr,     cc);
+    if (id != -1) result.emplace_back(id, 0);
+
+    // Marker at (cr, cc-1) sees this point as its top-right (1)
+    id = Board.getId(cr,     cc - 1);
+    if (id != -1) result.emplace_back(id, 1);
+
+    // Marker at (cr-1, cc-1) sees this point as its bottom-right (2)
+    id = Board.getId(cr - 1, cc - 1);
+    if (id != -1) result.emplace_back(id, 2);
+
+    // Marker at (cr-1, cc) sees this point as its bottom-left (3)
+    id = Board.getId(cr - 1, cc);
+    if (id != -1) result.emplace_back(id, 3);
+
+    return result;
+}
+
+}
+
+
+cv::aruco::CharucoBoard2::CharucoBoard2()
+{
+
+}
+
+cv::aruco::CharucoBoard2::CharucoBoard2(cv::Size _bSize, float _markerLength, float _markerSeparation,  const  cv::aruco::Dictionary  &_dictionary, cv::InputArray _ids)
+{
+    (void)_markerSeparation;
+    this->bSize = _bSize;
+    this->dictionary = _dictionary;
+    this->markerLength = _markerLength;
+    this->markerSeparation = 0;
+    //set the ids
+    if(_ids.empty()){
+        int markerId=0;
+        for(int y=0;y<_bSize.height;y++){
+            for(int x= 0;x<_bSize.width;x++,markerId++){
+                if(markerId>=_dictionary.bytesList.rows){
+                    CV_Error(cv::Error::StsBadArg, "Number of markers exceeds the number of markers in the dictionary");
+                }
+                this->ids.push_back(markerId);
+            }
+        }
+    }
+    else{
+        cv::Mat idsMat=_ids.getMat();
+        if(idsMat.total()!=size_t(_bSize.area()) || idsMat.type()!=CV_32SC1){
+            CV_Error(cv::Error::StsBadArg, "Ids must be a vector of int with the same number of elements as the board size");
+        }
+        this->ids=std::vector<int>(idsMat.begin<int>(),idsMat.end<int>());
+    }
+}
+
+void cv::aruco::CharucoBoard2::generateImage(int markerSizePix, cv::Mat &outImage) const
+{
+    int border=markerSizePix/4;
+    int nmarkers=bSize.area();
+    if(nmarkers > dictionary.bytesList.rows)
+        CV_Error(cv::Error::StsBadArg, "Number of markers exceeds the number of markers in the dictionary");
+
+    cv::Size imgSize(markerSizePix*bSize.width + 2*border , markerSizePix*bSize.height+2*border);
+    int markerIdx=0;
+    outImage = cv::Mat::zeros(imgSize, CV_8UC1);
+    outImage=255;
+    int startLineColor = 0;
+    for(int y=0; y<bSize.height; y++){
+        int curMarkerColor=startLineColor;
+        for(int x= 0; x<bSize.width; x++,markerIdx++){
+            cv::Mat markerImg;
+            dictionary.generateImageMarker(ids[markerIdx], markerSizePix, markerImg);
+            int posX = x * markerSizePix + border;
+            int posY = y * markerSizePix + border;
+            if(curMarkerColor)
+                markerImg=255-markerImg;
+            markerImg.copyTo(outImage(cv::Rect(posX, posY, markerSizePix, markerSizePix)));
+            curMarkerColor= curMarkerColor==1?0:1;
+        }
+        startLineColor=startLineColor==1?0:1;
+    }
+
+    for(int x=1;x<bSize.width;x+=2)
+        cv::rectangle(outImage,cv::Rect(border+x*markerSizePix,0,markerSizePix,border),cv::Scalar::all(0),cv::FILLED);
+    for(int x=bSize.height%2;x<bSize.width;x+=2)
+        cv::rectangle(outImage,cv::Rect(border+x*markerSizePix,border+markerSizePix*bSize.height,markerSizePix,border),cv::Scalar::all(0),cv::FILLED);
+    for(int y=1;y<bSize.height;y+=2)
+        cv::rectangle(outImage,cv::Rect(0,border+y*markerSizePix,border,markerSizePix),cv::Scalar::all(0),cv::FILLED);
+    for(int y=bSize.width%2;y<bSize.height;y+=2)
+        cv::rectangle(outImage,cv::Rect(border+markerSizePix*bSize.width,border+y*markerSizePix,border,markerSizePix),cv::Scalar::all(0),cv::FILLED);
+
+    cv::rectangle(outImage,cv::Rect(0,0,border,border),cv::Scalar::all(0),cv::FILLED);
+    cv::rectangle(outImage,cv::Rect(outImage.cols-border,0,border,border),cv::Scalar::all(0),cv::FILLED);
+    cv::rectangle(outImage,cv::Rect(0,outImage.rows-border,border,border),cv::Scalar::all(0),cv::FILLED);
+    cv::rectangle(outImage,cv::Rect(outImage.cols-border,outImage.rows-border,border,border),cv::Scalar::all(0),cv::FILLED);
+}
+
+void cv::aruco::CharucoBoard2::generateImage(cv::Size outSize, cv::Mat &outImage, int marginSize, int borderBits) const
+{
+    (void)borderBits; // kept for API compatibility
+    int markerSizePix = std::min((outSize.width  - 2*marginSize) / bSize.width,
+                                  (outSize.height - 2*marginSize) / bSize.height);
+    if (markerSizePix < 1)
+        CV_Error(cv::Error::StsBadArg, "Output image size too small for the board dimensions");
+
+    cv::Mat boardImg;
+    generateImage(markerSizePix, boardImg);
+
+    // scale to fill the available area while preserving the board's aspect ratio
+    int availW = outSize.width  - 2*marginSize;
+    int availH = outSize.height - 2*marginSize;
+    float scale = std::min((float)availW / boardImg.cols, (float)availH / boardImg.rows);
+    cv::Size scaledSize(std::round(boardImg.cols * scale), std::round(boardImg.rows * scale));
+    int interp = (scale < 1.0f) ? cv::INTER_AREA : cv::INTER_LINEAR;
+    cv::resize(boardImg, boardImg, scaledSize, 0, 0, interp);
+
+    outImage = cv::Mat(outSize, CV_8UC1, cv::Scalar::all(255));
+    int offsetX = (outSize.width  - boardImg.cols) / 2;
+    int offsetY = (outSize.height - boardImg.rows) / 2;
+    boardImg.copyTo(outImage(cv::Rect(offsetX, offsetY, boardImg.cols, boardImg.rows)));
+}
+
+
+std::pair<int, int> cv::aruco::CharucoBoard2::getIdPos(int id) const
+{
+    auto it=std::find(ids.begin(),ids.end(),id);
+    if(it==ids.end()) return {-1,-1};
+    int idx=std::distance(ids.begin(),it);
+    int row = idx / bSize.width;
+    int col = idx % bSize.width;
+    return {row, col};
+}
+
+int cv::aruco::CharucoBoard2::getId(int row, int col) const
+{
+    if(row<0 || row>=bSize.height || col<0 || col>=bSize.width) return -1;
+    int idx=row*bSize.width+col;
+    return ids[idx];
+}
+
+void cv::aruco::CharucoBoard2::matchImagePoints(cv::InputArrayOfArrays detectedCorners, cv::InputArray detectedIds, cv::OutputArray objPoints, cv::OutputArray imgPoints) const
+{
+
+    CV_Assert(detectedIds.total() > 0ull);
+    CV_Assert(detectedIds.total() == detectedCorners.total() || (detectedIds.total() == 4 && detectedCorners.total()==9 && bSize.width==2 && bSize.height==2));
+
+    size_t nDetectedMarkers = detectedIds.total();
+
+    std::vector<cv::Point3f> objPnts;
+    objPnts.reserve(nDetectedMarkers);
+
+    std::vector<cv::Point2f> imgPnts;
+    imgPnts.reserve(nDetectedMarkers);
+
+    cv::Mat detectedIdsMat = detectedIds.getMat();
+    cv::Mat detectedCornersMat;
+    std::vector<cv::Mat> detectedCornersVecMat;
+
+    if (detectedCorners.isMatVector()) {
+        detectedCorners.getMatVector(detectedCornersVecMat);
+    } else {
+        detectedCornersMat = detectedCorners.getMat();
+    }
+
+    //its a diamond?
+    if(detectedIds.total() == 4 && detectedCorners.total()==9 && bSize.width==2 && bSize.height==2){
+        //points are given in order, we do not need the detectedIds
+        int idx=0;
+        for(int row=0;row<3;row++){
+            for(int col=0;col<3;col++,idx++){
+                cv::Point3f p3d;
+                p3d.x = col * markerLength;
+                p3d.y = row * markerLength;
+                p3d.z = 0;
+                objPnts.push_back(p3d);
+                if (detectedCorners.isMatVector()) {
+                    imgPnts.push_back(detectedCornersVecMat[idx].ptr<cv::Point2f>(0)[0]);
+                } else {
+                    imgPnts.push_back(detectedCornersMat.ptr<cv::Point2f>(0)[idx]);
+                }
+            }
+        }
+    }
+    //its a chessboard
+    else{
+
+        for(unsigned int i = 0; i < detectedIdsMat.total(); i++) {
+            if (detectedCorners.isMatVector()) {
+                imgPnts.push_back(detectedCornersVecMat[i].ptr<cv::Point2f>(0)[0]);
+            } else {
+                imgPnts.push_back(detectedCornersMat.ptr<cv::Point2f>(0)[i]);
+            }
+            int currentId = detectedIdsMat.at<int>(i);
+            int row = currentId / (bSize.width+1);
+            int col = currentId % (bSize.width+1);
+            cv::Point3f p3d;
+            p3d.x = col * markerLength;
+            p3d.y = row * markerLength;
+            p3d.z = 0;
+            objPnts.push_back(p3d);
+        }
+
+    }
+
+
+    // create output
+    cv::Mat(objPnts).copyTo(objPoints);
+    cv::Mat(imgPnts).copyTo(imgPoints);
+
+}
+cv::aruco::CharucoDetector2::CharucoDetector2(const CharucoBoard2 &_board)
+{
+this->board=_board;
+
+}
+
+cv::aruco::CharucoDetector2::CharucoDetector2()
+{
+
+}
+void cv::aruco::CharucoDetector2::setBoard(const CharucoBoard2 &_board){
+    this->board=_board;
+}
+void cv::aruco::CharucoDetector2::detectBoard(cv::InputArray image, cv::OutputArray charucoCorners, cv::OutputArray charucoIds,
+                                              cv::InputOutputArrayOfArrays markerCorners, cv::InputOutputArray markerIds)
+{
+    CV_Assert(board.bSize.width > 0 && board.bSize.height > 0 && board.markerLength > 0.f);
+    CV_Assert(image.channels() == 1 || image.channels() == 3);
+    cv::Mat src_gray;
+    //obtain the gray image
+    if(image.channels()==3)
+        cvtColor(image, src_gray, cv::COLOR_BGR2GRAY);
+    else src_gray=image.getMat();
+
+    //detect all markers
+    auto allMarkers=detectBWMarkers(board, src_gray);
+    //remove markers not belonging to the list of ids of the board
+    allMarkers.erase(std::remove_if(allMarkers.begin(), allMarkers.end(),
+                                    [this](const Marker &m) {
+                                        return std::find(board.ids.begin(), board.ids.end(), m.id) == board.ids.end();
+                                    }), allMarkers.end());
+
+
+    if(allMarkers.empty())return;
+    //obtain the connected components
+    std::vector<std::vector<Marker> > connected_markers=connectedComponents(allMarkers);
+
+    //lets detect possible inconsistencies, i.e., markers in the wrong order, possibly belonging to another board configuration
+    std::vector<std::vector<Marker> > consistent_connected_markers;
+    for(auto &comp:connected_markers){
+        int threshold=10;
+        auto findex=buildFlannIndex(comp);
+        bool is_consistent=true;
+        //for each corner, of each marker we will analyze its nearst neighbor. If is really connected, we will check if
+        //the connection is consistent
+        for(auto marker:comp){
+            std::vector<int> indices;
+            std::vector<float> dists;
+             for(int c=0;c<4;c++){
+                cv::Mat query = (cv::Mat_<float>(1, 2) << marker[c].x, marker[c].y); // Single 2D query point
+                int nn=findex->radiusSearch(query, indices, dists, threshold*threshold, marker.size());
+                for(int ix=0;ix<nn;ix++){
+                    int idx=indices[ix];
+                     if(comp[idx/4].id==marker.id) continue;//same marker
+                    //check if the connection is consistent, i.e., if the global corner ids are the same
+                    int gid1=getGlobalCornerID(marker.id,c,board);
+                    int gid2=getGlobalCornerID(comp[idx/4].id,idx%4,board);
+                    if(gid1!=gid2){
+                        CV_LOG_WARNING(NULL, "Marker " << marker.id << " corner " << c << " connected to marker " << comp[idx/4].id << " corner " << (idx%4) << " but global corner ids differ: " << gid1 << " vs " << gid2);
+                        is_consistent=false;
+                    }
+                }
+            }
+            if(!is_consistent) break;
+        }
+        if(is_consistent)
+            consistent_connected_markers.push_back(comp);
+    }
+
+    if(consistent_connected_markers.empty())return;
+
+    //select the one with more markers belonging to the board (at least 2)
+    std::vector<Marker> connected_markers_filtered;
+     for(const auto &comp:consistent_connected_markers){
+        size_t validMarkers=0;
+        for(const auto &m:comp){
+            if(std::find(board.ids.begin(),board.ids.end(),m.id)!=board.ids.end()){
+                validMarkers++;
+            }
+        }
+        if(validMarkers>connected_markers_filtered.size() && validMarkers>=2){
+            connected_markers_filtered=comp;
+        }
+     }
+
+
+     if(connected_markers_filtered.empty()) return;
+     allMarkers=connected_markers_filtered;
+
+    //now, lets focus on the global corners. Unify the corners for subpixel analysis
+    //first, obtain the average position for each global corner id found
+    std::map<int,std::pair<cv::Point2f,int> > global_corners;
+    for(auto m:allMarkers){
+        for(int c=0;c<4;c++){
+            int gid=getGlobalCornerID(m.id,c,board);
+            if (global_corners.find(gid)==global_corners.end())
+                global_corners[gid]={m[c],1};
+            else{
+                auto &p=global_corners[gid];
+                p.first+=m[c];
+                p.second++;
+            }
+        }
+    }
+    //now, average
+    for(auto &gc:global_corners)
+        gc.second.first=gc.second.first / float(gc.second.second);
+
+    //////  subpixel corner refinement
+    // compute the window size for the subpixel refinement based on the size of the markers. Bigger makers, bigger search zone
+    double avrgLen=0;
+    for(auto m:allMarkers){
+        for(int i=0;i<4;i++){
+            avrgLen+=cv::norm(m[i]-m[(i+1)%4]);
+        }
+    }
+    avrgLen/=4*allMarkers.size();
+    //here is the formula to compute the half window size
+    int halfwsize= std::min(int(3* std::max(1.f,float(avrgLen)/float(34) )),9);
+
+    //add the global corners to a single vector
+    std::vector<cv::Point2f> Corners;
+    for (const auto &m:global_corners)
+        Corners.push_back(m.second.first);
+    //refine the corners
+    cv::cornerSubPix(src_gray, Corners, cv::Size(halfwsize,halfwsize), cv::Size(-1, -1),cv::TermCriteria( cv::TermCriteria::MAX_ITER | cv::TermCriteria::EPS, 12, 0.005));
+    // copy back to the global corners
+    int idex=0;
+    for(auto &gc:global_corners){
+        gc.second.first=Corners[idex++];
+    }
+
+    //now, assign the refined global corner positions back to the markers
+    for(auto it_gc = global_corners.begin(); it_gc != global_corners.end(); ++it_gc){
+        int gid = it_gc->first;
+        cv::Point2f corner_c = it_gc->second.first;
+        //find in how many markers it is involved
+        auto marker_corners = getMarkerCornersFromGlobalCornerID(gid,board);
+        for(auto it_mc = marker_corners.begin(); it_mc != marker_corners.end(); ++it_mc){
+            int markerid = it_mc->first;
+            int cornerid = it_mc->second;
+            //see if the makrer id is detected
+            auto markerid_copy=markerid;//capturing markerid only in C++20, lets use a copy for prev compilers
+            auto it=std::find_if(allMarkers.begin(),allMarkers.end(),[markerid_copy](const Marker &m){return m.id==markerid_copy;});
+            if(it!=allMarkers.end()){
+                (*it)[cornerid]=corner_c;
+            }
+        }
+    }
+
+
+    //copy results to output arrays
+    std::vector<int> gidv;
+    std::vector<cv::Point2f> gcorners;
+    for(auto it_gc = global_corners.begin(); it_gc != global_corners.end(); ++it_gc){
+        gidv.push_back(it_gc->first);
+        gcorners.push_back(it_gc->second.first);
+    }
+    if (charucoIds.needed()) {
+        cv::Mat(gidv).copyTo(charucoIds);
+    }
+
+    if (charucoCorners.needed()) {
+        cv::Mat(gcorners).copyTo(charucoCorners);
+    }
+
+    //Markers
+    // 2. Unpack results into OutputArrayOfArrays
+    if(markerCorners.needed())
+        copyVector2Output(allMarkers, markerCorners);
+    if( markerIds.needed()){
+        // 3. Assign to output ids
+        std::vector<int> marker_idsVec;
+        marker_idsVec.reserve(allMarkers.size());
+        for (const auto& m : allMarkers) marker_idsVec.push_back(m.id);
+        // Allocate and copy IDs
+        markerIds.create((int)marker_idsVec.size(), 1, CV_32SC1);
+        cv::Mat(marker_idsVec).copyTo(markerIds);
+    }
+}
+void cv::aruco::CharucoDetector2::detectDiamonds(cv::InputArray image, cv::OutputArrayOfArrays _diamondCorners, cv::OutputArray _diamondIds,
+                                      cv::InputOutputArrayOfArrays inMarkerCorners, cv::InputOutputArray inMarkerIds)    {
+
+    CV_Assert(image.channels() == 1 || image.channels() == 3);
+    cv::Mat src_gray;
+    //obtain the gray image
+    if(image.channels()==3)
+        cvtColor(image, src_gray, cv::COLOR_BGR2GRAY);
+    else src_gray=image.getMat();
+
+    //detect all markers
+    auto allMarkers=detectBWMarkers(board, src_gray);
+
+    if(allMarkers.empty())return;
+    //obtain the connected components
+    std::vector<std::vector<Marker> > connected_markers=connectedComponents(allMarkers);
+
+    //discard these that have more or less than 4 elements
+
+    std::vector<cv::Vec4i> diammons_ids;
+    std::vector<  std::vector<Marker> > diammons_markers;
+    std::vector<std::vector<cv::Point2f> > diamondCorners;
+
+    int threshold=10*10;
+    std::vector<int> indices;
+    std::vector<float> dists;
+    cv::Mat query(1,2,CV_32F);
+    for(const auto &comp:connected_markers){
+        if(comp.size()!=4) continue;
+        //make sure they   share 3 corners
+        auto flannIndex=buildFlannIndex(comp);
+        int totalSharedCorners=0,cornerWithMostSharedCorners=-1;
+        std::pair<int,int> centralCorner;//this is the central poisition, that let us know the order of the markers in the diamond
+        for(size_t m=0;m<comp.size();m++){
+            auto &marker=comp[m];
+             for(int c=0;c<4;c++){
+                 query.ptr<float>(0)[0]=marker[c].x;
+                 query.ptr<float>(0)[1]=marker[c].y;
+                 int nn=flannIndex->radiusSearch(query, indices, dists, threshold, 4);
+               //  std::cout<<"nn="<<nn<<" for marker "<<marker.id<<" corner "<<c<<std::endl;
+                 totalSharedCorners+=nn-1;
+                 if( nn>cornerWithMostSharedCorners)
+                 {
+                     cornerWithMostSharedCorners=nn;
+                     centralCorner={m,c};
+                 }
+            }
+        }
+        // std::cout<<"Component with markers "<<comp[0].id<<","<<comp[1].id<<","<<comp[2].id<<","<<comp[3].id<<" has "<<totalSharedCorners<<" shared corners"<<std::endl;
+        // std::cout<<"Central corner is marker "<<centralCorner.first<<" corner "<<centralCorner.second<<" with "<<cornerWithMostSharedCorners<<" shared corners"<<std::endl;
+        if(totalSharedCorners!=20) continue;
+
+        //find the diamon id eximiing the poition of the central corner, which is the one with more shared corners.
+        cv::Vec4i diamondIds;
+        query.ptr<float>(0)[0]=comp[centralCorner.first][centralCorner.second].x;
+        query.ptr<float>(0)[1]=comp[centralCorner.first][centralCorner.second].y;
+        int nn=flannIndex->radiusSearch(query, indices, dists, threshold, 4);
+        for(int i=0;i<nn;i++){
+
+            int markerIdx=indices[i]/4;
+            int cornerIdx=indices[i]%4;
+
+            int idIndex;
+            if( cornerIdx==2) idIndex=0;
+            else if(cornerIdx==3) idIndex=1;
+            else if(cornerIdx==1) idIndex=2;
+            else idIndex=3;
+            diamondIds[idIndex]=comp[markerIdx].id;
+
+        }
+
+        CharucoBoard2 dboard(cv::Size(2,2),1,1,board.dictionary,std::vector<int>{diamondIds[0],diamondIds[1],diamondIds[2],diamondIds[3]} );
+        std::vector<cv::Point2f> board_corners(9);
+        for(size_t m=0;m<comp.size();m++){
+            for(int c=0;c<4;c++){
+                auto gid=getGlobalCornerID(comp[m].id,c,dboard);
+                board_corners[gid]=comp[m][c];
+            }
+        }
+
+        //lets apply a corner refinement to the corners. first, estimate average lenght
+
+        // compute the window size for the subpixel refinement based on the size of the markers. Bigger makers, bigger search zone
+        double avrgLen=0;
+        for(auto m:comp){
+            for(int i=0;i<4;i++){
+                avrgLen+=cv::norm(m[i]-m[(i+1)%4]);
+            }
+        }
+        avrgLen/=4*comp.size();
+        //here is the formula to compute the half window size
+        int halfwsize= std::min(int(3* std::max(1.f,float(avrgLen)/float(34) )),9);
+        //now, subpix
+        cv::cornerSubPix(src_gray, board_corners, cv::Size(halfwsize,halfwsize), cv::Size(-1, -1),cv::TermCriteria( cv::TermCriteria::MAX_ITER | cv::TermCriteria::EPS, 12, 0.005));
+
+
+        diamondCorners.push_back(board_corners);
+        diammons_markers.push_back(comp);
+        diammons_ids.push_back(diamondIds);
+    }
+    if(diammons_markers.empty())return;
+
+
+
+
+     // //now, copy data to output
+     copyVector2Output(diamondCorners,_diamondCorners);
+
+     cv::Mat(diammons_ids).copyTo(_diamondIds);
+
+     //group the markers and their ids into a single vector
+     if( inMarkerCorners.needed() || inMarkerIds.needed()){
+         std::vector<Marker> markerCorners;
+         std::vector<int> markerIds;
+         for(size_t i=0;i<diammons_markers.size();i++){
+             for(size_t j=0;j<diammons_markers[i].size();j++){
+                 markerCorners.push_back(diammons_markers[i][j]);
+                 markerIds.push_back(diammons_markers[i][j].id);
+             }
+         }
+         if( inMarkerCorners.needed())
+             copyVector2Output(markerCorners,inMarkerCorners);
+         if( inMarkerIds.needed())
+             cv::Mat(markerIds).copyTo(inMarkerIds);
+     }
+
+}
+

--- a/modules/objdetect/src/aruco/charuco2.cpp
+++ b/modules/objdetect/src/aruco/charuco2.cpp
@@ -371,9 +371,9 @@ std::vector<std::vector<cv::Point>> MarkerDetector::visitedAwareTracingContour(c
                 for (; c <= cols - cv::VTraits<cv::v_uint8>::vlanes(); c+= cv::VTraits<cv::v_uint8>::vlanes())
                 {
                     cv::v_uint8 vmask = (cv::v_ne(cv::vx_load((uchar*)(row_ptr + c)), v_zero));
-                    if (v_check_any(vmask))
+                    if (cv::v_check_any(vmask))
                     {
-                        c += v_scan_forward(vmask);
+                        c += cv::v_scan_forward(vmask);
                         break;
                     }
                 }

--- a/modules/objdetect/src/aruco/charuco2.cpp
+++ b/modules/objdetect/src/aruco/charuco2.cpp
@@ -1085,7 +1085,7 @@ void cv::aruco::CharucoDetector2::detectBoard(cv::InputArray image, cv::OutputAr
              for(int c=0;c<4;c++){
                 cv::Mat query = (cv::Mat_<float>(1, 2) << marker[c].x, marker[c].y); // Single 2D query point
                 int nn=findex->radiusSearch(query, indices, dists, threshold*threshold, marker.size());
-                for(int ix=0;ix<nn;ix++){
+                for(int ix=0;ix<std::min(nn,int(indices.size()));ix++){
                     int idx=indices[ix];
                      if(comp[idx/4].id==marker.id) continue;//same marker
                     //check if the connection is consistent, i.e., if the global corner ids are the same
@@ -1253,6 +1253,7 @@ void cv::aruco::CharucoDetector2::detectDiamonds(cv::InputArray image, cv::Outpu
                  query.ptr<float>(0)[0]=marker[c].x;
                  query.ptr<float>(0)[1]=marker[c].y;
                  int nn=flannIndex->radiusSearch(query, indices, dists, threshold, 4);
+                 nn=std::min(int(indices.size()),nn);
                //  std::cout<<"nn="<<nn<<" for marker "<<marker.id<<" corner "<<c<<std::endl;
                  totalSharedCorners+=nn-1;
                  if( nn>cornerWithMostSharedCorners)

--- a/modules/objdetect/src/aruco/charuco2.h
+++ b/modules/objdetect/src/aruco/charuco2.h
@@ -1,0 +1,68 @@
+#pragma once
+#include "opencv2/objdetect/aruco_detector.hpp"
+#include "opencv2/objdetect/aruco_board.hpp"
+namespace  cv::aruco{
+
+class CharucoBoard2{
+public:
+    cv::Size bSize={-1,-1};
+    cv::aruco::Dictionary  dictionary;
+    std::vector<int> ids;
+    float markerLength = 0.f, markerSeparation = 0.f;
+    CharucoBoard2();
+    /**
+     * @brief CharucoBoard2
+     * @param bSize
+     * @param markerLength
+     * @param markerSeparation ignored
+     * @param dictionary
+     * @param ids
+     */
+    CharucoBoard2(cv::Size bSize, float markerLength, float markerSeparation,const cv::aruco::Dictionary &dictionary, cv::InputArray ids = cv::noArray());
+    void generateImage(int markerSizePix, cv::Mat& outImage) const;
+    void generateImage(cv::Size outSize, cv::Mat& outImage, int marginSize=0, int borderBits=1) const;
+    //returns the row,col of a given marker id
+    std::pair<int,int> getIdPos(int id)const;
+    //returns the id at the row,col indicated
+    int getId(int row,int col)const;
+
+    /** @brief Given a board configuration and a set of detected markers, returns the corresponding
+     * image points and object points, can be used in solvePnP()
+     *
+     * @param detectedCorners List of detected marker corners of the board.
+     * For cv::Board and cv::GridBoard the method expects std::vector<std::vector<Point2f>> or std::vector<Mat> with Aruco marker corners.
+     * For cv::CharucoBoard the method expects std::vector<Point2f> or Mat with ChAruco corners (chess board corners matched with Aruco markers).
+     *
+     * @param detectedIds List of identifiers for each marker or charuco corner.
+     * For any Board class the method expects std::vector<int> or Mat.
+     *
+     * @param objPoints Vector of marker points in the board coordinate space.
+     * For any Board class the method expects std::vector<cv::Point3f> objectPoints or cv::Mat
+     *
+     * @param imgPoints Vector of marker points in the image coordinate space.
+     * For any Board class the method expects std::vector<cv::Point2f> objectPoints or cv::Mat
+     *
+     * @sa solvePnP
+     */
+    void matchImagePoints(cv::InputArrayOfArrays detectedCorners, cv::InputArray detectedIds,
+                                  cv::OutputArray objPoints, cv::OutputArray imgPoints) const;
+
+};
+
+class     CharucoDetector2{
+    CharucoBoard2 board;
+ public:
+    CharucoDetector2(const CharucoBoard2& board);
+     CharucoDetector2();
+    void setBoard(const CharucoBoard2& board);
+    //void detectBoard(InputArray image, OutputArray imgPoints,  OutputArray objPoints,OutputArray markerIds) const;
+
+    void detectBoard(cv::InputArray image, cv::OutputArray charucoCorners, cv::OutputArray charucoIds,
+                     cv::InputOutputArrayOfArrays markerCorners=cv::noArray(), cv::InputOutputArray markerIds=cv::noArray());
+    void detectDiamonds(cv::InputArray image, cv::OutputArrayOfArrays _diamondCorners, cv::OutputArray _diamondIds,
+                        cv::InputOutputArrayOfArrays inMarkerCorners, cv::InputOutputArray inMarkerIds) ;
+
+
+};
+
+}

--- a/modules/objdetect/src/aruco/charuco2.h
+++ b/modules/objdetect/src/aruco/charuco2.h
@@ -1,7 +1,8 @@
 #pragma once
 #include "opencv2/objdetect/aruco_detector.hpp"
 #include "opencv2/objdetect/aruco_board.hpp"
-namespace  cv::aruco{
+namespace  cv{
+namespace aruco{
 
 class CharucoBoard2{
 public:
@@ -65,4 +66,5 @@ class     CharucoDetector2{
 
 };
 
+}
 }

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -355,7 +355,7 @@ struct  Charuco1DetectorImpl : public CharucoDetector::CharucoBaseDetectorImpl{
     }
 
     void detectBoardWithCheck(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
-                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) override{
+                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) CV_OVERRIDE{
         vector<vector<Point2f>> tmpMarkerCorners;
         vector<int> tmpMarkerIds;
         InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : _InputOutputArray(tmpMarkerCorners);
@@ -369,7 +369,7 @@ struct  Charuco1DetectorImpl : public CharucoDetector::CharucoBaseDetectorImpl{
     }
 
     void detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
-                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) override;
+                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) CV_OVERRIDE;
 };
 
 
@@ -386,18 +386,18 @@ struct  Charuco2DetectorImpl : public CharucoDetector::CharucoBaseDetectorImpl{
     virtual  ~Charuco2DetectorImpl() {}
 
     void detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
-                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) override{
+                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) CV_OVERRIDE{
         charucoDetector2.detectDiamonds(image,_diamondCorners,_diamondIds,inMarkerCorners,inMarkerIds);
          }
 
-    void setBoard(const CharucoBoard& _board) override {
+    void setBoard(const CharucoBoard& _board) CV_OVERRIDE {
         CharucoBaseDetectorImpl::setBoard(_board);
         charucoDetector2.setBoard(CharucoBoard2(_board.getChessboardSize(), _board.getMarkerLength(), 0,
                                                _board.getDictionary()));
-    }
+     }
 
     void detectBoardWithCheck(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
-                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) override{
+                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) CV_OVERRIDE{
 
         charucoDetector2.detectBoard(image,charucoCorners,charucoIds, markerCorners, markerIds);
     }

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -8,22 +8,39 @@
 #include <opencv2/core/utils/logger.hpp>
 #include "opencv2/objdetect/charuco_detector.hpp"
 #include "aruco_utils.hpp"
-
+#include "charuco2.h"
 namespace cv {
 namespace aruco {
 
 using namespace std;
-
-struct CharucoDetector::CharucoDetectorImpl {
+struct CharucoDetector::CharucoBaseDetectorImpl{
     CharucoBoard board;
     CharucoParameters charucoParameters;
     ArucoDetector arucoDetector;
-
-    CharucoDetectorImpl(const CharucoBoard& _board, const CharucoParameters _charucoParameters,
+    CharucoBaseDetectorImpl(const CharucoBoard& _board, const CharucoParameters _charucoParameters,
                         const ArucoDetector& _arucoDetector): board(_board), charucoParameters(_charucoParameters),
-                                                              arucoDetector(_arucoDetector)
+        arucoDetector(_arucoDetector)
     {}
+    virtual ~CharucoBaseDetectorImpl() {}
+    virtual void detectBoardWithCheck(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
+                                      InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) =0;
 
+    virtual void setBoard(const CharucoBoard& _board) {
+        board = _board;
+        arucoDetector.setDictionary(_board.getDictionary());
+    }
+
+    virtual void detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
+                                InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) = 0;
+};
+
+struct  Charuco1DetectorImpl : public CharucoDetector::CharucoBaseDetectorImpl{
+
+
+    Charuco1DetectorImpl(const CharucoBoard& _board, const CharucoParameters _charucoParameters,
+                        const ArucoDetector& _arucoDetector):  CharucoBaseDetectorImpl(_board, _charucoParameters, _arucoDetector)
+        {}
+    virtual  ~Charuco1DetectorImpl() {}
     bool checkBoard(InputArrayOfArrays markerCorners, InputArray markerIds, InputArray charucoCorners, InputArray charucoIds) {
         vector<Mat> mCorners;
         markerCorners.getMatVector(mCorners);
@@ -338,7 +355,7 @@ struct CharucoDetector::CharucoDetectorImpl {
     }
 
     void detectBoardWithCheck(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
-                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) {
+                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) override{
         vector<vector<Point2f>> tmpMarkerCorners;
         vector<int> tmpMarkerIds;
         InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : _InputOutputArray(tmpMarkerCorners);
@@ -350,11 +367,51 @@ struct CharucoDetector::CharucoDetectorImpl {
             charucoIds.release();
         }
     }
+
+    void detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
+                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) override;
 };
+
+
+struct  Charuco2DetectorImpl : public CharucoDetector::CharucoBaseDetectorImpl{
+    CharucoDetector2 charucoDetector2;
+
+    Charuco2DetectorImpl(const CharucoBoard& _board, const CharucoParameters _charucoParameters,
+                         const ArucoDetector& _arucoDetector):  CharucoBaseDetectorImpl(_board, _charucoParameters, _arucoDetector)
+    {
+
+
+         charucoDetector2 = CharucoDetector2(CharucoBoard2(_board.getChessboardSize(),_board.getMarkerLength(),0,_arucoDetector.getDictionary()));
+    }
+    virtual  ~Charuco2DetectorImpl() {}
+
+    void detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
+                        InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) override{
+        charucoDetector2.detectDiamonds(image,_diamondCorners,_diamondIds,inMarkerCorners,inMarkerIds);
+         }
+
+    void setBoard(const CharucoBoard& _board) override {
+        CharucoBaseDetectorImpl::setBoard(_board);
+        charucoDetector2.setBoard(CharucoBoard2(_board.getChessboardSize(), _board.getMarkerLength(), 0,
+                                               _board.getDictionary()));
+    }
+
+    void detectBoardWithCheck(InputArray image, OutputArray charucoCorners, OutputArray charucoIds,
+                              InputOutputArrayOfArrays markerCorners, InputOutputArray markerIds) override{
+
+        charucoDetector2.detectBoard(image,charucoCorners,charucoIds, markerCorners, markerIds);
+    }
+
+} ;
+
 
 CharucoDetector::CharucoDetector(const CharucoBoard &board, const CharucoParameters &charucoParams,
                                  const DetectorParameters &detectorParams, const RefineParameters& refineParams) {
-    this->charucoDetectorImpl = makePtr<CharucoDetectorImpl>(board, charucoParams, ArucoDetector(board.getDictionary(), detectorParams, refineParams));
+    if(board.getType()== CHARUCO_1)
+        this->charucoDetectorImpl = makePtr<Charuco1DetectorImpl>(board, charucoParams, ArucoDetector(board.getDictionary(), detectorParams, refineParams));
+    else
+        this->charucoDetectorImpl = makePtr<Charuco2DetectorImpl>(board, charucoParams, ArucoDetector(board.getDictionary(), detectorParams, refineParams));
+
 }
 
 const CharucoBoard& CharucoDetector::getBoard() const {
@@ -362,8 +419,7 @@ const CharucoBoard& CharucoDetector::getBoard() const {
 }
 
 void CharucoDetector::setBoard(const CharucoBoard& board) {
-     this->charucoDetectorImpl->board = board;
-      charucoDetectorImpl->arucoDetector.setDictionary(board.getDictionary());
+    charucoDetectorImpl->setBoard(board);
 }
 
 const CharucoParameters &CharucoDetector::getCharucoParameters() const {
@@ -395,9 +451,10 @@ void CharucoDetector::detectBoard(InputArray image, OutputArray charucoCorners, 
     charucoDetectorImpl->detectBoardWithCheck(image, charucoCorners, charucoIds, markerCorners, markerIds);
 }
 
-void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
-                                     InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) const {
-    CV_Assert(getBoard().getChessboardSize() == Size(3, 3));
+
+void Charuco1DetectorImpl::detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
+                                          InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) {
+    CV_Assert(board.getChessboardSize() == Size(3, 3));
     CV_Assert((inMarkerCorners.empty() && inMarkerIds.empty() && !image.empty()) || (inMarkerCorners.total() == inMarkerIds.total()));
 
     vector<vector<Point2f>> tmpMarkerCorners;
@@ -405,54 +462,45 @@ void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diam
     InputOutputArrayOfArrays _markerCorners = inMarkerCorners.needed() ? inMarkerCorners : _InputOutputArray(tmpMarkerCorners);
     InputOutputArray _markerIds = inMarkerIds.needed() ? inMarkerIds : _InputOutputArray(tmpMarkerIds);
     if (_markerCorners.empty() && _markerIds.empty()) {
-        charucoDetectorImpl->arucoDetector.detectMarkers(image, _markerCorners, _markerIds);
+        arucoDetector.detectMarkers(image, _markerCorners, _markerIds);
     }
 
     const float minRepDistanceRate = 1.302455f;
     vector<vector<Point2f>> diamondCorners;
     vector<Vec4i> diamondIds;
 
-    // stores if the detected markers have been assigned or not to a diamond
     vector<bool> assigned(_markerIds.total(), false);
-    if(_markerIds.total() < 4ull)
-    {
+    if(_markerIds.total() < 4ull) {
         if (_diamondCorners.needed()) _diamondCorners.release();
         if (_diamondIds.needed()) _diamondIds.release();
-        return; // a diamond need at least 4 markers
+        return;
     }
 
-    // convert input image to grey
     Mat grey;
     if(image.type() == CV_8UC3)
         cvtColor(image, grey, COLOR_BGR2GRAY);
     else
         grey = image.getMat();
-    auto board = getBoard();
+    CharucoBoard savedBoard = board;
 
-    // for each of the detected markers, try to find a diamond
     for(unsigned int i = 0; i < (unsigned int)_markerIds.total(); i++) {
         if(assigned[i]) continue;
 
-        // calculate marker perimeter
         float perimeterSq = 0;
         Mat corners = _markerCorners.getMat(i);
         for(int c = 0; c < 4; c++) {
-          Point2f edge = corners.at<Point2f>(c) - corners.at<Point2f>((c + 1) % 4);
-          perimeterSq += edge.x*edge.x + edge.y*edge.y;
+            Point2f edge = corners.at<Point2f>(c) - corners.at<Point2f>((c + 1) % 4);
+            perimeterSq += edge.x*edge.x + edge.y*edge.y;
         }
-        // maximum reprojection error relative to perimeter
         float minRepDistance = sqrt(perimeterSq) * minRepDistanceRate;
 
         int currentId = _markerIds.getMat().at<int>(i);
 
-        // prepare data to call refineDetectedMarkers()
-        // detected markers (only the current one)
         vector<Mat> currentMarker;
         vector<int> currentMarkerId;
         currentMarker.push_back(_markerCorners.getMat(i));
         currentMarkerId.push_back(currentId);
 
-        // marker candidates (the rest of markers if they have not been assigned)
         vector<Mat> candidates;
         vector<int> candidatesIdxs;
         for(unsigned int k = 0; k < assigned.size(); k++) {
@@ -462,35 +510,28 @@ void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diam
                 candidatesIdxs.push_back(k);
             }
         }
-        if(candidates.size() < 3ull) break; // we need at least 3 free markers
-        // modify charuco layout id to make sure all the ids are different than current id
+        if(candidates.size() < 3ull) break;
+
         vector<int> tmpIds(4ull);
         for(int k = 1; k < 4; k++)
             tmpIds[k] = currentId + 1 + k;
-        // current id is assigned to [0], so it is the marker on the top
         tmpIds[0] = currentId;
 
-        // create Charuco board layout for diamond (3x3 layout)
-        charucoDetectorImpl->board = CharucoBoard(Size(3, 3), board.getSquareLength(),
-                                                  board.getMarkerLength(), board.getDictionary(), tmpIds);
+        board = CharucoBoard(Size(3, 3), savedBoard.getSquareLength(),
+                             savedBoard.getMarkerLength(), savedBoard.getDictionary(), tmpIds);
 
-        // try to find the rest of markers in the diamond
         vector<int> acceptedIdxs;
-        if (currentMarker.size() != 4ull)
-        {
+        if(currentMarker.size() != 4ull) {
             RefineParameters refineParameters(minRepDistance, -1.f, false);
-            RefineParameters tmp = charucoDetectorImpl->arucoDetector.getRefineParameters();
-            charucoDetectorImpl->arucoDetector.setRefineParameters(refineParameters);
-            charucoDetectorImpl->arucoDetector.refineDetectedMarkers(grey, getBoard(), currentMarker, currentMarkerId,
-                                                                     candidates,
-                                                                     noArray(), noArray(), acceptedIdxs);
-            charucoDetectorImpl->arucoDetector.setRefineParameters(tmp);
+            RefineParameters tmp = arucoDetector.getRefineParameters();
+            arucoDetector.setRefineParameters(refineParameters);
+            arucoDetector.refineDetectedMarkers(grey, board, currentMarker, currentMarkerId,
+                                                candidates, noArray(), noArray(), acceptedIdxs);
+            arucoDetector.setRefineParameters(tmp);
         }
 
-        // if found, we have a diamond
         if(currentMarker.size() == 4ull) {
             assigned[i] = true;
-            // calculate diamond id, acceptedIdxs array indicates the markers taken from candidates array
             Vec4i markerId;
             markerId[0] = currentId;
             for(int k = 1; k < 4; k++) {
@@ -499,51 +540,43 @@ void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diam
                 assigned[currentMarkerIdx] = true;
             }
 
-            // interpolate the charuco corners of the diamond
             vector<Point2f> currentMarkerCorners;
             Mat aux;
-            charucoDetectorImpl->detectBoardWithCheck(grey, currentMarkerCorners, aux, currentMarker, currentMarkerId);
+            detectBoardWithCheck(grey, currentMarkerCorners, aux, currentMarker, currentMarkerId);
 
-            // if everything is ok, save the diamond
             if(currentMarkerCorners.size() > 0ull) {
-                // reorder corners
-                vector<Point2f> currentMarkerCornersReorder;
-                currentMarkerCornersReorder.resize(4);
+                vector<Point2f> currentMarkerCornersReorder(4);
                 currentMarkerCornersReorder[0] = currentMarkerCorners[0];
                 currentMarkerCornersReorder[1] = currentMarkerCorners[1];
                 currentMarkerCornersReorder[2] = currentMarkerCorners[3];
                 currentMarkerCornersReorder[3] = currentMarkerCorners[2];
-
                 diamondCorners.push_back(currentMarkerCornersReorder);
                 diamondIds.push_back(markerId);
             }
         }
     }
-    charucoDetectorImpl->board = board;
+    board = savedBoard;
 
     if(diamondIds.size() > 0ull) {
-        // parse output
         if (_diamondIds.needed())
-        {
             Mat(diamondIds).copyTo(_diamondIds);
-        }
-
-        if (_diamondCorners.needed())
-        {
+        if (_diamondCorners.needed()) {
             _diamondCorners.create((int)diamondCorners.size(), 1, CV_32FC2);
             for(unsigned int i = 0; i < diamondCorners.size(); i++) {
                 _diamondCorners.create(4, 1, CV_32FC2, i, true);
-                for(int j = 0; j < 4; j++) {
+                for(int j = 0; j < 4; j++)
                     _diamondCorners.getMat(i).at<Point2f>(j) = diamondCorners[i][j];
-                }
             }
         }
-    }
-    else
-    {
+    } else {
         if (_diamondCorners.needed()) _diamondCorners.release();
         if (_diamondIds.needed()) _diamondIds.release();
     }
+}
+
+void CharucoDetector::detectDiamonds(InputArray image, OutputArrayOfArrays _diamondCorners, OutputArray _diamondIds,
+                                     InputOutputArrayOfArrays inMarkerCorners, InputOutputArray inMarkerIds) const {
+    charucoDetectorImpl->detectDiamonds(image, _diamondCorners, _diamondIds, inMarkerCorners, inMarkerIds);
 }
 
 void drawDetectedCornersCharuco(InputOutputArray _image, InputArray _charucoCorners,
@@ -590,16 +623,24 @@ void drawDetectedDiamonds(InputOutputArray _image, InputArrayOfArrays _corners, 
     int nMarkers = (int)_corners.total();
     for(int i = 0; i < nMarkers; i++) {
         Mat currentMarker = _corners.getMat(i);
-        CV_Assert(currentMarker.total() == 4 && currentMarker.channels() == 2);
+        CV_Assert( (currentMarker.total() == 4 || currentMarker.total() == 9 ) && currentMarker.channels() == 2);
         if (currentMarker.type() != CV_32SC2)
             currentMarker.convertTo(currentMarker, CV_32SC2);
 
         // draw marker sides
-        for(int j = 0; j < 4; j++) {
-            Point p0, p1;
-            p0 = currentMarker.at<Point>(j);
-            p1 = currentMarker.at<Point>((j + 1) % 4);
-            line(_image, p0, p1, borderColor, 1);
+        if(currentMarker.total() == 4){
+            for(size_t j = 0; j < currentMarker.total(); j++) {
+                Point p0, p1;
+                p0 = currentMarker.at<Point>(j);
+                p1 = currentMarker.at<Point>((j + 1) % currentMarker.total());
+                line(_image, p0, p1, borderColor, 1);
+            }
+        }
+        else{//9 corners, draw the inner square
+            line(_image, currentMarker.at<Point>(0), currentMarker.at<Point>(2), borderColor, 1);
+            line(_image, currentMarker.at<Point>(2), currentMarker.at<Point>(8), borderColor, 1);
+            line(_image, currentMarker.at<Point>(8), currentMarker.at<Point>(6), borderColor, 1);
+            line(_image, currentMarker.at<Point>(6), currentMarker.at<Point>(0), borderColor, 1);
         }
 
         // draw first corner mark
@@ -609,10 +650,10 @@ void drawDetectedDiamonds(InputOutputArray _image, InputArrayOfArrays _corners, 
         // draw id composed by four numbers
         if(_ids.total() != 0) {
             Point cent(0, 0);
-            for(int p = 0; p < 4; p++)
+            for(size_t p = 0; p < currentMarker.total(); p++)
                 cent += currentMarker.at<Point>(p);
-            cent = cent / 4.;
-            stringstream s;
+            cent = cent / float(currentMarker.total());
+            std::stringstream s;
             s << "id=" << _ids.getMat().at< Vec4i >(i);
             putText(_image, s.str(), cent, FONT_HERSHEY_SIMPLEX, 0.5, textColor, 2);
         }

--- a/modules/objdetect/test/test_charuco2detection.cpp
+++ b/modules/objdetect/test/test_charuco2detection.cpp
@@ -1,0 +1,183 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include "test_aruco_utils.hpp"
+
+namespace opencv_test { namespace {
+
+/**
+ * @brief Check Charuco2 detection accuracy using synthetic images
+ */
+class CV_Charuco2Detection : public cvtest::BaseTest {
+    public:
+    CV_Charuco2Detection() {}
+    void run(int) override;
+};
+
+void CV_Charuco2Detection::run(int) {
+    Mat cameraMatrix = Mat::eye(3, 3, CV_64FC1);
+    Size imgSize(500, 500);
+    int squaresX = 5;
+    int squaresY = 5;
+    float squareLength = 0.04f;
+    aruco::Dictionary dictionary = aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+    aruco::CharucoBoard board(Size(squaresX, squaresY), squareLength, squareLength, dictionary, noArray(), aruco::CHARUCO_2);
+
+    cameraMatrix.at<double>(0, 0) = cameraMatrix.at<double>(1, 1) = 600;
+    cameraMatrix.at<double>(0, 2) = imgSize.width / 2.0;
+    cameraMatrix.at<double>(1, 2) = imgSize.height / 2.0;
+
+    Mat distCoeffs(5, 1, CV_64FC1, Scalar::all(0));
+
+    // for different perspectives
+    for(double distance : {0.3, 0.5}) {
+        for(int yaw = -45; yaw <= 45; yaw += 30) {
+            for(int pitch = -45; pitch <= 45; pitch += 30) {
+                Mat rvec, tvec;
+                getSyntheticRT(deg2rad(yaw), deg2rad(pitch), distance, rvec, tvec);
+
+                // Generate board image
+                Mat boardImg;
+                board.generateImage(Size(1000, 1000), boardImg);
+
+                // Project board image corners to find the transformation
+                float b = 0.25f * squareLength;
+                vector<Point3f> boardCorners3d;
+                boardCorners3d.push_back(Point3f(-b, -b, 0));
+                boardCorners3d.push_back(Point3f(squaresX * squareLength + b, -b, 0));
+                boardCorners3d.push_back(Point3f(squaresX * squareLength + b, squaresY * squareLength + b, 0));
+                boardCorners3d.push_back(Point3f(-b, squaresY * squareLength + b, 0));
+
+                // Center the board for projection (matching projectMarker/projectBoard behavior)
+                Point3f boardCenter(squaresX * squareLength / 2.f, squaresY * squareLength / 2.f, 0.f);
+                vector<Point3f> centeredBoardCorners3d = boardCorners3d;
+                for(auto& p : centeredBoardCorners3d) {
+                    p -= boardCenter;
+                }
+
+                vector<Point2f> boardCorners2d;
+                projectPoints(centeredBoardCorners3d, rvec, tvec, cameraMatrix, distCoeffs, boardCorners2d);
+
+                vector<Point2f> srcCorners;
+                srcCorners.push_back(Point2f(0, 0));
+                srcCorners.push_back(Point2f((float)boardImg.cols, 0));
+                srcCorners.push_back(Point2f((float)boardImg.cols, (float)boardImg.rows));
+                srcCorners.push_back(Point2f(0, (float)boardImg.rows));
+
+                Mat H = getPerspectiveTransform(srcCorners, boardCorners2d);
+                Mat img(imgSize, CV_8UC1, Scalar(255));
+                warpPerspective(boardImg, img, H, imgSize, INTER_LINEAR, BORDER_CONSTANT, Scalar(255));
+
+                // Detect
+                aruco::CharucoDetector detector(board);
+                vector<Point2f> charucoCorners;
+                vector<int> charucoIds;
+                detector.detectBoard(img, charucoCorners, charucoIds);
+
+                // Check results against projected ground truth corners
+                vector<Point3f> allCorners3d = board.getChessboardCorners();
+                vector<Point3f> centeredAllCorners3d = allCorners3d;
+                for(auto& p : centeredAllCorners3d) {
+                    p -= boardCenter;
+                }
+                vector<Point2f> allCorners2d;
+                projectPoints(centeredAllCorners3d, rvec, tvec, cameraMatrix, distCoeffs, allCorners2d);
+
+                ASSERT_GT(charucoIds.size(), (size_t)0) << "No Charuco corners detected at yaw=" << yaw << " pitch=" << pitch << " dist=" << distance;
+                for(size_t i = 0; i < charucoIds.size(); i++) {
+                    int id = charucoIds[i];
+                    ASSERT_LT(id, (int)allCorners2d.size()) << "Invalid Charuco corner id";
+                    double err = cv::norm(charucoCorners[i] - allCorners2d[id]);
+
+                    ASSERT_LT(err, 5.0) << "Charuco corner reprojection error too high at corner " << id;
+                }
+            }
+        }
+    }
+}
+
+TEST(CV_Charuco2Detection, accuracy) {
+    CV_Charuco2Detection test;
+    test.run(0);
+}
+
+/**
+ * @brief Check CharucoBoard creation for CHARUCO_2
+ */
+TEST(CV_CharucoBoardCreation, charuco2) {
+    Size boardSize(5, 5);
+    float squareLength = 0.04f;
+    aruco::Dictionary dict = aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+
+    // Using the main constructor with CHARUCO_2 type
+    aruco::CharucoBoard board1(boardSize, squareLength, squareLength, dict, noArray(), aruco::CHARUCO_2);
+    ASSERT_EQ(board1.getChessboardSize(), boardSize);
+    ASSERT_EQ(board1.getSquareLength(), squareLength);
+    ASSERT_EQ(board1.getMarkerLength(), squareLength);
+    ASSERT_EQ(board1.getChessboardCorners().size(), (size_t)((boardSize.width + 1) * (boardSize.height + 1)));
+
+    // Using the convenience constructor for CHARUCO_2
+    aruco::CharucoBoard board2(boardSize, squareLength, dict);
+    ASSERT_EQ(board2.getChessboardSize(), boardSize);
+    ASSERT_EQ(board2.getSquareLength(), squareLength);
+    ASSERT_EQ(board2.getMarkerLength(), squareLength);
+    ASSERT_EQ(board2.getChessboardCorners().size(), (size_t)((boardSize.width + 1) * (boardSize.height + 1)));
+
+    // getObjPoints should return W*H marker corners (4 per marker)
+    ASSERT_EQ(board1.getObjPoints().size(), (size_t)(boardSize.width * boardSize.height));
+    for (const auto& mc : board1.getObjPoints())
+        ASSERT_EQ(mc.size(), 4u);
+
+    // getRightBottomCorner should be at (W*sq, H*sq, 0)
+    Point3f rbc = board1.getRightBottomCorner();
+    EXPECT_NEAR(rbc.x, boardSize.width  * squareLength, 1e-6f);
+    EXPECT_NEAR(rbc.y, boardSize.height * squareLength, 1e-6f);
+    EXPECT_NEAR(rbc.z, 0.f, 1e-6f);
+
+    // getNearestMarkerIdx/Corners return empty (not throw) for CHARUCO_2
+    ASSERT_TRUE(board1.getNearestMarkerIdx().empty());
+    ASSERT_TRUE(board1.getNearestMarkerCorners().empty());
+}
+
+/**
+ * @brief Check Charuco2 matchImagePoints
+ */
+TEST(CV_Charuco2MatchImagePoints, accuracy) {
+    Size boardSize(3, 3);
+    float squareLength = 0.1f;
+    aruco::Dictionary dict = aruco::getPredefinedDictionary(aruco::DICT_4X4_50);
+    aruco::CharucoBoard board(boardSize, squareLength, dict);
+
+    // Corners for CHARUCO_2 are (W+1)*(H+1)
+    int nCorners = (boardSize.width + 1) * (boardSize.height + 1);
+    vector<Point2f> detectedCorners;
+    vector<int> detectedIds;
+
+    // Simulate detection of all corners with some arbitrary image coordinates
+    for(int i = 0; i < nCorners; i++) {
+        detectedCorners.push_back(Point2f((float)i * 10, (float)i * 10));
+        detectedIds.push_back(i);
+    }
+
+    Mat objPoints, imgPoints;
+    board.matchImagePoints(detectedCorners, detectedIds, objPoints, imgPoints);
+
+    ASSERT_EQ(objPoints.total(), (size_t)nCorners);
+    ASSERT_EQ(imgPoints.total(), (size_t)nCorners);
+
+    vector<Point3f> boardObjPoints = board.getChessboardCorners();
+    for(int i = 0; i < nCorners; i++) {
+        Point3f p3d = objPoints.at<Point3f>(i);
+        EXPECT_NEAR(p3d.x, boardObjPoints[i].x, 1e-5);
+        EXPECT_NEAR(p3d.y, boardObjPoints[i].y, 1e-5);
+        EXPECT_NEAR(p3d.z, boardObjPoints[i].z, 1e-5);
+
+        Point2f p2d = imgPoints.at<Point2f>(i);
+        EXPECT_NEAR(p2d.x, (float)i * 10, 1e-5);
+        EXPECT_NEAR(p2d.y, (float)i * 10, 1e-5);
+    }
+}
+
+}} // namespace

--- a/samples/cpp/tutorial_code/objectDetection/create_board_charuco.cpp
+++ b/samples/cpp/tutorial_code/objectDetection/create_board_charuco.cpp
@@ -13,15 +13,16 @@ const char* keys  =
         "{w        |  5    | Number of squares in X direction }"
         "{h        |  7    | Number of squares in Y direction }"
         "{sl       |  100  | Square side length (in pixels) }"
-        "{ml       |  60   | Marker side length (in pixels) }"
+        "{ml       |  60   | Marker side length (in pixels). Ignored for CHARUCO_2 (markerLength == squareLength) }"
         "{d        |       | dictionary: DICT_4X4_50=0, DICT_4X4_100=1, DICT_4X4_250=2,"
         "DICT_4X4_1000=3, DICT_5X5_50=4, DICT_5X5_100=5, DICT_5X5_250=6, DICT_5X5_1000=7, "
         "DICT_6X6_50=8, DICT_6X6_100=9, DICT_6X6_250=10, DICT_6X6_1000=11, DICT_7X7_50=12,"
         "DICT_7X7_100=13, DICT_7X7_250=14, DICT_7X7_1000=15, DICT_ARUCO_ORIGINAL = 16}"
         "{cd       |       | Input file with custom dictionary }"
-        "{m        |       | Margins size (in pixels). Default is (squareLength-markerLength) }"
+        "{m        |       | Margins size (in pixels). Default is (squareLength-markerLength) for CHARUCO_1, 0 for CHARUCO_2 }"
         "{bb       | 1     | Number of bits in marker borders }"
-        "{si       | false | show generated image }";
+        "{si       | false | show generated image }"
+        "{bt       | 0     | Board type: 0=CHARUCO_1 (classic), 1=CHARUCO_2 (full-cell markers) }";
 }
 //! [charuco_detect_board_keys]
 
@@ -37,7 +38,10 @@ int main(int argc, char *argv[]) {
     int squaresY = parser.get<int>("h");
     int squareLength = parser.get<int>("sl");
     int markerLength = parser.get<int>("ml");
-    int margins = squareLength - markerLength;
+    int boardType = parser.get<int>("bt");
+    bool isCharuco2 = (boardType == aruco::CHARUCO_2);
+
+    int margins = isCharuco2 ? 0 : squareLength - markerLength;
     if(parser.has("m")) {
         margins = parser.get<int>("m");
     }
@@ -54,7 +58,8 @@ int main(int argc, char *argv[]) {
 
     //! [create_charucoBoard]
     aruco::Dictionary dictionary = readDictionatyFromCommandLine(parser);
-    cv::aruco::CharucoBoard board(Size(squaresX, squaresY), (float)squareLength, (float)markerLength, dictionary);
+    cv::aruco::CharucoBoard board(Size(squaresX, squaresY), (float)squareLength, (float)markerLength, dictionary,
+                                  noArray(), isCharuco2 ? aruco::CHARUCO_2 : aruco::CHARUCO_1);
     //! [create_charucoBoard]
 
     // show created board

--- a/samples/python/aruco_detect_board_charuco.py
+++ b/samples/python/aruco_detect_board_charuco.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python
 
 """aruco_detect_board_charuco.py
-Usage example:
-python aruco_detect_board_charuco.py -w=5 -h=7 -sl=0.04 -ml=0.02 -d=10 -c=../data/aruco/tutorial_camera_charuco.yml
-                                     -i=../data/aruco/choriginal.jpg
+Detect markers and corners of a ChArUco board (CHARUCO_1 or CHARUCO_2 layout),
+optionally estimating the board pose when camera parameters are provided.
+
+Usage examples:
+  CHARUCO_1 (classic layout):
+    python aruco_detect_board_charuco.py -w=5 -h=7 -sl=0.04 -ml=0.02 -d=10 \
+        -c=../data/aruco/tutorial_camera_charuco.yml -i=../data/aruco/choriginal.jpg
+
+  CHARUCO_2 (full-cell layout):
+    python aruco_detect_board_charuco.py -w=5 -h=7 -sl=0.04 -d=10 --bt=1
 """
 
 import argparse
@@ -42,6 +49,8 @@ def main():
                         dest="ci", type=int)
     parser.add_argument("-c", help="Input file with calibrated camera parameters", default="", action="store",
                         dest="cam_param")
+    parser.add_argument("--bt", help="Board type: 0=CHARUCO_1 (classic), 1=CHARUCO_2 (full-cell markers)",
+                        default=0, type=int, dest="bt")
 
     args = parser.parse_args()
 
@@ -66,7 +75,10 @@ def main():
 
     aruco_dict = cv.aruco.getPredefinedDictionary(dict)
     board_size = (width, height)
-    board = cv.aruco.CharucoBoard(board_size, square_len, marker_len, aruco_dict)
+    board_type = cv.aruco.CHARUCO_2 if args.bt == cv.aruco.CHARUCO_2 else cv.aruco.CHARUCO_1
+    if board_type == cv.aruco.CHARUCO_2:
+        marker_len = square_len
+    board = cv.aruco.CharucoBoard(board_size, square_len, marker_len, aruco_dict, None, board_type)
     charuco_detector = cv.aruco.CharucoDetector(board)
 
     image = None

--- a/samples/python/create_board_charuco.py
+++ b/samples/python/create_board_charuco.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+"""create_board_charuco.py
+Create and save a ChArUco board image (CHARUCO_1 or CHARUCO_2 layout).
+
+Usage examples:
+  CHARUCO_1 (classic, markers inside white squares):
+    python create_board_charuco.py -w=5 -h=7 -sl=100 -ml=60 -d=0 -o=charuco1.png
+
+  CHARUCO_2 (full-cell markers, markerLength == squareLength):
+    python create_board_charuco.py -w=5 -h=7 -sl=100 -d=0 -bt=1 -o=charuco2.png
+"""
+
+import argparse
+import sys
+import cv2 as cv
+
+
+DICT_HELP = (
+    "dictionary: DICT_4X4_50=0, DICT_4X4_100=1, DICT_4X4_250=2, DICT_4X4_1000=3, "
+    "DICT_5X5_50=4, DICT_5X5_100=5, DICT_5X5_250=6, DICT_5X5_1000=7, "
+    "DICT_6X6_50=8, DICT_6X6_100=9, DICT_6X6_250=10, DICT_6X6_1000=11, "
+    "DICT_7X7_50=12, DICT_7X7_100=13, DICT_7X7_250=14, DICT_7X7_1000=15, "
+    "DICT_ARUCO_ORIGINAL=16"
+)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Create a ChArUco board image", add_help=False)
+    parser.add_argument("-H", "--help", help="show help", action="store_true", dest="show_help")
+    parser.add_argument("-o", help="Output image file (default: res.png)", default="res.png", dest="output")
+    parser.add_argument("-w", help="Number of squares in X direction", default=5, type=int)
+    parser.add_argument("-h", help="Number of squares in Y direction", default=7, type=int)
+    parser.add_argument("-sl", help="Square side length in pixels", default=100, type=int, dest="sl")
+    parser.add_argument("-ml", help="Marker side length in pixels. Ignored for CHARUCO_2 (markerLength == squareLength)",
+                        default=60, type=int, dest="ml")
+    parser.add_argument("-d", help=DICT_HELP, default=0, type=int, dest="d")
+    parser.add_argument("-m", help="Margins in pixels. Default: squareLength-markerLength for CHARUCO_1, 0 for CHARUCO_2",
+                        default=None, type=int, dest="m")
+    parser.add_argument("-bb", help="Number of bits in marker borders", default=1, type=int, dest="bb")
+    parser.add_argument("-si", help="Show generated image", action="store_true", dest="si")
+    parser.add_argument("-bt", help="Board type: 0=CHARUCO_1 (classic), 1=CHARUCO_2 (full-cell markers)",
+                        default=0, type=int, dest="bt")
+
+    args = parser.parse_args()
+
+    if args.show_help:
+        parser.print_help()
+        sys.exit()
+
+    is_charuco2 = (args.bt == cv.aruco.CHARUCO_2)
+    square_len = args.sl
+    marker_len = square_len if is_charuco2 else args.ml
+
+    if args.m is not None:
+        margins = args.m
+    else:
+        margins = 0 if is_charuco2 else square_len - marker_len
+
+    dictionary = cv.aruco.getPredefinedDictionary(args.d)
+    board_type = cv.aruco.CHARUCO_2 if is_charuco2 else cv.aruco.CHARUCO_1
+    board = cv.aruco.CharucoBoard((args.w, args.h), float(square_len), float(marker_len), dictionary,
+                                  None, board_type)
+
+    image_size = (args.w * square_len + 2 * margins, args.h * square_len + 2 * margins)
+    board_image = board.generateImage(image_size, marginSize=margins, borderBits=args.bb)
+
+    if args.si:
+        cv.imshow("board", board_image)
+        cv.waitKey(0)
+
+    cv.imwrite(args.output, board_image)
+    print(f"Board saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Summary

This PR integrates the [charuco2 library](https://github.com/rmsalinas/charuco2) into `modules/objdetect` as an optional detection backend, exposed as `CharucoBoardType::CHARUCO_2`.

**Backwards compatibility:** all existing code using `CharucoBoard` and `CharucoDetector` continues to compile and run without any changes. The default board type is `CHARUCO_1`, which preserves the original behaviour exactly.

**Same API:** `CHARUCO_2` boards are created and used through exactly the same `CharucoBoard` / `CharucoDetector` API. The only change required from the user is passing `CharucoBoardType::CHARUCO_2` (or `CharucoBoardType::CHARUCO_1`) to the `CharucoBoard` constructor.

**What is added:**
- New `CharucoBoardType` enum (`CHARUCO_1`, `CHARUCO_2`) in `aruco_board.hpp`
- Two new `CharucoBoard` constructors accepting `CharucoBoardType`; new `getType()` accessor
- New source files `charuco2.h` / `charuco2.cpp` containing the charuco2 library
- Internal pImpl split: `CharucoBoardBaseImpl` → `CharucoBoard1Impl` / `CharucoBoard2Impl`; the latter delegates to `CharucoBoard2` from the charuco2 library
- `CharucoDetector` dispatches to a new `Charuco2DetectorImpl` when the board type is `CHARUCO_2`
- New test file `test_charuco2detection.cpp` covering board construction, `matchImagePoints`, corner detection, and `generateImage` for CHARUCO_2

**Known design differences between types (by design, documented in headers):**
- Diamond corner count: 4 (CHARUCO_1) vs 9 (CHARUCO_2)
- Coordinate origin: outer board corner (CHARUCO_1) vs top-left marker corner (CHARUCO_2)
- `charucoParams`, `detectorParams`, `refineParams`, `markerCorners`/`markerIds` inputs are ignored for CHARUCO_2
- `getNearestMarkerIdx/Corners` returns empty for CHARUCO_2; `setLegacyPattern` throws for CHARUCO_2

### Files changed
| File | Change |
|---|---|
| `include/opencv2/objdetect/aruco_board.hpp` | `CharucoBoardType` enum, new constructors, `getType()`, full docs |
| `include/opencv2/objdetect/charuco_detector.hpp` | `friend Charuco2DetectorImpl`, updated docs |
| `src/aruco/aruco_board.cpp` | `CharucoBoardBaseImpl`, `CharucoBoard1Impl`, `CharucoBoard2Impl` |
| `src/aruco/charuco_detector.cpp` | `CharucoBaseDetectorImpl`, `Charuco1DetectorImpl`, `Charuco2DetectorImpl` |
| `src/aruco/charuco2.h` | New file — charuco2 library header |
| `src/aruco/charuco2.cpp` | New file — charuco2 library implementation |
| `test/test_charuco2detection.cpp` | New test suite for CHARUCO_2 |

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original work: https://github.com/rmsalinas/charuco2
- [x] There is accuracy test and test data (`test_charuco2detection.cpp`)
- [x] The feature is well documented in the public headers