### PR TITLE
Add CV_DISABLE_UBSAN to disable undefined behavior sanitizer

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -684,7 +684,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #endif
 
 /****************************************************************************************\
-*                                    Thread sanitizer                                    *
+*                                    Sanitizers                                         *
 \****************************************************************************************/
 #ifndef CV_THREAD_SANITIZER
 # if defined(__has_feature)
@@ -692,6 +692,12 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #     define CV_THREAD_SANITIZER
 #   endif
 # endif
+#endif
+
+#if defined(__clang__) || defined(__GNUC__)
+  #define CV_DISABLE_UBSAN __attribute__((no_sanitize("undefined")))
+#else
+  #define CV_DISABLE_UBSAN
 #endif
 
 /****************************************************************************************\

--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -361,6 +361,7 @@ CV_INLINE int cvRound( int value )
 }
 
 /** @overload */
+CV_DISABLE_UBSAN
 CV_INLINE int cvFloor( float value )
 {
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1494,6 +1494,7 @@ FillEdgeCollection( Mat& img, std::vector<PolyEdge>& edges, const void* color )
 
 
 /* draws simple or filled circle */
+CV_DISABLE_UBSAN
 static void
 Circle( Mat& img, Point center, int radius, const void* color, int fill )
 {

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2276,6 +2276,7 @@ void warpAffine(int src_type,
     parallel_for_(range, invoker, dst.total()/(double)(1<<16));
 }
 
+CV_DISABLE_UBSAN
 void warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, int bw)
 {
     CALL_HAL(warpAffineBlocklineNN, cv_hal_warpAffineBlocklineNN, adelta, bdelta, xy, X0, Y0, bw);
@@ -2306,6 +2307,7 @@ void warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, 
     }
 }
 
+CV_DISABLE_UBSAN
 void warpAffineBlockline(int *adelta, int *bdelta, short* xy, short* alpha, int X0, int Y0, int bw)
 {
     CALL_HAL(warpAffineBlockline, cv_hal_warpAffineBlockline, adelta, bdelta, xy, alpha, X0, Y0, bw);


### PR DESCRIPTION
Also fix code here and there that triggered the fuzzer.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
