### PR TITLE
test: add in-place test coverage for cv::broadcast (#28910)

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2624,6 +2624,24 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
+    // Issue #28910: Test in-place behaviour and missing branch coverage
+    {
+        std::vector<int> _shape_src{ 1, 3 };
+        std::vector<int> _data_src{ 1, 2, 3 };
+        Mat _src(static_cast<int>(_shape_src.size()), _shape_src.data(), CV_32SC1, _data_src.data());
+
+        std::vector<int> shape{ 2, 3 };
+
+        // In-place broadcast (dst is exactly the same as src)
+        broadcast(_src, shape, _src);
+
+        std::vector<int> data_ref{
+            1, 2, 3, // [0, :]
+            1, 2, 3  // [1, :]
+        };
+        Mat ref(static_cast<int>(shape.size()), shape.data(), _src.type(), data_ref.data());
+        fn_verify(ref, _src);
+    }
 }
 
 TEST(Core_minMaxIdx, regression_9207_2)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


This PR adds the missing test coverage for the in-place behavior in the cv::broadcast() function. It properly evaluates the alternative branch when _flatten_for_broadcast returns false.

Resolves #28910. 
