### PR TITLE
rvv: use vlseg/vsseg instead of vlse/vsse in universal intrinsic interleave ops

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1560,56 +1560,80 @@ OPENCV_HAL_IMPL_RVV_UNPACKS(v_float64, 64)
 #define OPENCV_HAL_IMPL_RVV_INTERLEAVED(_Tpvec, _Tp, suffix, width, hwidth, vl) \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b) \
 { \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x2_t seg = __riscv_vlseg2e##width##_v_u##width##m2x2( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 1))); \
 }\
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, v_##_Tpvec& c) \
 { \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
-    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x3_t seg = __riscv_vlseg3e##width##_v_u##width##m2x3( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 1))); \
+    c = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 2))); \
 } \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, \
                                 v_##_Tpvec& c, v_##_Tpvec& d) \
 { \
     \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    d = __riscv_vlse##width##_v_##suffix##m2(ptr+3, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x4_t seg = __riscv_vlseg4e##width##_v_u##width##m2x4( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 1))); \
+    c = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 2))); \
+    d = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 3))); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*2, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*2, b, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x2_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 1, v_reinterpret_as_u##width(b)); \
+    __riscv_vsseg2e##width##_v_u##width##m2x2( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*3, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*3, b, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+2, sizeof(_Tp)*3, c, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x3_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 1, v_reinterpret_as_u##width(b)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 2, v_reinterpret_as_u##width(c)); \
+    __riscv_vsseg3e##width##_v_u##width##m2x3( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, const v_##_Tpvec& d, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED ) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*4, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*4, b, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+2, sizeof(_Tp)*4, c, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+3, sizeof(_Tp)*4, d, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x4_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 1, v_reinterpret_as_u##width(b)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 2, v_reinterpret_as_u##width(c)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 3, v_reinterpret_as_u##width(d)); \
+    __riscv_vsseg4e##width##_v_u##width##m2x4( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 }
 
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint8, uchar, u8, 8, 4, VTraits<v_uint8>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, i8, 8, 4, VTraits<v_int8>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, s8, 8, 4, VTraits<v_int8>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint16, ushort, u16, 16, 8, VTraits<v_uint16>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, i16, 16, 8, VTraits<v_int16>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, s16, 16, 8, VTraits<v_int16>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint32, unsigned, u32, 32, 16, VTraits<v_uint32>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, i32, 32, 16, VTraits<v_int32>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, s32, 32, 16, VTraits<v_int32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float32, float, f32, 32, 16, VTraits<v_float32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint64, uint64, u64, 64, 32, VTraits<v_uint64>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, i64, 64, 32, VTraits<v_int64>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, s64, 64, 32, VTraits<v_int64>::vlanes())
 #if CV_SIMD_SCALABLE_64F
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float64, double, f64, 64, 32, VTraits<v_float64>::vlanes())
 #endif


### PR DESCRIPTION
### Summary

This PR optimizes the implementation of `v_load_deinterleave` and `v_store_interleave` in the RVV scalable HAL by replacing strided load/store instructions (`vlse`/`vsse`) with segmented load/store instructions (`vlseg`/`vsseg`).

### Motivation

The previous implementation for interleaved/deinterleaved data operations used multiple `vlse`/`vsse` instructions. For a 3-channel (RGB) operation, this required three independent strided memory accesses.

According to the RISC-V Vector 1.0 specification, segmented instructions (`vlseg2e`/`vlseg3e`/`vlseg4e`) are designed to read contiguous memory and distribute elements across multiple vector registers in hardware. This transition:

1. **Reduces instruction count**: From N instructions to 1.
2. **Improves cache utilization**: Replaces non-contiguous strided access with contiguous linear access.
3. **Hardware-level deinterleaving**: Offloads data shuffling from the execution unit to the memory subsystem.

### Detailed Changes

Modified `modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp`:

- Replaced `__riscv_vlse` calls with `__riscv_vlseg` in `v_load_deinterleave`.
- Replaced `__riscv_vsse` calls with `__riscv_vsseg` in `v_store_interleave`.
- Unified types by using `vuint...` as intermediate types for all data widths, followed by reinterpretation to target types.

### Impacted Functions

This optimization affects all vectorized paths handling multi-channel data:

- **Memory-bound & Channel Manipulations**: `cv::split`, `cv::merge`, and operations with explicit `Convert` or `Split` memory patterns.
- **Multi-channel Arithmetic**: `cv::add`, `cv::subtract`, `cv::multiply`, `cv::divide`, `cv::absdiff`, `cv::addWeighted`.
- **Image Transformations**: `cv::resize`, `cv::flip`.

### Performance Results

Benchmarked on **SpacemiT K1** (RVV 1.0, VLEN=128) using `opencv_perf_core` and `opencv_perf_imgproc`.

- **Sample count**: 20
- **Baseline**: Original strided implementation.

#### Multi-Channel Performance (Optimized)

Significant improvements observed in operations involving multi-channel data deinterleaving:

| **Test Case**                     | **Before (mean ms)** | **After (mean ms)** | **Speedup** |
| --------------------------------- | -------------------- | ------------------- | ----------- |
| Resize (640x480, 8UC3, Pure)      | 0.42                 | 0.28                | **+33.33%** |
| Subtract (640x480, 8UC3, Convert) | 1.70                 | 1.36                | **+20.00%** |
| Resize (640x480, 8UC3, Split)     | 1.19                 | 0.99                | **+16.81%** |
| Add (3840x2160, 32FC3)            | 69.51                | 60.14               | **+13.48%** |
| Subtract (640x480, 8UC3, Pure)    | 0.57                 | 0.50                | **+12.28%** |
| ScaleAdd (3840x2160, 32FC4)       | 97.76                | 89.24               | **+8.72%**  |
| Absdiff (3840x2160, 32FC4)        | 94.64                | 90.35               | **+4.53%**  |

#### Single-Channel Performance (Control)

Single-channel operations remain unaffected, confirming no performance regression for standard paths:

| **Test Case**               | **Before (mean ms)** | **After (mean ms)** | **Variance** |
| --------------------------- | -------------------- | ------------------- | ------------ |
| Subtract (3840x2160, 8UC1)  | 5.32                 | 5.32                | 0.00%        |
| Add (1920x1080, 32FC1)      | 5.31                 | 5.32                | -0.19%       |
| Multiply (3840x2160, 32FC1) | 20.43                | 20.24               | +0.93%       |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
