### PR TITLE
添加对boxFilter函数的内核大小验证，并为无效内核大小添加单元测试

### DIFF
--- a/modules/imgproc/src/box_filter.dispatch.cpp
+++ b/modules/imgproc/src/box_filter.dispatch.cpp
@@ -369,6 +369,8 @@ void boxFilter(InputArray _src, OutputArray _dst, int ddepth,
     CV_INSTRUMENT_REGION();
 
     CV_Assert(!_src.empty());
+    if( ksize.width <= 0 || ksize.height <= 0 )
+        CV_Error( cv::Error::StsBadSize, "Kernel size must be strictly positive" );
 
     CV_OCL_RUN(_dst.isUMat() &&
                (borderType == BORDER_REPLICATE || borderType == BORDER_CONSTANT ||

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -1972,6 +1972,16 @@ TEST(Imgproc_Blur, borderTypes)
     EXPECT_DOUBLE_EQ(0.0, cvtest::norm(expected_dst, dst, NORM_INF));
 }
 
+TEST(Imgproc_Blur, invalidKernelSize)
+{
+    Mat src(3, 3, CV_8UC1, Scalar::all(1)), dst;
+
+    EXPECT_THROW(cv::blur(src, dst, Size(0, 3)), cv::Exception);
+    EXPECT_THROW(cv::blur(src, dst, Size(3, 0)), cv::Exception);
+    EXPECT_THROW(cv::blur(src, dst, Size(-1, 3)), cv::Exception);
+    EXPECT_THROW(cv::blur(src, dst, Size(3, -1)), cv::Exception);
+}
+
 TEST(Imgproc_GaussianBlur, borderTypes)
 {
     Size kernelSize(3, 3);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
