### PR TITLE
fix(core): prevent overflow in Rect::br() when dimensions exceed INT_MAX

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1902,7 +1902,7 @@ Point_<_Tp> Rect_<_Tp>::tl() const
 template<typename _Tp> inline
 Point_<_Tp> Rect_<_Tp>::br() const
 {
-    return Point_<_Tp>(x + width, y + height);
+    return Point_<_Tp>(saturate_cast<_Tp>((int64_t)x + width), saturate_cast<_Tp>((int64_t)y + height));
 }
 
 template<typename _Tp> inline

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -923,7 +923,22 @@ TYPED_TEST_P(Rect_Test, OnTheEdge) {
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h    ))));
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h + 1))));
 }
-REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge);
+
+TYPED_TEST_P(Rect_Test, BottomRight_Overflow) {
+  TypeParam num_max = std::numeric_limits<TypeParam>::max();
+  TypeParam zero = TypeParam();
+  Rect_<TypeParam> r(zero, zero, num_max, num_max);
+  Point_<TypeParam> br = r.br();
+  if (std::numeric_limits<TypeParam>::is_integer) {
+    ASSERT_EQ(num_max, br.x);
+    ASSERT_EQ(num_max, br.y);
+  } else {
+    ASSERT_EQ(num_max, br.x);
+    ASSERT_EQ(num_max, br.y);
+  }
+}
+
+REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge, BottomRight_Overflow);
 
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);


### PR DESCRIPTION
## Summary

Fixes integer overflow in `Rect::br()` when `x + width` or `y + height` exceeds `INT_MAX`, which triggers UBSan (Undefined Behavior Sanitizer).

This issue was reported in [Issue #21037](https://github.com/opencv/opencv/issues/21037).

## Changes

1. **types.hpp**: Modified `Rect_<_Tp>::br()` to use `int64_t` type promotion before the addition, then `saturate_cast` to the target type. This prevents integer overflow while maintaining the expected saturation behavior.

2. **test_misc.cpp**: Added `BottomRight_Overflow` test case to verify `br()` returns correct values when `Rect` dimensions are at `numeric_limits<int>::max()`.

## Technical Details

- The fix uses `int64_t` promotion: `saturate_cast<_Tp>((int64_t)x + width)`
- Pattern matches existing overflow fixes in OpenCV (e.g., `Point::dot()` in PR #28930)
- `saturate_cast` clips the result to the target type's range for 8-bit and 16-bit types, but preserves the value for 32-bit integers when no clipping is needed

## Testing

- Added typed test for `Rect_<int>`, `Rect_<float>`, and `Rect_<double>`
- Verified fix passes with UBSan enabled