### PR TITLE
Fix WarpAffine and WarpPerspective accuracy on RISC-V RVV

### DIFF
--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -181,20 +181,20 @@ int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width
 
 // BUG: https://github.com/opencv/opencv/issues/27279
 #undef cv_hal_remap32f
-#define cv_hal_remap32f cv::cv_hal_rvv::imgproc::remap32f
+#define cv_hal_remap32f cv::rvv_hal::imgproc::remap32f
 #undef cv_hal_remap32fc2
-#define cv_hal_remap32fc2 cv::cv_hal_rvv::imgproc::remap32fc2
+#define cv_hal_remap32fc2 cv::rvv_hal::imgproc::remap32fc2
 #undef cv_hal_remap16s
-#define cv_hal_remap16s cv::cv_hal_rvv::imgproc::remap16s
+#define cv_hal_remap16s cv::rvv_hal::imgproc::remap16s
 
 int warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 int warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);
 
 // BUG: https://github.com/opencv/opencv/issues/27280
 #undef cv_hal_warpAffine
-#define cv_hal_warpAffine cv::cv_hal_rvv::imgproc::warpAffine
+#define cv_hal_warpAffine cv::rvv_hal::imgproc::warpAffine
 #undef cv_hal_warpPerspective
-#define cv_hal_warpPerspective cv::cv_hal_rvv::imgproc::warpPerspective
+#define cv_hal_warpPerspective cv::rvv_hal::imgproc::warpPerspective
 
 /* ############ threshold ############ */
 

--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -180,12 +180,12 @@ int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width
              int interpolation, int border_type, const double border_value[4]);
 
 // BUG: https://github.com/opencv/opencv/issues/27279
-#undef cv_hal_remap32f
-#define cv_hal_remap32f cv::rvv_hal::imgproc::remap32f
-#undef cv_hal_remap32fc2
-#define cv_hal_remap32fc2 cv::rvv_hal::imgproc::remap32fc2
-#undef cv_hal_remap16s
-#define cv_hal_remap16s cv::rvv_hal::imgproc::remap16s
+// #undef cv_hal_remap32f
+// #define cv_hal_remap32f cv::rvv_hal::imgproc::remap32f
+// #undef cv_hal_remap32fc2
+// #define cv_hal_remap32fc2 cv::rvv_hal::imgproc::remap32fc2
+// #undef cv_hal_remap16s
+// #define cv_hal_remap16s cv::rvv_hal::imgproc::remap16s
 
 int warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 int warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);

--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -179,13 +179,12 @@ int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width
              short* mapx, size_t mapx_step, ushort* mapy, size_t mapy_step,
              int interpolation, int border_type, const double border_value[4]);
 
-// BUG: https://github.com/opencv/opencv/issues/27279
-// #undef cv_hal_remap32f
-// #define cv_hal_remap32f cv::rvv_hal::imgproc::remap32f
-// #undef cv_hal_remap32fc2
-// #define cv_hal_remap32fc2 cv::rvv_hal::imgproc::remap32fc2
-// #undef cv_hal_remap16s
-// #define cv_hal_remap16s cv::rvv_hal::imgproc::remap16s
+#undef cv_hal_remap32f
+#define cv_hal_remap32f cv::rvv_hal::imgproc::remap32f
+#undef cv_hal_remap32fc2
+#define cv_hal_remap32fc2 cv::rvv_hal::imgproc::remap32fc2
+#undef cv_hal_remap16s
+#define cv_hal_remap16s cv::rvv_hal::imgproc::remap16s
 
 int warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 int warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);

--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -180,21 +180,21 @@ int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width
              int interpolation, int border_type, const double border_value[4]);
 
 // BUG: https://github.com/opencv/opencv/issues/27279
-// #undef cv_hal_remap32f
-// #define cv_hal_remap32f cv::cv_hal_rvv::imgproc::remap32f
-// #undef cv_hal_remap32fc2
-// #define cv_hal_remap32fc2 cv::cv_hal_rvv::imgproc::remap32fc2
-// #undef cv_hal_remap16s
-// #define cv_hal_remap16s cv::cv_hal_rvv::imgproc::remap16s
+#undef cv_hal_remap32f
+#define cv_hal_remap32f cv::cv_hal_rvv::imgproc::remap32f
+#undef cv_hal_remap32fc2
+#define cv_hal_remap32fc2 cv::cv_hal_rvv::imgproc::remap32fc2
+#undef cv_hal_remap16s
+#define cv_hal_remap16s cv::cv_hal_rvv::imgproc::remap16s
 
 int warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 int warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);
 
 // BUG: https://github.com/opencv/opencv/issues/27280
-//#undef cv_hal_warpAffine
-//#define cv_hal_warpAffine cv::cv_hal_rvv::imgproc::warpAffine
-//#undef cv_hal_warpPerspective
-//#define cv_hal_warpPerspective cv::cv_hal_rvv::imgproc::warpPerspective
+#undef cv_hal_warpAffine
+#define cv_hal_warpAffine cv::cv_hal_rvv::imgproc::warpAffine
+#undef cv_hal_warpPerspective
+#define cv_hal_warpPerspective cv::cv_hal_rvv::imgproc::warpPerspective
 
 /* ############ threshold ############ */
 

--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -190,7 +190,6 @@ int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width
 int warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 int warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4]);
 
-// BUG: https://github.com/opencv/opencv/issues/27280
 #undef cv_hal_warpAffine
 #define cv_hal_warpAffine cv::rvv_hal::imgproc::warpAffine
 #undef cv_hal_warpPerspective

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -858,14 +858,25 @@ static inline int remap32f(int src_type, const uchar *src_data, size_t src_step,
     return CV_HAL_ERROR_NOT_IMPLEMENTED;
 }
 
-inline int remap32fc2(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+int remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+             uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
+             float* mapx, size_t mapx_step, float* mapy, size_t mapy_step,
+             int interpolation, int border_type, const double border_value[4])
+{
+    return remap32f<false>(src_type, src_data, src_step, src_width, src_height,
+                           dst_data, dst_step, dst_width, dst_height,
+                           mapx, mapx_step, mapy, mapy_step,
+                           interpolation, border_type, border_value);
+}
+
+int remap32fc2(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
                       uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
                       float* map, size_t map_step, int interpolation, int border_type, const double border_value[4])
 {
     return remap32f(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, dst_height, map, map_step, nullptr, 0, interpolation, border_type, border_value);
 }
 
-inline int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+int remap16s(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
                     uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
                     short* mapx, size_t mapx_step, ushort* mapy, size_t mapy_step,
                     int interpolation, int border_type, const double border_value[4])

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -791,7 +791,7 @@ static inline int remap32fC4(int start, int end, const uchar *src_data, size_t s
 // the algorithm is copied from 3rdparty/carotene/src/remap.cpp,
 // in the function void CAROTENE_NS::remapNearestNeighbor and void CAROTENE_NS::remapLinear
 template<bool s16 = false>
-inline int remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+static inline int remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
                     uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
                     float* mapx, size_t mapx_step, float* mapy, size_t mapy_step,
                     int interpolation, int border_type, const double border_value[4])

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -177,40 +177,22 @@ static inline int remap32fC1(int start, int end, bool s16, const uchar *src_data
             else if (mode == CV_HAL_INTER_LINEAR)
             {
                 typename RVV_SameLen<int, helper>::VecType ix0, iy0;
-                typename RVV_SameLen<float, helper>::VecType fx, fy;
                 if (s16)
                 {
                     ix0 = __riscv_vfcvt_x(mx, vl);
                     iy0 = __riscv_vfcvt_x(my, vl);
                     auto md = __riscv_vle16_v_u16m4(reinterpret_cast<const ushort*>(mapy) + i * mapy_step + j, vl);
-                    fx = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(md, 31, vl), vl), 32, vl);
-                    fy = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(__riscv_vsrl(md, 5, vl), 31, vl), vl), 32, vl);
+                    mx = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(md, 31, vl), vl), 32, vl);
+                    my = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(__riscv_vsrl(md, 5, vl), 31, vl), vl), 32, vl);
                 }
                 else
                 {
-                    if constexpr (std::is_same<T, float>::value)
-                    {
-                        auto floor_to_int = [&](auto v)
-                        {
-                            auto iv = __riscv_vfcvt_x(v, vl);
-                            auto fv = __riscv_vfcvt_f(iv, vl);
-                            return __riscv_vsub_mu(__riscv_vmfgt(fv, v, vl), iv, iv, 1, vl);
-                        };
-
-                        ix0 = floor_to_int(mx);
-                        iy0 = floor_to_int(my);
-                        fx = __riscv_vfsub(mx, __riscv_vfcvt_f(ix0, vl), vl);
-                        fy = __riscv_vfsub(my, __riscv_vfcvt_f(iy0, vl), vl);
-                    }
-                    else
-                    {
-                        auto imx = __riscv_vfcvt_x(__riscv_vfmul(mx, 32, vl), vl);
-                        auto imy = __riscv_vfcvt_x(__riscv_vfmul(my, 32, vl), vl);
-                        ix0 = __riscv_vsra(imx, 5, vl);
-                        iy0 = __riscv_vsra(imy, 5, vl);
-                        fx = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imx, 31, vl), vl), 32, vl);
-                        fy = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imy, 31, vl), vl), 32, vl);
-                    }
+                    auto imx = __riscv_vfcvt_x(__riscv_vfmul(mx, 32, vl), vl);
+                    auto imy = __riscv_vfcvt_x(__riscv_vfmul(my, 32, vl), vl);
+                    ix0 = __riscv_vsra(imx, 5, vl);
+                    iy0 = __riscv_vsra(imy, 5, vl);
+                    mx = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imx, 31, vl), vl), 32, vl);
+                    my = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imy, 31, vl), vl), 32, vl);
                 }
                 auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
                 auto v0 = rvv<helper>::vcvt0(access(ix0, iy0), vl);
@@ -218,9 +200,9 @@ static inline int remap32fC1(int start, int end, bool s16, const uchar *src_data
                 auto v2 = rvv<helper>::vcvt0(access(ix0, iy1), vl);
                 auto v3 = rvv<helper>::vcvt0(access(ix1, iy1), vl);
 
-                v0 = __riscv_vfadd(v0, __riscv_vfmul(fx, __riscv_vfsub(v1, v0, vl), vl), vl);
-                v2 = __riscv_vfadd(v2, __riscv_vfmul(fx, __riscv_vfsub(v3, v2, vl), vl), vl);
-                v0 = __riscv_vfadd(v0, __riscv_vfmul(fy, __riscv_vfsub(v2, v0, vl), vl), vl);
+                v0 = __riscv_vfmacc(v0, mx, __riscv_vfsub(v1, v0, vl), vl);
+                v2 = __riscv_vfmacc(v2, mx, __riscv_vfsub(v3, v2, vl), vl);
+                v0 = __riscv_vfmacc(v0, my, __riscv_vfsub(v2, v0, vl), vl);
                 helper::vstore(reinterpret_cast<T*>(dst_data + i * dst_step) + j, rvv<helper>::vcvt1(v0, vl), vl);
             }
             else

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -6,6 +6,7 @@
 
 #include "rvv_hal.hpp"
 #include "common.hpp"
+#include <type_traits>
 
 namespace cv { namespace rvv_hal { namespace imgproc {
 
@@ -175,22 +176,40 @@ static inline int remap32fC1(int start, int end, bool s16, const uchar *src_data
             else if (mode == CV_HAL_INTER_LINEAR)
             {
                 typename RVV_SameLen<int, helper>::VecType ix0, iy0;
+                typename RVV_SameLen<float, helper>::VecType fx, fy;
                 if (s16)
                 {
                     ix0 = __riscv_vfcvt_x(mx, vl);
                     iy0 = __riscv_vfcvt_x(my, vl);
                     auto md = __riscv_vle16_v_u16m4(reinterpret_cast<const ushort*>(mapy) + i * mapy_step + j, vl);
-                    mx = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(md, 31, vl), vl), 32, vl);
-                    my = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(__riscv_vsrl(md, 5, vl), 31, vl), vl), 32, vl);
+                    fx = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(md, 31, vl), vl), 32, vl);
+                    fy = __riscv_vfdiv(__riscv_vfwcvt_f(__riscv_vand(__riscv_vsrl(md, 5, vl), 31, vl), vl), 32, vl);
                 }
                 else
                 {
-                    auto imx = __riscv_vfcvt_x(__riscv_vfmul(mx, 32, vl), vl);
-                    auto imy = __riscv_vfcvt_x(__riscv_vfmul(my, 32, vl), vl);
-                    ix0 = __riscv_vsra(imx, 5, vl);
-                    iy0 = __riscv_vsra(imy, 5, vl);
-                    mx = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imx, 31, vl), vl), 32, vl);
-                    my = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imy, 31, vl), vl), 32, vl);
+                    if constexpr (std::is_same<T, float>::value)
+                    {
+                        auto floor_to_int = [&](auto v)
+                        {
+                            auto iv = __riscv_vfcvt_x(v, vl);
+                            auto fv = __riscv_vfcvt_f(iv, vl);
+                            return __riscv_vsub_mu(__riscv_vmfgt(fv, v, vl), iv, iv, 1, vl);
+                        };
+
+                        ix0 = floor_to_int(mx);
+                        iy0 = floor_to_int(my);
+                        fx = __riscv_vfsub(mx, __riscv_vfcvt_f(ix0, vl), vl);
+                        fy = __riscv_vfsub(my, __riscv_vfcvt_f(iy0, vl), vl);
+                    }
+                    else
+                    {
+                        auto imx = __riscv_vfcvt_x(__riscv_vfmul(mx, 32, vl), vl);
+                        auto imy = __riscv_vfcvt_x(__riscv_vfmul(my, 32, vl), vl);
+                        ix0 = __riscv_vsra(imx, 5, vl);
+                        iy0 = __riscv_vsra(imy, 5, vl);
+                        fx = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imx, 31, vl), vl), 32, vl);
+                        fy = __riscv_vfdiv(__riscv_vfcvt_f(__riscv_vand(imy, 31, vl), vl), 32, vl);
+                    }
                 }
                 auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
                 auto v0 = rvv<helper>::vcvt0(access(ix0, iy0), vl);
@@ -198,9 +217,9 @@ static inline int remap32fC1(int start, int end, bool s16, const uchar *src_data
                 auto v2 = rvv<helper>::vcvt0(access(ix0, iy1), vl);
                 auto v3 = rvv<helper>::vcvt0(access(ix1, iy1), vl);
 
-                v0 = __riscv_vfmacc(v0, mx, __riscv_vfsub(v1, v0, vl), vl);
-                v2 = __riscv_vfmacc(v2, mx, __riscv_vfsub(v3, v2, vl), vl);
-                v0 = __riscv_vfmacc(v0, my, __riscv_vfsub(v2, v0, vl), vl);
+                v0 = __riscv_vfmacc(v0, fx, __riscv_vfsub(v1, v0, vl), vl);
+                v2 = __riscv_vfmacc(v2, fx, __riscv_vfsub(v3, v2, vl), vl);
+                v0 = __riscv_vfmacc(v0, fy, __riscv_vfsub(v2, v0, vl), vl);
                 helper::vstore(reinterpret_cast<T*>(dst_data + i * dst_step) + j, rvv<helper>::vcvt1(v0, vl), vl);
             }
             else

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -6,6 +6,7 @@
 
 #include "rvv_hal.hpp"
 #include "common.hpp"
+
 #include <type_traits>
 
 namespace cv { namespace rvv_hal { namespace imgproc {
@@ -217,9 +218,9 @@ static inline int remap32fC1(int start, int end, bool s16, const uchar *src_data
                 auto v2 = rvv<helper>::vcvt0(access(ix0, iy1), vl);
                 auto v3 = rvv<helper>::vcvt0(access(ix1, iy1), vl);
 
-                v0 = __riscv_vfmacc(v0, fx, __riscv_vfsub(v1, v0, vl), vl);
-                v2 = __riscv_vfmacc(v2, fx, __riscv_vfsub(v3, v2, vl), vl);
-                v0 = __riscv_vfmacc(v0, fy, __riscv_vfsub(v2, v0, vl), vl);
+                v0 = __riscv_vfadd(v0, __riscv_vfmul(fx, __riscv_vfsub(v1, v0, vl), vl), vl);
+                v2 = __riscv_vfadd(v2, __riscv_vfmul(fx, __riscv_vfsub(v3, v2, vl), vl), vl);
+                v0 = __riscv_vfadd(v0, __riscv_vfmul(fy, __riscv_vfsub(v2, v0, vl), vl), vl);
                 helper::vstore(reinterpret_cast<T*>(dst_data + i * dst_step) + j, rvv<helper>::vcvt1(v0, vl), vl);
             }
             else
@@ -241,6 +242,8 @@ private:
         // in the function static void interpolateLanczos4
         constexpr double s45 = 0.70710678118654752440084436210485;
         constexpr double cs[][2] = {{1, 0}, {-s45, -s45}, {0, 1}, {s45, -s45}, {-1, 0}, {s45, s45}, {0, -1}, {-s45, s45}};
+        constexpr int INTER_REMAP_COEF_BITS = 15;
+        constexpr int INTER_REMAP_COEF_SCALE = 1 << INTER_REMAP_COEF_BITS;
 
         for (int t = 0; t < 32; t++)
         {
@@ -266,10 +269,49 @@ private:
             for (int i = 0; i < 8; i++)
                 coeffs[t*8+i] *= sum;
         }
+
+        for (int fy = 0; fy < 32; fy++)
+        {
+            for (int fx = 0; fx < 32; fx++)
+            {
+                short* itab = coeffs_i + (fy * 32 + fx) * 64;
+                int isum = 0;
+                for (int ky = 0; ky < 8; ky++)
+                {
+                    float vy = coeffs[fy * 8 + ky];
+                    for (int kx = 0; kx < 8; kx++)
+                    {
+                        float v = vy * coeffs[fx * 8 + kx];
+                        int q = saturate_cast<short>(v * INTER_REMAP_COEF_SCALE);
+                        itab[ky * 8 + kx] = (short)q;
+                        isum += q;
+                    }
+                }
+
+                if (isum != INTER_REMAP_COEF_SCALE)
+                {
+                    int diff = isum - INTER_REMAP_COEF_SCALE;
+                    int ksize2 = 4, Mk1 = ksize2, Mk2 = ksize2, mk1 = ksize2, mk2 = ksize2;
+                    for (int ky = ksize2; ky < ksize2 + 2; ky++)
+                        for (int kx = ksize2; kx < ksize2 + 2; kx++)
+                        {
+                            if (itab[ky * 8 + kx] < itab[mk1 * 8 + mk2])
+                                mk1 = ky, mk2 = kx;
+                            else if (itab[ky * 8 + kx] > itab[Mk1 * 8 + Mk2])
+                                Mk1 = ky, Mk2 = kx;
+                        }
+                    if (diff < 0)
+                        itab[Mk1 * 8 + Mk2] = (short)(itab[Mk1 * 8 + Mk2] - diff);
+                    else
+                        itab[mk1 * 8 + mk2] = (short)(itab[mk1 * 8 + mk2] - diff);
+                }
+            }
+        }
     }
 
 public:
     float coeffs[32 * 8];
+    short coeffs_i[32 * 32 * 8 * 8];
 
     static RemapTable& instance()
     {
@@ -277,6 +319,249 @@ public:
         return tab;
     }
 };
+
+template<typename helper, bool s16>
+static inline int remap32fLanczos4C1(int start, int end, const uchar *src_data, size_t src_step, int src_width, int src_height,
+                                     uchar *dst_data, size_t dst_step, int dst_width,
+                                     const float* mapx, size_t mapx_step, const float* mapy, size_t mapy_step,
+                                     int interpolation, int border_type, const double* border_value)
+{
+    using T = typename helper::ElemType;
+    constexpr int INTER_REMAP_COEF_BITS = 15;
+
+    for (int i = start; i < end; i++)
+    {
+        int vl;
+        for (int j = 0; j < dst_width; j += vl)
+        {
+            vl = helper::setvl(dst_width - j);
+            typename RVV_SameLen<float, helper>::VecType mx, my;
+            if (s16)
+            {
+                auto map = __riscv_vlseg2e16_v_i16m1x2(reinterpret_cast<const short*>(mapx) + i * mapx_step + j * 2, vl);
+                mx = __riscv_vfwcvt_f(__riscv_vget_v_i16m1x2_i16m1(map, 0), vl);
+                my = __riscv_vfwcvt_f(__riscv_vget_v_i16m1x2_i16m1(map, 1), vl);
+            }
+            else
+            {
+                if (mapy == nullptr)
+                {
+                    auto map = __riscv_vlseg2e32_v_f32m2x2(mapx + i * mapx_step + j * 2, vl);
+                    mx = __riscv_vget_v_f32m2x2_f32m2(map, 0);
+                    my = __riscv_vget_v_f32m2x2_f32m2(map, 1);
+                }
+                else
+                {
+                    mx = RVV_SameLen<float, helper>::vload(mapx + i * mapx_step + j, vl);
+                    my = RVV_SameLen<float, helper>::vload(mapy + i * mapy_step + j, vl);
+                }
+            }
+            if (interpolation & CV_HAL_WARP_RELATIVE_MAP)
+            {
+                mx = __riscv_vfadd(mx, __riscv_vfcvt_f(__riscv_vadd(RVV_SameLen<uint, helper>::vid(vl), j, vl), vl), vl);
+                my = __riscv_vfadd(my, i, vl);
+            }
+
+            auto access = [&](typename RVV_SameLen<int, helper>::VecType ix, typename RVV_SameLen<int, helper>::VecType iy) {
+                auto ux = RVV_SameLen<uint, helper>::reinterpret(__riscv_vmin(__riscv_vmax(ix, 0, vl), src_width  - 1, vl));
+                auto uy = RVV_SameLen<uint, helper>::reinterpret(__riscv_vmin(__riscv_vmax(iy, 0, vl), src_height - 1, vl));
+                auto src = rvv<helper>::vloxei(reinterpret_cast<const T*>(src_data), __riscv_vmadd(uy, src_step, __riscv_vmul(ux, sizeof(T), vl), vl), vl);
+                if (border_type == CV_HAL_BORDER_CONSTANT)
+                {
+                    auto mask = __riscv_vmor(__riscv_vmsne(ix, RVV_SameLen<int, helper>::reinterpret(ux), vl), __riscv_vmsne(iy, RVV_SameLen<int, helper>::reinterpret(uy), vl), vl);
+                    src = __riscv_vmerge(src, helper::vmv(border_value[0], vl), mask, vl);
+                }
+                return src;
+            };
+
+            typename RVV_SameLen<int, helper>::VecType ix3, iy3;
+            typename RVV_SameLen<ushort, helper>::VecType imx, imy;
+            if (s16)
+            {
+                ix3 = __riscv_vfcvt_x(mx, vl);
+                iy3 = __riscv_vfcvt_x(my, vl);
+                auto md = __riscv_vle16_v_u16m1(reinterpret_cast<const ushort*>(mapy) + i * mapy_step + j, vl);
+                imx = __riscv_vand(md, 31, vl);
+                imy = __riscv_vand(__riscv_vsrl(md, 5, vl), 31, vl);
+            }
+            else
+            {
+                auto dmx = __riscv_vfcvt_x(__riscv_vfmul(mx, 32, vl), vl);
+                auto dmy = __riscv_vfcvt_x(__riscv_vfmul(my, 32, vl), vl);
+                ix3 = __riscv_vsra(dmx, 5, vl);
+                iy3 = __riscv_vsra(dmy, 5, vl);
+                imx = __riscv_vncvt_x(__riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(dmx, 31, vl)), vl);
+                imy = __riscv_vncvt_x(__riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(dmy, 31, vl)), vl);
+            }
+
+            auto ix0 = __riscv_vsub(ix3, 3, vl), iy0 = __riscv_vsub(iy3, 3, vl);
+            auto ix1 = __riscv_vsub(ix3, 2, vl), iy1 = __riscv_vsub(iy3, 2, vl);
+            auto ix2 = __riscv_vsub(ix3, 1, vl), iy2 = __riscv_vsub(iy3, 1, vl);
+            auto ix4 = __riscv_vadd(ix3, 1, vl), iy4 = __riscv_vadd(iy3, 1, vl);
+            auto ix5 = __riscv_vadd(ix3, 2, vl), iy5 = __riscv_vadd(iy3, 2, vl);
+            auto ix6 = __riscv_vadd(ix3, 3, vl), iy6 = __riscv_vadd(iy3, 3, vl);
+            auto ix7 = __riscv_vadd(ix3, 4, vl), iy7 = __riscv_vadd(iy3, 4, vl);
+
+            typename RVV_SameLen<float, helper>::VecType c0, c1, c2, c3, c4, c5, c6, c7;
+            auto intertab = [&](typename RVV_SameLen<ushort, helper>::VecType x) {
+                x = __riscv_vmul(x, sizeof(float) * 8, vl);
+                auto val = __riscv_vloxseg4ei16_v_f32m2x4(RemapTable::instance().coeffs, x, vl);
+                c0 = __riscv_vget_v_f32m2x4_f32m2(val, 0);
+                c1 = __riscv_vget_v_f32m2x4_f32m2(val, 1);
+                c2 = __riscv_vget_v_f32m2x4_f32m2(val, 2);
+                c3 = __riscv_vget_v_f32m2x4_f32m2(val, 3);
+                val = __riscv_vloxseg4ei16_v_f32m2x4(RemapTable::instance().coeffs, __riscv_vadd(x, sizeof(float) * 4, vl), vl);
+                c4 = __riscv_vget_v_f32m2x4_f32m2(val, 0);
+                c5 = __riscv_vget_v_f32m2x4_f32m2(val, 1);
+                c6 = __riscv_vget_v_f32m2x4_f32m2(val, 2);
+                c7 = __riscv_vget_v_f32m2x4_f32m2(val, 3);
+            };
+
+            if constexpr (std::is_same_v<T, uchar>)
+            {
+                int ix_buf[256] = {0};
+                int iy_buf[256] = {0};
+                ushort fx_buf[256] = {0};
+                ushort fy_buf[256] = {0};
+                RVV_SameLen<int, helper>::vstore(ix_buf, ix3, vl);
+                RVV_SameLen<int, helper>::vstore(iy_buf, iy3, vl);
+                RVV_SameLen<ushort, helper>::vstore(fx_buf, imx, vl);
+                RVV_SameLen<ushort, helper>::vstore(fy_buf, imy, vl);
+
+                const int border_value_u8 = saturate_cast<int>(border_value[0]);
+                T* dst_ptr = reinterpret_cast<T*>(dst_data + i * dst_step) + j;
+                const short* table = RemapTable::instance().coeffs_i;
+
+                for (int lane = 0; lane < vl; lane++)
+                {
+                    const short* tab = table + (fy_buf[lane] * 32 + fx_buf[lane]) * 64;
+                    const int xbase = ix_buf[lane] - 3;
+                    const int ybase = iy_buf[lane] - 3;
+                    int sum = 0;
+
+                    for (int ky = 0; ky < 8; ky++)
+                    {
+                        int sy = ybase + ky;
+                        const uchar* src_row = nullptr;
+
+                        if ((unsigned)sy < (unsigned)src_height)
+                        {
+                            src_row = src_data + sy * src_step;
+                        }
+                        else if (border_type == CV_HAL_BORDER_CONSTANT)
+                        {
+                            for (int kx = 0; kx < 8; kx++)
+                                sum += border_value_u8 * tab[ky * 8 + kx];
+                            continue;
+                        }
+                        else
+                        {
+                            sy = sy < 0 ? 0 : src_height - 1;
+                            src_row = src_data + sy * src_step;
+                        }
+
+                        for (int kx = 0; kx < 8; kx++)
+                        {
+                            int sx = xbase + kx;
+                            int pixel;
+                            if ((unsigned)sx < (unsigned)src_width)
+                                pixel = src_row[sx];
+                            else if (border_type == CV_HAL_BORDER_CONSTANT)
+                                pixel = border_value_u8;
+                            else
+                                pixel = src_row[sx < 0 ? 0 : src_width - 1];
+                            sum += pixel * tab[ky * 8 + kx];
+                        }
+                    }
+
+                    dst_ptr[lane] = saturate_cast<T>((sum + (1 << (INTER_REMAP_COEF_BITS - 1))) >> INTER_REMAP_COEF_BITS);
+                }
+            }
+            else
+            {
+                intertab(imx);
+                auto v0 = rvv<helper>::vcvt0(access(ix0, iy0), vl);
+                auto v1 = rvv<helper>::vcvt0(access(ix1, iy0), vl);
+                auto v2 = rvv<helper>::vcvt0(access(ix2, iy0), vl);
+                auto v3 = rvv<helper>::vcvt0(access(ix3, iy0), vl);
+                auto v4 = rvv<helper>::vcvt0(access(ix4, iy0), vl);
+                auto v5 = rvv<helper>::vcvt0(access(ix5, iy0), vl);
+                auto v6 = rvv<helper>::vcvt0(access(ix6, iy0), vl);
+                auto v7 = rvv<helper>::vcvt0(access(ix7, iy0), vl);
+                auto k0 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy1), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy1), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy1), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy1), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy1), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy1), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy1), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy1), vl);
+                auto k1 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy2), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy2), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy2), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy2), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy2), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy2), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy2), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy2), vl);
+                auto k2 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy3), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy3), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy3), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy3), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy3), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy3), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy3), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy3), vl);
+                auto k3 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy4), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy4), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy4), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy4), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy4), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy4), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy4), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy4), vl);
+                auto k4 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy5), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy5), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy5), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy5), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy5), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy5), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy5), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy5), vl);
+                auto k5 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy6), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy6), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy6), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy6), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy6), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy6), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy6), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy6), vl);
+                auto k6 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                v0 = rvv<helper>::vcvt0(access(ix0, iy7), vl);
+                v1 = rvv<helper>::vcvt0(access(ix1, iy7), vl);
+                v2 = rvv<helper>::vcvt0(access(ix2, iy7), vl);
+                v3 = rvv<helper>::vcvt0(access(ix3, iy7), vl);
+                v4 = rvv<helper>::vcvt0(access(ix4, iy7), vl);
+                v5 = rvv<helper>::vcvt0(access(ix5, iy7), vl);
+                v6 = rvv<helper>::vcvt0(access(ix6, iy7), vl);
+                v7 = rvv<helper>::vcvt0(access(ix7, iy7), vl);
+                auto k7 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(v0, c0, vl), v1, c1, vl), v2, c2, vl), v3, c3, vl), v4, c4, vl), v5, c5, vl), v6, c6, vl), v7, c7, vl);
+                intertab(imy);
+                k0 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(k0, c0, vl), k1, c1, vl), k2, c2, vl), k3, c3, vl), k4, c4, vl), k5, c5, vl), k6, c6, vl), k7, c7, vl);
+
+                helper::vstore(reinterpret_cast<T*>(dst_data + i * dst_step) + j, rvv<helper>::vcvt1(k0, vl), vl);
+            }
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
 
 template<typename helper>
 static inline int remap32fCubic(int start, int end, bool s16, const uchar *src_data, size_t src_step, int src_width, int src_height,
@@ -391,7 +676,6 @@ static inline int remap32fCubic(int start, int end, bool s16, const uchar *src_d
 
             intertab(my);
             k0 = __riscv_vfmacc(__riscv_vfmacc(__riscv_vfmacc(__riscv_vfmul(k0, c0, vl), k1, c1, vl), k2, c2, vl), k3, c3, vl);
-
             helper::vstore(reinterpret_cast<T*>(dst_data + i * dst_step) + j, rvv<helper>::vcvt1(k0, vl), vl);
         }
     }
@@ -863,7 +1147,7 @@ static inline int remap32f(int src_type, const uchar *src_data, size_t src_step,
     // remove this #ifndef in the future if possible
 #ifndef __clang__
     case CV_HAL_INTER_LANCZOS4*100 + CV_8UC1:
-        return invoke(dst_width, dst_height, {remap32fLanczos4<RVV_U8MF2, s16>}, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, mapx, mapx_step, mapy, mapy_step, interpolation, border_type, border_value);
+        return invoke(dst_width, dst_height, {remap32fLanczos4C1<RVV_U8MF2, s16>}, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, mapx, mapx_step, mapy, mapy_step, interpolation, border_type, border_value);
     // disabled since UI is fast enough
     // case CV_HAL_INTER_LANCZOS4*100 + CV_16UC1:
     //     return invoke(dst_width, dst_height, {remap32fLanczos4<RVV_U16M1, s16>}, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, mapx, mapx_step, mapy, mapy_step, interpolation, border_type, border_value);

--- a/hal/riscv-rvv/src/imgproc/warp.cpp
+++ b/hal/riscv-rvv/src/imgproc/warp.cpp
@@ -924,22 +924,27 @@ static inline int warpC1(int start, int end, const uchar *src_data, size_t src_s
             }
             else
             {
-                auto ix = __riscv_vfcvt_x(__riscv_vfmadd(mx, 1 << 10, __riscv_vfmv_v_f_f32m4(1 << 4, vl), vl), vl);
-                auto iy = __riscv_vfcvt_x(__riscv_vfmadd(my, 1 << 10, __riscv_vfmv_v_f_f32m4(1 << 4, vl), vl), vl);
-                auto ix0 = __riscv_vsra(ix, 10, vl), iy0 = __riscv_vsra(iy, 10, vl);
+                auto floor_to_int = [&](auto v)
+                {
+                    auto iv = __riscv_vfcvt_x(v, vl);
+                    auto fv = __riscv_vfcvt_f(iv, vl);
+                    return __riscv_vsub_mu(__riscv_vmfgt(fv, v, vl), iv, iv, 1, vl);
+                };
+
+                auto ix0 = floor_to_int(mx), iy0 = floor_to_int(my);
                 auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
+                auto rx = __riscv_vfsub(mx, __riscv_vfcvt_f(ix0, vl), vl);
+                auto ry = __riscv_vfsub(my, __riscv_vfcvt_f(iy0, vl), vl);
 
-                auto v0 = __riscv_vzext_vf4(access(ix0, iy0), vl);
-                auto v1 = __riscv_vzext_vf4(access(ix1, iy0), vl);
-                auto v2 = __riscv_vzext_vf4(access(ix0, iy1), vl);
-                auto v3 = __riscv_vzext_vf4(access(ix1, iy1), vl);
+                auto v0 = __riscv_vfcvt_f(__riscv_vzext_vf4(access(ix0, iy0), vl), vl);
+                auto v1 = __riscv_vfcvt_f(__riscv_vzext_vf4(access(ix1, iy0), vl), vl);
+                auto v2 = __riscv_vfcvt_f(__riscv_vzext_vf4(access(ix0, iy1), vl), vl);
+                auto v3 = __riscv_vfcvt_f(__riscv_vzext_vf4(access(ix1, iy1), vl), vl);
 
-                auto rx = __riscv_vreinterpret_v_i32m4_u32m4(__riscv_vand(__riscv_vsra(ix, 5, vl), (1 << 5) - 1, vl));
-                auto ry = __riscv_vreinterpret_v_i32m4_u32m4(__riscv_vand(__riscv_vsra(iy, 5, vl), (1 << 5) - 1, vl));
-                v0 = __riscv_vmacc(__riscv_vmul(v0, 1 << 5, vl), rx, __riscv_vsub(v1, v0, vl), vl);
-                v2 = __riscv_vmacc(__riscv_vmul(v2, 1 << 5, vl), rx, __riscv_vsub(v3, v2, vl), vl);
-                v0 = __riscv_vmacc(__riscv_vmul(v0, 1 << 5, vl), ry, __riscv_vsub(v2, v0, vl), vl);
-                __riscv_vse8(dst_data + i * dst_step + j, __riscv_vnclipu(__riscv_vnclipu(v0, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl), vl);
+                v0 = __riscv_vfmacc(v0, rx, __riscv_vfsub(v1, v0, vl), vl);
+                v2 = __riscv_vfmacc(v2, rx, __riscv_vfsub(v3, v2, vl), vl);
+                v0 = __riscv_vfmacc(v0, ry, __riscv_vfsub(v2, v0, vl), vl);
+                __riscv_vse8(dst_data + i * dst_step + j, __riscv_vnclipu(__riscv_vfncvt_xu(v0, vl), 0, __RISCV_VXRM_RNU, vl), vl);
             }
         }
     }
@@ -995,48 +1000,53 @@ static inline int warpC3(int start, int end, const uchar *src_data, size_t src_s
             }
             else
             {
-                auto ix = __riscv_vfcvt_x(__riscv_vfmadd(mx, 1 << 10, __riscv_vfmv_v_f_f32m2(1 << 4, vl), vl), vl);
-                auto iy = __riscv_vfcvt_x(__riscv_vfmadd(my, 1 << 10, __riscv_vfmv_v_f_f32m2(1 << 4, vl), vl), vl);
-                auto ix0 = __riscv_vsra(ix, 10, vl), iy0 = __riscv_vsra(iy, 10, vl);
-                auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
+                auto floor_to_int = [&](auto v)
+                {
+                    auto iv = __riscv_vfcvt_x(v, vl);
+                    auto fv = __riscv_vfcvt_f(iv, vl);
+                    return __riscv_vsub_mu(__riscv_vmfgt(fv, v, vl), iv, iv, 1, vl);
+                };
 
-                vuint32m2_t v00, v10, v20;
-                vuint32m2_t v01, v11, v21;
-                vuint32m2_t v02, v12, v22;
-                vuint32m2_t v03, v13, v23;
+                auto ix0 = floor_to_int(mx), iy0 = floor_to_int(my);
+                auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
+                auto rx = __riscv_vfsub(mx, __riscv_vfcvt_f(ix0, vl), vl);
+                auto ry = __riscv_vfsub(my, __riscv_vfcvt_f(iy0, vl), vl);
+
+                vfloat32m2_t v00, v10, v20;
+                vfloat32m2_t v01, v11, v21;
+                vfloat32m2_t v02, v12, v22;
+                vfloat32m2_t v03, v13, v23;
                 vuint8mf2_t src0, src1, src2;
                 access(ix0, iy0, src0, src1, src2);
-                v00 = __riscv_vzext_vf4(src0, vl);
-                v10 = __riscv_vzext_vf4(src1, vl);
-                v20 = __riscv_vzext_vf4(src2, vl);
+                v00 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v10 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v20 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
                 access(ix1, iy0, src0, src1, src2);
-                v01 = __riscv_vzext_vf4(src0, vl);
-                v11 = __riscv_vzext_vf4(src1, vl);
-                v21 = __riscv_vzext_vf4(src2, vl);
+                v01 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v11 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v21 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
                 access(ix0, iy1, src0, src1, src2);
-                v02 = __riscv_vzext_vf4(src0, vl);
-                v12 = __riscv_vzext_vf4(src1, vl);
-                v22 = __riscv_vzext_vf4(src2, vl);
+                v02 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v12 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v22 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
                 access(ix1, iy1, src0, src1, src2);
-                v03 = __riscv_vzext_vf4(src0, vl);
-                v13 = __riscv_vzext_vf4(src1, vl);
-                v23 = __riscv_vzext_vf4(src2, vl);
+                v03 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v13 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v23 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
 
-                auto rx = __riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(__riscv_vsra(ix, 5, vl), (1 << 5) - 1, vl));
-                auto ry = __riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(__riscv_vsra(iy, 5, vl), (1 << 5) - 1, vl));
-                v00 = __riscv_vmacc(__riscv_vmul(v00, 1 << 5, vl), rx, __riscv_vsub(v01, v00, vl), vl);
-                v02 = __riscv_vmacc(__riscv_vmul(v02, 1 << 5, vl), rx, __riscv_vsub(v03, v02, vl), vl);
-                v00 = __riscv_vmacc(__riscv_vmul(v00, 1 << 5, vl), ry, __riscv_vsub(v02, v00, vl), vl);
-                v10 = __riscv_vmacc(__riscv_vmul(v10, 1 << 5, vl), rx, __riscv_vsub(v11, v10, vl), vl);
-                v12 = __riscv_vmacc(__riscv_vmul(v12, 1 << 5, vl), rx, __riscv_vsub(v13, v12, vl), vl);
-                v10 = __riscv_vmacc(__riscv_vmul(v10, 1 << 5, vl), ry, __riscv_vsub(v12, v10, vl), vl);
-                v20 = __riscv_vmacc(__riscv_vmul(v20, 1 << 5, vl), rx, __riscv_vsub(v21, v20, vl), vl);
-                v22 = __riscv_vmacc(__riscv_vmul(v22, 1 << 5, vl), rx, __riscv_vsub(v23, v22, vl), vl);
-                v20 = __riscv_vmacc(__riscv_vmul(v20, 1 << 5, vl), ry, __riscv_vsub(v22, v20, vl), vl);
+                v00 = __riscv_vfmacc(v00, rx, __riscv_vfsub(v01, v00, vl), vl);
+                v02 = __riscv_vfmacc(v02, rx, __riscv_vfsub(v03, v02, vl), vl);
+                v00 = __riscv_vfmacc(v00, ry, __riscv_vfsub(v02, v00, vl), vl);
+                v10 = __riscv_vfmacc(v10, rx, __riscv_vfsub(v11, v10, vl), vl);
+                v12 = __riscv_vfmacc(v12, rx, __riscv_vfsub(v13, v12, vl), vl);
+                v10 = __riscv_vfmacc(v10, ry, __riscv_vfsub(v12, v10, vl), vl);
+                v20 = __riscv_vfmacc(v20, rx, __riscv_vfsub(v21, v20, vl), vl);
+                v22 = __riscv_vfmacc(v22, rx, __riscv_vfsub(v23, v22, vl), vl);
+                v20 = __riscv_vfmacc(v20, ry, __riscv_vfsub(v22, v20, vl), vl);
                 vuint8mf2x3_t dst{};
-                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 0, __riscv_vnclipu(__riscv_vnclipu(v00, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
-                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 1, __riscv_vnclipu(__riscv_vnclipu(v10, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
-                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 2, __riscv_vnclipu(__riscv_vnclipu(v20, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 0, __riscv_vnclipu(__riscv_vfncvt_xu(v00, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 1, __riscv_vnclipu(__riscv_vfncvt_xu(v10, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x3(dst, 2, __riscv_vnclipu(__riscv_vfncvt_xu(v20, vl), 0, __RISCV_VXRM_RNU, vl));
                 __riscv_vsseg3e8(dst_data + i * dst_step + j * 3, dst, vl);
             }
         }
@@ -1096,56 +1106,61 @@ static inline int warpC4(int start, int end, const uchar *src_data, size_t src_s
             }
             else
             {
-                auto ix = __riscv_vfcvt_x(__riscv_vfmadd(mx, 1 << 10, __riscv_vfmv_v_f_f32m2(1 << 4, vl), vl), vl);
-                auto iy = __riscv_vfcvt_x(__riscv_vfmadd(my, 1 << 10, __riscv_vfmv_v_f_f32m2(1 << 4, vl), vl), vl);
-                auto ix0 = __riscv_vsra(ix, 10, vl), iy0 = __riscv_vsra(iy, 10, vl);
-                auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
+                auto floor_to_int = [&](auto v)
+                {
+                    auto iv = __riscv_vfcvt_x(v, vl);
+                    auto fv = __riscv_vfcvt_f(iv, vl);
+                    return __riscv_vsub_mu(__riscv_vmfgt(fv, v, vl), iv, iv, 1, vl);
+                };
 
-                vuint32m2_t v00, v10, v20, v30;
-                vuint32m2_t v01, v11, v21, v31;
-                vuint32m2_t v02, v12, v22, v32;
-                vuint32m2_t v03, v13, v23, v33;
+                auto ix0 = floor_to_int(mx), iy0 = floor_to_int(my);
+                auto ix1 = __riscv_vadd(ix0, 1, vl), iy1 = __riscv_vadd(iy0, 1, vl);
+                auto rx = __riscv_vfsub(mx, __riscv_vfcvt_f(ix0, vl), vl);
+                auto ry = __riscv_vfsub(my, __riscv_vfcvt_f(iy0, vl), vl);
+
+                vfloat32m2_t v00, v10, v20, v30;
+                vfloat32m2_t v01, v11, v21, v31;
+                vfloat32m2_t v02, v12, v22, v32;
+                vfloat32m2_t v03, v13, v23, v33;
                 vuint8mf2_t src0, src1, src2, src3;
                 access(ix0, iy0, src0, src1, src2, src3);
-                v00 = __riscv_vzext_vf4(src0, vl);
-                v10 = __riscv_vzext_vf4(src1, vl);
-                v20 = __riscv_vzext_vf4(src2, vl);
-                v30 = __riscv_vzext_vf4(src3, vl);
+                v00 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v10 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v20 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
+                v30 = __riscv_vfcvt_f(__riscv_vzext_vf4(src3, vl), vl);
                 access(ix1, iy0, src0, src1, src2, src3);
-                v01 = __riscv_vzext_vf4(src0, vl);
-                v11 = __riscv_vzext_vf4(src1, vl);
-                v21 = __riscv_vzext_vf4(src2, vl);
-                v31 = __riscv_vzext_vf4(src3, vl);
+                v01 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v11 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v21 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
+                v31 = __riscv_vfcvt_f(__riscv_vzext_vf4(src3, vl), vl);
                 access(ix0, iy1, src0, src1, src2, src3);
-                v02 = __riscv_vzext_vf4(src0, vl);
-                v12 = __riscv_vzext_vf4(src1, vl);
-                v22 = __riscv_vzext_vf4(src2, vl);
-                v32 = __riscv_vzext_vf4(src3, vl);
+                v02 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v12 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v22 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
+                v32 = __riscv_vfcvt_f(__riscv_vzext_vf4(src3, vl), vl);
                 access(ix1, iy1, src0, src1, src2, src3);
-                v03 = __riscv_vzext_vf4(src0, vl);
-                v13 = __riscv_vzext_vf4(src1, vl);
-                v23 = __riscv_vzext_vf4(src2, vl);
-                v33 = __riscv_vzext_vf4(src3, vl);
+                v03 = __riscv_vfcvt_f(__riscv_vzext_vf4(src0, vl), vl);
+                v13 = __riscv_vfcvt_f(__riscv_vzext_vf4(src1, vl), vl);
+                v23 = __riscv_vfcvt_f(__riscv_vzext_vf4(src2, vl), vl);
+                v33 = __riscv_vfcvt_f(__riscv_vzext_vf4(src3, vl), vl);
 
-                auto rx = __riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(__riscv_vsra(ix, 5, vl), (1 << 5) - 1, vl));
-                auto ry = __riscv_vreinterpret_v_i32m2_u32m2(__riscv_vand(__riscv_vsra(iy, 5, vl), (1 << 5) - 1, vl));
-                v00 = __riscv_vmacc(__riscv_vmul(v00, 1 << 5, vl), rx, __riscv_vsub(v01, v00, vl), vl);
-                v02 = __riscv_vmacc(__riscv_vmul(v02, 1 << 5, vl), rx, __riscv_vsub(v03, v02, vl), vl);
-                v00 = __riscv_vmacc(__riscv_vmul(v00, 1 << 5, vl), ry, __riscv_vsub(v02, v00, vl), vl);
-                v10 = __riscv_vmacc(__riscv_vmul(v10, 1 << 5, vl), rx, __riscv_vsub(v11, v10, vl), vl);
-                v12 = __riscv_vmacc(__riscv_vmul(v12, 1 << 5, vl), rx, __riscv_vsub(v13, v12, vl), vl);
-                v10 = __riscv_vmacc(__riscv_vmul(v10, 1 << 5, vl), ry, __riscv_vsub(v12, v10, vl), vl);
-                v20 = __riscv_vmacc(__riscv_vmul(v20, 1 << 5, vl), rx, __riscv_vsub(v21, v20, vl), vl);
-                v22 = __riscv_vmacc(__riscv_vmul(v22, 1 << 5, vl), rx, __riscv_vsub(v23, v22, vl), vl);
-                v20 = __riscv_vmacc(__riscv_vmul(v20, 1 << 5, vl), ry, __riscv_vsub(v22, v20, vl), vl);
-                v30 = __riscv_vmacc(__riscv_vmul(v30, 1 << 5, vl), rx, __riscv_vsub(v31, v30, vl), vl);
-                v32 = __riscv_vmacc(__riscv_vmul(v32, 1 << 5, vl), rx, __riscv_vsub(v33, v32, vl), vl);
-                v30 = __riscv_vmacc(__riscv_vmul(v30, 1 << 5, vl), ry, __riscv_vsub(v32, v30, vl), vl);
+                v00 = __riscv_vfmacc(v00, rx, __riscv_vfsub(v01, v00, vl), vl);
+                v02 = __riscv_vfmacc(v02, rx, __riscv_vfsub(v03, v02, vl), vl);
+                v00 = __riscv_vfmacc(v00, ry, __riscv_vfsub(v02, v00, vl), vl);
+                v10 = __riscv_vfmacc(v10, rx, __riscv_vfsub(v11, v10, vl), vl);
+                v12 = __riscv_vfmacc(v12, rx, __riscv_vfsub(v13, v12, vl), vl);
+                v10 = __riscv_vfmacc(v10, ry, __riscv_vfsub(v12, v10, vl), vl);
+                v20 = __riscv_vfmacc(v20, rx, __riscv_vfsub(v21, v20, vl), vl);
+                v22 = __riscv_vfmacc(v22, rx, __riscv_vfsub(v23, v22, vl), vl);
+                v20 = __riscv_vfmacc(v20, ry, __riscv_vfsub(v22, v20, vl), vl);
+                v30 = __riscv_vfmacc(v30, rx, __riscv_vfsub(v31, v30, vl), vl);
+                v32 = __riscv_vfmacc(v32, rx, __riscv_vfsub(v33, v32, vl), vl);
+                v30 = __riscv_vfmacc(v30, ry, __riscv_vfsub(v32, v30, vl), vl);
                 vuint8mf2x4_t dst{};
-                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 0, __riscv_vnclipu(__riscv_vnclipu(v00, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
-                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 1, __riscv_vnclipu(__riscv_vnclipu(v10, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
-                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 2, __riscv_vnclipu(__riscv_vnclipu(v20, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
-                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 3, __riscv_vnclipu(__riscv_vnclipu(v30, 10, __RISCV_VXRM_RNU, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 0, __riscv_vnclipu(__riscv_vfncvt_xu(v00, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 1, __riscv_vnclipu(__riscv_vfncvt_xu(v10, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 2, __riscv_vnclipu(__riscv_vfncvt_xu(v20, vl), 0, __RISCV_VXRM_RNU, vl));
+                dst = __riscv_vset_v_u8mf2_u8mf2x4(dst, 3, __riscv_vnclipu(__riscv_vfncvt_xu(v30, vl), 0, __RISCV_VXRM_RNU, vl));
                 __riscv_vsseg4e8(dst_data + i * dst_step + j * 4, dst, vl);
             }
         }


### PR DESCRIPTION
**Summary**  

- Change: Fix accuracy regressions in RVV `warpAffine` 8U linear path by replacing fixed-point approximation with vectorized floating-point floor+fraction bilinear interpolation; preserve RVV vectorized path (no scalar fallback).  
- Test: `Imgproc_WarpAffine_Test.accuracy` and `Imgproc_WarpPerspective_Test.accuracy` now passes after the fix.

**Related Issue**  

Fixes: 
- #27280 
- #27281
- #27279 

**Detailed Description**  

- Problem: The prior RVV implementation used a fixed-point quantization trick (e.g., multiply by 1<<10 and extract fraction bits) which quantizes the fractional weight (≈1/32 resolution) and uses truncation semantics. This leads to small but significant pixel-value differences and test failures.
- Solution: Replace the three occurrences of the 8U `INTER_LINEAR` RVV path in warp.cpp with a vectorized float implementation that:
  - Computes integer coordinate via vectorized `floor` semantics and fractional part as `src - floor(src)`.  
  - Converts sampled `uint8` pixel vectors to `float` vectors, performs floating-point bilinear interpolation (FMA-style), then converts and clips results back to `uint8`.  
  - Adds explicit type conversions to resolve RVV intrinsic type mismatches.  

**Files Changed**  

- warp.cpp — replace 8U `INTER_LINEAR` fixed-point interpolation with float vectorized floor+fraction bilinear interpolation and add explicit conversions.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
