### PR TITLE
Parallel Gabor kernel weights computing

### DIFF
--- a/modules/imgproc/src/gabor.cpp
+++ b/modules/imgproc/src/gabor.cpp
@@ -78,18 +78,33 @@ cv::Mat cv::getGaborKernel( Size ksize, double sigma, double theta,
     double ey = -0.5/(sigma_y*sigma_y);
     double cscale = CV_PI*2/lambd;
 
-    for( int y = ymin; y <= ymax; y++ )
-        for( int x = xmin; x <= xmax; x++ )
-        {
-            double xr = x*c + y*s;
-            double yr = -x*s + y*c;
+    int rows = kernel.rows;
+    int cols = kernel.cols;
 
-            double v = scale*std::exp(ex*xr*xr + ey*yr*yr)*cos(cscale*xr + psi);
-            if( ktype == CV_32F )
-                kernel.at<float>(ymax - y, xmax - x) = (float)v;
-            else
-                kernel.at<double>(ymax - y, xmax - x) = v;
+    auto compute_gabor_row = [&](const cv::Range& range) {
+        for( int row = range.start; row < range.end; row++ )
+        {
+            int y = ymax - row;
+            
+            float* ptr_f = (ktype == CV_32F) ? kernel.ptr<float>(row) : nullptr;
+            double* ptr_d = (ktype == CV_64F) ? kernel.ptr<double>(row) : nullptr;
+
+            for( int col = 0; col < cols; col++ )
+            {
+                int x = xmax - col;
+                
+                double xr = x*c + y*s;
+                double yr = -x*s + y*c;
+
+                double v = scale*std::exp(ex*xr*xr + ey*yr*yr)*cos(cscale*xr + psi);
+                
+                if( ktype == CV_32F ) ptr_f[col] = (float)v;
+                else ptr_d[col] = v;
+            }
         }
+    };
+
+    cv::parallel_for_(cv::Range(0, rows), compute_gabor_row);
 
     return kernel;
 }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

This is the parallel optimization mentioned in my last PR. The detail can be found in here: [https://github.com/opencv/opencv/pull/29059](https://github.com/opencv/opencv/pull/29059). 

Here is the performance table of the test. And in order to use the **'summary.py'**, I rewrite my extra testing script to show the better performance of parallel optimization in large workloads.

# Here is the code of testing scripe:

```cpp
#include <opencv2/opencv.hpp>
#include <opencv2/core/utility.hpp>
#include <iostream>
#include <vector>
#include <string>
#include <numeric>
#include <cmath>
#include <algorithm>

using namespace cv;
using namespace std;

struct PerfStats {
    double min_val, median, gmean, gstddev, mean, stddev;
};

PerfStats computeStats(vector<double>& times) {
    PerfStats stats;
    sort(times.begin(), times.end());
    stats.min_val = times.front();
    stats.median = times[times.size() / 2];
    
    double sum = accumulate(times.begin(), times.end(), 0.0);
    stats.mean = sum / times.size();
    
    double sq_sum = inner_product(times.begin(), times.end(), times.begin(), 0.0);
    stats.stddev = sqrt((sq_sum / times.size()) - (stats.mean * stats.mean));
    
    stats.gmean = stats.median; 
    stats.gstddev = (stats.mean > 0) ? (stats.stddev / stats.mean) : 0; 
    return stats;
}

int main() {
    vector<int> sizes = {301, 501, 1001, 5001, 10001};
    int iterations = 50; 
    
    Mat dummy = getGaborKernel(Size(127, 127), 8.0, CV_PI/4, 10.0, 0.5, 0, CV_32F);

    cout << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
    cout << "<testsuites tests=\"" << sizes.size() << "\" failures=\"0\" disabled=\"0\" errors=\"0\" timestamp=\"2026-05-19T19:53:11\" time=\"0.0\" "
         << "cv_module_name=\"imgproc\" cv_implementation=\"plain\" cv_num_threads=\"-1\" "
         << "cv_compiler=\"/usr/bin/c++ (ver 13.3.0)\" cv_parallel_framework=\"pthreads\" cv_parallel_threads=\"32\" name=\"AllTests\">\n";
    cout << "  <testsuite name=\"Image_KernelSize_GaborFilter2d\" tests=\"" << sizes.size() << "\" failures=\"0\" disabled=\"0\" errors=\"0\">\n";
    
    int case_id = 0;
    
    for (int s : sizes) {
        vector<double> times_ns(iterations);
        long long bytesOut = s * s * 4; 
        
        for (int i = 0; i < iterations; ++i) {
            TickMeter tm;
            tm.start();
            
            Mat kernel = getGaborKernel(Size(s, s), 8.0, CV_PI/4, 10.0, 0.5, 0, CV_32F);
            
            tm.stop();
            times_ns[i] = tm.getTimeMicro() * 1000.0;
        }
        
        PerfStats stats = computeStats(times_ns);
        
        cout << "    <testcase name=\"GaborFilter2d/" << case_id 
             << "\" value_param=\"(&quot;GenerateKernel&quot;, " << s 
             << ")\" status=\"run\" classname=\"Image_KernelSize_GaborFilter2d\">\n";
        cout << "<properties>\n";
        cout << "<property name=\"ocl_memory_usage\" value=\"0\"/>\n";
        cout << "<property name=\"bytesIn\" value=\"0\"/>\n"; 
        cout << "<property name=\"bytesOut\" value=\"" << bytesOut << "\"/>\n"; 
        cout << "<property name=\"term\" value=\"0\"/>\n";
        cout << "<property name=\"samples\" value=\"" << iterations << "\"/>\n";
        cout << "<property name=\"outliers\" value=\"0\"/>\n";
        cout << "<property name=\"frequency\" value=\"1000000000\"/>\n";
        cout << "<property name=\"min\" value=\"" << (long long)stats.min_val << "\"/>\n";
        cout << "<property name=\"median\" value=\"" << (long long)stats.median << "\"/>\n";
        cout << "<property name=\"gmean\" value=\"" << (long long)stats.gmean << "\"/>\n";
        cout << "<property name=\"gstddev\" value=\"" << stats.gstddev << "\"/>\n";
        cout << "<property name=\"mean\" value=\"" << (long long)stats.mean << "\"/>\n";
        cout << "<property name=\"stddev\" value=\"" << (long long)stats.stddev << "\"/>\n";
        cout << "</properties>\n";
        cout << "    </testcase>\n";
        
        case_id++;
    }
    
    cout << "  </testsuite>\n";
    cout << "</testsuites>\n";
    
    return 0;
}
```

# And the result is here: 

## opencv_perf test

Geometric mean (ms)

|Name of Test|gabor base|gabor parallel|gabor parallel vs gabor base (x-factor)|
|---|:-:|:-:|:-:|
|GaborFilter2d::Image_KernelSize::("cv/shared/pic5.png", 16)|0.930|0.966|0.96|
|GaborFilter2d::Image_KernelSize::("cv/shared/pic5.png", 32)|0.931|0.971|0.96|
|GaborFilter2d::Image_KernelSize::("cv/shared/pic5.png", 64)|1.570|1.578|0.99|
|GaborFilter2d::Image_KernelSize::("stitching/a1.png", 16)|2.811|2.917|0.96|
|GaborFilter2d::Image_KernelSize::("stitching/a1.png", 32)|2.732|2.814|0.97|
|GaborFilter2d::Image_KernelSize::("stitching/a1.png", 64)|3.800|3.871|0.98|

## extra test of large workloads

Geometric mean (ms)

|Name of Test|extra base|extra parallel|extra parallel vs extra base (x-factor)|
|---|:-:|:-:|:-:|
|GaborFilter2d::Image_KernelSize::("GenerateKernel", 301)|0.834|0.086|9.67|
|GaborFilter2d::Image_KernelSize::("GenerateKernel", 501)|2.462|0.352|6.99|
|GaborFilter2d::Image_KernelSize::("GenerateKernel", 1001)|11.794|1.679|7.03|
|GaborFilter2d::Image_KernelSize::("GenerateKernel", 5001)|231.165|33.290|6.94|
|GaborFilter2d::Image_KernelSize::("GenerateKernel", 10001)|917.924|126.383|7.26|

**Conclusion**
- From the first test, the use of parallel optimization did not result in any obvious performance degradation.
- From the second test, the use of parallel optimization leads to significant performance improvements when dealing with large data volumes (from 7.0 to 9.67, almost 10.0).