### PR TITLE
fix getUnconnectedOutLayers() in new engine

### DIFF
--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -2383,6 +2383,29 @@ std::vector<int> Net::Impl::getUnconnectedOutLayers() const
 {
     std::vector<int> layersIds;
 
+    if (mainGraph) {
+        const std::vector<Arg>& outargs = mainGraph->outputs();
+        std::set<int> outArgIdxs;
+        for (const auto& out : outargs)
+            outArgIdxs.insert(out.idx);
+
+        int graph_ofs = 0;
+        for (const auto& graph : allgraphs) {
+            const std::vector<Ptr<Layer>>& prog = graph->prog();
+            for (int i = 0; i < (int)prog.size(); i++) {
+                for (const auto& layerOut : prog[i]->outputs) {
+                    if (outArgIdxs.count(layerOut.idx)) {
+                        layersIds.push_back(graph_ofs + i);
+                        break;
+                    }
+                }
+            }
+            graph_ofs += (int)prog.size();
+        }
+        if (!layersIds.empty())
+            return layersIds;
+    }
+
     // registerOutput() flow
     if (!outputNameToId.empty())
     {

--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -2378,7 +2378,6 @@ std::vector<String> Net::Impl::getLayerNames() const
 }
 
 
-// FIXIT drop "unconnected" API
 std::vector<int> Net::Impl::getUnconnectedOutLayers() const
 {
     std::vector<int> layersIds;

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -3581,15 +3581,13 @@ TEST_P(Test_ONNX_layers, getUnconnectedOutLayers)
     std::vector<int>    outIds   = net.getUnconnectedOutLayers();
     std::vector<String> outNames = net.getUnconnectedOutLayersNames();
 
-    EXPECT_FALSE(outIds.empty());
     EXPECT_EQ(outIds.size(), outNames.size());
+    EXPECT_EQ(1, outIds.size());
 
-    for (int id : outIds)
-    {
-        EXPECT_GT(id, 0);
-        Ptr<Layer> layer = net.getLayer(id);
-        ASSERT_TRUE(layer);
-    }
+    EXPECT_EQ("output0", outNames[0]);
+    EXPECT_GT(outIds[0], 0);
+    Ptr<Layer> layer = net.getLayer(outIds[0]);
+    ASSERT_TRUE(layer);
 }
 
 }} // namespace

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -3566,4 +3566,30 @@ TEST_P(Test_ONNX_layers, RandomNormalLike_complex)
 
 INSTANTIATE_TEST_CASE_P(/**/, Test_ONNX_nets, dnnBackendsAndTargets());
 
+TEST_P(Test_ONNX_layers, getUnconnectedOutLayers)
+{
+    auto engine_forced = static_cast<cv::dnn::EngineType>(
+        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", cv::dnn::ENGINE_AUTO));
+    if (engine_forced == cv::dnn::ENGINE_ORT)
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
+
+    Net net = readNetFromONNX(_tf("models/yolov8x.onnx", false));
+    ASSERT_FALSE(net.empty());
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+
+    std::vector<int>    outIds   = net.getUnconnectedOutLayers();
+    std::vector<String> outNames = net.getUnconnectedOutLayersNames();
+
+    EXPECT_FALSE(outIds.empty());
+    EXPECT_EQ(outIds.size(), outNames.size());
+
+    for (int id : outIds)
+    {
+        EXPECT_GT(id, 0);
+        Ptr<Layer> layer = net.getLayer(id);
+        ASSERT_TRUE(layer);
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
Solves https://github.com/opencv/opencv/issues/26491
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
