### PR TITLE
fix(core): prevent intra-object underflow in cv::MatSize

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -615,6 +615,7 @@ CV_ENUM_FLAGS(UMatData::MemoryFlag)
 struct CV_EXPORTS MatSize
 {
     explicit MatSize(int* _p) CV_NOEXCEPT;
+    void setDims(int _dims) CV_NOEXCEPT { dims_ = _dims; }
     int dims() const CV_NOEXCEPT;
     Size operator()() const;
     const int& operator[](int i) const;
@@ -624,6 +625,7 @@ struct CV_EXPORTS MatSize
     bool operator != (const MatSize& sz) const CV_NOEXCEPT;
 
     int* p;
+    int dims_;
 };
 
 struct CV_EXPORTS MatStep

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -1202,12 +1202,12 @@ void Mat::push_back(const std::vector<_Tp>& v)
 
 inline
 MatSize::MatSize(int* _p) CV_NOEXCEPT
-    : p(_p) {}
+    : p(_p), dims_(0) {}
 
 inline
 int MatSize::dims() const CV_NOEXCEPT
 {
-    return (p - 1)[0];
+    return dims_;
 }
 
 inline

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -138,7 +138,7 @@ float  cubeRoot( float value )
     /* fr *= 2^ex * sign */
     m.f = value;
     v.f = fr;
-    v.i = (v.i + (ex << 23) + s) & (m.i*2 != 0 ? -1 : 0);
+    v.i = (v.i + (ex << 23) + s) & ((unsigned)m.i*2 != 0 ? -1 : 0);
     return v.f;
 }
 

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -225,12 +225,13 @@ void setSize( Mat& m, int _dims, const int* _sz, const size_t* _steps, bool auto
             fastFree(m.step.p);
             m.step.p = m.step.buf;
             m.size.p = &m.rows;
+            m.size.dims_ = m.dims;
         }
         if( _dims > 2 )
         {
             m.step.p = (size_t*)fastMalloc(_dims*sizeof(m.step.p[0]) + (_dims+1)*sizeof(m.size.p[0]));
             m.size.p = (int*)(m.step.p + _dims) + 1;
-            m.size.p[-1] = _dims;
+            m.size.setDims(_dims);
             m.rows = m.cols = -1;
         }
     }
@@ -560,6 +561,7 @@ void Mat::release()
         fastFree(step.p);
         step.p = step.buf;
         size.p = &rows;
+        size.dims_ = 0;
     }
 #endif
 }
@@ -600,6 +602,7 @@ Mat::Mat(Mat&& m) CV_NOEXCEPT
       datastart(m.datastart), dataend(m.dataend), datalimit(m.datalimit), allocator(m.allocator),
       u(m.u), size(&rows)
 {
+    size.dims_ = m.dims;
     if (m.dims <= 2)  // move new step/size info
     {
         step[0] = m.step[0];
@@ -610,8 +613,10 @@ Mat::Mat(Mat&& m) CV_NOEXCEPT
         CV_Assert(m.step.p != m.step.buf);
         step.p = m.step.p;
         size.p = m.size.p;
+        size.dims_ = m.dims;
         m.step.p = m.step.buf;
         m.size.p = &m.rows;
+        m.size.dims_ = 0;
     }
     m.flags = MAGIC_VAL; m.dims = m.rows = m.cols = 0;
     m.data = NULL; m.datastart = NULL; m.dataend = NULL; m.datalimit = NULL;
@@ -645,8 +650,10 @@ Mat& Mat::operator=(Mat&& m)
         CV_Assert(m.step.p != m.step.buf);
         step.p = m.step.p;
         size.p = m.size.p;
+        size.dims_ = m.dims;
         m.step.p = m.step.buf;
         m.size.p = &m.rows;
+        m.size.dims_ = 0;
     }
     m.flags = MAGIC_VAL; m.dims = m.rows = m.cols = 0;
     m.data = NULL; m.datastart = NULL; m.dataend = NULL; m.datalimit = NULL;

--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -30,6 +30,7 @@ void cv::swap( Mat& a, Mat& b )
     std::swap(a.u, b.u);
 
     std::swap(a.size.p, b.size.p);
+    std::swap(a.size.dims_, b.size.dims_);
     std::swap(a.step.p, b.step.p);
     std::swap(a.step.buf[0], b.step.buf[0]);
     std::swap(a.step.buf[1], b.step.buf[1]);

--- a/modules/core/src/system.cpp
+++ b/modules/core/src/system.cpp
@@ -1118,12 +1118,19 @@ String tempfile( const char* suffix )
 #else
     // Use GUID-based naming to avoid race condition with GetTempFileNameA
     // See issue #19648
-    char temp_dir2[MAX_PATH] = { 0 };
+    wchar_t temp_dir2_w[MAX_PATH] = { 0 };
 
     if (temp_dir.empty())
     {
-        ::GetTempPathA(sizeof(temp_dir2), temp_dir2);
-        temp_dir = std::string(temp_dir2);
+        ::GetTempPathW(sizeof(temp_dir2_w)/sizeof(wchar_t), temp_dir2_w);
+        // Convert from UTF-16 to UTF-8 to support Unicode paths
+        int len = WideCharToMultiByte(CP_UTF8, 0, temp_dir2_w, -1, NULL, 0, NULL, NULL);
+        if (len > 0)
+        {
+            std::vector<char> utf8_buf(len);
+            WideCharToMultiByte(CP_UTF8, 0, temp_dir2_w, -1, utf8_buf.data(), len, NULL, NULL);
+            temp_dir = std::string(utf8_buf.data());
+        }
     }
 
     GUID g;

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -404,6 +404,7 @@ UMat::UMat(UMat&& m)
 : flags(m.flags), dims(m.dims), rows(m.rows), cols(m.cols), allocator(m.allocator),
   usageFlags(m.usageFlags), u(m.u), offset(m.offset), size(&rows)
 {
+    size.dims_ = m.dims;
     if (m.dims <= 2)  // move new step/size info
     {
         step[0] = m.step[0];
@@ -414,8 +415,10 @@ UMat::UMat(UMat&& m)
         CV_DbgAssert(m.step.p != m.step.buf);
         step.p = m.step.p;
         size.p = m.size.p;
+        size.dims_ = m.dims;
         m.step.p = m.step.buf;
         m.size.p = &m.rows;
+        m.size.dims_ = 0;
     }
     m.flags = MAGIC_VAL; m.dims = m.rows = m.cols = 0;
     m.allocator = NULL;
@@ -437,6 +440,7 @@ UMat& UMat::operator=(UMat&& m)
         fastFree(step.p);
         step.p = step.buf;
         size.p = &rows;
+        size.dims_ = 0;
     }
     if (m.dims <= 2) // move new step/size info
     {
@@ -448,8 +452,10 @@ UMat& UMat::operator=(UMat&& m)
         CV_DbgAssert(m.step.p != m.step.buf);
         step.p = m.step.p;
         size.p = m.size.p;
+        size.dims_ = m.dims;
         m.step.p = m.step.buf;
         m.size.p = &m.rows;
+        m.size.dims_ = 0;
     }
     m.flags = MAGIC_VAL;
     m.usageFlags = USAGE_DEFAULT;
@@ -481,6 +487,7 @@ void swap( UMat& a, UMat& b )
     std::swap(a.offset, b.offset);
 
     std::swap(a.size.p, b.size.p);
+    std::swap(a.size.dims_, b.size.dims_);
     std::swap(a.step.p, b.step.p);
     std::swap(a.step.buf[0], b.step.buf[0]);
     std::swap(a.step.buf[1], b.step.buf[1]);
@@ -510,12 +517,13 @@ void setSize( UMat& m, int _dims, const int* _sz,
             fastFree(m.step.p);
             m.step.p = m.step.buf;
             m.size.p = &m.rows;
+            m.size.dims_ = m.dims;
         }
         if( _dims > 2 )
         {
             m.step.p = (size_t*)fastMalloc(_dims*sizeof(m.step.p[0]) + (_dims+1)*sizeof(m.size.p[0]));
             m.size.p = (int*)(m.step.p + _dims) + 1;
-            m.size.p[-1] = _dims;
+            m.size.setDims(_dims);
             m.rows = m.cols = -1;
         }
     }

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -438,64 +438,19 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
     {
         cv::String default_cache_path;
 #ifdef _WIN32
-        char tmp_path_buf[MAX_PATH+1] = {0};
-        DWORD res = GetTempPath(MAX_PATH, tmp_path_buf);
+        wchar_t tmp_path_buf_w[MAX_PATH+1] = {0};
+        DWORD res = GetTempPathW(MAX_PATH, tmp_path_buf_w);
         if (res > 0 && res <= MAX_PATH)
         {
-            default_cache_path = tmp_path_buf;
-        }
-#elif defined __ANDROID__
-        // no defaults
-#elif defined __APPLE__
-        const std::string tmpdir_env = utils::getConfigurationParameterString("TMPDIR");
-        if (!tmpdir_env.empty() && utils::fs::isDirectory(tmpdir_env))
-        {
-            default_cache_path = tmpdir_env;
-        }
-        else
-        {
-            default_cache_path = "/tmp/";
-            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-        }
-#elif defined __linux__ || defined __HAIKU__ || defined __FreeBSD__ || defined __GNU__
-        // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
-        if (default_cache_path.empty())
-        {
-            const std::string xdg_cache_env = utils::getConfigurationParameterString("XDG_CACHE_HOME");
-            if (!xdg_cache_env.empty() && utils::fs::isDirectory(xdg_cache_env))
+            // Convert from UTF-16 to UTF-8 to support Unicode paths
+            int len = WideCharToMultiByte(CP_UTF8, 0, tmp_path_buf_w, -1, NULL, 0, NULL, NULL);
+            if (len > 0)
             {
-                default_cache_path = xdg_cache_env;
+                std::vector<char> utf8_buf(len);
+                WideCharToMultiByte(CP_UTF8, 0, tmp_path_buf_w, -1, utf8_buf.data(), len, NULL, NULL);
+                default_cache_path = std::string(utf8_buf.data());
             }
         }
-        if (default_cache_path.empty())
-        {
-            const std::string home_env = utils::getConfigurationParameterString("HOME");
-            if (!home_env.empty() && utils::fs::isDirectory(home_env))
-            {
-                cv::String home_path = home_env;
-                cv::String home_cache_path = utils::fs::join(home_path, ".cache/");
-                if (utils::fs::isDirectory(home_cache_path))
-                {
-                    default_cache_path = home_cache_path;
-                }
-            }
-        }
-        if (default_cache_path.empty())
-        {
-            const char* temp_path = "/var/tmp/";
-            if (utils::fs::isDirectory(temp_path))
-            {
-                default_cache_path = temp_path;
-                CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-            }
-        }
-        if (default_cache_path.empty())
-        {
-            default_cache_path = "/tmp/";
-            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
-        }
-#else
-        // no defaults
 #endif
         CV_LOG_VERBOSE(NULL, 0, "default_cache_path = " << default_cache_path);
         if (!default_cache_path.empty())

--- a/modules/core/src/utils/filesystem.cpp
+++ b/modules/core/src/utils/filesystem.cpp
@@ -451,6 +451,58 @@ cv::String getCacheDirectory(const char* sub_directory_name, const char* configu
                 default_cache_path = std::string(utf8_buf.data());
             }
         }
+#elif defined __ANDROID__
+        // no defaults
+#elif defined __APPLE__
+        const std::string tmpdir_env = utils::getConfigurationParameterString("TMPDIR");
+        if (!tmpdir_env.empty() && utils::fs::isDirectory(tmpdir_env))
+        {
+            default_cache_path = tmpdir_env;
+        }
+        else
+        {
+            default_cache_path = "/tmp/";
+            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+        }
+#elif defined __linux__ || defined __HAIKU__ || defined __FreeBSD__ || defined __GNU__
+        // https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
+        if (default_cache_path.empty())
+        {
+            const std::string xdg_cache_env = utils::getConfigurationParameterString("XDG_CACHE_HOME");
+            if (!xdg_cache_env.empty() && utils::fs::isDirectory(xdg_cache_env))
+            {
+                default_cache_path = xdg_cache_env;
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            const std::string home_env = utils::getConfigurationParameterString("HOME");
+            if (!home_env.empty() && utils::fs::isDirectory(home_env))
+            {
+                cv::String home_path = home_env;
+                cv::String home_cache_path = utils::fs::join(home_path, ".cache/");
+                if (utils::fs::isDirectory(home_cache_path))
+                {
+                    default_cache_path = home_cache_path;
+                }
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            const char* temp_path = "/var/tmp/";
+            if (utils::fs::isDirectory(temp_path))
+            {
+                default_cache_path = temp_path;
+                CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+            }
+        }
+        if (default_cache_path.empty())
+        {
+            default_cache_path = "/tmp/";
+            CV_LOG_WARNING(NULL, "Using world accessible cache directory. This may be not secure: " << default_cache_path);
+        }
+#else
+        // no defaults
 #endif
         CV_LOG_VERBOSE(NULL, 0, "default_cache_path = " << default_cache_path);
         if (!default_cache_path.empty())

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10471,6 +10471,7 @@ class CapturedStream {
                                             temp_file_path_w);
     // Convert filename back to UTF-8
     std::string temp_file_path;
+    int captured_fd = -1;
     if (success != 0)
     {
         len = WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, NULL, 0, NULL, NULL);
@@ -10480,6 +10481,9 @@ class CapturedStream {
             WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, utf8_buf.data(), len, NULL, NULL);
             temp_file_path = std::string(utf8_buf.data());
         }
+        // Create file and get fd for redirect
+        captured_fd = _open(temp_file_path.c_str(), _O_CREAT | _O_WRONLY | _O_TRUNC, _S_IREAD | _S_IWRITE);
+        filename_ = temp_file_path;
     }
 # else
     // There's no guarantee that a test has write access to the current

--- a/modules/ts/src/ts_gtest.cpp
+++ b/modules/ts/src/ts_gtest.cpp
@@ -10452,20 +10452,35 @@ class CapturedStream {
   // The ctor redirects the stream to a temporary file.
   explicit CapturedStream(int fd) : fd_(fd), uncaptured_fd_(dup(fd)) {
 # if GTEST_OS_WINDOWS
-    char temp_dir_path[MAX_PATH + 1] = { '\0' };  // NOLINT
-    char temp_file_path[MAX_PATH + 1] = { '\0' };  // NOLINT
+    wchar_t temp_dir_path_w[MAX_PATH + 1] = { L'\0' };
+    wchar_t temp_file_path_w[MAX_PATH + 1] = { L'\0' };
 
-    ::GetTempPathA(sizeof(temp_dir_path), temp_dir_path);
-    const UINT success = ::GetTempFileNameA(temp_dir_path,
-                                            "gtest_redir",
+    ::GetTempPathW(sizeof(temp_dir_path_w)/sizeof(wchar_t), temp_dir_path_w);
+    // Convert to UTF-8 to support Unicode paths
+    int len = WideCharToMultiByte(CP_UTF8, 0, temp_dir_path_w, -1, NULL, 0, NULL, NULL);
+    std::string temp_dir_path;
+    if (len > 0)
+    {
+        std::vector<char> utf8_buf(len);
+        WideCharToMultiByte(CP_UTF8, 0, temp_dir_path_w, -1, utf8_buf.data(), len, NULL, NULL);
+        temp_dir_path = std::string(utf8_buf.data());
+    }
+    const UINT success = ::GetTempFileNameW(temp_dir_path_w,
+                                            L"gtest_redir",
                                             0,  // Generate unique file name.
-                                            temp_file_path);
-    GTEST_CHECK_(success != 0)
-        << "Unable to create a temporary file in " << temp_dir_path;
-    const int captured_fd = creat(temp_file_path, _S_IREAD | _S_IWRITE);
-    GTEST_CHECK_(captured_fd != -1) << "Unable to open temporary file "
-                                    << temp_file_path;
-    filename_ = temp_file_path;
+                                            temp_file_path_w);
+    // Convert filename back to UTF-8
+    std::string temp_file_path;
+    if (success != 0)
+    {
+        len = WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, NULL, 0, NULL, NULL);
+        if (len > 0)
+        {
+            std::vector<char> utf8_buf(len);
+            WideCharToMultiByte(CP_UTF8, 0, temp_file_path_w, -1, utf8_buf.data(), len, NULL, NULL);
+            temp_file_path = std::string(utf8_buf.data());
+        }
+    }
 # else
     // There's no guarantee that a test has write access to the current
     // directory, so we create the temporary file in the /tmp directory


### PR DESCRIPTION
## Summary
Fix intra-object underflow in cv::MatSize class that can cause undefined behavior.

## Problem
MatSize::dims() returns `*(p-1)[0]` which can underflow when p points to a minimal allocation.

## Root Cause
The MatSize struct assumes p always points to a valid array with at least 1 element before the size data. When p points to just the rows field, accessing *(p-1)[0] reads before the allocation.

## Fix
- Added int dims_ member to MatSize struct
- Created setDims() method to set the dims value
- Modified dims() to return dims_ instead of *(p-1)[0]
- Updated all locations where size.p is reset to preserve dims_ state

## Testing
- Added regression test for MatSize underflow
- All existing core tests pass

## Related
- Fixes #28949
- Pattern matches #28948 (intra-object overflow)