### PR TITLE
[Bug Fix] Slice2 empty-range crash in new DNN engine

### DIFF
--- a/modules/dnn/src/layers/slice2_layer.cpp
+++ b/modules/dnn/src/layers/slice2_layer.cpp
@@ -115,13 +115,16 @@ public:
                             std::min(end, inpsz);
             if (allStarts)
                 allStarts[axis] = start;
-            if (allEnds)
-                allEnds[axis] = end;
             if (allSteps)
                 allSteps[axis] = step;
             int outsz = step > 0 ? (end - start + step-1)/step :
                                    (start - end - step-1)/(-step);
-            CV_Assert(outsz >= 0);
+            if (outsz < 0) {
+                outsz = 0;
+                end = start;
+            }
+            if (allEnds)
+                allEnds[axis] = end;
             outShape[axis] = outsz;
         }
 

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -1533,4 +1533,40 @@ TEST_P(Reproducibility_FacePaint_ONNX, Accuracy)
 INSTANTIATE_TEST_CASE_P(/**/, Reproducibility_FacePaint_ONNX,
                         testing::ValuesIn(getAvailableTargets(DNN_BACKEND_OPENCV)));
 
+typedef testing::TestWithParam<Target> Reproducibility_SwinIR_ONNX;
+TEST_P(Reproducibility_SwinIR_ONNX, Accuracy)
+{
+    Target targetId = GetParam();
+    applyTestTag(CV_TEST_TAG_MEMORY_512MB, CV_TEST_TAG_LONG);
+
+    std::string modelname = _tf("onnx/models/swinir_x4_gan.onnx", false);
+    Net net = readNetFromONNX(modelname, ENGINE_NEW);
+    ASSERT_FALSE(net.empty());
+
+    net.setPreferableBackend(DNN_BACKEND_OPENCV);
+    net.setPreferableTarget(targetId);
+
+    std::string imgname = findDataFile("cv/dnn_superres/butterfly.png");
+    Mat image = imread(imgname);
+    ASSERT_FALSE(image.empty());
+
+    Mat input = blobFromImage(image, 1.0 / 255.0, Size(64, 64),
+                              Scalar(0, 0, 0), true, false, CV_32F);
+    net.setInput(input);
+    Mat out = net.forward();
+
+    ASSERT_EQ(out.dims, 4);
+    EXPECT_EQ(out.size[0], 1);
+    EXPECT_EQ(out.size[1], 3);
+    EXPECT_EQ(out.size[2], 256);
+    EXPECT_EQ(out.size[3], 256);
+
+    double minVal, maxVal;
+    cv::minMaxLoc(out.reshape(1, 1), &minVal, &maxVal);
+    EXPECT_GE(minVal, -0.2);
+    EXPECT_LE(maxVal,  1.2);
+}
+INSTANTIATE_TEST_CASE_P(/**/, Reproducibility_SwinIR_ONNX,
+                        testing::ValuesIn(getAvailableTargets(DNN_BACKEND_OPENCV)));
+
 }} // namespace

--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -1539,6 +1539,14 @@ TEST_P(Reproducibility_SwinIR_ONNX, Accuracy)
     Target targetId = GetParam();
     applyTestTag(CV_TEST_TAG_MEMORY_512MB, CV_TEST_TAG_LONG);
 
+    auto engine_forced = static_cast<EngineType>(
+        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO));
+    if (engine_forced == ENGINE_CLASSIC)
+    {
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
+        return;
+    }
+
     std::string modelname = _tf("onnx/models/swinir_x4_gan.onnx", false);
     Net net = readNetFromONNX(modelname, ENGINE_NEW);
     ASSERT_FALSE(net.empty());


### PR DESCRIPTION
 Closes: https://github.com/opencv/opencv/issues/29023
 Merge with: https://github.com/opencv/opencv_extra/pull/1363
 
  ## Summary

  ENGINE_NEW asserted `CV_Assert(outsz >= 0)` in `slice2_layer.cpp` when an ONNX Slice op had `start > end` with positive step. Per ONNX spec, such slices are valid and 
  produce an empty-range output (size 0). The hard assertion crashed SwinIR inference on ENGINE_NEW.

  ## Fix

  - Replaced the fatal assertion with a graceful clamp: when `outsz < 0`, set `outsz = 0` and `end = start`.
  - Moved `allEnds[axis] = end` to after the clamp so downstream shape inference receives a consistent value (the previous order propagated un-clamped garbage end values
   into `normalize_axis()`, causing SIGSEGV).

  ## Test

  Adds `Reproducibility_SwinIR_ONNX` accuracy test in `test_model.cpp`. Test data registered in opencv_extra PR with matching branch name `fix/dnn-slice2-empty-range`.

  - Without fix: 3/3 FAIL with `slice2_layer.cpp:124: (-215:Assertion failed) outsz >= 0`
  - With fix: 3/3 PASS (CPU, OCL, OCL_FP16)

  ### Pull Request Readiness Checklist

  See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

  - [x] I agree to contribute to the project under Apache 2 License.
  - [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
  - [x] The PR is proposed to the proper branch
  - [x] There is a reference to the original bug report and related work
  - [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
        Patch to opencv_extra has the same branch name.
  - [x] The feature is well documented and sample code can be built with the project CMake