### PR TITLE
Enable 1D int8 AvgPool with OpenVINO with 2025.3

### DIFF
--- a/modules/dnn/src/int8layers/pooling_layer.cpp
+++ b/modules/dnn/src/int8layers/pooling_layer.cpp
@@ -296,9 +296,16 @@ public:
                         ov::Shape(pads_begin), ov::Shape(pads_end), ov::Shape(kernel_size),
                         rounding_type, pad_type);
         } else if (type == AVE) {
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_GE(2025030000)
+            std::vector<size_t> dilations(kernel_size.size(), 1);
+            pool = std::make_shared<ov::op::v16::AvgPool>(input, ov::Strides(strides), ov::Strides(dilations),
+                        ov::Shape(pads_begin), ov::Shape(pads_end), ov::Shape(kernel_size),
+                        !avePoolPaddedArea, rounding_type, pad_type);
+#else
             pool = std::make_shared<ov::op::v1::AvgPool>(input, ov::Strides(strides),
                         ov::Shape(pads_begin), ov::Shape(pads_end), ov::Shape(kernel_size),
                         !avePoolPaddedArea, rounding_type, pad_type);
+#endif
         } else if (type == SUM) {
             ov::Shape inpShape = input.get_shape();
             CV_Assert(inpShape.size() == 2 + kernel_size.size());

--- a/modules/dnn/test/test_int8_layers.cpp
+++ b/modules/dnn/test/test_int8_layers.cpp
@@ -204,7 +204,10 @@ TEST_P(Test_Int8_layers, AvePooling)
     if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         testLayer("layer_pooling_ave", "Caffe", 0.0021, 0.0075);
     testLayer("ave_pool_same", "TensorFlow", 0.00153, 0.0041);
-    testLayer("average_pooling_1d", "ONNX", 0.002, 0.0048);
+#if defined(INF_ENGINE_RELEASE) && INF_ENGINE_VER_MAJOR_LT(2025030000)
+    if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
+#endif
+        testLayer("average_pooling_1d", "ONNX", 0.002, 0.0048);
     if (backend != DNN_BACKEND_INFERENCE_ENGINE_NGRAPH)
         testLayer("average_pooling", "ONNX", 0.0014, 0.0032);
     testLayer("average_pooling_dynamic_axes", "ONNX", 0.0014, 0.006);


### PR DESCRIPTION
### Pull Request Readiness Checklist

resolves #28659

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
