### PR TITLE
core: expose initial root values in solvePoly API

### DIFF
--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2624,6 +2624,24 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
+    // Issue #28910: Test in-place behaviour and missing branch coverage
+    {
+        std::vector<int> _shape_src{ 1, 3 };
+        std::vector<int> _data_src{ 1, 2, 3 };
+        Mat _src(static_cast<int>(_shape_src.size()), _shape_src.data(), CV_32SC1, _data_src.data());
+
+        std::vector<int> shape{ 2, 3 };
+
+        // In-place broadcast (dst is exactly the same as src)
+        broadcast(_src, shape, _src);
+
+        std::vector<int> data_ref{
+            1, 2, 3, // [0, :]
+            1, 2, 3  // [1, :]
+        };
+        Mat ref(static_cast<int>(shape.size()), shape.data(), _src.type(), data_ref.data());
+        fn_verify(ref, _src);
+    }
 }
 
 TEST(Core_minMaxIdx, regression_9207_2)

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2624,23 +2624,34 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
-    // Issue #28910: Test in-place behaviour and missing branch coverage
+    // Issue #28910: Test true in-place behaviour without reallocation
     {
-        std::vector<int> _shape_src{ 1, 3 };
-        std::vector<int> _data_src{ 1, 2, 3 };
-        Mat _src(static_cast<int>(_shape_src.size()), _shape_src.data(), CV_32SC1, _data_src.data());
-
         std::vector<int> shape{ 2, 3 };
 
-        // In-place broadcast (dst is exactly the same as src)
-        broadcast(_src, shape, _src);
+        // 1. Pre-allocate dst with the TARGET shape (2x3).
+        // This strictly prevents _dst.create() inside cv::broadcast from allocating new memory!
+        Mat dst = Mat::zeros(static_cast<int>(shape.size()), shape.data(), CV_32SC1);
 
+        // 2. Create src as a view (ROI) of the first row of dst.
+        // src is now 1x3, but shares the EXACT SAME memory buffer as dst (True In-place).
+        Mat src = dst.row(0);
+
+        // Fill the source data
+        src.at<int>(0, 0) = 1;
+        src.at<int>(0, 1) = 2;
+        src.at<int>(0, 2) = 3;
+
+        // 3. True in-place broadcast! 
+        // src(1x3) will be broadcasted to dst(2x3) within the same memory block.
+        broadcast(src, shape, dst);
+
+        // 4. Verify the broadcasted result
         std::vector<int> data_ref{
             1, 2, 3, // [0, :]
             1, 2, 3  // [1, :]
         };
-        Mat ref(static_cast<int>(shape.size()), shape.data(), _src.type(), data_ref.data());
-        fn_verify(ref, _src);
+        Mat ref(static_cast<int>(shape.size()), shape.data(), CV_32SC1, data_ref.data());
+        fn_verify(ref, dst);
     }
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

To resolve this, I have moved the initial root values to the function interface, allowing users to provide custom initial guesses (`init_p` and `init_r`) if the algorithm fails to converge or falls into a periodic cycle. 

# Key changes:
- Modified `cv::solvePoly` signature in `core.hpp` to include `init_p_re`, `init_p_im`, `init_r_re`, and `init_r_im`.
- Updated the implementation in `mathfuncs.cpp` to use these parameters.
- **Backward Compatibility:** Preserved original behavior by setting default values to the original ones (`p = 1.0`, `r = 1.0 + 1.0i`).

# Related Issue
Fixes #23644

### Testing
Tested locally with the reproducer code provided in the issue. 
- Default call (old behavior): Failed to converge as expected.
- Custom initial values (0.4, 0.9): Successfully found the roots [3, 0] and [-1, 0].