### PR TITLE
Feat: Full OpenCL support for KAZE

### DIFF
--- a/modules/features2d/perf/opencl/perf_kaze.cpp
+++ b/modules/features2d/perf/opencl/perf_kaze.cpp
@@ -1,0 +1,184 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "../perf_precomp.hpp"
+#include "opencv2/ts/ocl_perf.hpp"
+
+#ifdef HAVE_OPENCL
+
+namespace opencv_test {
+namespace ocl {
+
+typedef Size_MatType KAZEFixture;
+
+OCL_PERF_TEST_P(KAZEFixture, detectAndCompute, ::testing::Combine(OCL_PERF_ENUM(OCL_SIZE_1, OCL_SIZE_2, OCL_SIZE_3), OCL_PERF_ENUM((MatType)CV_8UC1)))
+{
+    const Size_MatType_t params = GetParam();
+    const Size srcSize = get<0>(params);
+    const int type = get<1>(params);
+
+    checkDeviceMaxMemoryAllocSize(srcSize, type);
+
+    UMat img(srcSize, type), mask;
+    declare.in(img, WARMUP_RNG);
+
+    Ptr<KAZE> kaze = KAZE::create(false, true);
+    vector<KeyPoint> points;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, mask, points, descriptors, false);
+
+    EXPECT_GT(points.size(), 20u);
+    EXPECT_EQ((size_t)descriptors.rows, points.size());
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType KAZEOclUprightFixture;
+
+OCL_PERF_TEST_P(KAZEOclUprightFixture, detectAndComputeUpright,
+    ::testing::Combine(
+        ::testing::Values(
+            cv::Size(320, 240), cv::Size(640, 480), cv::Size(960, 540),
+            cv::Size(1280, 720), cv::Size(1920, 1080), cv::Size(2560, 1440), cv::Size(3840, 2160)
+        ),
+        OCL_PERF_ENUM((MatType)CV_8UC1)
+    ))
+{
+    const Size_MatType_t params = GetParam();
+    const cv::Size srcSize = get<0>(params);
+
+    UMat img(srcSize, CV_8U);
+    declare.in(img, WARMUP_RNG);
+
+    Ptr<KAZE> kaze = KAZE::create(false, true);
+    vector<KeyPoint> kps;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, noArray(), kps, descriptors, false);
+
+    EXPECT_GT(kps.size(), 0u);
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType KAZEOclNonUprightFixture;
+
+OCL_PERF_TEST_P(KAZEOclNonUprightFixture, detectAndCompute,
+    ::testing::Combine(
+        ::testing::Values(
+            cv::Size(320, 240), cv::Size(640, 480), cv::Size(960, 540),
+            cv::Size(1280, 720), cv::Size(1920, 1080)
+        ),
+        OCL_PERF_ENUM((MatType)CV_8UC1)
+    ))
+{
+    const Size_MatType_t params = GetParam();
+    const cv::Size srcSize = get<0>(params);
+
+    UMat img(srcSize, CV_8U);
+    declare.in(img, WARMUP_RNG);
+
+    Ptr<KAZE> kaze = KAZE::create(false, false);
+    vector<KeyPoint> kps;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, noArray(), kps, descriptors, false);
+
+    EXPECT_GT(kps.size(), 0u);
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType KAZEOclExtendedUprightFixture;
+
+OCL_PERF_TEST_P(KAZEOclExtendedUprightFixture, detectAndComputeExtendedUpright,
+    ::testing::Combine(
+        ::testing::Values(
+            cv::Size(320, 240), cv::Size(640, 480), cv::Size(960, 540),
+            cv::Size(1280, 720), cv::Size(1920, 1080)
+        ),
+        OCL_PERF_ENUM((MatType)CV_8UC1)
+    ))
+{
+    const Size_MatType_t params = GetParam();
+    const cv::Size srcSize = get<0>(params);
+
+    UMat img(srcSize, CV_8U);
+    declare.in(img, WARMUP_RNG);
+
+    Ptr<KAZE> kaze = KAZE::create(true, true);
+    vector<KeyPoint> kps;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, noArray(), kps, descriptors, false);
+
+    EXPECT_GT(kps.size(), 0u);
+    SANITY_CHECK_NOTHING();
+}
+
+typedef Size_MatType KAZEOclExtendedNonUprightFixture;
+
+OCL_PERF_TEST_P(KAZEOclExtendedNonUprightFixture, detectAndComputeExtended,
+    ::testing::Combine(
+        ::testing::Values(
+            cv::Size(320, 240), cv::Size(640, 480), cv::Size(960, 540),
+            cv::Size(1280, 720), cv::Size(1920, 1080)
+        ),
+        OCL_PERF_ENUM((MatType)CV_8UC1)
+    ))
+{
+    const Size_MatType_t params = GetParam();
+    const cv::Size srcSize = get<0>(params);
+
+    UMat img(srcSize, CV_8U);
+    declare.in(img, WARMUP_RNG);
+
+    Ptr<KAZE> kaze = KAZE::create(true, false);
+    vector<KeyPoint> kps;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, noArray(), kps, descriptors, false);
+
+    EXPECT_GT(kps.size(), 0u);
+    SANITY_CHECK_NOTHING();
+}
+
+typedef tuple<std::string, int> KAZEOclRealImagesParams;
+typedef TestBaseWithParam<KAZEOclRealImagesParams> KAZEOclRealImagesFixture;
+
+OCL_PERF_TEST_P(KAZEOclRealImagesFixture, detectAndComputeRealImages,
+    ::testing::Combine(
+        ::testing::Values(
+            std::string("stitching/boat1.jpg"),
+            std::string("stitching/boat2.jpg"),
+            std::string("stitching/boat3.jpg"),
+            std::string("stitching/boat4.jpg"),
+            std::string("stitching/boat5.jpg"),
+            std::string("stitching/boat6.jpg")
+        ),
+        ::testing::Values(0)
+    ))
+{
+    const std::string imgName = get<0>(GetParam());
+
+    Mat img_mat = imread(getDataPath(imgName), IMREAD_GRAYSCALE);
+    if (img_mat.empty())
+        throw cvtest::SkipTestException("Image not found: " + imgName);
+
+    UMat img;
+    img_mat.copyTo(img);
+    declare.in(img);
+
+    Ptr<KAZE> kaze = KAZE::create(false, true);
+    vector<KeyPoint> kps;
+    UMat descriptors;
+
+    OCL_TEST_CYCLE() kaze->detectAndCompute(img, noArray(), kps, descriptors, false);
+
+    EXPECT_GT(kps.size(), 0u);
+    SANITY_CHECK_NOTHING();
+}
+
+} // ocl
+} // opencv_test
+
+#endif // HAVE_OPENCL

--- a/modules/features2d/src/kaze.cpp
+++ b/modules/features2d/src/kaze.cpp
@@ -113,8 +113,16 @@ namespace cv
             CV_INSTRUMENT_REGION();
 
 #ifdef HAVE_OPENCL
-            bool use_opencl = ocl::useOpenCL() && upright
+            // Only use OpenCL if input is already UMat
+#if defined(_M_IX86) || defined(__i386__)
+            // KAZE kernels use significant private memory (e.g. float[109] arrays).
+            // On 32-bit platforms, this may exceed driver limits and cause crashes.
+            bool use_opencl = false;
+#else
+            bool use_opencl = ocl::useOpenCL()
+                              && image.isUMat()
                               && !ocl::Device::getDefault().hostUnifiedMemory();
+#endif
             if (use_opencl)
             {
                 UMat img_gray = image.getUMat();
@@ -147,6 +155,7 @@ namespace cv
                 options.diffusivity = diffusivity;
 
                 KAZEFeatures impl(options);
+
                 UTPyramid uPyr;
                 impl.Create_Nonlinear_Scale_Space_UMat(img1_32, uPyr);
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -307,7 +307,7 @@ create_nonlinear_scale_space(InputArray image, const AKAZEOptions &options,
   }
 
   // derivatives, flow and diffusion step
-  MatType Lx, Ly, Lsmooth, Lflow, Lstep;
+  MatType Lx, Ly, Lsmooth, Lflow;
 
   // compute derivatives for computing k contrast
   GaussianBlur(img, Lsmooth, Size(5, 5), 1.0f, 1.0f, BORDER_REPLICATE);
@@ -348,12 +348,40 @@ create_nonlinear_scale_space(InputArray image, const AKAZEOptions &options,
     // Compute the conductivity equation
     compute_diffusivity(Lx, Ly, Lflow, kcontrast, options.diffusivity);
 
-    // Perform Fast Explicit Diffusion on Lt
+    // Perform Fast Explicit Diffusion on Lt (fused in-place kernel preferred)
     const std::vector<float> &tsteps = tsteps_evolution[i - 1];
-    for (size_t j = 0; j < tsteps.size(); j++) {
-      const float step_size = tsteps[j] * 0.5f;
-      non_linear_diffusion_step(e.Lt, Lflow, Lstep, step_size);
-      add(e.Lt, Lstep, e.Lt);
+
+#ifdef HAVE_OPENCL
+    if (cv::ocl::isOpenCLActivated() && std::is_same<MatType, UMat>::value)
+    {
+      UMat lt_buf1;
+      lt_buf1.create(e.Lt.size(), e.Lt.type());
+      if (ocl_pingpong_nld_step(e.Lt, lt_buf1, Lflow, tsteps[0] * 0.5f))
+      {
+        bool src_is_lt0 = false;
+        for (size_t j = 1; j < tsteps.size(); j++)
+        {
+          if (src_is_lt0)
+            ocl_pingpong_nld_step(e.Lt, lt_buf1, Lflow, tsteps[j] * 0.5f);
+          else
+            ocl_pingpong_nld_step(lt_buf1, e.Lt, Lflow, tsteps[j] * 0.5f);
+          src_is_lt0 = !src_is_lt0;
+        }
+        if (!src_is_lt0)
+          lt_buf1.copyTo(e.Lt);
+        continue;
+      }
+    }
+#endif
+    // Fallback to original 2-step approach
+    {
+      MatType Lstep;
+      Lstep.create(e.Lt.size(), e.Lt.type());
+      for (size_t j = 0; j < tsteps.size(); j++) {
+        const float step_size = tsteps[j] * 0.5f;
+        non_linear_diffusion_step(e.Lt, Lflow, Lstep, step_size);
+        add(e.Lt, Lstep, e.Lt);
+      }
     }
   }
 
@@ -385,7 +413,14 @@ convertScalePyramid(const std::vector<Evolution<MatTypeSrc> >& src, std::vector<
  */
 void AKAZEFeatures::Create_Nonlinear_Scale_Space(InputArray image)
 {
-  if (ocl::isOpenCLActivated() && image.isUMat() && !ocl::Device::getDefault().hostUnifiedMemory()) {
+#if defined(_M_IX86) || defined(__i386__)
+  // The AKAZE compute_diffusivity kernels use significant private memory (float arrays
+  // inside each work-item). On 32-bit platforms, this may exceed driver limits.
+  bool use_opencl = false;
+#else
+  bool use_opencl = ocl::isOpenCLActivated() && image.isUMat() && !ocl::Device::getDefault().hostUnifiedMemory();
+#endif
+  if (use_opencl) {
     // will run OCL version of scale space pyramid
     UMatPyramid uPyr;
     // init UMat pyramid with sizes

--- a/modules/features2d/src/kaze/KAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/KAZEFeatures.cpp
@@ -1227,6 +1227,49 @@ static inline int kaze_ksize_for_sigma(float sigma)
     return cvCeil(2.0f * (1.0f + (sigma - 0.8f) / 0.3f)) | 1;
 }
 
+static void sync_evolution_from_uPyr(const UTPyramid& uPyr, TPyramid& evolution_)
+{
+    for (size_t lv = 0; lv < uPyr.size(); lv++)
+    {
+        uPyr[lv].Lx.copyTo(evolution_[lv].Lx);
+        uPyr[lv].Ly.copyTo(evolution_[lv].Ly);
+    }
+}
+
+static inline bool
+ocl_compute_kaze_orientation_level(InputArray Lx_, InputArray Ly_,
+                                   InputArray keypoints_x_, InputArray keypoints_y_,
+                                   InputArray keypoints_size_, InputArray keypoints_angle_,
+                                   int nkeypoints)
+{
+    UMat Lx = Lx_.getUMat();
+    UMat Ly = Ly_.getUMat();
+    UMat keypoints_x = keypoints_x_.getUMat();
+    UMat keypoints_y = keypoints_y_.getUMat();
+    UMat keypoints_size = keypoints_size_.getUMat();
+    UMat keypoints_angle = keypoints_angle_.getUMat();
+
+    int lx_step = (int)(Lx.step / Lx.elemSize1());
+    int lx_rows = Lx.rows;
+    int lx_cols = Lx.cols;
+
+    size_t globalSize[] = {(size_t)nkeypoints};
+
+    ocl::Kernel ker("KAZE_compute_orientation_level", ocl::features2d::kaze_oclsrc);
+    if (ker.empty())
+        return false;
+
+    return ker.args(
+        ocl::KernelArg::PtrReadOnly(Lx),
+        ocl::KernelArg::PtrReadOnly(Ly),
+        lx_step, lx_rows, lx_cols,
+        ocl::KernelArg::PtrReadOnly(keypoints_x),
+        ocl::KernelArg::PtrReadOnly(keypoints_y),
+        ocl::KernelArg::PtrReadOnly(keypoints_size),
+        ocl::KernelArg::PtrWriteOnly(keypoints_angle),
+        nkeypoints).run(1, globalSize, 0, false);
+}
+
 // Dispatch the KAZE upright descriptor kernel for one pyramid level.
 // lx_step: row stride of Lx/Ly in float elements (= Lx.cols for continuous mat).
 static inline bool
@@ -1243,8 +1286,7 @@ ocl_compute_kaze_upright_descriptor_level(InputArray Lx_, InputArray Ly_,
     UMat descriptors = descriptors_.getUMat();
 
     int nkeypoints = (int)keypoints_x.total();
-    // For continuous UMat, step_in_float_elements == cols
-    int lx_step = Lx.cols;
+    int lx_step = (int)(Lx.step / Lx.elemSize1());
     int lx_rows = Lx.rows;
     int lx_cols = Lx.cols;
 
@@ -1263,6 +1305,47 @@ ocl_compute_kaze_upright_descriptor_level(InputArray Lx_, InputArray Ly_,
         ocl::KernelArg::PtrReadOnly(keypoints_x),
         ocl::KernelArg::PtrReadOnly(keypoints_y),
         ocl::KernelArg::PtrReadOnly(keypoints_size),
+        ocl::KernelArg::PtrWriteOnly(descriptors),
+        nkeypoints).run(1, globalSize, 0, false);
+}
+
+// Dispatch the KAZE rotation-invariant descriptor kernel for one pyramid level.
+// lx_step: row stride of Lx/Ly in float elements (= Lx.cols for continuous mat).
+static inline bool
+ocl_compute_kaze_descriptor_level(InputArray Lx_, InputArray Ly_,
+                                   InputArray keypoints_x_, InputArray keypoints_y_,
+                                   InputArray keypoints_size_, InputArray keypoints_angle_,
+                                   OutputArray descriptors_, bool extended)
+{
+    UMat Lx = Lx_.getUMat();
+    UMat Ly = Ly_.getUMat();
+    UMat keypoints_x = keypoints_x_.getUMat();
+    UMat keypoints_y = keypoints_y_.getUMat();
+    UMat keypoints_size = keypoints_size_.getUMat();
+    UMat keypoints_angle = keypoints_angle_.getUMat();
+    UMat descriptors = descriptors_.getUMat();
+
+    int nkeypoints = (int)keypoints_x.total();
+    int lx_step = (int)(Lx.step / Lx.elemSize1());
+    int lx_rows = Lx.rows;
+    int lx_cols = Lx.cols;
+
+    size_t globalSize[] = {(size_t)nkeypoints};
+
+    const char* kernel_name = extended ? "KAZE_compute_descriptor_128"
+                                       : "KAZE_compute_descriptor_64";
+    ocl::Kernel ker(kernel_name, ocl::features2d::kaze_oclsrc);
+    if (ker.empty())
+        return false;
+
+    return ker.args(
+        ocl::KernelArg::PtrReadOnly(Lx),
+        ocl::KernelArg::PtrReadOnly(Ly),
+        lx_step, lx_rows, lx_cols,
+        ocl::KernelArg::PtrReadOnly(keypoints_x),
+        ocl::KernelArg::PtrReadOnly(keypoints_y),
+        ocl::KernelArg::PtrReadOnly(keypoints_size),
+        ocl::KernelArg::PtrReadOnly(keypoints_angle),
         ocl::KernelArg::PtrWriteOnly(descriptors),
         nkeypoints).run(1, globalSize, 0, false);
 }
@@ -1290,18 +1373,89 @@ void KAZEFeatures::Create_Nonlinear_Scale_Space_UMat(InputArray image, UTPyramid
         GaussianBlur(uPyr[0].Lt, uPyr[0].Lsmooth, Size(k1, k1), options_.sderivatives, options_.sderivatives, BORDER_REPLICATE);
     }
 
-    // Compute kcontrast on CPU using first-level Lt (one GPU→CPU sync)
+    // Compute kcontrast from L0 gradients. Uses OpenCV Scharr (correct UMat handling)
+    // + fused mag2 kernel (replaces multiply(Lx^2) + multiply(Ly^2) + add(mag2)).
     {
-        Mat lt_cpu;
-        uPyr[0].Lt.copyTo(lt_cpu);
-        options_.kcontrast = compute_k_percentile(lt_cpu, options_.kcontrast_percentille,
-                                                   options_.sderivatives, options_.kcontrast_bins, 0, 0);
+        int nbins = options_.kcontrast_bins;
+        int rows = uPyr[0].Lsmooth.rows;
+        int cols = uPyr[0].Lsmooth.cols;
+
+        UMat Lx_k, Ly_k;
+        Scharr(uPyr[0].Lsmooth, Lx_k, CV_32F, 1, 0, 1.0, 0.0, BORDER_DEFAULT);
+        Scharr(uPyr[0].Lsmooth, Ly_k, CV_32F, 0, 1, 1.0, 0.0, BORDER_DEFAULT);
+
+        UMat mag2(rows, cols, CV_32F);
+
+        bool ocl_ok = false;
+        size_t localSize[] = {16, 16};
+        size_t globalSize[] = {
+            (size_t)alignSize(cols, (int)localSize[0]),
+            (size_t)alignSize(rows, (int)localSize[1])
+        };
+
+        int kstep = (int)(Lx_k.step / sizeof(float));
+        int mag2_step = (int)(mag2.step / mag2.elemSize1());
+
+        ocl::Kernel ker("KAZE_compute_mag2", ocl::features2d::kaze_oclsrc);
+        if (!ker.empty() && ker.args(
+            ocl::KernelArg::PtrReadOnly(Lx_k),
+            ocl::KernelArg::PtrReadOnly(Ly_k),
+            kstep, cols, rows,
+            ocl::KernelArg::PtrWriteOnly(mag2),
+            mag2_step
+        ).run(2, globalSize, localSize, false))
+        {
+            double maxVal = 0.0;
+            minMaxLoc(mag2, NULL, &maxVal, NULL, NULL);
+            float hmax = sqrt((float)maxVal);
+
+            if (hmax > 1e-10f)
+            {
+                UMat histogram(1, nbins, CV_32S, Scalar::all(0));
+
+                ocl::Kernel hist_ker("KAZE_compute_kcontrast_histogram", ocl::features2d::kaze_oclsrc);
+                if (!hist_ker.empty() && hist_ker.args(
+                    ocl::KernelArg::PtrReadOnly(Lx_k),
+                    ocl::KernelArg::PtrReadOnly(Ly_k),
+                    kstep, cols, rows, hmax, nbins,
+                    ocl::KernelArg::PtrWriteOnly(histogram),
+                    ocl::KernelArg::Local(nbins * (int)sizeof(int))
+                ).run(2, globalSize, localSize, false))
+                {
+                    Mat hist_cpu = histogram.getMat(ACCESS_READ);
+                    const int* hist_data = hist_cpu.ptr<int>();
+
+                    float npoints = 0.0f;
+                    for (int b = 0; b < nbins; b++)
+                        npoints += (float)hist_data[b];
+
+                    int nthreshold = (int)(npoints * options_.kcontrast_percentille);
+                    int nelements = 0, k = 0;
+                    for (k = 0; nelements < nthreshold && k < nbins; k++)
+                        nelements += hist_data[k];
+
+                    if (nelements < nthreshold)
+                        options_.kcontrast = 0.03f;
+                    else
+                        options_.kcontrast = hmax * ((float)k / (float)nbins);
+                    ocl_ok = true;
+                }
+            }
+        }
+
+        if (!ocl_ok)
+        {
+            Mat lt_cpu;
+            uPyr[0].Lt.copyTo(lt_cpu);
+            options_.kcontrast = compute_k_percentile(lt_cpu, options_.kcontrast_percentille,
+                                                       options_.sderivatives, options_.kcontrast_bins, 0, 0);
+        }
     }
 
     // Build scale space (levels 1 .. n-1)
     {
         int k1 = kaze_ksize_for_sigma(options_.sderivatives);
-        UMat Lx_diff, Ly_diff, Lflow, Lstep;
+        UMat Lx_diff, Ly_diff, Lflow;
 
         for (size_t i = 1; i < uPyr.size(); i++)
         {
@@ -1316,12 +1470,40 @@ void KAZEFeatures::Create_Nonlinear_Scale_Space_UMat(InputArray image, UTPyramid
 
             compute_diffusivity(Lx_diff, Ly_diff, Lflow, options_.kcontrast, options_.diffusivity);
 
-            // Fast Explicit Diffusion steps
+            // Fast Explicit Diffusion steps with fused kernel (no Lstep buffer)
             const std::vector<float>& tsteps = tsteps_[i - 1];
-            for (size_t j = 0; j < tsteps.size(); j++)
+
+#ifdef HAVE_OPENCL
+            if (cv::ocl::isOpenCLActivated())
             {
-                non_linear_diffusion_step(uPyr[i].Lt, Lflow, Lstep, tsteps[j] * 0.5f);
-                add(uPyr[i].Lt, Lstep, uPyr[i].Lt);
+                UMat lt_buf1;
+                lt_buf1.create(uPyr[i].Lt.size(), uPyr[i].Lt.type());
+                if (ocl_pingpong_nld_step(uPyr[i].Lt, lt_buf1, Lflow, tsteps[0] * 0.5f))
+                {
+                    bool src_is_lt0 = false;
+                    for (size_t j = 1; j < tsteps.size(); j++)
+                    {
+                        if (src_is_lt0)
+                            ocl_pingpong_nld_step(uPyr[i].Lt, lt_buf1, Lflow, tsteps[j] * 0.5f);
+                        else
+                            ocl_pingpong_nld_step(lt_buf1, uPyr[i].Lt, Lflow, tsteps[j] * 0.5f);
+                        src_is_lt0 = !src_is_lt0;
+                    }
+                    if (!src_is_lt0)
+                        lt_buf1.copyTo(uPyr[i].Lt);
+                    continue;
+                }
+            }
+#endif
+            // Fallback to original 2-step approach (non-OCL or fused unavailable)
+            {
+                UMat Lstep_bak;
+                Lstep_bak.create(uPyr[i].Lt.size(), uPyr[i].Lt.type());
+                for (size_t j = 0; j < tsteps.size(); j++)
+                {
+                    non_linear_diffusion_step(uPyr[i].Lt, Lflow, Lstep_bak, tsteps[j] * 0.5f);
+                    add(uPyr[i].Lt, Lstep_bak, uPyr[i].Lt);
+                }
             }
         }
     }
@@ -1392,6 +1574,7 @@ void KAZEFeatures::Compute_Descriptors_UMat(std::vector<KeyPoint>& kpts, OutputA
     }
 
     int descriptor_size = options_.extended ? 128 : 64;
+    bool upright = options_.upright;
 
     // Group keypoint indices by pyramid level
     std::vector<std::vector<int>> kpts_by_level(uPyr.size());
@@ -1418,6 +1601,55 @@ void KAZEFeatures::Compute_Descriptors_UMat(std::vector<KeyPoint>& kpts, OutputA
                 kpt_to_row[ki] = row++;
     }
 
+
+    if (!upright)
+    {
+        for (size_t lv = 0; lv < uPyr.size(); lv++)
+        {
+            const std::vector<int>& indices = kpts_by_level[lv];
+            int n = (int)indices.size();
+            if (n == 0)
+                continue;
+
+            // Pack keypoint data into UMats for orientation
+            UMat kpts_x(n, 1, CV_32F);
+            UMat kpts_y(n, 1, CV_32F);
+            UMat kpts_sz(n, 1, CV_32F);
+            UMat kpts_angle(n, 1, CV_32F);
+            {
+                Mat mx = kpts_x.getMat(ACCESS_WRITE);
+                Mat my = kpts_y.getMat(ACCESS_WRITE);
+                Mat ms = kpts_sz.getMat(ACCESS_WRITE);
+                Mat ma = kpts_angle.getMat(ACCESS_WRITE);
+                for (int i = 0; i < n; i++)
+                {
+                    const KeyPoint& kp = kpts[indices[i]];
+                    mx.at<float>(i) = kp.pt.x;
+                    my.at<float>(i) = kp.pt.y;
+                    ms.at<float>(i) = kp.size;
+                }
+            }
+
+            bool ok = ocl_compute_kaze_orientation_level(
+                uPyr[lv].Lx, uPyr[lv].Ly,
+                kpts_x, kpts_y, kpts_sz, kpts_angle, n);
+
+            if (ok)
+            {
+                Mat ma = kpts_angle.getMat(ACCESS_READ);
+                for (int i = 0; i < n; i++)
+                    kpts[indices[i]].angle = ma.at<float>(i);
+            }
+            else
+            {
+                // Fallback to CPU orientation
+                sync_evolution_from_uPyr(uPyr, evolution_);
+                for (int ki : indices)
+                    Compute_Main_Orientation(kpts[ki], evolution_, options_);
+            }
+        }
+    }
+
     for (size_t lv = 0; lv < uPyr.size(); lv++)
     {
         const std::vector<int>& indices = kpts_by_level[lv];
@@ -1429,34 +1661,50 @@ void KAZEFeatures::Compute_Descriptors_UMat(std::vector<KeyPoint>& kpts, OutputA
         UMat kpts_x(n, 1, CV_32F);
         UMat kpts_y(n, 1, CV_32F);
         UMat kpts_sz(n, 1, CV_32F);
+        UMat kpts_angle(n, 1, CV_32F);
         {
             Mat mx = kpts_x.getMat(ACCESS_WRITE);
             Mat my = kpts_y.getMat(ACCESS_WRITE);
             Mat ms = kpts_sz.getMat(ACCESS_WRITE);
+            Mat ma = kpts_angle.getMat(ACCESS_WRITE);
             for (int i = 0; i < n; i++)
             {
                 const KeyPoint& kp = kpts[indices[i]];
                 mx.at<float>(i) = kp.pt.x;
                 my.at<float>(i) = kp.pt.y;
                 ms.at<float>(i) = kp.size;
+                ma.at<float>(i) = kp.angle;
             }
         }
 
         // Compute descriptors for this level on GPU
         UMat desc_level(n, descriptor_size, CV_32F);
-        bool ok = ocl_compute_kaze_upright_descriptor_level(
-            uPyr[lv].Lx, uPyr[lv].Ly,
-            kpts_x, kpts_y, kpts_sz,
-            desc_level, options_.extended);
-
-        if (!ok)
+        bool ok;
+        if (upright)
         {
-            // GPU failed — fall back to full CPU path
-            Mat cpu_desc;
-            Feature_Description(kpts, cpu_desc);
-            cpu_desc.copyTo(desc);
-            return;
+            ok = ocl_compute_kaze_upright_descriptor_level(
+                uPyr[lv].Lx, uPyr[lv].Ly,
+                kpts_x, kpts_y, kpts_sz,
+                desc_level, options_.extended);
         }
+        else
+        {
+            ok = ocl_compute_kaze_descriptor_level(
+                uPyr[lv].Lx, uPyr[lv].Ly,
+                kpts_x, kpts_y, kpts_sz, kpts_angle,
+                desc_level, options_.extended);
+        }
+
+            if (!ok)
+            {
+                // GPU failed — fall back to full CPU path
+                sync_evolution_from_uPyr(uPyr, evolution_);
+                Mat cpu_desc;
+                Feature_Description(kpts, cpu_desc);
+                cpu_desc.copyTo(desc);
+                return;
+            }
+
 
         // Download and copy into correct rows of the output matrix
         Mat level_mat = desc_level.getMat(ACCESS_READ);

--- a/modules/features2d/src/kaze/akaze_diffusion.hpp
+++ b/modules/features2d/src/kaze/akaze_diffusion.hpp
@@ -19,7 +19,6 @@ nld_step_scalar_one_lane(const Mat& Lt, const Mat& Lf, Mat& Lstep, float step_si
 {
   CV_INSTRUMENT_REGION();
 
-  Lstep.create(Lt.size(), Lt.type());
   const int cols = Lt.cols - 2;
   int row = row_begin;
 
@@ -149,6 +148,53 @@ ocl_non_linear_diffusion_step(InputArray Lt_, InputArray Lf_, OutputArray Lstep_
 }
 
 static inline bool
+ocl_pingpong_nld_step(InputArray Lt_src_, InputArray Lt_dst_, InputArray Lf_, float step_size)
+{
+  if(!Lt_src_.isUMat() || !Lt_dst_.isUMat() || !Lf_.isUMat() || !Lt_src_.isContinuous())
+    return false;
+
+  UMat Lt_src = Lt_src_.getUMat();
+  UMat Lt_dst = Lt_dst_.getUMat();
+  UMat Lf = Lf_.getUMat();
+
+  int rows = Lt_src.rows;
+  int cols = Lt_src.cols;
+  size_t globalSize[] = {(size_t)cols, (size_t)rows};
+
+  ocl::Kernel ker("AKAZE_pingpong_nld_step", ocl::features2d::akaze_oclsrc);
+  if( ker.empty() )
+    return false;
+
+  return ker.args(
+    ocl::KernelArg::PtrReadOnly(Lt_src),
+    rows, cols,
+    ocl::KernelArg::PtrWriteOnly(Lt_dst),
+    ocl::KernelArg::PtrReadOnly(Lf),
+    step_size).run(2, globalSize, 0, false);
+}
+
+static inline bool
+ocl_pm_g1(InputArray Lx_, InputArray Ly_, OutputArray Lflow_, float kcontrast)
+{
+  UMat Lx = Lx_.getUMat();
+  UMat Ly = Ly_.getUMat();
+  UMat Lflow = Lflow_.getUMat();
+
+  int total = Lx.rows * Lx.cols;
+  size_t globalSize[] = {(size_t)total};
+
+  ocl::Kernel ker("AKAZE_pm_g1", ocl::features2d::akaze_oclsrc);
+  if( ker.empty() )
+    return false;
+
+  return ker.args(
+    ocl::KernelArg::PtrReadOnly(Lx),
+    ocl::KernelArg::PtrReadOnly(Ly),
+    ocl::KernelArg::PtrWriteOnly(Lflow),
+    kcontrast, total).run(1, globalSize, 0, false);
+}
+
+static inline bool
 ocl_pm_g2(InputArray Lx_, InputArray Ly_, OutputArray Lflow_, float kcontrast)
 {
   UMat Lx = Lx_.getUMat();
@@ -168,14 +214,54 @@ ocl_pm_g2(InputArray Lx_, InputArray Ly_, OutputArray Lflow_, float kcontrast)
     ocl::KernelArg::PtrWriteOnly(Lflow),
     kcontrast, total).run(1, globalSize, 0, false);
 }
+
+static inline bool
+ocl_weickert(InputArray Lx_, InputArray Ly_, OutputArray Lflow_, float kcontrast)
+{
+  UMat Lx = Lx_.getUMat();
+  UMat Ly = Ly_.getUMat();
+  UMat Lflow = Lflow_.getUMat();
+
+  int total = Lx.rows * Lx.cols;
+  size_t globalSize[] = {(size_t)total};
+
+  ocl::Kernel ker("AKAZE_weickert", ocl::features2d::akaze_oclsrc);
+  if( ker.empty() )
+    return false;
+
+  return ker.args(
+    ocl::KernelArg::PtrReadOnly(Lx),
+    ocl::KernelArg::PtrReadOnly(Ly),
+    ocl::KernelArg::PtrWriteOnly(Lflow),
+    kcontrast, total).run(1, globalSize, 0, false);
+}
+
+static inline bool
+ocl_charbonnier(InputArray Lx_, InputArray Ly_, OutputArray Lflow_, float kcontrast)
+{
+  UMat Lx = Lx_.getUMat();
+  UMat Ly = Ly_.getUMat();
+  UMat Lflow = Lflow_.getUMat();
+
+  int total = Lx.rows * Lx.cols;
+  size_t globalSize[] = {(size_t)total};
+
+  ocl::Kernel ker("AKAZE_charbonnier", ocl::features2d::akaze_oclsrc);
+  if( ker.empty() )
+    return false;
+
+  return ker.args(
+    ocl::KernelArg::PtrReadOnly(Lx),
+    ocl::KernelArg::PtrReadOnly(Ly),
+    ocl::KernelArg::PtrWriteOnly(Lflow),
+    kcontrast, total).run(1, globalSize, 0, false);
+}
 #endif // HAVE_OPENCL
 
 static inline void
 non_linear_diffusion_step(InputArray Lt_, InputArray Lf_, OutputArray Lstep_, float step_size)
 {
   CV_INSTRUMENT_REGION();
-
-  Lstep_.create(Lt_.size(), Lt_.type());
 
   CV_OCL_RUN(Lt_.isUMat() && Lf_.isUMat() && Lstep_.isUMat(),
     ocl_non_linear_diffusion_step(Lt_, Lf_, Lstep_, step_size));
@@ -195,16 +281,23 @@ compute_diffusivity(InputArray Lx, InputArray Ly, OutputArray Lflow, float kcont
 
   switch (diffusivity) {
     case KAZE::DIFF_PM_G1:
+      CV_OCL_RUN(Lx.isUMat() && Ly.isUMat() && Lflow.isUMat(),
+        ocl_pm_g1(Lx, Ly, Lflow, kcontrast))
       pm_g1(Lx, Ly, Lflow, kcontrast);
     break;
     case KAZE::DIFF_PM_G2:
-      CV_OCL_RUN(Lx.isUMat() && Ly.isUMat() && Lflow.isUMat(), ocl_pm_g2(Lx, Ly, Lflow, kcontrast));
+      CV_OCL_RUN(Lx.isUMat() && Ly.isUMat() && Lflow.isUMat(),
+        ocl_pm_g2(Lx, Ly, Lflow, kcontrast))
       pm_g2(Lx, Ly, Lflow, kcontrast);
     break;
     case KAZE::DIFF_WEICKERT:
+      CV_OCL_RUN(Lx.isUMat() && Ly.isUMat() && Lflow.isUMat(),
+        ocl_weickert(Lx, Ly, Lflow, kcontrast))
       weickert_diffusivity(Lx, Ly, Lflow, kcontrast);
     break;
     case KAZE::DIFF_CHARBONNIER:
+      CV_OCL_RUN(Lx.isUMat() && Ly.isUMat() && Lflow.isUMat(),
+        ocl_charbonnier(Lx, Ly, Lflow, kcontrast))
       charbonnier_diffusivity(Lx, Ly, Lflow, kcontrast);
     break;
     default:

--- a/modules/features2d/src/opencl/akaze.cl
+++ b/modules/features2d/src/opencl/akaze.cl
@@ -4,6 +4,26 @@
 
 
 /**
+ * @brief This function computes the Perona and Malik conductivity coefficient g1
+ * g1 = exp(-dL^2 / k^2)
+ * @param lx First order image derivative in X-direction (horizontal)
+ * @param ly First order image derivative in Y-direction (vertical)
+ * @param dst Output image
+ * @param k Contrast factor parameter
+ */
+__kernel void
+AKAZE_pm_g1(__global const float* lx, __global const float* ly, __global float* dst,
+    float k, int size)
+{
+    int i = get_global_id(0);
+    if (!(i < size))
+        return;
+
+    const float k2inv = 1.0f / (k * k);
+    dst[i] = exp(-(lx[i] * lx[i] + ly[i] * ly[i]) * k2inv);
+}
+
+/**
  * @brief This function computes the Perona and Malik conductivity coefficient g2
  * g2 = 1 / (1 + dL^2 / k^2)
  * @param lx First order image derivative in X-direction (horizontal)
@@ -24,6 +44,50 @@ AKAZE_pm_g2(__global const float* lx, __global const float* ly, __global float* 
 
     const float k2inv = 1.0f / (k * k);
     dst[i] = 1.0f / (1.0f + ((lx[i] * lx[i] + ly[i] * ly[i]) * k2inv));
+}
+
+/**
+ * @brief This function computes Weickert conductivity coefficient
+ * g3 = 1 - exp(-3.315 / (dL^2 / k^2)^4)
+ * @param lx First order image derivative in X-direction (horizontal)
+ * @param ly First order image derivative in Y-direction (vertical)
+ * @param dst Output image
+ * @param k Contrast factor parameter
+ */
+__kernel void
+AKAZE_weickert(__global const float* lx, __global const float* ly, __global float* dst,
+    float k, int size)
+{
+    int i = get_global_id(0);
+    if (i >= size)
+        return;
+
+    const float inv_k = 1.0f / (k * k);
+    float dL = inv_k * (lx[i] * lx[i] + ly[i] * ly[i]);
+    float dL4 = dL * dL;
+    dL4 = dL4 * dL4;
+    dst[i] = 1.0f - exp(-3.315f / dL4);
+}
+
+/**
+ * @brief This function computes Charbonnier conductivity coefficient
+ * gc = 1 / sqrt(1 + dL^2 / k^2)
+ * @param lx First order image derivative in X-direction (horizontal)
+ * @param ly First order image derivative in Y-direction (vertical)
+ * @param dst Output image
+ * @param k Contrast factor parameter
+ */
+__kernel void
+AKAZE_charbonnier(__global const float* lx, __global const float* ly, __global float* dst,
+    float k, int size)
+{
+    int i = get_global_id(0);
+    if (i >= size)
+        return;
+
+    const float inv_k = 1.0f / (k * k);
+    float den = sqrt(1.0f + inv_k * (lx[i] * lx[i] + ly[i] * ly[i]));
+    dst[i] = 1.0f / den;
 }
 
 __kernel void
@@ -95,6 +159,94 @@ AKAZE_nld_step_scalar(__global const float* lt, int lt_step, int lt_offset, int 
     }
 
     dst[c + j] = res * step_size;
+}
+
+/**
+ * @brief Fused nonlinear diffusion step with ping-pong buffering
+ * @details Combines non_linear_diffusion_step and add(Lt, Lstep, Lt) into a single
+ * kernel. Reads from src (read-only), writes result to dst (write-only).
+ * This avoids read-write races: all neighbor reads go to src, all writes go to dst.
+ * No Lstep intermediate buffer is needed; the two buffers ping-pong between steps.
+ *
+ * The 5-point stencil labeling scheme:
+ *        [    a    ]
+ *        [ -1 c +1 ]
+ *        [    b    ]
+ *
+ * @param src Current evolution image (read-only)
+ * @param dst Output evolution image (write-only)
+ * @param rows Image height
+ * @param cols Image width
+ * @param lf Conductivity (flow) image
+ * @param step_size FED step size (tau * 0.5)
+ */
+__kernel void
+AKAZE_pingpong_nld_step(__global const float* src, int rows, int cols,
+    __global float* dst, __global const float* lf, float step_size)
+{
+    int i = get_global_id(1);
+    int j = get_global_id(0);
+
+    if (!(i < rows && j < cols))
+        return;
+
+    int a = (i - 1) * cols;
+    int c = i * cols;
+    int b = (i + 1) * cols;
+
+    float cur = src[c + j];
+    float res = 0.0f;
+
+    if (i == 0)
+    {
+        if (j == 0 || j == (cols - 1))
+        {
+            res = 0.0f;
+        }
+        else
+        {
+            res = (lf[c + j] + lf[c + j + 1]) * (src[c + j + 1] - cur) +
+                  (lf[c + j] + lf[c + j - 1]) * (src[c + j - 1] - cur) +
+                  (lf[c + j] + lf[b + j    ]) * (src[b + j    ] - cur);
+        }
+    }
+    else if (i == (rows - 1))
+    {
+        if (j == 0 || j == (cols - 1))
+        {
+            res = 0.0f;
+        }
+        else
+        {
+            res = (lf[c + j] + lf[c + j + 1]) * (src[c + j + 1] - cur) +
+                  (lf[c + j] + lf[c + j - 1]) * (src[c + j - 1] - cur) +
+                  (lf[c + j] + lf[a + j    ]) * (src[a + j    ] - cur);
+        }
+    }
+    else
+    {
+        if (j == 0)
+        {
+            res = (lf[c + 0] + lf[c + 1]) * (src[c + 1] - cur) +
+                  (lf[c + 0] + lf[b + 0]) * (src[b + 0] - cur) +
+                  (lf[c + 0] + lf[a + 0]) * (src[a + 0] - cur);
+        }
+        else if (j == (cols - 1))
+        {
+            res = (lf[c + j] + lf[c + j - 1]) * (src[c + j - 1] - cur) +
+                  (lf[c + j] + lf[b + j    ]) * (src[b + j    ] - cur) +
+                  (lf[c + j] + lf[a + j    ]) * (src[a + j    ] - cur);
+        }
+        else
+        {
+            res = (lf[c + j] + lf[c + j + 1]) * (src[c + j + 1] - cur) +
+                  (lf[c + j] + lf[c + j - 1]) * (src[c + j - 1] - cur) +
+                  (lf[c + j] + lf[b + j    ]) * (src[b + j    ] - cur) +
+                  (lf[c + j] + lf[a + j    ]) * (src[a + j    ] - cur);
+        }
+    }
+
+    dst[c + j] = cur + res * step_size;
 }
 
 /**

--- a/modules/features2d/src/opencl/kaze.cl
+++ b/modules/features2d/src/opencl/kaze.cl
@@ -4,15 +4,45 @@
 
 inline float gaussian(float x, float y, float sigma)
 {
-    return exp(-(x*x + y*y) / (2.0f*sigma*sigma));
+    return native_exp(-(x*x + y*y) / (2.0f*sigma*sigma));
 }
 
+// Pre-computed gaussian weights for descriptor 9×9 sample grid (81 values, row-major).
+// gauss_s1(ri,ci) = exp(-((ri-5)^2 + (ci-5)^2) / 12.5)
+__constant float gauss_s1_weights[81] = {
+    0.01831564f, 0.03762826f, 0.06587475f, 0.09827359f, 0.12493021f, 0.13533528f, 0.12493021f, 0.09827359f, 0.06587475f,
+    0.03762826f, 0.07730474f, 0.13533528f, 0.20189652f, 0.25666078f, 0.27803730f, 0.25666078f, 0.20189652f, 0.13533528f,
+    0.06587475f, 0.13533528f, 0.23692776f, 0.35345468f, 0.44932896f, 0.48675226f, 0.44932896f, 0.35345468f, 0.23692776f,
+    0.09827359f, 0.20189652f, 0.35345468f, 0.52729242f, 0.67032005f, 0.72614904f, 0.67032005f, 0.52729242f, 0.35345468f,
+    0.12493021f, 0.25666078f, 0.44932896f, 0.67032005f, 0.85214379f, 0.92311635f, 0.85214379f, 0.67032005f, 0.44932896f,
+    0.13533528f, 0.27803730f, 0.48675226f, 0.72614904f, 0.92311635f, 1.00000000f, 0.92311635f, 0.72614904f, 0.48675226f,
+    0.12493021f, 0.25666078f, 0.44932896f, 0.67032005f, 0.85214379f, 0.92311635f, 0.85214379f, 0.67032005f, 0.44932896f,
+    0.09827359f, 0.20189652f, 0.35345468f, 0.52729242f, 0.67032005f, 0.72614904f, 0.67032005f, 0.52729242f, 0.35345468f,
+    0.06587475f, 0.13533528f, 0.23692776f, 0.35345468f, 0.44932896f, 0.48675226f, 0.44932896f, 0.35345468f, 0.23692776f
+};
+
+// Pre-computed gaussian weights for 4×4 subregion outer weighting (16 values, row-major).
+// cx=sr+0.5, cy=sc+0.5 for sr,sc in {0,1,2,3}
+// gauss_s2(sr,sc) = exp(-((sr-1.5)^2 + (sc-1.5)^2) / 4.5)
+__constant float gauss_s2_weights[16] = {
+    0.36787944f, 0.57375342f, 0.57375342f, 0.36787944f,
+    0.57375342f, 0.89483932f, 0.89483932f, 0.57375342f,
+    0.57375342f, 0.89483932f, 0.89483932f, 0.57375342f,
+    0.36787944f, 0.57375342f, 0.57375342f, 0.36787944f
+};
+
 /**
- * @brief Compute KAZE upright 64-dimensional descriptor
+ * @brief Compute KAZE upright 64-dimensional descriptor (optimized)
  * @details Matches CPU Get_KAZE_Upright_Descriptor_64 exactly:
  *          - integer scale via round(kpt_size/2)
  *          - bilinear with y1=(int)(y-0.5), y2=(int)(y+0.5) convention
  *          - clamp-on-border (not skip)
+ *
+ * Optimizations:
+ * - Pre-computed gaussian weights (__constant, no exp() calls in inner loop)
+ * - Vectorized vload2 for bilinear pixel pairs
+ * - Pre-computed row addresses outside ci loop
+ * - Simplified loop structure
  *
  * @param Lx     First-order x-derivative (sigma_size-scaled), row-major float array
  * @param Ly     First-order y-derivative (sigma_size-scaled), row-major float array
@@ -40,89 +70,106 @@ KAZE_compute_upright_descriptor_64(
     if (idx >= nkeypoints)
         return;
 
-    const int dsize = 64;
-    const int sample_step = 5;
-    const int pattern_size = 12;
-
     float kpt_x = keypoints_x[idx];
     float kpt_y = keypoints_y[idx];
     float kpt_sz = keypoints_size[idx];
 
-    int scale = (int)(kpt_sz / 2.0f + 0.5f);  // cvRound equivalent
+    int scale = (int)(kpt_sz / 2.0f + 0.5f);
     float xf = kpt_x;
     float yf = kpt_y;
 
-    float dx = 0.0f, dy = 0.0f, mdx = 0.0f, mdy = 0.0f;
-    float gauss_s1, gauss_s2;
-    float rx, ry;
-    float sample_x, sample_y;
-    int x1, y1, x2, y2;
-    int kx, ky, i, j, dcount = 0;
-    float fx, fy;
-    float res1, res2, res3, res4;
+    const int dsize = 64;
     float len = 0.0f;
+    int dcount = 0;
 
-    float cx = -0.5f, cy = 0.5f;
-
-    i = -8;
-    while (i < pattern_size)
+    for (int sr = 0; sr < 4; sr++)
     {
-        j = -8;
-        i = i - 4;
-        cx += 1.0f;
-        cy = -0.5f;
-
-        while (j < pattern_size)
+        int base_k = sr * 5 - 12;
+        for (int sc = 0; sc < 4; sc++)
         {
-            dx = dy = mdx = mdy = 0.0f;
-            cy += 1.0f;
-            j = j - 4;
+            int base_l = sc * 5 - 12;
 
-            ky = i + sample_step;
-            kx = j + sample_step;
+            float dx = 0.0f, dy = 0.0f, mdx = 0.0f, mdy = 0.0f;
 
-            float ys = yf + (float)(ky * scale);
-            float xs = xf + (float)(kx * scale);
-
-            for (int k = i; k < i + 9; k++)
+            for (int ri = 0; ri < 9; ri++)
             {
-                for (int l = j; l < j + 9; l++)
+                int k = base_k + ri;
+                float sample_y = (float)k * scale + yf;
+                int y1 = (int)(sample_y - 0.5f);
+                int y2 = (int)(sample_y + 0.5f);
+                y1 = clamp(y1, 0, lx_rows - 1);
+                y2 = clamp(y2, 0, lx_rows - 1);
+
+                int row0 = y1 * lx_step;
+                int row1 = y2 * lx_step;
+                float fy = sample_y - (float)y1;
+                float inv_fy = 1.0f - fy;
+
+                for (int ci = 0; ci < 9; ci++)
                 {
-                    sample_y = (float)k * scale + yf;
-                    sample_x = (float)l * scale + xf;
+                    int l = base_l + ci;
+                    float sample_x = (float)l * scale + xf;
 
-                    gauss_s1 = gaussian(xs - sample_x, ys - sample_y, 2.5f * scale);
+                    int x1_raw = (int)(sample_x - 0.5f);
+                    int x2_raw = (int)(sample_x + 0.5f);
+                    int x1 = clamp(x1_raw, 0, lx_cols - 1);
+                    int x2 = clamp(x2_raw, 0, lx_cols - 1);
 
-                    // Match CPU bilinear convention: y1=(int)(y-0.5), y2=(int)(y+0.5)
-                    y1 = (int)(sample_y - 0.5f);
-                    x1 = (int)(sample_x - 0.5f);
-                    y1 = clamp(y1, 0, lx_rows - 1);
-                    x1 = clamp(x1, 0, lx_cols - 1);
+                    float fx = sample_x - (float)x1;
+                    float inv_fx = 1.0f - fx;
 
-                    y2 = (int)(sample_y + 0.5f);
-                    x2 = (int)(sample_x + 0.5f);
-                    y2 = clamp(y2, 0, lx_rows - 1);
-                    x2 = clamp(x2, 0, lx_cols - 1);
+                    float gs1 = gauss_s1_weights[ri * 9 + ci];
 
-                    fx = sample_x - (float)x1;
-                    fy = sample_y - (float)y1;
+                    bool use_v2 = (x1_raw >= 0 && x2_raw < lx_cols);
 
-                    res1 = Lx[y1 * lx_step + x1];
-                    res2 = Lx[y1 * lx_step + x2];
-                    res3 = Lx[y2 * lx_step + x1];
-                    res4 = Lx[y2 * lx_step + x2];
-                    rx = (1.0f - fx)*(1.0f - fy)*res1 + fx*(1.0f - fy)*res2
-                       + (1.0f - fx)*fy*res3 + fx*fy*res4;
+                    float lx00, lx01, ly00, ly01;
+                    float lx10, lx11, ly10, ly11;
 
-                    res1 = Ly[y1 * lx_step + x1];
-                    res2 = Ly[y1 * lx_step + x2];
-                    res3 = Ly[y2 * lx_step + x1];
-                    res4 = Ly[y2 * lx_step + x2];
-                    ry = (1.0f - fx)*(1.0f - fy)*res1 + fx*(1.0f - fy)*res2
-                       + (1.0f - fx)*fy*res3 + fx*fy*res4;
+                    if (use_v2)
+                    {
+                        float2 vx = vload2(0, Lx + row0 + x1);
+                        float2 vy = vload2(0, Ly + row0 + x1);
+                        lx00 = vx.s0; lx01 = vx.s1;
+                        ly00 = vy.s0; ly01 = vy.s1;
+                    }
+                    else
+                    {
+                        lx00 = Lx[row0 + x1];
+                        lx01 = Lx[row0 + x2];
+                        ly00 = Ly[row0 + x1];
+                        ly01 = Ly[row0 + x2];
+                    }
 
-                    rx = gauss_s1 * rx;
-                    ry = gauss_s1 * ry;
+                    if (y1 != y2)
+                    {
+                        if (use_v2)
+                        {
+                            float2 vx = vload2(0, Lx + row1 + x1);
+                            float2 vy = vload2(0, Ly + row1 + x1);
+                            lx10 = vx.s0; lx11 = vx.s1;
+                            ly10 = vy.s0; ly11 = vy.s1;
+                        }
+                        else
+                        {
+                            lx10 = Lx[row1 + x1];
+                            lx11 = Lx[row1 + x2];
+                            ly10 = Ly[row1 + x1];
+                            ly11 = Ly[row1 + x2];
+                        }
+                    }
+                    else
+                    {
+                        lx10 = lx00; lx11 = lx01;
+                        ly10 = ly00; ly11 = ly01;
+                    }
+
+                    float rx = inv_fx * inv_fy * lx00 + fx * inv_fy * lx01
+                             + inv_fx * fy * lx10 + fx * fy * lx11;
+                    float ry = inv_fx * inv_fy * ly00 + fx * inv_fy * ly01
+                             + inv_fx * fy * ly10 + fx * fy * ly11;
+
+                    rx = gs1 * rx;
+                    ry = gs1 * ry;
 
                     dx  += rx;
                     dy  += ry;
@@ -131,34 +178,35 @@ KAZE_compute_upright_descriptor_64(
                 }
             }
 
-            gauss_s2 = gaussian(cx - 2.0f, cy - 2.0f, 1.5f);
+            float gs2 = gauss_s2_weights[sr * 4 + sc];
 
-            descriptors[idx * dsize + dcount++] = dx  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = dy  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdx * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdy * gauss_s2;
+            descriptors[idx * dsize + dcount++] = dx  * gs2;
+            descriptors[idx * dsize + dcount++] = dy  * gs2;
+            descriptors[idx * dsize + dcount++] = mdx * gs2;
+            descriptors[idx * dsize + dcount++] = mdy * gs2;
 
-            len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy) * gauss_s2 * gauss_s2;
-
-            j += 9;
+            len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy) * gs2 * gs2;
         }
-        i += 9;
     }
 
-    // L2 normalize
     len = sqrt(len);
     if (len > 1e-10f)
     {
         float len_inv = 1.0f / len;
-        for (i = 0; i < dsize; i++)
+        for (int i = 0; i < dsize; i++)
             descriptors[idx * dsize + i] *= len_inv;
     }
 }
 
 /**
- * @brief Compute KAZE upright 128-dimensional descriptor (extended mode)
+ * @brief Compute KAZE upright 128-dimensional descriptor (optimized)
  * @details Matches CPU Get_KAZE_Upright_Descriptor_128: splits dx/dy by sign of the
  *          cross-component for 8 values per subregion.
+ *
+ * Optimizations:
+ * - Pre-computed gaussian weights (__constant, no exp() calls in inner loop)
+ * - Vectorized vload2 for bilinear pixel pairs
+ * - Pre-computed row addresses outside ci loop
  */
 __kernel void
 KAZE_compute_upright_descriptor_128(
@@ -175,10 +223,6 @@ KAZE_compute_upright_descriptor_128(
     if (idx >= nkeypoints)
         return;
 
-    const int dsize = 128;
-    const int sample_step = 5;
-    const int pattern_size = 12;
-
     float kpt_x = keypoints_x[idx];
     float kpt_y = keypoints_y[idx];
     float kpt_sz = keypoints_size[idx];
@@ -187,78 +231,99 @@ KAZE_compute_upright_descriptor_128(
     float xf = kpt_x;
     float yf = kpt_y;
 
-    float dxp = 0.0f, dxn = 0.0f, mdxp = 0.0f, mdxn = 0.0f;
-    float dyp = 0.0f, dyn = 0.0f, mdyp = 0.0f, mdyn = 0.0f;
-    float gauss_s1, gauss_s2;
-    float rx, ry;
-    float sample_x, sample_y;
-    int x1, y1, x2, y2;
-    int kx, ky, i, j, dcount = 0;
-    float fx, fy;
-    float res1, res2, res3, res4;
+    const int dsize = 128;
     float len = 0.0f;
+    int dcount = 0;
 
-    float cx = -0.5f, cy = 0.5f;
-
-    i = -8;
-    while (i < pattern_size)
+    for (int sr = 0; sr < 4; sr++)
     {
-        j = -8;
-        i = i - 4;
-        cx += 1.0f;
-        cy = -0.5f;
-
-        while (j < pattern_size)
+        int base_k = sr * 5 - 12;
+        for (int sc = 0; sc < 4; sc++)
         {
-            dxp = dxn = mdxp = mdxn = 0.0f;
-            dyp = dyn = mdyp = mdyn = 0.0f;
-            cy += 1.0f;
-            j = j - 4;
+            int base_l = sc * 5 - 12;
 
-            ky = i + sample_step;
-            kx = j + sample_step;
+            float dxp = 0.0f, dxn = 0.0f, mdxp = 0.0f, mdxn = 0.0f;
+            float dyp = 0.0f, dyn = 0.0f, mdyp = 0.0f, mdyn = 0.0f;
 
-            float ys = yf + (float)(ky * scale);
-            float xs = xf + (float)(kx * scale);
-
-            for (int k = i; k < i + 9; k++)
+            for (int ri = 0; ri < 9; ri++)
             {
-                for (int l = j; l < j + 9; l++)
+                int k = base_k + ri;
+                float sample_y = (float)k * scale + yf;
+                int y1 = (int)(sample_y - 0.5f);
+                int y2 = (int)(sample_y + 0.5f);
+                y1 = clamp(y1, 0, lx_rows - 1);
+                y2 = clamp(y2, 0, lx_rows - 1);
+
+                int row0 = y1 * lx_step;
+                int row1 = y2 * lx_step;
+                float fy = sample_y - (float)y1;
+                float inv_fy = 1.0f - fy;
+
+                for (int ci = 0; ci < 9; ci++)
                 {
-                    sample_y = (float)k * scale + yf;
-                    sample_x = (float)l * scale + xf;
+                    int l = base_l + ci;
+                    float sample_x = (float)l * scale + xf;
 
-                    gauss_s1 = gaussian(xs - sample_x, ys - sample_y, 2.5f * scale);
+                    int x1_raw = (int)(sample_x - 0.5f);
+                    int x2_raw = (int)(sample_x + 0.5f);
+                    int x1 = clamp(x1_raw, 0, lx_cols - 1);
+                    int x2 = clamp(x2_raw, 0, lx_cols - 1);
 
-                    y1 = (int)(sample_y - 0.5f);
-                    x1 = (int)(sample_x - 0.5f);
-                    y1 = clamp(y1, 0, lx_rows - 1);
-                    x1 = clamp(x1, 0, lx_cols - 1);
+                    float fx = sample_x - (float)x1;
+                    float inv_fx = 1.0f - fx;
 
-                    y2 = (int)(sample_y + 0.5f);
-                    x2 = (int)(sample_x + 0.5f);
-                    y2 = clamp(y2, 0, lx_rows - 1);
-                    x2 = clamp(x2, 0, lx_cols - 1);
+                    float gs1 = gauss_s1_weights[ri * 9 + ci];
 
-                    fx = sample_x - (float)x1;
-                    fy = sample_y - (float)y1;
+                    bool use_v2 = (x1_raw >= 0 && x2_raw < lx_cols);
 
-                    res1 = Lx[y1 * lx_step + x1];
-                    res2 = Lx[y1 * lx_step + x2];
-                    res3 = Lx[y2 * lx_step + x1];
-                    res4 = Lx[y2 * lx_step + x2];
-                    rx = (1.0f - fx)*(1.0f - fy)*res1 + fx*(1.0f - fy)*res2
-                       + (1.0f - fx)*fy*res3 + fx*fy*res4;
+                    float lx00, lx01, ly00, ly01;
+                    float lx10, lx11, ly10, ly11;
 
-                    res1 = Ly[y1 * lx_step + x1];
-                    res2 = Ly[y1 * lx_step + x2];
-                    res3 = Ly[y2 * lx_step + x1];
-                    res4 = Ly[y2 * lx_step + x2];
-                    ry = (1.0f - fx)*(1.0f - fy)*res1 + fx*(1.0f - fy)*res2
-                       + (1.0f - fx)*fy*res3 + fx*fy*res4;
+                    if (use_v2)
+                    {
+                        float2 vx = vload2(0, Lx + row0 + x1);
+                        float2 vy = vload2(0, Ly + row0 + x1);
+                        lx00 = vx.s0; lx01 = vx.s1;
+                        ly00 = vy.s0; ly01 = vy.s1;
+                    }
+                    else
+                    {
+                        lx00 = Lx[row0 + x1];
+                        lx01 = Lx[row0 + x2];
+                        ly00 = Ly[row0 + x1];
+                        ly01 = Ly[row0 + x2];
+                    }
 
-                    rx = gauss_s1 * rx;
-                    ry = gauss_s1 * ry;
+                    if (y1 != y2)
+                    {
+                        if (use_v2)
+                        {
+                            float2 vx = vload2(0, Lx + row1 + x1);
+                            float2 vy = vload2(0, Ly + row1 + x1);
+                            lx10 = vx.s0; lx11 = vx.s1;
+                            ly10 = vy.s0; ly11 = vy.s1;
+                        }
+                        else
+                        {
+                            lx10 = Lx[row1 + x1];
+                            lx11 = Lx[row1 + x2];
+                            ly10 = Ly[row1 + x1];
+                            ly11 = Ly[row1 + x2];
+                        }
+                    }
+                    else
+                    {
+                        lx10 = lx00; lx11 = lx01;
+                        ly10 = ly00; ly11 = ly01;
+                    }
+
+                    float rx = inv_fx * inv_fy * lx00 + fx * inv_fy * lx01
+                             + inv_fx * fy * lx10 + fx * fy * lx11;
+                    float ry = inv_fx * inv_fy * ly00 + fx * inv_fy * ly01
+                             + inv_fx * fy * ly10 + fx * fy * ly11;
+
+                    rx = gs1 * rx;
+                    ry = gs1 * ry;
 
                     if (ry >= 0.0f) { dxp += rx;  mdxp += fabs(rx); }
                     else            { dxn += rx;  mdxn += fabs(rx); }
@@ -267,30 +332,620 @@ KAZE_compute_upright_descriptor_128(
                 }
             }
 
-            gauss_s2 = gaussian(cx - 2.0f, cy - 2.0f, 1.5f);
+            float gs2 = gauss_s2_weights[sr * 4 + sc];
 
-            descriptors[idx * dsize + dcount++] = dxp  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = dxn  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdxp * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdxn * gauss_s2;
-            descriptors[idx * dsize + dcount++] = dyp  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = dyn  * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdyp * gauss_s2;
-            descriptors[idx * dsize + dcount++] = mdyn * gauss_s2;
+            descriptors[idx * dsize + dcount++] = dxp  * gs2;
+            descriptors[idx * dsize + dcount++] = dxn  * gs2;
+            descriptors[idx * dsize + dcount++] = mdxp * gs2;
+            descriptors[idx * dsize + dcount++] = mdxn * gs2;
+            descriptors[idx * dsize + dcount++] = dyp  * gs2;
+            descriptors[idx * dsize + dcount++] = dyn  * gs2;
+            descriptors[idx * dsize + dcount++] = mdyp * gs2;
+            descriptors[idx * dsize + dcount++] = mdyn * gs2;
 
             len += (dxp*dxp + dxn*dxn + mdxp*mdxp + mdxn*mdxn
-                  + dyp*dyp + dyn*dyn + mdyp*mdyp + mdyn*mdyn) * gauss_s2 * gauss_s2;
-
-            j += 9;
+                  + dyp*dyp + dyn*dyn + mdyp*mdyp + mdyn*mdyn) * gs2 * gs2;
         }
-        i += 9;
     }
 
     len = sqrt(len);
     if (len > 1e-10f)
     {
         float len_inv = 1.0f / len;
-        for (i = 0; i < dsize; i++)
+        for (int i = 0; i < dsize; i++)
             descriptors[idx * dsize + i] *= len_inv;
     }
+}
+
+/**
+ * @brief Compute KAZE rotation-invariant 64-dimensional descriptor (optimized)
+ * @details Matches CPU Get_KAZE_Descriptor_64 exactly:
+ *          - Uses keypoint angle to rotate sampling coordinates and derivatives
+ *          - integer scale via round(kpt_size/2)
+ *          - bilinear with cvFloor convention (matches CPU)
+ *          - clamp-on-border (not skip)
+ *
+ * Optimizations:
+ * - Pre-computed gaussian weights (__constant, no exp() calls in inner loop)
+ * - Vectorized vload2 for bilinear pixel pairs
+ * - Pre-computed row addresses outside ci loop
+ *
+ * @param Lx     First-order x-derivative (sigma_size-scaled), row-major float array
+ * @param Ly     First-order y-derivative (sigma_size-scaled), row-major float array
+ * @param lx_step    Row stride of Lx/Ly in float elements (= cols for continuous mat)
+ * @param lx_rows    Image height
+ * @param lx_cols    Image width
+ * @param keypoints_x  Keypoint x coordinates
+ * @param keypoints_y  Keypoint y coordinates
+ * @param keypoints_size  Keypoint sizes (diameter = 2*sigma)
+ * @param keypoints_angle Keypoint orientations in degrees
+ * @param descriptors  Output descriptor matrix, shape [nkeypoints, 64]
+ * @param nkeypoints   Number of keypoints
+ */
+__kernel void
+KAZE_compute_descriptor_64(
+    __global const float* Lx,
+    __global const float* Ly,
+    int lx_step, int lx_rows, int lx_cols,
+    __global const float* keypoints_x,
+    __global const float* keypoints_y,
+    __global const float* keypoints_size,
+    __global const float* keypoints_angle,
+    __global float* descriptors,
+    int nkeypoints)
+{
+    int idx = get_global_id(0);
+    if (idx >= nkeypoints)
+        return;
+
+    float kpt_x = keypoints_x[idx];
+    float kpt_y = keypoints_y[idx];
+    float kpt_sz = keypoints_size[idx];
+    float kpt_angle_deg = keypoints_angle[idx];
+
+    int scale = (int)(kpt_sz / 2.0f + 0.5f);
+    float xf = kpt_x;
+    float yf = kpt_y;
+    float angle = kpt_angle_deg * (float)(M_PI_F / 180.0f);
+    float co = native_cos(angle);
+    float si = native_sin(angle);
+
+    const int dsize = 64;
+    float len = 0.0f;
+    int dcount = 0;
+
+    for (int sr = 0; sr < 4; sr++)
+    {
+        int base_k = sr * 5 - 12;
+        for (int sc = 0; sc < 4; sc++)
+        {
+            int base_l = sc * 5 - 12;
+
+            float dx = 0.0f, dy = 0.0f, mdx = 0.0f, mdy = 0.0f;
+
+            for (int ri = 0; ri < 9; ri++)
+            {
+                int k = base_k + ri;
+                for (int ci = 0; ci < 9; ci++)
+                {
+                    int l = base_l + ci;
+
+                    float sample_x = xf + (-l * scale * si + k * scale * co);
+                    float sample_y = yf + (l * scale * co + k * scale * si);
+
+                    int y1 = (int)floor(sample_y);
+                    int x1 = (int)floor(sample_x);
+                    y1 = clamp(y1, 0, lx_rows - 1);
+                    x1 = clamp(x1, 0, lx_cols - 1);
+
+                    int y2 = y1 + 1;
+                    int x2 = x1 + 1;
+                    y2 = clamp(y2, 0, lx_rows - 1);
+                    x2 = clamp(x2, 0, lx_cols - 1);
+
+                    float fx = sample_x - (float)x1;
+                    float fy = sample_y - (float)y1;
+                    float inv_fx = 1.0f - fx;
+                    float inv_fy = 1.0f - fy;
+
+                    float gs1 = gauss_s1_weights[ri * 9 + ci];
+
+                    int row0 = y1 * lx_step;
+                    int row1 = y2 * lx_step;
+
+                    float lx00, lx01, lx10, lx11;
+                    if (x1 < lx_cols - 1)
+                    {
+                        float2 v = vload2(0, Lx + row0 + x1);
+                        lx00 = v.s0; lx01 = v.s1;
+                    }
+                    else
+                    {
+                        lx00 = Lx[row0 + x1];
+                        lx01 = lx00;
+                    }
+
+                    if (y1 != y2)
+                    {
+                        if (x1 < lx_cols - 1)
+                        {
+                            float2 v = vload2(0, Lx + row1 + x1);
+                            lx10 = v.s0; lx11 = v.s1;
+                        }
+                        else
+                        {
+                            lx10 = Lx[row1 + x1];
+                            lx11 = lx10;
+                        }
+                    }
+                    else
+                    {
+                        lx10 = lx00;
+                        lx11 = lx01;
+                    }
+
+                    float ly00, ly01, ly10, ly11;
+                    if (x1 < lx_cols - 1)
+                    {
+                        float2 v = vload2(0, Ly + row0 + x1);
+                        ly00 = v.s0; ly01 = v.s1;
+                    }
+                    else
+                    {
+                        ly00 = Ly[row0 + x1];
+                        ly01 = ly00;
+                    }
+
+                    if (y1 != y2)
+                    {
+                        if (x1 < lx_cols - 1)
+                        {
+                            float2 v = vload2(0, Ly + row1 + x1);
+                            ly10 = v.s0; ly11 = v.s1;
+                        }
+                        else
+                        {
+                            ly10 = Ly[row1 + x1];
+                            ly11 = ly10;
+                        }
+                    }
+                    else
+                    {
+                        ly10 = ly00;
+                        ly11 = ly01;
+                    }
+
+                    float rx = inv_fx * inv_fy * lx00 + fx * inv_fy * lx01
+                             + inv_fx * fy * lx10 + fx * fy * lx11;
+                    float ry = inv_fx * inv_fy * ly00 + fx * inv_fy * ly01
+                             + inv_fx * fy * ly10 + fx * fy * ly11;
+
+                    float rry = gs1 * (rx * co + ry * si);
+                    float rrx = gs1 * (-rx * si + ry * co);
+
+                    dx += rrx;
+                    dy += rry;
+                    mdx += fabs(rrx);
+                    mdy += fabs(rry);
+                }
+            }
+
+            float gs2 = gauss_s2_weights[sr * 4 + sc];
+
+            descriptors[idx * dsize + dcount++] = dx * gs2;
+            descriptors[idx * dsize + dcount++] = dy * gs2;
+            descriptors[idx * dsize + dcount++] = mdx * gs2;
+            descriptors[idx * dsize + dcount++] = mdy * gs2;
+
+            len += (dx*dx + dy*dy + mdx*mdx + mdy*mdy) * gs2 * gs2;
+        }
+    }
+
+    len = sqrt(len);
+    if (len > 1e-10f)
+    {
+        float len_inv = 1.0f / len;
+        for (int i = 0; i < dsize; i++)
+            descriptors[idx * dsize + i] *= len_inv;
+    }
+}
+
+/**
+ * @brief Compute KAZE rotation-invariant 128-dimensional descriptor (optimized)
+ * @details Matches CPU Get_KAZE_Descriptor_128: splits derivatives by sign of cross-component
+ *          for 8 values per subregion, with rotation applied
+ *
+ * Optimizations:
+ * - Pre-computed gaussian weights (__constant, no exp() calls in inner loop)
+ * - Vectorized vload2 for bilinear pixel pairs
+ */
+__kernel void
+KAZE_compute_descriptor_128(
+    __global const float* Lx,
+    __global const float* Ly,
+    int lx_step, int lx_rows, int lx_cols,
+    __global const float* keypoints_x,
+    __global const float* keypoints_y,
+    __global const float* keypoints_size,
+    __global const float* keypoints_angle,
+    __global float* descriptors,
+    int nkeypoints)
+{
+    int idx = get_global_id(0);
+    if (idx >= nkeypoints)
+        return;
+
+    float kpt_x = keypoints_x[idx];
+    float kpt_y = keypoints_y[idx];
+    float kpt_sz = keypoints_size[idx];
+    float kpt_angle_deg = keypoints_angle[idx];
+
+    int scale = (int)(kpt_sz / 2.0f + 0.5f);
+    float xf = kpt_x;
+    float yf = kpt_y;
+    float angle = kpt_angle_deg * (float)(M_PI_F / 180.0f);
+    float co = native_cos(angle);
+    float si = native_sin(angle);
+
+    const int dsize = 128;
+    float len = 0.0f;
+    int dcount = 0;
+
+    for (int sr = 0; sr < 4; sr++)
+    {
+        int base_k = sr * 5 - 12;
+        for (int sc = 0; sc < 4; sc++)
+        {
+            int base_l = sc * 5 - 12;
+
+            float dxp = 0.0f, dxn = 0.0f, mdxp = 0.0f, mdxn = 0.0f;
+            float dyp = 0.0f, dyn = 0.0f, mdyp = 0.0f, mdyn = 0.0f;
+
+            for (int ri = 0; ri < 9; ri++)
+            {
+                int k = base_k + ri;
+                for (int ci = 0; ci < 9; ci++)
+                {
+                    int l = base_l + ci;
+
+                    float sample_x = xf + (-l * scale * si + k * scale * co);
+                    float sample_y = yf + (l * scale * co + k * scale * si);
+
+                    int y1 = (int)floor(sample_y);
+                    int x1 = (int)floor(sample_x);
+                    y1 = clamp(y1, 0, lx_rows - 1);
+                    x1 = clamp(x1, 0, lx_cols - 1);
+
+                    int y2 = y1 + 1;
+                    int x2 = x1 + 1;
+                    y2 = clamp(y2, 0, lx_rows - 1);
+                    x2 = clamp(x2, 0, lx_cols - 1);
+
+                    float fx = sample_x - (float)x1;
+                    float fy = sample_y - (float)y1;
+                    float inv_fx = 1.0f - fx;
+                    float inv_fy = 1.0f - fy;
+
+                    float gs1 = gauss_s1_weights[ri * 9 + ci];
+
+                    int row0 = y1 * lx_step;
+                    int row1 = y2 * lx_step;
+
+                    float lx00, lx01, lx10, lx11;
+                    if (x1 < lx_cols - 1)
+                    {
+                        float2 v = vload2(0, Lx + row0 + x1);
+                        lx00 = v.s0; lx01 = v.s1;
+                    }
+                    else
+                    {
+                        lx00 = Lx[row0 + x1];
+                        lx01 = lx00;
+                    }
+
+                    if (y1 != y2)
+                    {
+                        if (x1 < lx_cols - 1)
+                        {
+                            float2 v = vload2(0, Lx + row1 + x1);
+                            lx10 = v.s0; lx11 = v.s1;
+                        }
+                        else
+                        {
+                            lx10 = Lx[row1 + x1];
+                            lx11 = lx10;
+                        }
+                    }
+                    else
+                    {
+                        lx10 = lx00;
+                        lx11 = lx01;
+                    }
+
+                    float ly00, ly01, ly10, ly11;
+                    if (x1 < lx_cols - 1)
+                    {
+                        float2 v = vload2(0, Ly + row0 + x1);
+                        ly00 = v.s0; ly01 = v.s1;
+                    }
+                    else
+                    {
+                        ly00 = Ly[row0 + x1];
+                        ly01 = ly00;
+                    }
+
+                    if (y1 != y2)
+                    {
+                        if (x1 < lx_cols - 1)
+                        {
+                            float2 v = vload2(0, Ly + row1 + x1);
+                            ly10 = v.s0; ly11 = v.s1;
+                        }
+                        else
+                        {
+                            ly10 = Ly[row1 + x1];
+                            ly11 = ly10;
+                        }
+                    }
+                    else
+                    {
+                        ly10 = ly00;
+                        ly11 = ly01;
+                    }
+
+                    float rx = inv_fx * inv_fy * lx00 + fx * inv_fy * lx01
+                             + inv_fx * fy * lx10 + fx * fy * lx11;
+                    float ry = inv_fx * inv_fy * ly00 + fx * inv_fy * ly01
+                             + inv_fx * fy * ly10 + fx * fy * ly11;
+
+                    float rry = gs1 * (rx * co + ry * si);
+                    float rrx = gs1 * (-rx * si + ry * co);
+
+                    if (rry >= 0.0f) {
+                        dxp += rrx;
+                        mdxp += fabs(rrx);
+                    }
+                    else {
+                        dxn += rrx;
+                        mdxn += fabs(rrx);
+                    }
+
+                    if (rrx >= 0.0f) {
+                        dyp += rry;
+                        mdyp += fabs(rry);
+                    }
+                    else {
+                        dyn += rry;
+                        mdyn += fabs(rry);
+                    }
+                }
+            }
+
+            float gs2 = gauss_s2_weights[sr * 4 + sc];
+
+            descriptors[idx * dsize + dcount++] = dxp * gs2;
+            descriptors[idx * dsize + dcount++] = dxn * gs2;
+            descriptors[idx * dsize + dcount++] = mdxp * gs2;
+            descriptors[idx * dsize + dcount++] = mdxn * gs2;
+            descriptors[idx * dsize + dcount++] = dyp * gs2;
+            descriptors[idx * dsize + dcount++] = dyn * gs2;
+            descriptors[idx * dsize + dcount++] = mdyp * gs2;
+            descriptors[idx * dsize + dcount++] = mdyn * gs2;
+
+            len += (dxp*dxp + dxn*dxn + mdxp*mdxp + mdxn*mdxn
+                  + dyp*dyp + dyn*dyn + mdyp*mdyp + mdyn*mdyn) * gs2 * gs2;
+        }
+    }
+
+    len = sqrt(len);
+    if (len > 1e-10f)
+    {
+        float len_inv = 1.0f / len;
+        for (int i = 0; i < dsize; i++)
+            descriptors[idx * dsize + i] *= len_inv;
+    }
+}
+
+/**
+ * @brief Fused kernel: squared gradient magnitude from Lx/Ly derivatives.
+ * @details Replaces multiply(Lx^2) + multiply(Ly^2) + add(mag2) with a single pass.
+ *          Lx and Ly are already computed by Scharr. Writes mag2 for minMaxLoc.
+ *
+ * @param Lx Input x-derivative
+ * @param Ly Input y-derivative
+ * @param step Row stride of Lx/Ly in float elements
+ * @param cols Image width
+ * @param rows Image height
+ * @param mag2_out Output squared magnitude (Lx^2 + Ly^2)
+ * @param mag2_step Row stride of mag2_out in float elements
+ */
+__kernel void
+KAZE_compute_mag2(
+    __global const float* Lx,
+    __global const float* Ly,
+    int step, int cols, int rows,
+    __global float* mag2_out, int mag2_step)
+{
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    if (x >= cols || y >= rows)
+        return;
+
+    int idx = y * step + x;
+    float lx = Lx[idx];
+    float ly = Ly[idx];
+
+    mag2_out[y * mag2_step + x] = lx * lx + ly * ly;
+}
+
+/**
+ * @brief Compute histogram of gradient magnitudes for kcontrast estimation.
+ * @details Each workgroup builds a local histogram using local atomics, then
+ *          merges to global via atomic_add. Skips border pixels (1px border)
+ *          to match CPU compute_k_percentile.
+ *
+ * @param Lx     Scharr x-derivative of Lsmooth (row-major float)
+ * @param Ly     Scharr y-derivative of Lsmooth (row-major float)
+ * @param lx_step    Row stride of Lx/Ly in float elements
+ * @param cols   Image width
+ * @param rows   Image height
+ * @param hmax   sqrt(max(Lx^2 + Ly^2)) gradient magnitude max
+ * @param nbins  Number of histogram bins (e.g. 300)
+ * @param histogram  Output histogram (single global histogram, size=nbins)
+ * @param local_hist Local memory buffer, size=nbins ints
+ */
+__kernel void
+KAZE_compute_kcontrast_histogram(
+    __global const float* Lx,
+    __global const float* Ly,
+    int lx_step, int cols, int rows,
+    float hmax, int nbins,
+    __global int* histogram,
+    __local int* local_hist)
+{
+    for (int i = get_local_id(0); i < nbins; i += get_local_size(0))
+        local_hist[i] = 0;
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    int x = get_global_id(0);
+    int y = get_global_id(1);
+
+    // Skip borders to match CPU compute_k_percentile
+    if (x > 0 && x < cols - 1 && y > 0 && y < rows - 1)
+    {
+        int idx = y * lx_step + x;
+        float lx_val = Lx[idx];
+        float ly_val = Ly[idx];
+        float mag_sq = lx_val * lx_val + ly_val * ly_val;
+
+        if (mag_sq > 0.0f)
+        {
+            float mag = native_sqrt(mag_sq);
+            int bin = (int)(nbins * mag / hmax);
+            if (bin == nbins)
+                bin--;
+            atomic_inc(&local_hist[bin]);
+        }
+    }
+
+    barrier(CLK_LOCAL_MEM_FENCE);
+
+    // Merge to global using atomics (one thread per workgroup)
+    if (get_local_id(0) == 0 && get_local_id(1) == 0)
+    {
+        for (int i = 0; i < nbins; i++)
+        {
+            if (local_hist[i] > 0)
+                atomic_add(&histogram[i], local_hist[i]);
+        }
+    }
+}
+
+/**
+ * @brief Compute KAZE main orientation for keypoints (one pyramid level)
+ * @details Matches CPU Compute_Main_Orientation:
+ *          - Sample 13x13 window (i^2+j^2 < 36) with Gaussian weighting
+ *          - Find dominant orientation using pi/3 sliding window
+ *
+ * @param Lx     First-order x-derivative, row-major float array
+ * @param Ly     First-order y-derivative, row-major float array
+ * @param lx_step    Row stride of Lx/Ly in float elements
+ * @param lx_rows    Image height
+ * @param lx_cols    Image width
+ * @param keypoints_x  Keypoint x coordinates
+ * @param keypoints_y  Keypoint y coordinates
+ * @param keypoints_size  Keypoint sizes
+ * @param keypoints_angle  Output angles in degrees
+ * @param nkeypoints   Number of keypoints
+ */
+__kernel void
+KAZE_compute_orientation_level(
+    __global const float* Lx,
+    __global const float* Ly,
+    int lx_step, int lx_rows, int lx_cols,
+    __global const float* keypoints_x,
+    __global const float* keypoints_y,
+    __global const float* keypoints_size,
+    __global float* keypoints_angle,
+    int nkeypoints)
+{
+    int idx = get_global_id(0);
+    if (idx >= nkeypoints)
+        return;
+
+    float xf = keypoints_x[idx];
+    float yf = keypoints_y[idx];
+    float kpt_sz = keypoints_size[idx];
+    int scale = (int)(kpt_sz / 2.0f + 0.5f);
+
+    float max_mag_sq = -1.0f;
+    float final_angle = 0.0f;
+
+    // Store samples to avoid redundant global memory reads in the sliding window loop
+    // Circular mask i^2+j^2 < 36 has 109 points.
+    float samplesX[109];
+    float samplesY[109];
+    float samplesAng[109];
+    int sample_count = 0;
+
+    for (int i = -6; i <= 6; ++i) {
+        for (int j = -6; j <= 6; ++j) {
+            if (i*i + j*j < 36) {
+                int ix = (int)(xf + i * scale + 0.5f);
+                int iy = (int)(yf + j * scale + 0.5f);
+
+                if (iy >= 0 && iy < lx_rows && ix >= 0 && ix < lx_cols) {
+                    float gw = gaussian((float)iy - yf, (float)ix - xf, 2.5f * scale);
+                    float rx = gw * Lx[iy * lx_step + ix];
+                    float ry = gw * Ly[iy * lx_step + ix];
+                    samplesX[sample_count] = rx;
+                    samplesY[sample_count] = ry;
+                    float ang = atan2(ry, rx);
+                    if (ang < 0.0f) ang += 2.0f * M_PI_F;
+                    samplesAng[sample_count] = ang;
+                } else {
+                    samplesX[sample_count] = 0.0f;
+                    samplesY[sample_count] = 0.0f;
+                    samplesAng[sample_count] = 0.0f;
+                }
+                sample_count++;
+            }
+        }
+    }
+
+    // Sliding window loop: Slides pi/3 window around feature point
+    for (float ang1 = 0.0f; ang1 < 2.0f * M_PI_F; ang1 += 0.15f) {
+        float ang2 = ang1 + (M_PI_F / 3.0f);
+        if (ang2 > 2.0f * M_PI_F) {
+            ang2 -= 2.0f * M_PI_F;
+        }
+
+        float currSumX = 0.0f;
+        float currSumY = 0.0f;
+
+        for (int k = 0; k < sample_count; ++k) {
+            float ang = samplesAng[k];
+            bool in_window = false;
+            if (ang1 < ang2) {
+                if (ang > ang1 && ang < ang2) in_window = true;
+            } else {
+                if (ang > ang1 || ang < ang2) in_window = true;
+            }
+
+            if (in_window) {
+                currSumX += samplesX[k];
+                currSumY += samplesY[k];
+            }
+        }
+
+        float mag_sq = currSumX * currSumX + currSumY * currSumY;
+        if (mag_sq > max_mag_sq) {
+            max_mag_sq = mag_sq;
+            final_angle = atan2(currSumY, currSumX);
+        }
+    }
+
+    // Convert radians to degrees
+    keypoints_angle[idx] = final_angle * (180.0f / M_PI_F);
 }

--- a/modules/features2d/test/ocl/test_akaze.cpp
+++ b/modules/features2d/test/ocl/test_akaze.cpp
@@ -73,52 +73,44 @@ TEST(Features2d_AKAZE, ocl_accuracy)
     EXPECT_GT(match_rate, 0.95f) << "Descriptor match rate should be > 95%, got " << match_rate;
 }
 
-TEST(Features2d_KAZE, ocl_accuracy)
+static void kaze_ocl_accuracy_cpu_vs_ocl(bool extended, bool upright, KAZE::DiffusivityType diffusivity)
 {
     Mat testImg(640, 480, CV_8U);
     theRNG().fill(testImg, RNG::UNIFORM, Scalar(0), Scalar(255), true);
 
-    // CPU version - use upright=true to match GPU implementation
-    Ptr<KAZE> kaze_cpu = KAZE::create(false, true, 0.001f, 4, 4, KAZE::DIFF_PM_G2);
+    Ptr<KAZE> kaze_cpu = KAZE::create(extended, upright, 0.001f, 4, 4, diffusivity);
     vector<KeyPoint> kp_cpu;
     Mat desc_cpu;
     kaze_cpu->detectAndCompute(testImg, noArray(), kp_cpu, desc_cpu);
 
-    // OpenCL version - use upright=true to match GPU implementation
     UMat testImg_umat;
     testImg.copyTo(testImg_umat);
-    Ptr<KAZE> kaze_ocl = KAZE::create(false, true, 0.001f, 4, 4, KAZE::DIFF_PM_G2);
+    Ptr<KAZE> kaze_ocl = KAZE::create(extended, upright, 0.001f, 4, 4, diffusivity);
     vector<KeyPoint> kp_ocl;
     UMat desc_ocl_umat;
     kaze_ocl->detectAndCompute(testImg_umat, noArray(), kp_ocl, desc_ocl_umat);
     Mat desc_ocl = desc_ocl_umat.getMat(ACCESS_READ);
 
-    // Check that both detected keypoints
     ASSERT_FALSE(kp_cpu.empty()) << "CPU should detect keypoints";
     ASSERT_FALSE(kp_ocl.empty()) << "OpenCL should detect keypoints";
 
-    // Allow small keypoint count difference due to border handling
     float kp_ratio = (float)kp_ocl.size() / kp_cpu.size();
     EXPECT_GT(kp_ratio, 0.95f) << "OpenCL keypoint count should be within 5% of CPU, got " << kp_ratio;
     EXPECT_LT(kp_ratio, 1.05f) << "OpenCL keypoint count should be within 5% of CPU, got " << kp_ratio;
 
-    // Check descriptor dimensions match
     ASSERT_EQ(desc_cpu.cols, desc_ocl.cols) << "Descriptor size should match";
     ASSERT_EQ(desc_cpu.type(), desc_ocl.type()) << "Descriptor type should match";
 
-    // Match keypoints by position (within 1 pixel tolerance)
     int matched_kpts = 0;
     int total_compared = 0;
     double total_diff = 0;
 
     for (size_t i = 0; i < kp_cpu.size(); i++) {
-        // Find matching keypoint in OpenCL results
         for (size_t j = 0; j < kp_ocl.size(); j++) {
             float dx = fabs(kp_cpu[i].pt.x - kp_ocl[j].pt.x);
             float dy = fabs(kp_cpu[i].pt.y - kp_ocl[j].pt.y);
 
             if (dx < 1.0f && dy < 1.0f) {
-                // Found matching keypoint, compare descriptors
                 matched_kpts++;
                 for (int k = 0; k < desc_cpu.cols; k++) {
                     double diff = fabs(desc_cpu.at<float>((int)i, k) - desc_ocl.at<float>((int)j, k));
@@ -133,6 +125,86 @@ TEST(Features2d_KAZE, ocl_accuracy)
     float avg_diff = total_compared > 0 ? (float)(total_diff / total_compared) : 0.0f;
     EXPECT_GT(matched_kpts, (int)(kp_cpu.size() * 0.9f)) << "Should match at least 90% of keypoints by position";
     EXPECT_LT(avg_diff, 0.01f) << "Average descriptor difference should be < 0.01, got " << avg_diff;
+}
+
+TEST(Features2d_KAZE, ocl_accuracy)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, true, KAZE::DIFF_PM_G2);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_upright_false)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, false, KAZE::DIFF_PM_G2);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_false)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, false, KAZE::DIFF_PM_G2);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_true)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, true, KAZE::DIFF_PM_G2);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_pm_g1)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, true, KAZE::DIFF_PM_G1);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_weickert)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, true, KAZE::DIFF_WEICKERT);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_charbonnier)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, true, KAZE::DIFF_CHARBONNIER);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_upright_false_pm_g1)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, false, KAZE::DIFF_PM_G1);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_false_pm_g1)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, false, KAZE::DIFF_PM_G1);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_true_pm_g1)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, true, KAZE::DIFF_PM_G1);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_upright_false_weickert)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, false, KAZE::DIFF_WEICKERT);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_false_weickert)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, false, KAZE::DIFF_WEICKERT);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_true_weickert)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, true, KAZE::DIFF_WEICKERT);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_upright_false_charbonnier)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(false, false, KAZE::DIFF_CHARBONNIER);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_false_charbonnier)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, false, KAZE::DIFF_CHARBONNIER);
+}
+
+TEST(Features2d_KAZE, ocl_accuracy_extended_upright_true_charbonnier)
+{
+    kaze_ocl_accuracy_cpu_vs_ocl(true, true, KAZE::DIFF_CHARBONNIER);
 }
 
 }} // namespace


### PR DESCRIPTION
Add OpenCL rotation-invariant descriptor kernel and OCL
kcontrast histogram computation. Extend OCL dispatch to
handle all descriptor types (upright, extended, normal).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
