### PR TITLE
test(core): add in-place test coverage for cv::broadcast

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -59,7 +59,7 @@ struct BaseElemWiseOp
         {
             beta = exp(rng.uniform(-0.5, 0.1)*m*2*CV_LOG2);
             beta *= rng.uniform(0, 2) ? 1 : -1;
-        }
+        } 
 
         if( !(flags & FIX_GAMMA) )
         {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2626,6 +2626,28 @@ TEST(BroadcastTo, basic) {
     }
 }
 
+TEST(BroadcastTo, in_place_coverage) {
+    // 1. Create a 1x3 source matrix
+    std::vector<int> src_shape = { 1, 3 };
+    cv::Mat src(src_shape, CV_32FC1, cv::Scalar(5.0f));
+
+    // 2. Define the target shape (3x3)
+    std::vector<int> target_shape = { 3, 3 };
+
+    // 3. Clone to test in-place behavior (input = output)
+    cv::Mat in_place_mat = src.clone();
+
+    // 4. Execute broadcast in-place
+    cv::broadcast(in_place_mat, target_shape, in_place_mat);
+
+    // 5. Verification
+    EXPECT_EQ(in_place_mat.dims, (int)target_shape.size());
+    for (size_t i = 0; i < target_shape.size(); i++) {
+        EXPECT_EQ(in_place_mat.size[i], target_shape[i]);
+    }
+    EXPECT_FLOAT_EQ(in_place_mat.at<float>(2, 2), 5.0f);
+}
+
 TEST(Core_minMaxIdx, regression_9207_2)
 {
     const int rows = 13;


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description

This PR adds test coverage for the in-place behavior of `cv::broadcast` (addressing the false branch of `_flatten_for_broadcast`). 

Fixes #28910