### PR TITLE
core: expose initial root values in solvePoly API

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -2025,7 +2025,10 @@ The function cv::solvePoly finds real and complex roots of a polynomial equation
 @param roots output (complex) array of roots.
 @param maxIters maximum number of iterations the algorithm does.
 */
-CV_EXPORTS_W double solvePoly(InputArray coeffs, OutputArray roots, int maxIters = 300);
+/*CV_EXPORTS_W double solvePoly(InputArray coeffs, OutputArray roots, int maxIters = 300);*/
+CV_EXPORTS_W double solvePoly(InputArray coeffs, OutputArray roots, int maxIters = 300,
+    double init_p_re = 1.0, double init_p_im = 0.0,
+    double init_r_re = 1.0, double init_r_im = 1.0);
 
 /** @brief Calculates eigenvalues and eigenvectors of a symmetric matrix.
 

--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -1711,7 +1711,9 @@ int cv::solveCubic( InputArray _coeffs, OutputArray _roots )
 
 /* finds complex roots of a polynomial using Durand-Kerner method:
    http://en.wikipedia.org/wiki/Durand%E2%80%93Kerner_method */
-double cv::solvePoly( InputArray _coeffs0, OutputArray _roots0, int maxIters )
+double cv::solvePoly(InputArray _coeffs0, OutputArray _roots0, int maxIters,
+    double init_p_re, double init_p_im,
+    double init_r_re, double init_r_im)
 {
     CV_INSTRUMENT_REGION();
 
@@ -1748,7 +1750,8 @@ double cv::solvePoly( InputArray _coeffs0, OutputArray _roots0, int maxIters )
             break;
     }
 
-    C p(1, 0), r(1, 1);
+   /* C p(1, 0), r(1, 1);*/
+    C p(init_p_re, init_p_im), r(init_r_re, init_r_im);
 
     for( i = 0; i < n; i++ )
     {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

### Description
This PR addresses issue #23644. As discussed by @asmorkalov, the Durand-Kerner method used in `solvePoly` is not generally convergent and can fail for certain polynomials like $x^2 - 2x - 3 = 0$ due to the fixed initial guesses.

To resolve this, I have moved the initial root values to the function interface, allowing users to provide custom initial guesses (`init_p` and `init_r`) if the algorithm fails to converge or falls into a periodic cycle. 

#### Key changes:
- Modified `cv::solvePoly` signature in `core.hpp` to include `init_p_re`, `init_p_im`, `init_r_re`, and `init_r_im`.
- Updated the implementation in `mathfuncs.cpp` to use these parameters.
- **Backward Compatibility:** Preserved original behavior by setting default values to the original ones (`p = 1.0`, `r = 1.0 + 1.0i`).

### Related Issue
Fixes #23644

### Testing
Tested locally with the reproducer code provided in the issue. 
- Default call (old behavior): Failed to converge as expected.
- Custom initial values (0.4, 0.9): Successfully found the roots [3, 0] and [-1, 0].