### PR TITLE
Core (OpenCL): Fix memory leak in initializeContextFromGL()

### DIFF
--- a/modules/core/src/opengl.cpp
+++ b/modules/core/src/opengl.cpp
@@ -1682,27 +1682,21 @@ Context& initializeContextFromGL()
 
                 if(extensionSize > 0)
                 {
-                    char* extensions = nullptr;
+                    std::string devString;
 
                     try {
-                        extensions = new char[extensionSize];
+                        std::vector<char> extensions(extensionSize);
 
-                        status = clGetDeviceInfo(devices[j], CL_DEVICE_EXTENSIONS, extensionSize, extensions, &extensionSize);
-                        if (status != CL_SUCCESS)
-                            continue;
+                        status = clGetDeviceInfo(devices[j], CL_DEVICE_EXTENSIONS, extensionSize, &extensions[0], &extensionSize);
+                        if (status == CL_SUCCESS) {
+                            devString = &extensions[0];
+                        }
                     } catch(...) {
                         CV_Error(cv::Error::OpenCLInitError, "OpenCL: Exception thrown during device extensions gathering");
                     }
 
-                    std::string devString;
-
-                    if(extensions != nullptr) {
-                        devString = extensions;
-                        delete[] extensions;
-                    }
-                    else {
-                        CV_Error(cv::Error::OpenCLInitError, "OpenCL: Unexpected error during device extensions gathering");
-                    }
+                    if (status != CL_SUCCESS)
+                        continue;
 
                     size_t oldPos = 0;
                     size_t spacePos = devString.find(' ', oldPos); // extensions string is space delimited


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Problem
During static analysis, a memory leak was identified in `initializeContextFromGL()` when `clGetDeviceInfo()` fails.

The issue occurs because:
* A raw `char[]` buffer is heap-allocated to query OpenCL device extensions.
* If `clGetDeviceInfo()` fails, the function executes a `continue` statement to try the next device.
* The `delete[]` statement is skipped, and the allocated memory is leaked.

This creates a potential memory leak path during OpenCL context initialization.

### Fix
We replace the raw heap allocation using `char[]` with an RAII-based `std::vector<char>` implementation.

### Benefits
* **Automatic memory deallocation**: No manual `delete[]` is required.
* **Exception-safe cleanup**: Memory is guaranteed to be released on early exits, `continue` statements, or thrown exceptions.
* **Prevents leaks**: Safely cleans up all allocation paths.

Because `std::vector` automatically releases memory when leaving scope, all allocation paths are safely cleaned up.
