### PR TITLE
bug fix in countViolations

### DIFF
--- a/modules/core/perf/opencl/perf_arithm.cpp
+++ b/modules/core/perf/opencl/perf_arithm.cpp
@@ -796,7 +796,7 @@ OCL_PERF_TEST_P(MeanStdDevFixture, MeanStdDev,
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
     const int type = get<1>(params);
-    const double eps = 2e-5;
+    const double eps = 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 
@@ -826,7 +826,7 @@ OCL_PERF_TEST_P(MeanStdDevFixture, MeanStdDevWithMask,
     const Size_MatType_t params = GetParam();
     const Size srcSize = get<0>(params);
     const int type = get<1>(params);
-    const double eps = 2e-5;
+    const double eps = 1e-4;
 
     checkDeviceMaxMemoryAllocSize(srcSize, type);
 

--- a/modules/core/perf/perf_dot.cpp
+++ b/modules/core/perf/perf_dot.cpp
@@ -25,7 +25,7 @@ PERF_TEST_P( MatType_Length, dot,
 
     TEST_CYCLE_N(1000) product = a.dot(b);
 
-    SANITY_CHECK(product, 1e-6, ERROR_RELATIVE);
+    SANITY_CHECK(product, 1e-5, ERROR_RELATIVE);
 }
 
 } // namespace

--- a/modules/core/perf/perf_stat.cpp
+++ b/modules/core/perf/perf_stat.cpp
@@ -16,7 +16,7 @@ PERF_TEST_P(Size_MatType, sum, TYPICAL_MATS)
 
     TEST_CYCLE() s = sum(arr);
 
-    SANITY_CHECK(s, 1e-6, ERROR_RELATIVE);
+    SANITY_CHECK(s, 1e-5, ERROR_RELATIVE);
 }
 
 PERF_TEST_P(Size_MatType, mean, TYPICAL_MATS)

--- a/modules/imgproc/perf/perf_moments.cpp
+++ b/modules/imgproc/perf/perf_moments.cpp
@@ -35,7 +35,7 @@ PERF_TEST_P(MomentsFixture_val, Moments1,
     mat += 1;
 
 
-    SANITY_CHECK_MOMENTS(m, 3.3e-4, ERROR_RELATIVE);
+    SANITY_CHECK_MOMENTS(m, 2e-3, ERROR_RELATIVE);
 }
 
 } // namespace

--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -435,14 +435,25 @@ void Regression::write(cv::InputArray array)
 
 static int countViolations(const cv::Mat& expected, const cv::Mat& actual, const cv::Mat& diff, double eps, double* max_violation = 0, double* max_allowed = 0)
 {
-    cv::Mat diff64f;
+    cv::Mat diff64f, expected64f, actual64f;
+    cv::Mat neg, expected_abs, actual_abs;
     diff.reshape(1).convertTo(diff64f, CV_64F);
+    expected.reshape(1).convertTo(expected64f, CV_64F);
+    actual.reshape(1).convertTo(actual64f, CV_64F);
 
-    cv::Mat expected_abs = cv::abs(expected.reshape(1));
-    cv::Mat actual_abs = cv::abs(actual.reshape(1));
+    // Compute threshold = eps * max(|expected|, |actual|)
+    // Note: cv::abs() returns a lazy MatExpr whose evaluation can produce tiny
+    // negative denorms for zero-valued float32 inputs (SIMD rounding artifact),
+    // resulting in negative thresholds that flag all elements as violations.
+    // Fix: convert to CV_64F and use eager max(x,-x) for guaranteed non-negative abs.
+    cv::multiply(expected64f, cv::Scalar(-1.0), neg);
+    cv::max(expected64f, neg, expected_abs);
+    cv::multiply(actual64f, cv::Scalar(-1.0), neg);
+    cv::max(actual64f, neg, actual_abs);
+
     cv::Mat maximum, mask;
     cv::max(expected_abs, actual_abs, maximum);
-    cv::multiply(maximum, cv::Vec<double, 1>(eps), maximum, CV_64F);
+    cv::multiply(maximum, cv::Scalar(eps), maximum);
     cv::compare(diff64f, maximum, mask, cv::CMP_GT);
 
     int v = cv::countNonZero(mask);


### PR DESCRIPTION
- Earlier wrong cv::multiply api usage has been fixed. Scale param has been set to 6 by mistake by passing CV_64F. 
- cv::abs returns tiny negative value due to float32 sign-bit problem. This issue has been fixed.
- Relative errors has been adjusted in perf_dot, perf_stat, perf_moments to avoid introducing new error while changing scale from 6 to 1 in cv::multiply.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
