### PR TITLE
RISC-V: add RVV convertScale paths for selected depth conversions

### DIFF
--- a/hal/riscv-rvv/src/core/convert_scale.cpp
+++ b/hal/riscv-rvv/src/core/convert_scale.cpp
@@ -62,6 +62,79 @@ inline int convertScale_8U32F(const uchar* src, size_t src_step, uchar* dst, siz
     return CV_HAL_ERROR_OK;
 }
 
+inline int convertScale_16U32F(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const ushort* src_row = reinterpret_cast<const ushort*>(src + i * src_step);
+        float* dst_row = reinterpret_cast<float*>(dst + i * dst_step);
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e16m4(width - j);
+            auto vec_src = __riscv_vle16_v_u16m4(src_row + j, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            __riscv_vse32_v_f32m8(dst_row + j, vec_fma, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+inline int convertScale_16S32F(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const short* src_row = reinterpret_cast<const short*>(src + i * src_step);
+        float* dst_row = reinterpret_cast<float*>(dst + i * dst_step);
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e16m4(width - j);
+            auto vec_src = __riscv_vle16_v_i16m4(src_row + j, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            __riscv_vse32_v_f32m8(dst_row + j, vec_fma, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+inline int convertScale_32F8U(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const float* src_row = reinterpret_cast<const float*>(src + i * src_step);
+        uchar* dst_row = dst + i * dst_step;
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e32m8(width - j);
+            auto vec_src = __riscv_vle32_v_f32m8(src_row + j, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src, a, vec_b, vl);
+            auto vec_dst_u16 = __riscv_vfncvt_xu(vec_fma, vl);
+            auto vec_dst = __riscv_vnclipu(vec_dst_u16, 0, __RISCV_VXRM_RNU, vl);
+            __riscv_vse8_v_u8m2(dst_row + j, vec_dst, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
 inline int convertScale_32F32F(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
 {
     int vlmax = __riscv_vsetvlmax_e32m8();
@@ -102,9 +175,25 @@ int convertScale(const uchar* src, size_t src_step, uchar* dst, size_t dst_step,
             return convertScale_8U32F(src, src_step, dst, dst_step, width, height, alpha, beta);
         }
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    case CV_16U:
+        switch (ddepth)
+        {
+        case CV_32F:
+            return convertScale_16U32F(src, src_step, dst, dst_step, width, height, alpha, beta);
+        }
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    case CV_16S:
+        switch (ddepth)
+        {
+        case CV_32F:
+            return convertScale_16S32F(src, src_step, dst, dst_step, width, height, alpha, beta);
+        }
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
     case CV_32F:
         switch (ddepth)
         {
+        case CV_8U:
+            return convertScale_32F8U(src, src_step, dst, dst_step, width, height, alpha, beta);
         case CV_32F:
             return convertScale_32F32F(src, src_step, dst, dst_step, width, height, alpha, beta);
         }

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1560,80 +1560,56 @@ OPENCV_HAL_IMPL_RVV_UNPACKS(v_float64, 64)
 #define OPENCV_HAL_IMPL_RVV_INTERLEAVED(_Tpvec, _Tp, suffix, width, hwidth, vl) \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b) \
 { \
-    vuint##width##m2x2_t seg = __riscv_vlseg2e##width##_v_u##width##m2x2( \
-        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
-    a = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 0))); \
-    b = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 1))); \
+    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
+    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
 }\
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, v_##_Tpvec& c) \
 { \
-    vuint##width##m2x3_t seg = __riscv_vlseg3e##width##_v_u##width##m2x3( \
-        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
-    a = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 0))); \
-    b = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 1))); \
-    c = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 2))); \
+    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
+    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
+    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, \
                                 v_##_Tpvec& c, v_##_Tpvec& d) \
 { \
     \
-    vuint##width##m2x4_t seg = __riscv_vlseg4e##width##_v_u##width##m2x4( \
-        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
-    a = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 0))); \
-    b = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 1))); \
-    c = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 2))); \
-    d = v_reinterpret_as_##suffix( \
-        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 3))); \
+    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
+    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
+    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
+    d = __riscv_vlse##width##_v_##suffix##m2(ptr+3, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    vuint##width##m2x2_t seg; \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 0, v_reinterpret_as_u##width(a)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 1, v_reinterpret_as_u##width(b)); \
-    __riscv_vsseg2e##width##_v_u##width##m2x2( \
-        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr, sizeof(_Tp)*2, a, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+1, sizeof(_Tp)*2, b, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    vuint##width##m2x3_t seg; \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 0, v_reinterpret_as_u##width(a)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 1, v_reinterpret_as_u##width(b)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 2, v_reinterpret_as_u##width(c)); \
-    __riscv_vsseg3e##width##_v_u##width##m2x3( \
-        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr, sizeof(_Tp)*3, a, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+1, sizeof(_Tp)*3, b, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+2, sizeof(_Tp)*3, c, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, const v_##_Tpvec& d, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED ) \
 { \
-    vuint##width##m2x4_t seg; \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 0, v_reinterpret_as_u##width(a)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 1, v_reinterpret_as_u##width(b)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 2, v_reinterpret_as_u##width(c)); \
-    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 3, v_reinterpret_as_u##width(d)); \
-    __riscv_vsseg4e##width##_v_u##width##m2x4( \
-        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr, sizeof(_Tp)*4, a, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+1, sizeof(_Tp)*4, b, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+2, sizeof(_Tp)*4, c, VTraits<v_##_Tpvec>::vlanes()); \
+    __riscv_vsse##width(ptr+3, sizeof(_Tp)*4, d, VTraits<v_##_Tpvec>::vlanes()); \
 }
 
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint8, uchar, u8, 8, 4, VTraits<v_uint8>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, s8, 8, 4, VTraits<v_int8>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, i8, 8, 4, VTraits<v_int8>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint16, ushort, u16, 16, 8, VTraits<v_uint16>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, s16, 16, 8, VTraits<v_int16>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, i16, 16, 8, VTraits<v_int16>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint32, unsigned, u32, 32, 16, VTraits<v_uint32>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, s32, 32, 16, VTraits<v_int32>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, i32, 32, 16, VTraits<v_int32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float32, float, f32, 32, 16, VTraits<v_float32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint64, uint64, u64, 64, 32, VTraits<v_uint64>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, s64, 64, 32, VTraits<v_int64>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, i64, 64, 32, VTraits<v_int64>::vlanes())
 #if CV_SIMD_SCALABLE_64F
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float64, double, f64, 64, 32, VTraits<v_float64>::vlanes())
 #endif

--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1560,56 +1560,80 @@ OPENCV_HAL_IMPL_RVV_UNPACKS(v_float64, 64)
 #define OPENCV_HAL_IMPL_RVV_INTERLEAVED(_Tpvec, _Tp, suffix, width, hwidth, vl) \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b) \
 { \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*2, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x2_t seg = __riscv_vlseg2e##width##_v_u##width##m2x2( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x2_u##width##m2(seg, 1))); \
 }\
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, v_##_Tpvec& c) \
 { \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
-    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*3, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x3_t seg = __riscv_vlseg3e##width##_v_u##width##m2x3( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 1))); \
+    c = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x3_u##width##m2(seg, 2))); \
 } \
 inline void v_load_deinterleave(const _Tp* ptr, v_##_Tpvec& a, v_##_Tpvec& b, \
                                 v_##_Tpvec& c, v_##_Tpvec& d) \
 { \
     \
-    a = __riscv_vlse##width##_v_##suffix##m2(ptr  , sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    b = __riscv_vlse##width##_v_##suffix##m2(ptr+1, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    c = __riscv_vlse##width##_v_##suffix##m2(ptr+2, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
-    d = __riscv_vlse##width##_v_##suffix##m2(ptr+3, sizeof(_Tp)*4, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x4_t seg = __riscv_vlseg4e##width##_v_u##width##m2x4( \
+        (const uint##width##_t*)ptr, VTraits<v_##_Tpvec>::vlanes()); \
+    a = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 0))); \
+    b = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 1))); \
+    c = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 2))); \
+    d = v_reinterpret_as_##suffix( \
+        v_uint##width(__riscv_vget_v_u##width##m2x4_u##width##m2(seg, 3))); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*2, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*2, b, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x2_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x2(seg, 1, v_reinterpret_as_u##width(b)); \
+    __riscv_vsseg2e##width##_v_u##width##m2x2( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, hal::StoreMode /*mode*/=hal::STORE_UNALIGNED) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*3, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*3, b, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+2, sizeof(_Tp)*3, c, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x3_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 1, v_reinterpret_as_u##width(b)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x3(seg, 2, v_reinterpret_as_u##width(c)); \
+    __riscv_vsseg3e##width##_v_u##width##m2x3( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 } \
 inline void v_store_interleave( _Tp* ptr, const v_##_Tpvec& a, const v_##_Tpvec& b, \
                                 const v_##_Tpvec& c, const v_##_Tpvec& d, \
                                 hal::StoreMode /*mode*/=hal::STORE_UNALIGNED ) \
 { \
-    __riscv_vsse##width(ptr, sizeof(_Tp)*4, a, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+1, sizeof(_Tp)*4, b, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+2, sizeof(_Tp)*4, c, VTraits<v_##_Tpvec>::vlanes()); \
-    __riscv_vsse##width(ptr+3, sizeof(_Tp)*4, d, VTraits<v_##_Tpvec>::vlanes()); \
+    vuint##width##m2x4_t seg; \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 0, v_reinterpret_as_u##width(a)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 1, v_reinterpret_as_u##width(b)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 2, v_reinterpret_as_u##width(c)); \
+    seg = __riscv_vset_v_u##width##m2_u##width##m2x4(seg, 3, v_reinterpret_as_u##width(d)); \
+    __riscv_vsseg4e##width##_v_u##width##m2x4( \
+        (uint##width##_t*)ptr, seg, VTraits<v_##_Tpvec>::vlanes()); \
 }
 
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint8, uchar, u8, 8, 4, VTraits<v_uint8>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, i8, 8, 4, VTraits<v_int8>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int8, schar, s8, 8, 4, VTraits<v_int8>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint16, ushort, u16, 16, 8, VTraits<v_uint16>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, i16, 16, 8, VTraits<v_int16>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int16, short, s16, 16, 8, VTraits<v_int16>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint32, unsigned, u32, 32, 16, VTraits<v_uint32>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, i32, 32, 16, VTraits<v_int32>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int32, int, s32, 32, 16, VTraits<v_int32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float32, float, f32, 32, 16, VTraits<v_float32>::vlanes())
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(uint64, uint64, u64, 64, 32, VTraits<v_uint64>::vlanes())
-OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, i64, 64, 32, VTraits<v_int64>::vlanes())
+OPENCV_HAL_IMPL_RVV_INTERLEAVED(int64, int64, s64, 64, 32, VTraits<v_int64>::vlanes())
 #if CV_SIMD_SCALABLE_64F
 OPENCV_HAL_IMPL_RVV_INTERLEAVED(float64, double, f64, 64, 32, VTraits<v_float64>::vlanes())
 #endif


### PR DESCRIPTION

### Summary

This PR extends the RISC-V RVV HAL `convertScale` implementation with optimized paths for selected `convertTo()` depth conversions:

- `CV_32F -> CV_8U`
- `CV_16U -> CV_32F`
- `CV_16S -> CV_32F`

The change is confined to `hal/riscv-rvv/src/core/convert_scale.cpp`. It does not modify the generic `convertTo()` implementation or affect dispatch for non-RISC-V targets.

### Rationale

`Mat::convertTo()` reaches architecture-specific implementations through the HAL `convertScale` interface. Adding these paths in the RVV HAL keeps the optimization in the existing backend layer and avoids introducing RISC-V-specific branches into common OpenCV code.

The selected conversions were chosen based on measured benefit and practical relevance. `CV_32F -> CV_8U` provides the largest speedup, while `CV_16U -> CV_32F` and `CV_16S -> CV_32F` provide consistent improvements for common image-processing data paths.

### Benchmark

Tested on Banana Pi BPI-F3, an 8-core RISC-V board with RVV 1.0 support.

Build and test configuration:

- OpenCV `4.14.0-pre`
- Release build
- RVV HAL enabled
- Compiler: `riscv64-unknown-linux-gnu-g++ 14.2.1`
- Test binary: `opencv_perf_core`
- Test filter: `*convertTo*`
- Samples: `--perf_force_samples=20 --perf_min_samples=20`

Benchmark command:

```bash
./opencv_perf_core \
  --gtest_filter=*convertTo* \
  --perf_force_samples=20 \
  --perf_min_samples=20
```

Each benchmark case was measured with 20 forced samples. The baseline/after comparison was repeated to check run-to-run stability. The optimized conversion pairs showed consistent improvements.

Second-run comparison for the optimized pairs:

```text
OPTIMIZED_PAIRS: 24 cases, gmean 2.6009x

CV_32F -> CV_8U:   16.0718x
CV_16U -> CV_32F:   1.2334x
CV_16S -> CV_32F:   1.1376x
```

`CV_32F -> CV_8U` showed the largest improvement, with speedups in the `14.5x` to `18.8x` range across the tested image sizes, channel counts, and alpha values.

### Notes on Measurement

The initial benchmark run showed noise in conversion pairs not touched by this PR, likely due to board-level variance such as frequency scaling, thermal state, or background scheduling.

A second run showed untouched pairs close to neutral:

```text
UNTOUCHED_OTHER: gmean 0.9941x
```

The optimized conversion pairs remained consistently faster across both runs, with no observed regression in the added RVV paths.



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
