### PR TITLE
core: add true in-place test coverage for cv::broadcast

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2624,6 +2624,24 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
+    // Issue #28910: Test in-place behaviour and missing branch coverage
+    {
+        std::vector<int> _shape_src{ 1, 3 };
+        std::vector<int> _data_src{ 1, 2, 3 };
+        Mat _src(static_cast<int>(_shape_src.size()), _shape_src.data(), CV_32SC1, _data_src.data());
+
+        std::vector<int> shape{ 2, 3 };
+
+        // In-place broadcast (dst is exactly the same as src)
+        broadcast(_src, shape, _src);
+
+        std::vector<int> data_ref{
+            1, 2, 3, // [0, :]
+            1, 2, 3  // [1, :]
+        };
+        Mat ref(static_cast<int>(shape.size()), shape.data(), _src.type(), data_ref.data());
+        fn_verify(ref, _src);
+    }
 }
 
 TEST(Core_minMaxIdx, regression_9207_2)

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2624,23 +2624,34 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
-    // Issue #28910: Test in-place behaviour and missing branch coverage
+    // Issue #28910: Test true in-place behaviour without reallocation
     {
-        std::vector<int> _shape_src{ 1, 3 };
-        std::vector<int> _data_src{ 1, 2, 3 };
-        Mat _src(static_cast<int>(_shape_src.size()), _shape_src.data(), CV_32SC1, _data_src.data());
-
         std::vector<int> shape{ 2, 3 };
 
-        // In-place broadcast (dst is exactly the same as src)
-        broadcast(_src, shape, _src);
+        // 1. Pre-allocate dst with the TARGET shape (2x3).
+        // This strictly prevents _dst.create() inside cv::broadcast from allocating new memory!
+        Mat dst = Mat::zeros(static_cast<int>(shape.size()), shape.data(), CV_32SC1);
 
+        // 2. Create src as a view (ROI) of the first row of dst.
+        // src is now 1x3, but shares the EXACT SAME memory buffer as dst (True In-place).
+        Mat src = dst.row(0);
+
+        // Fill the source data
+        src.at<int>(0, 0) = 1;
+        src.at<int>(0, 1) = 2;
+        src.at<int>(0, 2) = 3;
+
+        // 3. True in-place broadcast! 
+        // src(1x3) will be broadcasted to dst(2x3) within the same memory block.
+        broadcast(src, shape, dst);
+
+        // 4. Verify the broadcasted result
         std::vector<int> data_ref{
             1, 2, 3, // [0, :]
             1, 2, 3  // [1, :]
         };
-        Mat ref(static_cast<int>(shape.size()), shape.data(), _src.type(), data_ref.data());
-        fn_verify(ref, _src);
+        Mat ref(static_cast<int>(shape.size()), shape.data(), CV_32SC1, data_ref.data());
+        fn_verify(ref, dst);
     }
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake

---

**Resolves #28910**
**Follow-up to closed PR #28997**

Hello @asmorkalov, 
As discussed in the previous PR, I have corrected the test to ensure a **true in-place** behavior without triggering `OutputArray::create()`. 

In this approach, I pre-allocate `dst` to the target shape and pass `dst.row(0)` as the `src` input. This guarantees that both inputs share the exact same memory buffer while properly testing the 1D to 2D broadcast logic.

Local tests (`opencv_test_core`) passed successfully. Please let me know if this approach is correct.