### PR TITLE
Fixed OpenCV World module build with QT 5.

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -84,7 +84,7 @@ endif()
 ocv_target_compile_definitions(${the_module} PRIVATE OPENCV_MODULE_IS_PART_OF_WORLD=1)
 
 # NOTE: https://github.com/opencv/opencv/issues/25543
-if (WITH_QT)
+if (WITH_QT AND QT_VERSION_MAJOR GREATER 5)
   qt_disable_unicode_defines(${the_module})
 endif()
 


### PR DESCRIPTION
The dependency was added in https://github.com/opencv/opencv/pull/28128

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
