### PR TITLE
dnn(tflite): fix TransposeConv output shape read from explicit input

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -969,9 +969,20 @@ void TFLiteImporter::parseDeconvolution(const Operator& op, const std::string& o
     layerParams.set("num_output", oc);
 
     // Add adjust padding similar to TensorFlow (see tf_importer)
-    const auto* outShape = modelTensors->Get(op.outputs()->Get(0))->shape();
-    const int outH = outShape->Get(1);
-    const int outW = outShape->Get(2);
+    int outH = 0, outW = 0;
+    int shapeTensorIdx = op.inputs()->Get(0);
+    if (allTensors.count(shapeTensorIdx) && !allTensors[shapeTensorIdx].empty() &&
+        allTensors[shapeTensorIdx].total() >= 3) {
+        Mat outShapeTensor = allTensors[shapeTensorIdx];
+        outH = outShapeTensor.at<int32_t>(1);
+        outW = outShapeTensor.at<int32_t>(2);
+    }
+    if (outH == 0 || outW == 0) {
+        const auto* outShape = modelTensors->Get(op.outputs()->Get(0))->shape();
+        outH = outShape->Get(1);
+        outW = outShape->Get(2);
+    }
+
     if (params->padding == kTfLitePaddingSame)
     {
         layerParams.set("adj_w", (outW - 1) % params->stride_width);


### PR DESCRIPTION
TransposeConv in TFLite stores the desired output shape as an explicit
int32 tensor at inputs[0]. The importer was reading outH/outW from the
output tensor's flatbuffer metadata instead, which can differ from the
explicit shape when padding does not divide evenly - causing adj_w/adj_h
to be computed incorrectly and producing wrong deconvolution output.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
