### PR TITLE
Feature/fast nl means denoising 16u

### DIFF
--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -492,11 +492,11 @@ namespace cv { namespace cuda { namespace device
             buffer_rows = src.cols + block_window * grid.x;
         }
 
-        template<typename T, typename DT>
-        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<DT> buffer,
+        template<typename T>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepi buffer,
                           int search_window, int block_window, float h, cudaStream_t stream)
         {
-            typedef FastNonLocalMeans<T, DT> FNLM;
+            typedef FastNonLocalMeans<T, int> FNLM;
             FNLM fnlm(search_window, block_window, h);
 
             fnlm.src = (PtrStepSz<T>)src;
@@ -504,21 +504,42 @@ namespace cv { namespace cuda { namespace device
 
             dim3 block(FNLM::CTA_SIZE, 1);
             dim3 grid(divUp(src.cols, FNLM::TILE_COLS), divUp(src.rows, FNLM::TILE_ROWS));
-            int smem = search_window * search_window * sizeof(DT);
+            int smem = search_window * search_window * sizeof(int);
 
 
-            fast_nlm_kernel<T, DT><<<grid, block, smem>>>(fnlm, (PtrStepSz<T>)dst);
+            fast_nlm_kernel<T, int><<<grid, block, smem>>>(fnlm, (PtrStepSz<T>)dst);
             cudaSafeCall ( cudaGetLastError () );
             if (stream == 0)
                 cudaSafeCall( cudaDeviceSynchronize() );
         }
 
-        template void nlm_fast_gpu<uchar, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float,  cudaStream_t);
-        template void nlm_fast_gpu<uchar2, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
-        template void nlm_fast_gpu<uchar3, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
-        template void nlm_fast_gpu<ushort, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float,  cudaStream_t);
-        template void nlm_fast_gpu<ushort2, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
-        template void nlm_fast_gpu<ushort3, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
+        template<typename T>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<float> buffer,
+                          int search_window, int block_window, float h, cudaStream_t stream)
+        {
+            typedef FastNonLocalMeans<T, float> FNLM;
+            FNLM fnlm(search_window, block_window, h);
+
+            fnlm.src = (PtrStepSz<T>)src;
+            fnlm.buffer = buffer;
+
+            dim3 block(FNLM::CTA_SIZE, 1);
+            dim3 grid(divUp(src.cols, FNLM::TILE_COLS), divUp(src.rows, FNLM::TILE_ROWS));
+            int smem = search_window * search_window * sizeof(float);
+
+
+            fast_nlm_kernel<T, float><<<grid, block, smem>>>(fnlm, (PtrStepSz<T>)dst);
+            cudaSafeCall ( cudaGetLastError () );
+            if (stream == 0)
+                cudaSafeCall( cudaDeviceSynchronize() );
+        }
+
+        template void nlm_fast_gpu<uchar>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float,  cudaStream_t);
+        template void nlm_fast_gpu<uchar2>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<uchar3>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<ushort>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float,  cudaStream_t);
+        template void nlm_fast_gpu<ushort2>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<ushort3>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
 
 
 

--- a/modules/photo/src/cuda/nlm.cu
+++ b/modules/photo/src/cuda/nlm.cu
@@ -264,7 +264,11 @@ namespace cv { namespace cuda { namespace device
         __device__ __forceinline__ int calcDist(const uchar2& a, const uchar2& b) { return (a.x-b.x)*(a.x-b.x) + (a.y-b.y)*(a.y-b.y); }
         __device__ __forceinline__ int calcDist(const uchar3& a, const uchar3& b) { return (a.x-b.x)*(a.x-b.x) + (a.y-b.y)*(a.y-b.y) + (a.z-b.z)*(a.z-b.z); }
 
-        template <class T> struct FastNonLocalMeans
+        __device__ __forceinline__ float calcDist(const ushort&  a, const ushort&  b) { return (float)(a-b)*(float)(a-b); }
+        __device__ __forceinline__ float calcDist(const ushort2& a, const ushort2& b) { return (float)(a.x-b.x)*(float)(a.x-b.x) + (float)(a.y-b.y)*(float)(a.y-b.y); }
+        __device__ __forceinline__ float calcDist(const ushort3& a, const ushort3& b) { return (float)(a.x-b.x)*(float)(a.x-b.x) + (float)(a.y-b.y)*(float)(a.y-b.y) + (float)(a.z-b.z)*(float)(a.z-b.z); }
+
+        template <class T, class DT = int> struct FastNonLocalMeans
         {
             enum
             {
@@ -292,9 +296,9 @@ namespace cv { namespace cuda { namespace device
                 search_window(search_window_), block_window(block_window_), minus_h2_inv(-1.f/(h * h * VecTraits<T>::cn)) {}
 
             PtrStep<T> src;
-            mutable PtrStepi buffer;
+            mutable PtrStep<DT> buffer;
 
-            __device__ __forceinline__ void initSums_BruteForce(int i, int j, int* dist_sums, PtrStepi& col_sums, PtrStepi& up_col_sums) const
+            __device__ __forceinline__ void initSums_BruteForce(int i, int j, DT* dist_sums, PtrStep<DT>& col_sums, PtrStep<DT>& up_col_sums) const
             {
                 for(int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
                 {
@@ -315,10 +319,10 @@ namespace cv { namespace cuda { namespace device
 #if 1
                     for (int tx = -block_radius; tx <= block_radius; ++tx)
                     {
-                        int col_sum = 0;
+                        DT col_sum = 0;
                         for (int ty = -block_radius; ty <= block_radius; ++ty)
                         {
-                            int dist = calcDist(src(ay + ty, ax + tx), src(by + ty, bx + tx));
+                            DT dist = calcDist(src(ay + ty, ax + tx), src(by + ty, bx + tx));
 
                             dist_sums[index] += dist;
                             col_sum += dist;
@@ -329,7 +333,7 @@ namespace cv { namespace cuda { namespace device
                     for (int ty = -block_radius; ty <= block_radius; ++ty)
                         for (int tx = -block_radius; tx <= block_radius; ++tx)
                         {
-                            int dist = calcDist(src(ay + ty, ax + tx), src(by + ty, bx + tx));
+                            DT dist = calcDist(src(ay + ty, ax + tx), src(by + ty, bx + tx));
 
                             dist_sums[index] += dist;
                             col_sums(tx + block_radius, index) += dist;
@@ -340,7 +344,7 @@ namespace cv { namespace cuda { namespace device
                 }
             }
 
-            __device__ __forceinline__ void shiftRight_FirstRow(int i, int j, int first, int* dist_sums, PtrStepi& col_sums, PtrStepi& up_col_sums) const
+            __device__ __forceinline__ void shiftRight_FirstRow(int i, int j, int first, DT* dist_sums, PtrStep<DT>& col_sums, PtrStep<DT>& up_col_sums) const
             {
                 for(int index = threadIdx.x; index < search_window * search_window; index += STRIDE)
                 {
@@ -353,7 +357,7 @@ namespace cv { namespace cuda { namespace device
                     int by = i + y - search_radius;
                     int bx = j + x - search_radius + block_radius;
 
-                    int col_sum = 0;
+                    DT col_sum = 0;
 
                     for (int ty = -block_radius; ty <= block_radius; ++ty)
                         col_sum += calcDist(src(ay + ty, ax), src(by + ty, bx));
@@ -365,7 +369,7 @@ namespace cv { namespace cuda { namespace device
                 }
             }
 
-            __device__ __forceinline__ void shiftRight_UpSums(int i, int j, int first, int* dist_sums, PtrStepi& col_sums, PtrStepi& up_col_sums) const
+            __device__ __forceinline__ void shiftRight_UpSums(int i, int j, int first, DT* dist_sums, PtrStep<DT>& col_sums, PtrStep<DT>& up_col_sums) const
             {
                 int ay = i;
                 int ax = j + block_radius;
@@ -384,7 +388,7 @@ namespace cv { namespace cuda { namespace device
                     T b_up   = src(by - block_radius - 1, bx);
                     T b_down = src(by + block_radius, bx);
 
-                    int col_sum = up_col_sums(j, index) + calcDist(a_down, b_down) - calcDist(a_up, b_up);
+                    DT col_sum = up_col_sums(j, index) + calcDist(a_down, b_down) - calcDist(a_up, b_up);
 
                     dist_sums[index] += col_sum  - col_sums(first, index);
                     col_sums(first, index) = col_sum;
@@ -392,7 +396,7 @@ namespace cv { namespace cuda { namespace device
                 }
             }
 
-            __device__ __forceinline__ void convolve_window(int i, int j, const int* dist_sums, T& dst) const
+            __device__ __forceinline__ void convolve_window(int i, int j, const DT* dist_sums, T& dst) const
             {
                 typedef typename TypeVec<float, VecTraits<T>::cn>::vec_type sum_type;
 
@@ -435,15 +439,16 @@ namespace cv { namespace cuda { namespace device
                 int tex = ::min(tbx + TILE_COLS, dst.cols);
                 int tey = ::min(tby + TILE_ROWS, dst.rows);
 
-                PtrStepi col_sums;
+                PtrStep<DT> col_sums;
                 col_sums.data = buffer.ptr(dst.cols + blockIdx.x * block_window) + blockIdx.y * search_window * search_window;
                 col_sums.step = buffer.step;
 
-                PtrStepi up_col_sums;
+                PtrStep<DT> up_col_sums;
                 up_col_sums.data = buffer.data + blockIdx.y * search_window * search_window;
                 up_col_sums.step = buffer.step;
 
-                extern __shared__ int dist_sums[]; //search_window * search_window
+                extern __shared__ char dist_sums_raw[];
+                DT* dist_sums = (DT*)dist_sums_raw;
 
                 int first = 0;
 
@@ -460,9 +465,9 @@ namespace cv { namespace cuda { namespace device
                         else
                         {
                             if (i == tby)
-                              shiftRight_FirstRow(i, j, first, dist_sums, col_sums, up_col_sums);
+                               shiftRight_FirstRow(i, j, first, dist_sums, col_sums, up_col_sums);
                             else
-                              shiftRight_UpSums(i, j, first, dist_sums, col_sums, up_col_sums);
+                               shiftRight_UpSums(i, j, first, dist_sums, col_sums, up_col_sums);
 
                             first = (first + 1) % block_window;
                         }
@@ -475,8 +480,8 @@ namespace cv { namespace cuda { namespace device
 
         };
 
-        template<typename T>
-        __global__ void fast_nlm_kernel(const FastNonLocalMeans<T> fnlm, PtrStepSz<T> dst) { fnlm(dst); }
+        template<typename T, typename DT>
+        __global__ void fast_nlm_kernel(const FastNonLocalMeans<T, DT> fnlm, PtrStepSz<T> dst) { fnlm(dst); }
 
         void nln_fast_get_buffer_size(const PtrStepSzb& src, int search_window, int block_window, int& buffer_cols, int& buffer_rows)
         {
@@ -487,11 +492,11 @@ namespace cv { namespace cuda { namespace device
             buffer_rows = src.cols + block_window * grid.x;
         }
 
-        template<typename T>
-        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepi buffer,
+        template<typename T, typename DT>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<DT> buffer,
                           int search_window, int block_window, float h, cudaStream_t stream)
         {
-            typedef FastNonLocalMeans<T> FNLM;
+            typedef FastNonLocalMeans<T, DT> FNLM;
             FNLM fnlm(search_window, block_window, h);
 
             fnlm.src = (PtrStepSz<T>)src;
@@ -499,18 +504,21 @@ namespace cv { namespace cuda { namespace device
 
             dim3 block(FNLM::CTA_SIZE, 1);
             dim3 grid(divUp(src.cols, FNLM::TILE_COLS), divUp(src.rows, FNLM::TILE_ROWS));
-            int smem = search_window * search_window * sizeof(int);
+            int smem = search_window * search_window * sizeof(DT);
 
 
-            fast_nlm_kernel<<<grid, block, smem>>>(fnlm, (PtrStepSz<T>)dst);
+            fast_nlm_kernel<T, DT><<<grid, block, smem>>>(fnlm, (PtrStepSz<T>)dst);
             cudaSafeCall ( cudaGetLastError () );
             if (stream == 0)
                 cudaSafeCall( cudaDeviceSynchronize() );
         }
 
-        template void nlm_fast_gpu<uchar>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float,  cudaStream_t);
-        template void nlm_fast_gpu<uchar2>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
-        template void nlm_fast_gpu<uchar3>(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<uchar, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float,  cudaStream_t);
+        template void nlm_fast_gpu<uchar2, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<uchar3, int>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<ushort, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float,  cudaStream_t);
+        template void nlm_fast_gpu<ushort2, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
+        template void nlm_fast_gpu<ushort3, float>(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
 
 
 

--- a/modules/photo/src/denoising.cpp
+++ b/modules/photo/src/denoising.cpp
@@ -45,7 +45,7 @@
 #include "fast_nlmeans_multi_denoising_invoker.hpp"
 #include "fast_nlmeans_denoising_opencl.hpp"
 
-template<typename ST, typename IT, typename UIT, typename D>
+template<typename ST, typename IT, typename UIT, typename D, typename DT = int>
 static void fastNlMeansDenoising_( const Mat& src, Mat& dst, const std::vector<float>& h,
                                    int templateWindowSize, int searchWindowSize)
 {
@@ -55,43 +55,43 @@ static void fastNlMeansDenoising_( const Mat& src, Mat& dst, const std::vector<f
     switch (CV_MAT_CN(src.type())) {
         case 1:
             parallel_for_(cv::Range(0, src.rows),
-                          FastNlMeansDenoisingInvoker<ST, IT, UIT, D, int>(
+                          FastNlMeansDenoisingInvoker<ST, IT, UIT, D, int, DT>(
                               src, dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
             break;
         case 2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
         case 3:
             if (hn == 1)
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
         case 4:
             if (hn == 1)
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, src.rows),
-                              FastNlMeansDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i>(
+                              FastNlMeansDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i, DT>(
                                   src, dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             break;
@@ -137,9 +137,14 @@ void cv::fastNlMeansDenoising( InputArray _src, OutputArray _dst, const std::vec
                                                                              templateWindowSize,
                                                                              searchWindowSize);
                     break;
+                case CV_16U:
+                    fastNlMeansDenoising_<ushort, int64, uint64, DistSquared, int64>(src, dst, h,
+                                                                             templateWindowSize,
+                                                                             searchWindowSize);
+                    break;
                 default:
                     CV_Error(Error::StsBadArg,
-                             "Unsupported depth! Only CV_8U is supported for NORM_L2");
+                             "Unsupported depth! Only CV_8U and CV_16U are supported for NORM_L2");
             }
             break;
         case NORM_L1:
@@ -240,7 +245,7 @@ static void fastNlMeansDenoisingMultiCheckPreconditions(
         }
 }
 
-template<typename ST, typename IT, typename UIT, typename D>
+template<typename ST, typename IT, typename UIT, typename D, typename DT = int>
 static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& dst,
                                         int imgToDenoiseIndex, int temporalWindowSize,
                                         const std::vector<float>& h,
@@ -252,7 +257,7 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
     switch (CV_MAT_CN(srcImgs[0].type())) {
         case 1:
             parallel_for_(cv::Range(0, srcImgs[0].rows),
-                          FastNlMeansMultiDenoisingInvoker<ST, IT, UIT, D, int>(
+                          FastNlMeansMultiDenoisingInvoker<ST, IT, UIT, D, int, DT>(
                               srcImgs, imgToDenoiseIndex, temporalWindowSize,
                               dst, templateWindowSize, searchWindowSize, &h[0]),
                           granularity);
@@ -260,13 +265,13 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
         case 2:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, int, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 2>, IT, UIT, D, Vec2i, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
@@ -274,13 +279,13 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
         case 3:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, int, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 3>, IT, UIT, D, Vec3i, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
@@ -288,13 +293,13 @@ static void fastNlMeansDenoisingMulti_( const std::vector<Mat>& srcImgs, Mat& ds
         case 4:
             if (hn == 1)
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, int, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
             else
                 parallel_for_(cv::Range(0, srcImgs[0].rows),
-                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i>(
+                              FastNlMeansMultiDenoisingInvoker<Vec<ST, 4>, IT, UIT, D, Vec4i, DT>(
                                   srcImgs, imgToDenoiseIndex, temporalWindowSize,
                                   dst, templateWindowSize, searchWindowSize, &h[0]),
                               granularity);
@@ -346,9 +351,16 @@ void cv::fastNlMeansDenoisingMulti( InputArrayOfArrays _srcImgs, OutputArray _ds
                                                             h,
                                                             templateWindowSize, searchWindowSize);
                     break;
+                case CV_16U:
+                    fastNlMeansDenoisingMulti_<ushort, int64, uint64,
+                                               DistSquared, int64>(srcImgs, dst,
+                                                            imgToDenoiseIndex, temporalWindowSize,
+                                                            h,
+                                                            templateWindowSize, searchWindowSize);
+                    break;
                 default:
                     CV_Error(Error::StsBadArg,
-                             "Unsupported depth! Only CV_8U is supported for NORM_L2");
+                             "Unsupported depth! Only CV_8U and CV_16U are supported for NORM_L2");
             }
             break;
         case NORM_L1:

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -112,8 +112,12 @@ namespace cv { namespace cuda { namespace device
     {
         void nln_fast_get_buffer_size(const PtrStepSzb& src, int search_window, int block_window, int& buffer_cols, int& buffer_rows);
 
-        template<typename T, typename DT>
-        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<DT> buffer,
+        template<typename T>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepi buffer,
+                          int search_window, int block_window, float h, cudaStream_t stream);
+
+        template<typename T>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<float> buffer,
                           int search_window, int block_window, float h, cudaStream_t stream);
 
         void fnlm_split_channels(const PtrStepSz<uchar3>& lab, PtrStepb l, PtrStep<uchar2> ab, cudaStream_t stream);
@@ -147,15 +151,15 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
     if (src.depth() == CV_8U)
     {
         GpuMat buffer = pool.getBuffer(brows, bcols, CV_32S);
-        typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
-        static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar, int>, nlm_fast_gpu<uchar2, int>, nlm_fast_gpu<uchar3, int>, 0};
+        typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
+        static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar>, nlm_fast_gpu<uchar2>, nlm_fast_gpu<uchar3>, 0};
         funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
     }
     else
     {
         GpuMat buffer = pool.getBuffer(brows, bcols, CV_32F);
         typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
-        static const nlm_fast_t funcs[] = { nlm_fast_gpu<ushort, float>, nlm_fast_gpu<ushort2, float>, nlm_fast_gpu<ushort3, float>, 0};
+        static const nlm_fast_t funcs[] = { nlm_fast_gpu<ushort>, nlm_fast_gpu<ushort2>, nlm_fast_gpu<ushort3>, 0};
         funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
     }
 }

--- a/modules/photo/src/denoising.cuda.cpp
+++ b/modules/photo/src/denoising.cuda.cpp
@@ -112,8 +112,8 @@ namespace cv { namespace cuda { namespace device
     {
         void nln_fast_get_buffer_size(const PtrStepSzb& src, int search_window, int block_window, int& buffer_cols, int& buffer_rows);
 
-        template<typename T>
-        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepi buffer,
+        template<typename T, typename DT>
+        void nlm_fast_gpu(const PtrStepSzb& src, PtrStepSzb dst, PtrStepSz<DT> buffer,
                           int search_window, int block_window, float h, cudaStream_t stream);
 
         void fnlm_split_channels(const PtrStepSz<uchar3>& lab, PtrStepb l, PtrStep<uchar2> ab, cudaStream_t stream);
@@ -125,7 +125,7 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
 {
     const GpuMat src = _src.getGpuMat();
 
-    CV_Assert(src.depth() == CV_8U && src.channels() < 4);
+    CV_Assert((src.depth() == CV_8U || src.depth() == CV_16U) && src.channels() < 4);
 
     int border_size = search_window/2 + block_window/2;
     Size esize = src.size() + Size(border_size, border_size) * 2;
@@ -138,16 +138,26 @@ void cv::cuda::fastNlMeansDenoising(InputArray _src, OutputArray _dst, float h, 
 
     int bcols, brows;
     device::imgproc::nln_fast_get_buffer_size(src_hdr, search_window, block_window, bcols, brows);
-    GpuMat buffer = pool.getBuffer(brows, bcols, CV_32S);
 
     using namespace cv::cuda::device::imgproc;
-    typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepi, int, int, float, cudaStream_t);
-    static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar>, nlm_fast_gpu<uchar2>, nlm_fast_gpu<uchar3>, 0};
 
     _dst.create(src.size(), src.type());
     GpuMat dst = _dst.getGpuMat();
 
-    funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
+    if (src.depth() == CV_8U)
+    {
+        GpuMat buffer = pool.getBuffer(brows, bcols, CV_32S);
+        typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepSz<int>, int, int, float, cudaStream_t);
+        static const nlm_fast_t funcs[] = { nlm_fast_gpu<uchar, int>, nlm_fast_gpu<uchar2, int>, nlm_fast_gpu<uchar3, int>, 0};
+        funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
+    }
+    else
+    {
+        GpuMat buffer = pool.getBuffer(brows, bcols, CV_32F);
+        typedef void (*nlm_fast_t)(const PtrStepSzb&, PtrStepSzb, PtrStepSz<float>, int, int, float, cudaStream_t);
+        static const nlm_fast_t funcs[] = { nlm_fast_gpu<ushort, float>, nlm_fast_gpu<ushort2, float>, nlm_fast_gpu<ushort3, float>, 0};
+        funcs[src.channels()-1](src_hdr, dst, buffer, search_window, block_window, h, StreamAccessor::getStream(stream));
+    }
 }
 
 void cv::cuda::fastNlMeansDenoisingColored(InputArray _src, OutputArray _dst, float h_luminance, float h_color, int search_window, int block_window, Stream& stream)

--- a/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_invoker.hpp
@@ -50,7 +50,7 @@
 
 using namespace cv;
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT = int>
 struct FastNlMeansDenoisingInvoker :
         public ParallelLoopBody
 {
@@ -80,15 +80,15 @@ private:
     std::vector<WT> almost_dist2weight_;
 
     void calcDistSumsForFirstElementInRow(
-        int i, Array2d<int>& dist_sums,
-        Array3d<int>& col_dist_sums,
-        Array3d<int>& up_col_dist_sums) const;
+        int i, Array2d<DT>& dist_sums,
+        Array3d<DT>& col_dist_sums,
+        Array3d<DT>& up_col_dist_sums) const;
 
     void calcDistSumsForElementInFirstRow(
         int i, int j, int first_col_num,
-        Array2d<int>& dist_sums,
-        Array3d<int>& col_dist_sums,
-        Array3d<int>& up_col_dist_sums) const;
+        Array2d<DT>& dist_sums,
+        Array3d<DT>& col_dist_sums,
+        Array3d<DT>& up_col_dist_sums) const;
 };
 
 inline int getNearestPowerOf2(int value)
@@ -99,8 +99,8 @@ inline int getNearestPowerOf2(int value)
     return p;
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansDenoisingInvoker(
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT, DT>::FastNlMeansDenoisingInvoker(
     const Mat& src, Mat& dst,
     int template_window_size,
     int search_window_size,
@@ -129,8 +129,13 @@ FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansDenoisingInvoker(
     almost_template_window_size_sq_bin_shift_ = getNearestPowerOf2(template_window_size_sq);
     double almost_dist2actual_dist_multiplier = ((double)(1 << almost_template_window_size_sq_bin_shift_)) / template_window_size_sq;
 
-    int max_dist = D::template maxDist<T>();
-    int almost_max_dist = (int)(max_dist / almost_dist2actual_dist_multiplier + 1);
+    DT max_dist = D::template maxDist<T>();
+    float max_h = h[0];
+    for (int c = 1; c < pixelInfo<T>::channels; c++)
+        if (h[c] > max_h) max_h = h[c];
+    double max_threshold_dist = 6.91 * max_h * max_h * pixelInfo<T>::channels;
+    DT limit_dist = (max_threshold_dist < max_dist) ? (DT)max_threshold_dist : max_dist;
+    int almost_max_dist = (int)(limit_dist / almost_dist2actual_dist_multiplier + 1);
     almost_dist2weight_.resize(almost_max_dist);
 
     for (int almost_dist = 0; almost_dist < almost_max_dist; almost_dist++)
@@ -145,21 +150,21 @@ FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansDenoisingInvoker(
         dst_ = Mat::zeros(src_.size(), src_.type());
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& range) const
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT, DT>::operator() (const Range& range) const
 {
     int row_from = range.start;
     int row_to = range.end - 1;
 
     // sums of cols anf rows for current pixel p
-    Array2d<int> dist_sums(search_window_size_, search_window_size_);
+    Array2d<DT> dist_sums(search_window_size_, search_window_size_);
 
     // for lazy calc optimization (sum of cols for current pixel)
-    Array3d<int> col_dist_sums(template_window_size_, search_window_size_, search_window_size_);
+    Array3d<DT> col_dist_sums(template_window_size_, search_window_size_, search_window_size_);
 
     int first_col_num = -1;
     // last elements of column sum (for each element in row)
-    Array3d<int> up_col_dist_sums(src_.cols, search_window_size_, search_window_size_);
+    Array3d<DT> up_col_dist_sums(src_.cols, search_window_size_, search_window_size_);
 
     for (int i = row_from; i <= row_to; i++)
     {
@@ -198,9 +203,9 @@ void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& ra
 
                     for (int y = 0; y < search_window_size; y++)
                     {
-                        int * dist_sums_row = dist_sums.row_ptr(y);
-                        int * col_dist_sums_row = col_dist_sums.row_ptr(first_col_num, y);
-                        int * up_col_dist_sums_row = up_col_dist_sums.row_ptr(j, y);
+                        DT * dist_sums_row = dist_sums.row_ptr(y);
+                        DT * col_dist_sums_row = col_dist_sums.row_ptr(first_col_num, y);
+                        DT * up_col_dist_sums_row = up_col_dist_sums.row_ptr(j, y);
 
                         const T * b_up_ptr = extended_src_.ptr<T>(start_by - template_window_half_size_ - 1 + y);
                         const T * b_down_ptr = extended_src_.ptr<T>(start_by + template_window_half_size_ + y);
@@ -236,11 +241,13 @@ void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& ra
             for (int y = 0; y < search_window_size_; y++)
             {
                 const T* cur_row_ptr = extended_src_.ptr<T>(border_size_ + search_window_y + y);
-                int* dist_sums_row = dist_sums.row_ptr(y);
+                DT* dist_sums_row = dist_sums.row_ptr(y);
                 for (int x = 0; x < search_window_size_; x++)
                 {
-                    int almostAvgDist = dist_sums_row[x] >> almost_template_window_size_sq_bin_shift_;
-                    WT weight = almost_dist2weight_[almostAvgDist];
+                    DT almostAvgDist = dist_sums_row[x] >> almost_template_window_size_sq_bin_shift_;
+                    WT weight = 0;
+                    if (almostAvgDist < (DT)almost_dist2weight_.size())
+                        weight = almost_dist2weight_[(size_t)almostAvgDist];
                     T p = cur_row_ptr[border_size_ + search_window_x + x];
                     incWithWeight<T, IT, WT>(estimation, weights_sum, weight, p);
                 }
@@ -253,12 +260,12 @@ void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& ra
     }
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForFirstElementInRow(
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT, DT>::calcDistSumsForFirstElementInRow(
     int i,
-    Array2d<int>& dist_sums,
-    Array3d<int>& col_dist_sums,
-    Array3d<int>& up_col_dist_sums) const
+    Array2d<DT>& dist_sums,
+    Array3d<DT>& col_dist_sums,
+    Array3d<DT>& up_col_dist_sums) const
 {
     int j = 0;
 
@@ -275,7 +282,7 @@ inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForFirst
             for (int ty = -template_window_half_size_; ty <= template_window_half_size_; ty++)
                 for (int tx = -template_window_half_size_; tx <= template_window_half_size_; tx++)
                 {
-                    int dist = D::template calcDist<T>(extended_src_,
+                    DT dist = D::template calcDist<T>(extended_src_,
                         border_size_ + i + ty, border_size_ + j + tx,
                         border_size_ + start_y + ty, border_size_ + start_x + tx);
 
@@ -287,12 +294,12 @@ inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForFirst
         }
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForElementInFirstRow(
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+inline void FastNlMeansDenoisingInvoker<T, IT, UIT, D, WT, DT>::calcDistSumsForElementInFirstRow(
     int i, int j, int first_col_num,
-    Array2d<int>& dist_sums,
-    Array3d<int>& col_dist_sums,
-    Array3d<int>& up_col_dist_sums) const
+    Array2d<DT>& dist_sums,
+    Array3d<DT>& col_dist_sums,
+    Array3d<DT>& up_col_dist_sums) const
 {
     int ay = border_size_ + i;
     int ax = border_size_ + j + template_window_half_size_;

--- a/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp
+++ b/modules/photo/src/fast_nlmeans_denoising_invoker_commons.hpp
@@ -190,53 +190,62 @@ public:
     }
 };
 
+template <typename T> struct DistType { typedef int type; };
+template <> struct DistType<ushort> { typedef int64 type; };
+template <int cn> struct DistType<Vec<ushort, cn> > { typedef int64 type; };
+
 class DistSquared
 {
     template <typename T> struct calcDist_
     {
-        static inline int f(const T a, const T b)
+        static inline typename DistType<T>::type f(const T a, const T b)
         {
-            return (int)(a-b) * (int)(a-b);
+            typedef typename DistType<T>::type result_type;
+            return (result_type)(a-b) * (result_type)(a-b);
         }
     };
 
     template <typename ET> struct calcDist_<Vec<ET, 2> >
     {
-        static inline int f(const Vec<ET, 2> a, const Vec<ET, 2> b)
+        static inline typename DistType<Vec<ET, 2> >::type f(const Vec<ET, 2> a, const Vec<ET, 2> b)
         {
-            return (int)(a[0]-b[0])*(int)(a[0]-b[0]) + (int)(a[1]-b[1])*(int)(a[1]-b[1]);
+            typedef typename DistType<Vec<ET, 2> >::type result_type;
+            return (result_type)(a[0]-b[0])*(result_type)(a[0]-b[0]) + (result_type)(a[1]-b[1])*(result_type)(a[1]-b[1]);
         }
     };
 
     template <typename ET> struct calcDist_<Vec<ET, 3> >
     {
-        static inline int f(const Vec<ET, 3> a, const Vec<ET, 3> b)
+        static inline typename DistType<Vec<ET, 3> >::type f(const Vec<ET, 3> a, const Vec<ET, 3> b)
         {
+            typedef typename DistType<Vec<ET, 3> >::type result_type;
             return
-                (int)(a[0]-b[0])*(int)(a[0]-b[0]) +
-                (int)(a[1]-b[1])*(int)(a[1]-b[1]) +
-                (int)(a[2]-b[2])*(int)(a[2]-b[2]);
+                (result_type)(a[0]-b[0])*(result_type)(a[0]-b[0]) +
+                (result_type)(a[1]-b[1])*(result_type)(a[1]-b[1]) +
+                (result_type)(a[2]-b[2])*(result_type)(a[2]-b[2]);
         }
     };
 
     template <typename ET> struct calcDist_<Vec<ET, 4> >
     {
-        static inline int f(const Vec<ET, 4> a, const Vec<ET, 4> b)
+        static inline typename DistType<Vec<ET, 4> >::type f(const Vec<ET, 4> a, const Vec<ET, 4> b)
         {
+            typedef typename DistType<Vec<ET, 4> >::type result_type;
             return
-                (int)(a[0]-b[0])*(int)(a[0]-b[0]) +
-                (int)(a[1]-b[1])*(int)(a[1]-b[1]) +
-                (int)(a[2]-b[2])*(int)(a[2]-b[2]) +
-                (int)(a[3]-b[3])*(int)(a[3]-b[3]);
+                (result_type)(a[0]-b[0])*(result_type)(a[0]-b[0]) +
+                (result_type)(a[1]-b[1])*(result_type)(a[1]-b[1]) +
+                (result_type)(a[2]-b[2])*(result_type)(a[2]-b[2]) +
+                (result_type)(a[3]-b[3])*(result_type)(a[3]-b[3]);
         }
     };
 
     template <typename T> struct calcUpDownDist_
     {
-        static inline int f(T a_up, T a_down, T b_up, T b_down)
+        static inline typename DistType<T>::type f(T a_up, T a_down, T b_up, T b_down)
         {
-            int A = a_down - b_down;
-            int B = a_up - b_up;
+            typedef typename DistType<T>::type result_type;
+            result_type A = (result_type)a_down - (result_type)b_down;
+            result_type B = (result_type)a_up - (result_type)b_up;
             return (A-B)*(A+B);
         }
     };
@@ -246,7 +255,7 @@ class DistSquared
     private:
         typedef Vec<ET, n> T;
     public:
-        static inline int f(T a_up, T a_down, T b_up, T b_down)
+        static inline typename DistType<T>::type f(T a_up, T a_down, T b_up, T b_down)
         {
             return calcDist<T>(a_down, b_down) - calcDist<T>(a_up, b_up);
         }
@@ -279,13 +288,13 @@ class DistSquared
     };
 
 public:
-    template <typename T> static inline int calcDist(const T a, const T b)
+    template <typename T> static inline typename DistType<T>::type calcDist(const T a, const T b)
     {
         return calcDist_<T>::f(a, b);
     }
 
     template <typename T>
-    static inline int calcDist(const Mat& m, int i1, int j1, int i2, int j2)
+    static inline typename DistType<T>::type calcDist(const Mat& m, int i1, int j1, int i2, int j2)
     {
         const T a = m.at<T>(i1, j1);
         const T b = m.at<T>(i2, j2);
@@ -293,7 +302,7 @@ public:
     }
 
     template <typename T>
-    static inline int calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
+    static inline typename DistType<T>::type calcUpDownDist(T a_up, T a_down, T b_up, T b_down)
     {
         return calcUpDownDist_<T>::f(a_up, a_down, b_up, b_down);
     }
@@ -306,9 +315,10 @@ public:
     }
 
     template <typename T>
-    static inline int maxDist()
+    static inline typename DistType<T>::type maxDist()
     {
-        return (int)pixelInfo<T>::sampleMax() * (int)pixelInfo<T>::sampleMax() *
+        typedef typename DistType<T>::type result_type;
+        return (result_type)pixelInfo<T>::sampleMax() * (result_type)pixelInfo<T>::sampleMax() *
             pixelInfo<T>::channels;
     }
 };

--- a/modules/photo/src/fast_nlmeans_multi_denoising_invoker.hpp
+++ b/modules/photo/src/fast_nlmeans_multi_denoising_invoker.hpp
@@ -50,7 +50,7 @@
 
 using namespace cv;
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT = int>
 struct FastNlMeansMultiDenoisingInvoker :
         ParallelLoopBody
 {
@@ -85,17 +85,17 @@ private:
     int almost_template_window_size_sq_bin_shift;
     std::vector<WT> almost_dist2weight;
 
-    void calcDistSumsForFirstElementInRow(int i, Array3d<int>& dist_sums,
-                                          Array4d<int>& col_dist_sums,
-                                          Array4d<int>& up_col_dist_sums) const;
+    void calcDistSumsForFirstElementInRow(int i, Array3d<DT>& dist_sums,
+                                          Array4d<DT>& col_dist_sums,
+                                          Array4d<DT>& up_col_dist_sums) const;
 
     void calcDistSumsForElementInFirstRow(int i, int j, int first_col_num,
-                                          Array3d<int>& dist_sums, Array4d<int>& col_dist_sums,
-                                          Array4d<int>& up_col_dist_sums) const;
+                                          Array3d<DT>& dist_sums, Array4d<DT>& col_dist_sums,
+                                          Array4d<DT>& up_col_dist_sums) const;
 };
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansMultiDenoisingInvoker(
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT, DT>::FastNlMeansMultiDenoisingInvoker(
     const std::vector<Mat>& srcImgs,
     int imgToDenoiseIndex,
     int temporalWindowSize,
@@ -140,8 +140,13 @@ FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansMultiDenoisingIn
     int almost_template_window_size_sq = 1 << almost_template_window_size_sq_bin_shift;
     double almost_dist2actual_dist_multiplier = (double) almost_template_window_size_sq / template_window_size_sq;
 
-    int max_dist = D::template maxDist<T>();
-    int almost_max_dist = (int)(max_dist / almost_dist2actual_dist_multiplier + 1);
+    DT max_dist = D::template maxDist<T>();
+    float max_h = h[0];
+    for (int c = 1; c < pixelInfo<T>::channels; c++)
+        if (h[c] > max_h) max_h = h[c];
+    double max_threshold_dist = 6.91 * max_h * max_h * pixelInfo<T>::channels;
+    DT limit_dist = (max_threshold_dist < max_dist) ? (DT)max_threshold_dist : max_dist;
+    int almost_max_dist = (int)(limit_dist / almost_dist2actual_dist_multiplier + 1);
     almost_dist2weight.resize(almost_max_dist);
 
     for (int almost_dist = 0; almost_dist < almost_max_dist; almost_dist++)
@@ -156,19 +161,19 @@ FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::FastNlMeansMultiDenoisingIn
         dst_ = Mat::zeros(srcImgs[0].size(), srcImgs[0].type());
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Range& range) const
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT, DT>::operator() (const Range& range) const
 {
     int row_from = range.start;
     int row_to = range.end - 1;
 
-    Array3d<int> dist_sums(temporal_window_size_, search_window_size_, search_window_size_);
+    Array3d<DT> dist_sums(temporal_window_size_, search_window_size_, search_window_size_);
 
     // for lazy calc optimization
-    Array4d<int> col_dist_sums(template_window_size_, temporal_window_size_, search_window_size_, search_window_size_);
+    Array4d<DT> col_dist_sums(template_window_size_, temporal_window_size_, search_window_size_, search_window_size_);
 
     int first_col_num = -1;
-    Array4d<int> up_col_dist_sums(cols_, temporal_window_size_, search_window_size_, search_window_size_);
+    Array4d<DT> up_col_dist_sums(cols_, temporal_window_size_, search_window_size_, search_window_size_);
 
     for (int i = row_from; i <= row_to; i++)
     {
@@ -212,15 +217,15 @@ void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Rang
                     for (int d = 0; d < temporal_window_size_; d++)
                     {
                         Mat cur_extended_src = extended_srcs_[d];
-                        Array2d<int> cur_dist_sums = dist_sums[d];
-                        Array2d<int> cur_col_dist_sums = col_dist_sums[first_col_num][d];
-                        Array2d<int> cur_up_col_dist_sums = up_col_dist_sums[j][d];
+                        Array2d<DT> cur_dist_sums = dist_sums[d];
+                        Array2d<DT> cur_col_dist_sums = col_dist_sums[first_col_num][d];
+                        Array2d<DT> cur_up_col_dist_sums = up_col_dist_sums[j][d];
                         for (int y = 0; y < search_window_size; y++)
                         {
-                            int* dist_sums_row = cur_dist_sums.row_ptr(y);
+                            DT* dist_sums_row = cur_dist_sums.row_ptr(y);
 
-                            int* col_dist_sums_row = cur_col_dist_sums.row_ptr(y);
-                            int* up_col_dist_sums_row = cur_up_col_dist_sums.row_ptr(y);
+                            DT* col_dist_sums_row = cur_col_dist_sums.row_ptr(y);
+                            DT* up_col_dist_sums_row = cur_up_col_dist_sums.row_ptr(y);
 
                             const T* b_up_ptr = cur_extended_src.ptr<T>(start_by - template_window_half_size_ - 1 + y);
                             const T* b_down_ptr = cur_extended_src.ptr<T>(start_by + template_window_half_size_ + y);
@@ -256,13 +261,15 @@ void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Rang
                 {
                     const T* cur_row_ptr = esrc_d.ptr<T>(border_size_ + search_window_y + y);
 
-                    int* dist_sums_row = dist_sums.row_ptr(d, y);
+                    DT* dist_sums_row = dist_sums.row_ptr(d, y);
 
                     for (int x = 0; x < search_window_size_; x++)
                     {
-                        int almostAvgDist = dist_sums_row[x] >> almost_template_window_size_sq_bin_shift;
+                        DT almostAvgDist = dist_sums_row[x] >> almost_template_window_size_sq_bin_shift;
 
-                        WT weight =  almost_dist2weight[almostAvgDist];
+                        WT weight = 0;
+                        if (almostAvgDist < (DT)almost_dist2weight.size())
+                            weight = almost_dist2weight[(size_t)almostAvgDist];
                         T p = cur_row_ptr[border_size_ + search_window_x + x];
                         incWithWeight<T, IT, WT>(estimation, weights_sum, weight, p);
                     }
@@ -276,9 +283,9 @@ void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::operator() (const Rang
     }
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForFirstElementInRow(
-        int i, Array3d<int>& dist_sums, Array4d<int>& col_dist_sums, Array4d<int>& up_col_dist_sums) const
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT, DT>::calcDistSumsForFirstElementInRow(
+        int i, Array3d<DT>& dist_sums, Array4d<DT>& col_dist_sums, Array4d<DT>& up_col_dist_sums) const
 {
     int j = 0;
 
@@ -295,14 +302,14 @@ inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsFor
                 int start_y = i + y - search_window_half_size_;
                 int start_x = j + x - search_window_half_size_;
 
-                int* dist_sums_ptr = &dist_sums[d][y][x];
-                int* col_dist_sums_ptr = &col_dist_sums[0][d][y][x];
+                DT* dist_sums_ptr = &dist_sums[d][y][x];
+                DT* col_dist_sums_ptr = &col_dist_sums[0][d][y][x];
                 int col_dist_sums_step = col_dist_sums.step_size(0);
                 for (int tx = -template_window_half_size_; tx <= template_window_half_size_; tx++)
                 {
                     for (int ty = -template_window_half_size_; ty <= template_window_half_size_; ty++)
                     {
-                        int dist = D::template calcDist<T>(
+                        DT dist = D::template calcDist<T>(
                                     main_extended_src_.at<T>(border_size_ + i + ty, border_size_ + j + tx),
                                     cur_extended_src.at<T>(border_size_ + start_y + ty, border_size_ + start_x + tx));
 
@@ -317,10 +324,10 @@ inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsFor
     }
 }
 
-template <typename T, typename IT, typename UIT, typename D, typename WT>
-inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsForElementInFirstRow(
-    int i, int j, int first_col_num, Array3d<int>& dist_sums,
-    Array4d<int>& col_dist_sums, Array4d<int>& up_col_dist_sums) const
+template <typename T, typename IT, typename UIT, typename D, typename WT, typename DT>
+inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT, DT>::calcDistSumsForElementInFirstRow(
+    int i, int j, int first_col_num, Array3d<DT>& dist_sums,
+    Array4d<DT>& col_dist_sums, Array4d<DT>& up_col_dist_sums) const
 {
     int ay = border_size_ + i;
     int ax = border_size_ + j + template_window_half_size_;
@@ -342,7 +349,7 @@ inline void FastNlMeansMultiDenoisingInvoker<T, IT, UIT, D, WT>::calcDistSumsFor
                 int by = start_by + y;
                 int bx = start_bx + x;
 
-                int* col_dist_sums_ptr = &col_dist_sums[new_last_col_num][d][y][x];
+                DT* col_dist_sums_ptr = &col_dist_sums[new_last_col_num][d][y][x];
                 for (int ty = -template_window_half_size_; ty <= template_window_half_size_; ty++)
                 {
                     *col_dist_sums_ptr += D::template calcDist<T>(

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -191,6 +191,71 @@ TEST(Photo_DenoisingGrayscaleMulti16bitL1, regression)
     cv::Mat expected;
     result_8u.convertTo(expected, CV_16U);
 
+}
+
+TEST(Photo_DenoisingGrayscale16bitL2, accuracy)
+{
+    // Generate a programmatic image with some structure
+    Mat original_8u(100, 100, CV_8UC1);
+    for (int r = 0; r < 100; ++r)
+    {
+        for (int c = 0; c < 100; ++c)
+        {
+            original_8u.at<uchar>(r, c) = (uchar)((r * 2 + c) % 256);
+        }
+    }
+
+    // Add noise
+    Mat noised_8u = original_8u.clone();
+    for (int r = 10; r < 90; ++r)
+    {
+        for (int c = 10; c < 90; ++c)
+        {
+            noised_8u.at<uchar>(r, c) = (uchar)std::min(255, std::max(0, (int)noised_8u.at<uchar>(r, c) + ((r + c) % 15 - 7)));
+        }
+    }
+
+    Mat noised_16u;
+    noised_8u.convertTo(noised_16u, CV_16U);
+
+    Mat result_8u, result_16u;
+    std::vector<float> h = {10};
+    fastNlMeansDenoising(noised_8u, result_8u, h, 7, 21, NORM_L2);
+    fastNlMeansDenoising(noised_16u, result_16u, h, 7, 21, NORM_L2);
+
+    Mat expected;
+    result_8u.convertTo(expected, CV_16U);
+
+    EXPECT_MAT_NEAR(result_16u, expected, 1);
+}
+
+TEST(Photo_DenoisingGrayscaleMulti16bitL2, accuracy)
+{
+    const int imgs_count = 3;
+    vector<Mat> original_8u(imgs_count);
+    vector<Mat> original_16u(imgs_count);
+
+    for (int i = 0; i < imgs_count; ++i)
+    {
+        original_8u[i] = Mat(100, 100, CV_8UC1);
+        for (int r = 0; r < 100; ++r)
+        {
+            for (int c = 0; c < 100; ++c)
+            {
+                original_8u[i].at<uchar>(r, c) = (uchar)((r * 2 + c + i * 5) % 256);
+            }
+        }
+        original_8u[i].convertTo(original_16u[i], CV_16U);
+    }
+
+    Mat result_8u, result_16u;
+    std::vector<float> h = {15};
+    fastNlMeansDenoisingMulti(original_8u, result_8u, /*imgToDenoiseIndex*/ imgs_count / 2, /*temporalWindowSize*/ imgs_count, h, 7, 21, NORM_L2);
+    fastNlMeansDenoisingMulti(original_16u, result_16u, /*imgToDenoiseIndex*/ imgs_count / 2, /*temporalWindowSize*/ imgs_count, h, 7, 21, NORM_L2);
+
+    cv::Mat expected;
+    result_8u.convertTo(expected, CV_16U);
+
     EXPECT_MAT_NEAR(result_16u, expected, 1);
 }
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ x] The PR is proposed to the proper branch
- [ x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake


### Problem
Currently, `fastNlMeansDenoising()` only supports 8-bit images under `NORM_L2`.

For 16-bit images:
* Squared pixel differences can reach values up to 4.29 billion.
* Standard 32-bit accumulators overflow during intermediate calculations.

Additionally:
* The precomputed weight lookup table for all possible 16-bit intensity differences attempts to allocate nearly 13 GB.
* This immediately causes an Out-Of-Memory (OOM) crash.

### Fix

#### High-Precision Accumulators
To safely handle large intermediate computations:
* **CPU implementation**: Uses 64-bit integer accumulators.
* **GPU implementation**: Uses floating-point accumulators.

This prevents overflow while preserving denoising quality for high-dynamic-range 16-bit images.

#### Compact Weight Lookup Tables
The exponential weighting function rapidly decays toward zero for large block distances. Instead of allocating lookup tables for the entire 16-bit range, we:
* Store only non-zero weights.
* Dynamically restrict lookup table size.

This reduces memory usage to only a few kilobytes and prevents the 13 GB out-of-memory crash.

#### Template Dispatching & ABI Compliance
Template-based dispatching is used to:
* Preserve peak performance for standard 8-bit pipelines.
* Safely execute 16-bit denoising using high-precision implementations.

Additionally, we have overloaded `nlm_fast_gpu` to preserve the exact signatures of the original 8-bit implementations, ensuring full ABI compliance with the reference branch.
