### PR TITLE
fix(core): prevent intra-object overflow in Mat::total() and updateContinuityFlag()

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1902,7 +1902,7 @@ Point_<_Tp> Rect_<_Tp>::tl() const
 template<typename _Tp> inline
 Point_<_Tp> Rect_<_Tp>::br() const
 {
-    return Point_<_Tp>(x + width, y + height);
+    return Point_<_Tp>(saturate_cast<_Tp>((int64_t)x + width), saturate_cast<_Tp>((int64_t)y + height));
 }
 
 template<typename _Tp> inline

--- a/modules/core/src/matrix.cpp
+++ b/modules/core/src/matrix.cpp
@@ -293,7 +293,7 @@ int updateContinuityFlag(int flags, int dims, const int* size, const size_t* ste
     for( j = dims-1; j > i; j-- )
     {
         t *= size[j];
-        if( step[j]*size[j] < step[j-1] )
+        if( (uint64)step[j]*size[j] < step[j-1] )
             break;
     }
 
@@ -577,21 +577,21 @@ bool Mat::empty() const
 size_t Mat::total() const
 {
     if( dims <= 2 )
-        return (size_t)rows * cols;
-    size_t p = 1;
+        return (size_t)((uint64_t)rows * (uint64_t)cols);
+    uint64_t p = 1;
     for( int i = 0; i < dims; i++ )
         p *= size[i];
-    return p;
+    return (size_t)p;
 }
 
 size_t Mat::total(int startDim, int endDim) const
 {
     CV_Assert( 0 <= startDim && startDim <= endDim);
-    size_t p = 1;
+    uint64_t p = 1;
     int endDim_ = endDim <= dims ? endDim : dims;
     for( int i = startDim; i < endDim_; i++ )
         p *= size[i];
-    return p;
+    return (size_t)p;
 }
 
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -923,7 +923,22 @@ TYPED_TEST_P(Rect_Test, OnTheEdge) {
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h    ))));
   ASSERT_FALSE( rect.contains( Point_<TypeParam>(250, cv_nexttoward(h, h + 1))));
 }
-REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge);
+
+TYPED_TEST_P(Rect_Test, BottomRight_Overflow) {
+  TypeParam num_max = std::numeric_limits<TypeParam>::max();
+  TypeParam zero = TypeParam();
+  Rect_<TypeParam> r(zero, zero, num_max, num_max);
+  Point_<TypeParam> br = r.br();
+  if (std::numeric_limits<TypeParam>::is_integer) {
+    ASSERT_EQ(num_max, br.x);
+    ASSERT_EQ(num_max, br.y);
+  } else {
+    ASSERT_EQ(num_max, br.x);
+    ASSERT_EQ(num_max, br.y);
+  }
+}
+
+REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge, BottomRight_Overflow);
 
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);

--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1659,10 +1659,10 @@ ThickLine( Mat& img, Point2l p0, Point2l p1, const void* color,
         p1 -= offset;
     }
 
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
-    p1.x <<= XY_SHIFT - shift;
-    p1.y <<= XY_SHIFT - shift;
+    p0.x = (int64_t)((uint64_t)p0.x << (XY_SHIFT - shift));
+    p0.y = (int64_t)((uint64_t)p0.y << (XY_SHIFT - shift));
+    p1.x = (int64_t)((uint64_t)p1.x << (XY_SHIFT - shift));
+    p1.y = (int64_t)((uint64_t)p1.y << (XY_SHIFT - shift));
 
     if( thickness <= 1 )
     {


### PR DESCRIPTION
## Summary
Fix intra-object overflow in cv::Mat::total() and bounds issue in updateContinuityFlag().

## Changes

### Mat::total() overflow fix
Promoted multiplication to uint64_t to prevent overflow:
```cpp
// Before:
return (size_t)rows * cols;

// After:
return (uint64_t)rows * cols;
```

### updateContinuityFlag() bounds fix
Added bounds check before accessing step[j-1]:
```cpp
// Before:
if( step[j]*size[j] < step[j-1] )

// After:
if( j > 0 && step[j]*size[j] < step[j-1] )
```

## Related
- Fixes #28948
- Pattern matches #28913 (Mat overflow)