### PR TITLE
dnn: vectorize SigmoidFunctor using universal intrinsics

### DIFF
--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1287,6 +1287,16 @@ struct SigmoidFunctor : public BaseDefaultFunctor<SigmoidFunctor>
 {
     typedef SigmoidLayer Layer;
 
+    int vlanes;
+
+    explicit SigmoidFunctor() {
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        vlanes = VTraits<v_float32>::vlanes();
+#else
+        vlanes = 1;
+#endif
+    }
+
     bool supportBackend(int backendId, int)
     {
 #ifdef HAVE_INF_ENGINE
@@ -1309,6 +1319,45 @@ struct SigmoidFunctor : public BaseDefaultFunctor<SigmoidFunctor>
             y = y / (1 + y);
         }
         return y;
+    }
+
+    void apply(const float* srcptr, float* dstptr, int stripeStart, int len, size_t planeSize, int cn0, int cn1) const {
+        CV_UNUSED(stripeStart);
+        for (int cn = cn0; cn < cn1; cn++, srcptr += planeSize, dstptr += planeSize) {
+            int i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            // Using identity: 1 / (1 + exp(-x)) === 1 - (1 / (1 + exp(x)))
+            // Clamping x to [-80.f, 88.f] prevents both v_exp overflow (inf) and subnormal underflow.
+            v_float32 one = vx_setall_f32(1.0f);
+            v_float32 min_val = vx_setall_f32(-80.0f), max_val = vx_setall_f32(88.0f);
+            int step2 = vlanes * 2;
+
+            // 2-way unrolled loop optimized for minimal register dependency
+            for (; i <= len - step2; i += step2) {
+                v_float32 x0 = vx_load(srcptr + i);
+                v_float32 x1 = vx_load(srcptr + i + vlanes);
+
+                x0 = v_min(v_max(x0, min_val), max_val);
+                x1 = v_min(v_max(x1, min_val), max_val);
+
+                // y = 1.0f - (1.0f / (1.0f + exp(x)))
+                v_float32 dst0 = v_sub(one, v_div(one, v_add(one, v_exp(x0))));
+                v_float32 dst1 = v_sub(one, v_div(one, v_add(one, v_exp(x1))));
+
+                vx_store(dstptr + i, dst0);
+                vx_store(dstptr + i + vlanes, dst1);
+            }
+
+            for (; i <= len - vlanes; i += vlanes) {
+                v_float32 x = vx_load(srcptr + i);
+                x = v_min(v_max(x, min_val), max_val);
+                vx_store(dstptr + i, v_sub(one, v_div(one, v_add(one, v_exp(x)))));
+            }
+#endif
+            for (; i < len; i++) {
+                dstptr[i] = calculate(srcptr[i]);
+            }
+        }
     }
 
 #ifdef HAVE_CUDA


### PR DESCRIPTION
### Summary / Motivation

Currently, the `SigmoidFunctor` in the `dnn` module does not provide a vectorized `apply()` implementation. On SIMD-enabled architectures, the execution falls back to a scalar loop, resulting in hardware underutilization. This PR implements a vectorized `apply()` method using OpenCV Universal Intrinsics to improve throughput.  

### Technical Details & Implementation Logic

- **Algebraic Identity Optimization**: The implementation utilizes the identity $\sigma(x) = 1 - \frac{1}{1 + e^{x}}$. This approach allows for direct processing of input $x$, eliminating the requirement for an explicit vector negation instruction (`v_sub`).  
- **Numerical Guarding & Range Limitation**: Input values are constrained to the interval $[-80.0f, 88.0f]$ using `v_min` and `v_max` operations prior to the exponential calculation.  
  - The upper bound of $+88.0f$ prevents `v_exp` overflow to infinity, avoiding subsequent `NaN` or `inf` state corruption.  
  - The lower bound of $-80.0f$ ensures results stay above the subnormal range, preventing significant microcode execution penalties on specific hardware architectures while maintaining floating-point precision.  
- **Pipeline Efficiency**: A 2-way unrolled loop structure is utilized ($step2 = vlanes \times 2$) to optimize instruction-level parallelism. This design masks `v_exp` execution latency and ensures efficient register utilization.  
- **Boundary Handling**: The implementation includes a cleanup loop for remaining vector lanes and a scalar fallback for inputs smaller than a single vector width.  

### Verification Results

- **Hardware Platform**: RISC-V RVV 1.0 (SpacemiT K1 SoC).  

- **Correctness**: Verified against scalar baselines. The implementation passed 6 accuracy tests across ONNX and Int8 layers.  


### Test Execution Logs:
```bash
yang@k1:~$ ./opencv_test_dnn --gtest_filter="*Sigmoid*"
...
HAL: YES (RVV HAL (ver 0.0.1))
CPU features: RVV
Note: Google Test filter = *Sigmoid*
[==========] Running 6 tests from 2 test cases.
[----------] 3 tests from Test_Int8_layers
[ RUN      ] Test_Int8_layers.Sigmoid/0
[       OK ] Test_Int8_layers.Sigmoid/0 (5 ms)
[ RUN      ] Test_Int8_layers.Sigmoid_dynamic_axes/0
[       OK ] Test_Int8_layers.Sigmoid_dynamic_axes/0 (4 ms)
[ RUN      ] Test_Int8_layers.Sigmoid_1d/0
[       OK ] Test_Int8_layers.Sigmoid_1d/0 (2 ms)
[----------] 3 tests from Test_Int8_layers (12 ms total)

[----------] 3 tests from Test_ONNX_layers
[ RUN      ] Test_ONNX_layers.MaxPooling_Sigmoid/0
[       OK ] Test_ONNX_layers.MaxPooling_Sigmoid/0 (2 ms)
[ RUN      ] Test_ONNX_layers.MaxPoolSigmoid1d/0
[       OK ] Test_ONNX_layers.MaxPoolSigmoid1d/0 (2 ms)
[ RUN      ] Test_ONNX_layers.Quantized_Sigmoid/0
[       OK ] Test_ONNX_layers.Quantized_Sigmoid/0 (3 ms)
[----------] 3 tests from Test_ONNX_layers (8 ms total)

[==========] 6 tests from 2 test cases ran. (20 ms total)
[  PASSED  ] 6 tests.
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
