### PR TITLE
Removed internal structs from DNN interface to fix Obj-C/Swift bindings.

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -545,33 +545,6 @@ CV__DNN_INLINE_NS_BEGIN
         virtual void setProg(const std::vector<Ptr<Layer> >& newprog) = 0;
     };
 
-    /** @brief Single entry in a @ref PerfProfile.
-     *
-     * In DNN_PROFILE_DETAILED mode, @p label is "layer_name (type)" and @p count is 1.
-     * In DNN_PROFILE_SUMMARY mode, @p label is the layer type and @p count is the
-     * number of layers of that type that contributed to @p timeMs.
-     */
-    struct CV_EXPORTS_W_SIMPLE PerfProfileEntry
-    {
-        CV_WRAP PerfProfileEntry() : timeMs(0.0), count(0) {}
-        CV_PROP_RW String label;
-        CV_PROP_RW double timeMs;
-        CV_PROP_RW int count;
-    };
-
-    /** @brief Self-describing snapshot of profiling data from one inference.
-     *
-     * Carries the @ref ProfilingMode it was captured in so it can be saved, kept across
-     * runs (e.g. best-of-N by total time), and printed later via @ref Net::printPerfProfile
-     * without needing access to the originating @ref Net.
-     */
-    struct CV_EXPORTS_W_SIMPLE PerfProfile
-    {
-        CV_WRAP PerfProfile() : mode(DNN_PROFILE_NONE) {}
-        CV_PROP_RW ProfilingMode mode;
-        CV_PROP_RW std::vector<PerfProfileEntry> entries;
-    };
-
     /** @brief This class allows to create and manipulate comprehensive artificial neural networks.
      *
      * Neural network is presented as directed acyclic graph (DAG), where vertices are Layer instances,

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -48,6 +48,33 @@ typedef std::unordered_map<std::string, int64_t> NamesHash;
 struct OrtNamesCache;
 #endif
 
+/** @brief Single entry in a @ref PerfProfile.
+ *
+ * In DNN_PROFILE_DETAILED mode, @p label is "layer_name (type)" and @p count is 1.
+ * In DNN_PROFILE_SUMMARY mode, @p label is the layer type and @p count is the
+ * number of layers of that type that contributed to @p timeMs.
+ */
+struct PerfProfileEntry
+{
+    PerfProfileEntry() : timeMs(0.0), count(0) {}
+    String label;
+    double timeMs;
+    int count;
+};
+
+/** @brief Self-describing snapshot of profiling data from one inference.
+ *
+ * Carries the @ref ProfilingMode it was captured in so it can be saved, kept across
+ * runs (e.g. best-of-N by total time), and printed later via @ref Net::printPerfProfile
+ * without needing access to the originating @ref Net.
+ */
+struct PerfProfile
+{
+    PerfProfile() : mode(DNN_PROFILE_NONE) {}
+    ProfilingMode mode;
+    std::vector<PerfProfileEntry> entries;
+};
+
 // NB: Implementation is divided between of multiple .cpp files
 struct Net::Impl : public detail::NetImplBase
 {


### PR DESCRIPTION
Error:
```
Objective-C: Processing OpenCV modules: 12
  Traceback (most recent call last):
    File "/Users/opencv-cn/GHA-OCV-4/_work/opencv/opencv/opencv/modules/objc/generator/../generator/gen_objc.py", line 1723, in <module>
      generator.gen(srcfiles, module, dstdir, objc_base_path,
    File "/Users/opencv-cn/GHA-OCV-4/_work/opencv/opencv/opencv/modules/objc/generator/../generator/gen_objc.py", line 958, in gen
      self.gen_class(ci, self.module, extension_implementations, extension_signatures)
    File "/Users/opencv-cn/GHA-OCV-4/_work/opencv/opencv/opencv/modules/objc/generator/../generator/gen_objc.py", line 1354, in gen_class
      type_data = type_dict[pi.ctype] if pi.ctype != "uchar" else {"objc_type" : "unsigned char", "is_primitive" : True}
  KeyError: 'vector_PerfProfileEntry'
  Command PhaseScriptExecution failed with a nonzero exit code
```
Introduced in https://github.com/opencv/opencv/pull/28752

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
