### PR TITLE
core: fix unsigned Rect intersection underflow

### DIFF
--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -2002,28 +2002,33 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     const Rect_<_Tp>& Rx_max = (a.x < b.x) ? b : a;
     const Rect_<_Tp>& Ry_min = (a.y < b.y) ? a : b;
     const Rect_<_Tp>& Ry_max = (a.y < b.y) ? b : a;
-    // Looking at the formula below, we will compute Rx_min.width - (Rx_max.x - Rx_min.x)
-    // but we want to avoid overflows. Rx_min.width >= 0 and (Rx_max.x - Rx_min.x) >= 0
-    // by definition so the difference does not overflow. The only thing that can overflow
-    // is (Rx_max.x - Rx_min.x). And it can only overflow if Rx_min.x < 0.
-    // Let us first deal with the following case.
-    if ((Rx_min.x < 0 && Rx_min.x + Rx_min.width < Rx_max.x) ||
-        (Ry_min.y < 0 && Ry_min.y + Ry_min.height < Ry_max.y)) {
-        a = Rect_<_Tp>();
-        return a;
+    if (std::is_signed<_Tp>::value) {
+        // Looking at the formula below, we will compute Rx_min.width - (Rx_max.x - Rx_min.x)
+        // but we want to avoid overflows. Rx_min.width >= 0 and (Rx_max.x - Rx_min.x) >= 0
+        // by definition so the difference does not overflow. The only thing that can overflow
+        // is (Rx_max.x - Rx_min.x). And it can only overflow if Rx_min.x < 0.
+        // Let us first deal with the following case.
+        if ((Rx_min.x < 0 && Rx_min.x + Rx_min.width < Rx_max.x) ||
+            (Ry_min.y < 0 && Ry_min.y + Ry_min.height < Ry_max.y)) {
+            a = Rect_<_Tp>();
+            return a;
+        }
+        // We now know that either Rx_min.x >= 0, or
+        // Rx_min.x < 0 && Rx_min.x + Rx_min.width >= Rx_max.x and therefore
+        // Rx_min.width >= (Rx_max.x - Rx_min.x) which means (Rx_max.x - Rx_min.x)
+        // is inferior to a valid int and therefore does not overflow.
+        a.width = std::min(Rx_min.width - (Rx_max.x - Rx_min.x), Rx_max.width);
+        a.height = std::min(Ry_min.height - (Ry_max.y - Ry_min.y), Ry_max.height);
+    } else {
+        const _Tp x_diff = Rx_max.x - Rx_min.x;
+        const _Tp y_diff = Ry_max.y - Ry_min.y;
+        if (Rx_min.width <= x_diff || Ry_min.height <= y_diff) {
+            a = Rect_<_Tp>();
+            return a;
+        }
+        a.width = std::min(Rx_min.width - x_diff, Rx_max.width);
+        a.height = std::min(Ry_min.height - y_diff, Ry_max.height);
     }
-    // We now know that either Rx_min.x >= 0, or
-    // Rx_min.x < 0 && Rx_min.x + Rx_min.width >= Rx_max.x and therefore
-    // Rx_min.width >= (Rx_max.x - Rx_min.x) which means (Rx_max.x - Rx_min.x)
-    // is inferior to a valid int and therefore does not overflow.
-    const _Tp x_diff = Rx_max.x - Rx_min.x;
-    const _Tp y_diff = Ry_max.y - Ry_min.y;
-    if (Rx_min.width <= x_diff || Ry_min.height <= y_diff) {
-        a = Rect_<_Tp>();
-        return a;
-    }
-    a.width = std::min(Rx_min.width - x_diff, Rx_max.width);
-    a.height = std::min(Ry_min.height - y_diff, Ry_max.height);
     a.x = Rx_max.x;
     a.y = Ry_max.y;
     if (a.empty())

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -2016,8 +2016,14 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     // Rx_min.x < 0 && Rx_min.x + Rx_min.width >= Rx_max.x and therefore
     // Rx_min.width >= (Rx_max.x - Rx_min.x) which means (Rx_max.x - Rx_min.x)
     // is inferior to a valid int and therefore does not overflow.
-    a.width = std::min(Rx_min.width - (Rx_max.x - Rx_min.x), Rx_max.width);
-    a.height = std::min(Ry_min.height - (Ry_max.y - Ry_min.y), Ry_max.height);
+    const _Tp x_diff = Rx_max.x - Rx_min.x;
+    const _Tp y_diff = Ry_max.y - Ry_min.y;
+    if (Rx_min.width <= x_diff || Ry_min.height <= y_diff) {
+        a = Rect_<_Tp>();
+        return a;
+    }
+    a.width = std::min(Rx_min.width - x_diff, Rx_max.width);
+    a.height = std::min(Ry_min.height - y_diff, Ry_max.height);
     a.x = Rx_max.x;
     a.y = Ry_max.y;
     if (a.empty())

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -928,7 +928,6 @@ REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge);
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
-// https://github.com/opencv/opencv/issues/11988
 TEST(Core_Rect, unsigned_intersection)
 {
     typedef Rect_<unsigned> R;

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -931,10 +931,13 @@ INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 TEST(Core_Rect, unsigned_intersection)
 {
     typedef Rect_<unsigned> R;
+    const unsigned num_max = std::numeric_limits<unsigned>::max();
 
     EXPECT_EQ(R(5, 5, 5, 5), R(0, 0, 10, 10) & R(5, 5, 10, 10));
     EXPECT_EQ(R(), R(0, 0, 10, 10) & R(20, 0, 5, 5));
     EXPECT_EQ(R(), R(0, 0, 10, 10) & R(0, 20, 5, 5));
+    EXPECT_EQ(R(num_max - 5, 0, 5, 10), R(0, 0, num_max, 10) & R(num_max - 5, 0, 10, 10));
+    EXPECT_EQ(R(), R(0, 0, num_max / 2, 10) & R(num_max / 2 + 1, 0, 10, 10));
 }
 
 // Expected that SkipTestException thrown in the constructor should skip test but not fail

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -928,6 +928,16 @@ REGISTER_TYPED_TEST_CASE_P(Rect_Test, Overflows, OnTheEdge);
 typedef ::testing::Types<int, float, double> RectTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(Negative_Test, Rect_Test, RectTypes);
 
+// https://github.com/opencv/opencv/issues/11988
+TEST(Core_Rect, unsigned_intersection)
+{
+    typedef Rect_<unsigned> R;
+
+    EXPECT_EQ(R(5, 5, 5, 5), R(0, 0, 10, 10) & R(5, 5, 10, 10));
+    EXPECT_EQ(R(), R(0, 0, 10, 10) & R(20, 0, 5, 5));
+    EXPECT_EQ(R(), R(0, 0, 10, 10) & R(0, 20, 5, 5));
+}
+
 // Expected that SkipTestException thrown in the constructor should skip test but not fail
 struct TestFixtureSkip: public ::testing::Test {
     TestFixtureSkip(bool throwEx = true) {


### PR DESCRIPTION
### Problem
Fixes #11988.

`Rect_<unsigned>` intersection (`operator &`) may return a non-empty rectangle for completely disjoint rectangles. 
For example, `Rect_<unsigned>(0, 0, 10, 10) & Rect_<unsigned>(20, 0, 5, 5)` incorrectly returned `[5 x 5 from (20, 0)]` instead of an empty rectangle.

**Root Cause:**
The issue stems from an unsigned integer underflow in `modules/core/include/opencv2/core/types.hpp`.
When calculating the intersection width:
`Rx_min.width - (Rx_max.x - Rx_min.x)`
If the rectangles do not overlap, this subtraction wraps around to a very large unsigned value (e.g., `0xFFFFFFFF`). Consequently, `std::min(..., Rx_max.width)` incorrectly chooses and returns `Rx_max.width`.

### Fix
Added an explicit no-overlap (disjoint) check before computing the final intersection width and height. This strictly prevents the unsigned underflow by ensuring the distance between the origins (`x_diff`, `y_diff`) is strictly less than the corresponding dimensions.

```cpp
if (Rx_min.width <= x_diff || Ry_min.height <= y_diff)
    return Rect_<_Tp>();
```
    
### Tests
Added regression tests in `modules/core/test/test_misc.cpp` (`Core_Rect.unsigned_intersection`) to prevent future regressions.

**Test Commands:**
```Bash
cmake --build build --target opencv_test_core -j8
build/bin/opencv_test_core --gtest_filter=Core_Rect.unsigned_intersection
build/bin/opencv_test_core --gtest_filter='*Rect*'
```

**Results:**
- `Core_Rect.unsigned_intersection`: PASSED 1 test
- `*Rect*`: PASSED 9 tests
    
### Checklist

- [x] I agree to contribute to the project under Apache 2 License.
    
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
    
- [x] The PR is proposed to the proper branch
    
- [x] There is a reference to the original bug report and related work
    
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable