### PR TITLE
Add missing DataLayout constants in generated bindings for 5.x

### DIFF
--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -20,7 +20,13 @@
             "public" : [
                 ["SVD_MODIFY_A", 1], ["SVD_NO_UV", 2], ["SVD_FULL_UV", 4],
                 ["FILLED", -1],
-                ["REDUCE_SUM", 0], ["REDUCE_AVG", 1], ["REDUCE_MAX", 2], ["REDUCE_MIN", 3]
+                ["REDUCE_SUM", 0], ["REDUCE_AVG", 1], ["REDUCE_MAX", 2], ["REDUCE_MIN", 3],
+                ["DATA_LAYOUT_UNKNOWN", 0], ["DATA_LAYOUT_ND", 1], ["DATA_LAYOUT_NCHW", 2],
+                ["DATA_LAYOUT_NCDHW", 3], ["DATA_LAYOUT_NHWC", 4], ["DATA_LAYOUT_NDHWC", 5],
+                ["DATA_LAYOUT_PLANAR", 6], ["DATA_LAYOUT_BLOCK", 7],
+                ["DNN_LAYOUT_UNKNOWN", 0], ["DNN_LAYOUT_ND", 1], ["DNN_LAYOUT_NCHW", 2],
+                ["DNN_LAYOUT_NCDHW", 3], ["DNN_LAYOUT_NHWC", 4], ["DNN_LAYOUT_NDHWC", 5],
+                ["DNN_LAYOUT_PLANAR", 6], ["DNN_LAYOUT_BLOCK", 7]
             ]
         }
     },
@@ -165,6 +171,14 @@
             "jni_var": "Range %(n)s(%(n)s_start, %(n)s_end)",
             "suffix": "II",
             "j_import": "org.opencv.core.Range"
+        },
+        "DataLayout": {
+            "cast_from": "int",
+            "cast_to": "cv::DataLayout",
+            "j_type": "int",
+            "jn_type": "int",
+            "jni_type": "jint",
+            "suffix": "I"
         },
         "CvTermCriteria": {
             "j_type": "TermCriteria",

--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -23,10 +23,7 @@
                 ["REDUCE_SUM", 0], ["REDUCE_AVG", 1], ["REDUCE_MAX", 2], ["REDUCE_MIN", 3],
                 ["DATA_LAYOUT_UNKNOWN", 0], ["DATA_LAYOUT_ND", 1], ["DATA_LAYOUT_NCHW", 2],
                 ["DATA_LAYOUT_NCDHW", 3], ["DATA_LAYOUT_NHWC", 4], ["DATA_LAYOUT_NDHWC", 5],
-                ["DATA_LAYOUT_PLANAR", 6], ["DATA_LAYOUT_BLOCK", 7],
-                ["DNN_LAYOUT_UNKNOWN", 0], ["DNN_LAYOUT_ND", 1], ["DNN_LAYOUT_NCHW", 2],
-                ["DNN_LAYOUT_NCDHW", 3], ["DNN_LAYOUT_NHWC", 4], ["DNN_LAYOUT_NDHWC", 5],
-                ["DNN_LAYOUT_PLANAR", 6], ["DNN_LAYOUT_BLOCK", 7]
+                ["DATA_LAYOUT_PLANAR", 6], ["DATA_LAYOUT_BLOCK", 7]
             ]
         }
     },

--- a/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
+++ b/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
@@ -6,154 +6,153 @@ import java.util.List;
 import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
-import org.opencv.core.Range;
 import org.opencv.core.Scalar;
 import org.opencv.core.Size;
+import org.opencv.core.Range;
 import org.opencv.dnn.Dnn;
 import org.opencv.dnn.Image2BlobParams;
 import org.opencv.test.OpenCVTestCase;
 
 public class DnnBlobFromImageWithParamsTest extends OpenCVTestCase {
 
-    // Verifies that DATA_LAYOUT_* and DNN_LAYOUT_* constants are accessible from Core
-    // and carry the correct integer values. Exercises the missing_consts fix in
-    // modules/core/misc/java/gen_dict.json (issue #27264).
-    public void testDataLayoutConstants()
-    {
-        assertEquals(0, Core.DATA_LAYOUT_UNKNOWN);
-        assertEquals(1, Core.DATA_LAYOUT_ND);
-        assertEquals(2, Core.DATA_LAYOUT_NCHW);
-        assertEquals(3, Core.DATA_LAYOUT_NCDHW);
-        assertEquals(4, Core.DATA_LAYOUT_NHWC);
-        assertEquals(5, Core.DATA_LAYOUT_NDHWC);
-        assertEquals(6, Core.DATA_LAYOUT_PLANAR);
-        assertEquals(7, Core.DATA_LAYOUT_BLOCK);
+        // test for DATA_LAYOUT_* and DNN_LAYOUT_* access from Core
+        public void testDataLayoutConstants()
+        {
+            assertEquals(0, Core.DATA_LAYOUT_UNKNOWN);
+            assertEquals(1, Core.DATA_LAYOUT_ND);
+            assertEquals(2, Core.DATA_LAYOUT_NCHW);
+            assertEquals(3, Core.DATA_LAYOUT_NCDHW);
+            assertEquals(4, Core.DATA_LAYOUT_NHWC);
+            assertEquals(5, Core.DATA_LAYOUT_NDHWC);
+            assertEquals(6, Core.DATA_LAYOUT_PLANAR);
+            assertEquals(7, Core.DATA_LAYOUT_BLOCK);
 
-        // DNN_LAYOUT_* aliases must match the primary names
-        assertEquals(Core.DATA_LAYOUT_UNKNOWN, Core.DNN_LAYOUT_UNKNOWN);
-        assertEquals(Core.DATA_LAYOUT_ND,      Core.DNN_LAYOUT_ND);
-        assertEquals(Core.DATA_LAYOUT_NCHW,    Core.DNN_LAYOUT_NCHW);
-        assertEquals(Core.DATA_LAYOUT_NCDHW,   Core.DNN_LAYOUT_NCDHW);
-        assertEquals(Core.DATA_LAYOUT_NHWC,    Core.DNN_LAYOUT_NHWC);
-        assertEquals(Core.DATA_LAYOUT_NDHWC,   Core.DNN_LAYOUT_NDHWC);
-        assertEquals(Core.DATA_LAYOUT_PLANAR,  Core.DNN_LAYOUT_PLANAR);
-        assertEquals(Core.DATA_LAYOUT_BLOCK,   Core.DNN_LAYOUT_BLOCK);
-    }
+            assertEquals(Core.DATA_LAYOUT_UNKNOWN, Core.DNN_LAYOUT_UNKNOWN);
+            assertEquals(Core.DATA_LAYOUT_ND,      Core.DNN_LAYOUT_ND);
+            assertEquals(Core.DATA_LAYOUT_NCHW,    Core.DNN_LAYOUT_NCHW);
+            assertEquals(Core.DATA_LAYOUT_NCDHW,   Core.DNN_LAYOUT_NCDHW);
+            assertEquals(Core.DATA_LAYOUT_NHWC,    Core.DNN_LAYOUT_NHWC);
+            assertEquals(Core.DATA_LAYOUT_NDHWC,   Core.DNN_LAYOUT_NDHWC);
+            assertEquals(Core.DATA_LAYOUT_PLANAR,  Core.DNN_LAYOUT_PLANAR);
+            assertEquals(Core.DATA_LAYOUT_BLOCK,   Core.DNN_LAYOUT_BLOCK);
+        }
 
-    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_4ch/NHWC_scalar_scale
-    public void testBlobFromImageWithParamsNHWCScalarScale()
-    {
-        Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
-        Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
+        public void testBlobFromImageWithParamsNHWCScalarScale()
+        {
+            // https://github.com/opencv/opencv/issues/27264
+            Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+            Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
 
-        Image2BlobParams params = new Image2BlobParams();
-        params.set_scalefactor(scalefactor);
-        params.set_datalayout(Core.DATA_LAYOUT_NHWC);
+            Image2BlobParams params = new Image2BlobParams();
+            params.set_scalefactor(scalefactor);
+            params.set_datalayout(Core.DATA_LAYOUT_NHWC);
 
-        Mat blob = Dnn.blobFromImageWithParams(img, params); // shape [1, 10, 10, 4]
+            Mat blob = Dnn.blobFromImageWithParams(img, params); // [1, 10, 10, 4]
 
-        float[] expected = {
-            (float)(scalefactor.val[0] * 0),
-            (float)(scalefactor.val[1] * 1),
-            (float)(scalefactor.val[2] * 2),
-            (float)(scalefactor.val[3] * 3)
-        };
-
-        for (int h = 0; h < 10; h++) {
-            for (int w = 0; w < 10; w++) {
-                float[] actual = new float[4];
-                blob.get(new int[]{0, h, w, 0}, actual);
-                for (int c = 0; c < 4; c++) {
-                    assertEquals(expected[c], actual[c], 1e-5f);
+            float[] expectedValues = { (float)scalefactor.val[0] * 0, (float)scalefactor.val[1] * 1, (float)scalefactor.val[2] * 2, (float)scalefactor.val[3] * 3 }; // Target Value.
+            for (int h = 0; h < 10; h++)
+            {
+                for (int w = 0; w < 10; w++)
+                {
+                      float[] actualValues = new float[4];
+                      blob.get(new int[]{0, h, w, 0}, actualValues);
+                      for (int c = 0; c < 4; c++)
+                      {
+                          // Check equal
+                          assertEquals(expectedValues[c], actualValues[c]);
+                      }
                 }
             }
         }
-    }
 
-    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_CustomPadding/letter_box
-    public void testBlobFromImageWithParamsCustomPaddingLetterBox()
-    {
-        Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+        public void testBlobFromImageWithParamsCustomPaddingLetterBox()
+        {
+            Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
 
-        Scalar customPaddingValue = new Scalar(5, 6, 7, 8);
-        Size targetSize = new Size(20, 20);
+            // Custom padding value that you have added
+            Scalar customPaddingValue = new Scalar(5, 6, 7, 8); // Example padding value
+            Size targetSize = new Size(20, 20);
 
-        Mat targetImg = img.clone();
-        Core.copyMakeBorder(targetImg, targetImg, 0, 0,
-                (int)targetSize.width / 2, (int)targetSize.width / 2,
-                Core.BORDER_CONSTANT, customPaddingValue);
+            Mat targetImg = img.clone();
+            Core.copyMakeBorder(targetImg, targetImg, 0, 0, (int)targetSize.width / 2, (int)targetSize.width / 2, Core.BORDER_CONSTANT, customPaddingValue);
 
-        Image2BlobParams params = new Image2BlobParams();
-        params.set_size(targetSize);
-        params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
-        params.set_borderValue(customPaddingValue);
+            // Set up Image2BlobParams with your new functionality
+            Image2BlobParams params = new Image2BlobParams();
+            params.set_size(targetSize);
+            params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
+            params.set_borderValue(customPaddingValue); // Use your new feature here
 
-        Mat blob       = Dnn.blobFromImageWithParams(img, params);
-        Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
+            // Create blob with custom padding
+            Mat blob = Dnn.blobFromImageWithParams(img, params);
 
-        assertEquals(0.0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
-    }
+            // Create target blob for comparison
+            Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
 
-    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_4ch/letter_box
-    public void testBlobFromImageWithParams4chLetterBox()
-    {
-        Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
-
-        // Letterbox pads left/right with zeros; each row becomes valVec for each channel.
-        byte[] valVec = { 0,0,0,0,0, 1,1,1,1,1,1,1,1,1,1, 0,0,0,0,0 };
-        Mat rowM = new Mat(1, 20, CvType.CV_8UC1);
-        rowM.put(0, 0, valVec);
-
-        Mat[] targetChannels = new Mat[4];
-        for (int i = 0; i < 4; i++) {
-            Core.multiply(rowM, new Scalar(i), targetChannels[i] = new Mat());
+            assertEquals(0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
         }
 
-        Mat targetImg = new Mat();
-        Core.merge(Arrays.asList(targetChannels), targetImg);
-        Size targetSize = new Size(20, 20);
+        public void testBlobFromImageWithParams4chLetterBox()
+        {
+            Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
 
-        Image2BlobParams params = new Image2BlobParams();
-        params.set_size(targetSize);
-        params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
+            // Construct target mat.
+            Mat[] targetChannels = new Mat[4];
 
-        Mat blob       = Dnn.blobFromImageWithParams(img, params);
-        Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
+            // The letterbox will add zero at the left and right of output blob.
+            // After the letterbox, every row data would have same value showing as valVec.
+            byte[] valVec = { 0,0,0,0,0, 1,1,1,1,1,1,1,1,1,1, 0,0,0,0,0};
 
-        assertEquals(0.0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
-    }
+            Mat rowM = new Mat(1, 20, CvType.CV_8UC1);
+            rowM.put(0, 0, valVec);
+            for (int i = 0; i < 4; i++) {
+                Core.multiply(rowM, new Scalar(i), targetChannels[i] = new Mat());
+            }
 
-    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImagesWithParams_4ch/multi_image
-    public void testBlobFromImageWithParams4chMultiImage()
-    {
-        Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
-        Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
+            Mat targetImg = new Mat();
+            Core.merge(Arrays.asList(targetChannels), targetImg);
+            Size targetSize = new Size(20, 20);
 
-        Image2BlobParams params = new Image2BlobParams();
-        params.set_scalefactor(scalefactor);
-        params.set_datalayout(Core.DATA_LAYOUT_NHWC);
+            Image2BlobParams params = new Image2BlobParams();
+            params.set_size(targetSize);
+            params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
+            Mat blob = Dnn.blobFromImageWithParams(img, params);
+            Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize); // only convert data from uint8 to float32.
 
-        Mat img2 = new Mat();
-        Core.multiply(img, Scalar.all(2), img2);
+            assertEquals(0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
+        }
 
-        List<Mat> images = new ArrayList<>();
-        images.add(img);
-        images.add(img2);
+        // https://github.com/opencv/opencv/issues/27264
+        public void testBlobFromImageWithParams4chMultiImage()
+        {
+            Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
 
-        Mat blobs = Dnn.blobFromImagesWithParams(images, params); // shape [2, 10, 10, 4]
+            Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
 
-        Range[] ranges = new Range[4];
-        ranges[0] = new Range(0, 1);
-        ranges[1] = new Range(0, blobs.size(1));
-        ranges[2] = new Range(0, blobs.size(2));
-        ranges[3] = new Range(0, blobs.size(3));
-        Mat blob0 = blobs.submat(ranges).clone();
+            Image2BlobParams param = new Image2BlobParams();
+            param.set_scalefactor(scalefactor);
+            param.set_datalayout(Core.DATA_LAYOUT_NHWC);
 
-        ranges[0] = new Range(1, 2);
-        Mat blob1 = blobs.submat(ranges).clone();
+            List<Mat> images = new ArrayList<>();
+            images.add(img);
+            Mat img2 = new Mat();
+            Core.multiply(img, Scalar.all(2), img2);
+            images.add(img2);
 
-        // img2 = 2 * img, so blob1 must equal 2 * blob0
-        Core.multiply(blob0, Scalar.all(2), blob0);
-        assertEquals(0.0, Core.norm(blob0, blob1, Core.NORM_INF), 1e-5);
-    }
+            Mat blobs = Dnn.blobFromImagesWithParams(images, param);
+
+            Range[] ranges = new Range[4];
+            ranges[0] = new Range(0, 1);
+            ranges[1] = new Range(0, blobs.size(1));
+            ranges[2] = new Range(0, blobs.size(2));
+            ranges[3] = new Range(0, blobs.size(3));
+
+            Mat blob0 = blobs.submat(ranges).clone();
+
+            ranges[0] = new Range(1, 2);
+            Mat blob1 = blobs.submat(ranges).clone();
+
+            Core.multiply(blob0, Scalar.all(2), blob0);
+
+            assertEquals(0, Core.norm(blob0, blob1, Core.NORM_INF), EPS);
+        }
 }

--- a/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
+++ b/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
@@ -6,137 +6,154 @@ import java.util.List;
 import org.opencv.core.Core;
 import org.opencv.core.CvType;
 import org.opencv.core.Mat;
+import org.opencv.core.Range;
 import org.opencv.core.Scalar;
 import org.opencv.core.Size;
-import org.opencv.core.Range;
 import org.opencv.dnn.Dnn;
 import org.opencv.dnn.Image2BlobParams;
 import org.opencv.test.OpenCVTestCase;
 
 public class DnnBlobFromImageWithParamsTest extends OpenCVTestCase {
 
-        public void testBlobFromImageWithParamsNHWCScalarScale()
-        {
-            // https://github.com/opencv/opencv/issues/27264
-            /*
-            Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
-            Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
+    // Verifies that DATA_LAYOUT_* and DNN_LAYOUT_* constants are accessible from Core
+    // and carry the correct integer values. Exercises the missing_consts fix in
+    // modules/core/misc/java/gen_dict.json (issue #27264).
+    public void testDataLayoutConstants()
+    {
+        assertEquals(0, Core.DATA_LAYOUT_UNKNOWN);
+        assertEquals(1, Core.DATA_LAYOUT_ND);
+        assertEquals(2, Core.DATA_LAYOUT_NCHW);
+        assertEquals(3, Core.DATA_LAYOUT_NCDHW);
+        assertEquals(4, Core.DATA_LAYOUT_NHWC);
+        assertEquals(5, Core.DATA_LAYOUT_NDHWC);
+        assertEquals(6, Core.DATA_LAYOUT_PLANAR);
+        assertEquals(7, Core.DATA_LAYOUT_BLOCK);
 
-            Image2BlobParams params = new Image2BlobParams();
-            params.set_scalefactor(scalefactor);
-            params.set_datalayout(Core.DATA_LAYOUT_NHWC);
-            return;
+        // DNN_LAYOUT_* aliases must match the primary names
+        assertEquals(Core.DATA_LAYOUT_UNKNOWN, Core.DNN_LAYOUT_UNKNOWN);
+        assertEquals(Core.DATA_LAYOUT_ND,      Core.DNN_LAYOUT_ND);
+        assertEquals(Core.DATA_LAYOUT_NCHW,    Core.DNN_LAYOUT_NCHW);
+        assertEquals(Core.DATA_LAYOUT_NCDHW,   Core.DNN_LAYOUT_NCDHW);
+        assertEquals(Core.DATA_LAYOUT_NHWC,    Core.DNN_LAYOUT_NHWC);
+        assertEquals(Core.DATA_LAYOUT_NDHWC,   Core.DNN_LAYOUT_NDHWC);
+        assertEquals(Core.DATA_LAYOUT_PLANAR,  Core.DNN_LAYOUT_PLANAR);
+        assertEquals(Core.DATA_LAYOUT_BLOCK,   Core.DNN_LAYOUT_BLOCK);
+    }
 
-            Mat blob = Dnn.blobFromImageWithParams(img, params); // [1, 10, 10, 4]
+    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_4ch/NHWC_scalar_scale
+    public void testBlobFromImageWithParamsNHWCScalarScale()
+    {
+        Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+        Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
 
-            float[] expectedValues = { (float)scalefactor.val[0] * 0, (float)scalefactor.val[1] * 1, (float)scalefactor.val[2] * 2, (float)scalefactor.val[3] * 3 }; // Target Value.
-            for (int h = 0; h < 10; h++)
-            {
-                for (int w = 0; w < 10; w++)
-                {
-                      float[] actualValues = new float[4];
-                      blob.get(new int[]{0, h, w, 0}, actualValues);
-                      for (int c = 0; c < 4; c++)
-                      {
-                          // Check equal
-                          assertEquals(expectedValues[c], actualValues[c]);
-                      }
+        Image2BlobParams params = new Image2BlobParams();
+        params.set_scalefactor(scalefactor);
+        params.set_datalayout(Core.DATA_LAYOUT_NHWC);
+
+        Mat blob = Dnn.blobFromImageWithParams(img, params); // shape [1, 10, 10, 4]
+
+        float[] expected = {
+            (float)(scalefactor.val[0] * 0),
+            (float)(scalefactor.val[1] * 1),
+            (float)(scalefactor.val[2] * 2),
+            (float)(scalefactor.val[3] * 3)
+        };
+
+        for (int h = 0; h < 10; h++) {
+            for (int w = 0; w < 10; w++) {
+                float[] actual = new float[4];
+                blob.get(new int[]{0, h, w, 0}, actual);
+                for (int c = 0; c < 4; c++) {
+                    assertEquals(expected[c], actual[c], 1e-5f);
                 }
             }
-            */
+        }
+    }
+
+    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_CustomPadding/letter_box
+    public void testBlobFromImageWithParamsCustomPaddingLetterBox()
+    {
+        Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+
+        Scalar customPaddingValue = new Scalar(5, 6, 7, 8);
+        Size targetSize = new Size(20, 20);
+
+        Mat targetImg = img.clone();
+        Core.copyMakeBorder(targetImg, targetImg, 0, 0,
+                (int)targetSize.width / 2, (int)targetSize.width / 2,
+                Core.BORDER_CONSTANT, customPaddingValue);
+
+        Image2BlobParams params = new Image2BlobParams();
+        params.set_size(targetSize);
+        params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
+        params.set_borderValue(customPaddingValue);
+
+        Mat blob       = Dnn.blobFromImageWithParams(img, params);
+        Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
+
+        assertEquals(0.0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
+    }
+
+    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImageWithParams_4ch/letter_box
+    public void testBlobFromImageWithParams4chLetterBox()
+    {
+        Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+
+        // Letterbox pads left/right with zeros; each row becomes valVec for each channel.
+        byte[] valVec = { 0,0,0,0,0, 1,1,1,1,1,1,1,1,1,1, 0,0,0,0,0 };
+        Mat rowM = new Mat(1, 20, CvType.CV_8UC1);
+        rowM.put(0, 0, valVec);
+
+        Mat[] targetChannels = new Mat[4];
+        for (int i = 0; i < 4; i++) {
+            Core.multiply(rowM, new Scalar(i), targetChannels[i] = new Mat());
         }
 
-        public void testBlobFromImageWithParamsCustomPaddingLetterBox()
-        {
-            Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+        Mat targetImg = new Mat();
+        Core.merge(Arrays.asList(targetChannels), targetImg);
+        Size targetSize = new Size(20, 20);
 
-            // Custom padding value that you have added
-            Scalar customPaddingValue = new Scalar(5, 6, 7, 8); // Example padding value
-            Size targetSize = new Size(20, 20);
+        Image2BlobParams params = new Image2BlobParams();
+        params.set_size(targetSize);
+        params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
 
-            Mat targetImg = img.clone();
-            Core.copyMakeBorder(targetImg, targetImg, 0, 0, (int)targetSize.width / 2, (int)targetSize.width / 2, Core.BORDER_CONSTANT, customPaddingValue);
+        Mat blob       = Dnn.blobFromImageWithParams(img, params);
+        Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
 
-            // Set up Image2BlobParams with your new functionality
-            Image2BlobParams params = new Image2BlobParams();
-            params.set_size(targetSize);
-            params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
-            params.set_borderValue(customPaddingValue); // Use your new feature here
+        assertEquals(0.0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
+    }
 
-            // Create blob with custom padding
-            Mat blob = Dnn.blobFromImageWithParams(img, params);
+    // C++ reference: modules/dnn/test/test_misc.cpp — blobFromImagesWithParams_4ch/multi_image
+    public void testBlobFromImageWithParams4chMultiImage()
+    {
+        Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+        Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
 
-            // Create target blob for comparison
-            Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize);
+        Image2BlobParams params = new Image2BlobParams();
+        params.set_scalefactor(scalefactor);
+        params.set_datalayout(Core.DATA_LAYOUT_NHWC);
 
-            assertEquals(0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
-        }
+        Mat img2 = new Mat();
+        Core.multiply(img, Scalar.all(2), img2);
 
-        public void testBlobFromImageWithParams4chLetterBox()
-        {
-            Mat img = new Mat(40, 20, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
+        List<Mat> images = new ArrayList<>();
+        images.add(img);
+        images.add(img2);
 
-            // Construct target mat.
-            Mat[] targetChannels = new Mat[4];
+        Mat blobs = Dnn.blobFromImagesWithParams(images, params); // shape [2, 10, 10, 4]
 
-            // The letterbox will add zero at the left and right of output blob.
-            // After the letterbox, every row data would have same value showing as valVec.
-            byte[] valVec = { 0,0,0,0,0, 1,1,1,1,1,1,1,1,1,1, 0,0,0,0,0};
+        Range[] ranges = new Range[4];
+        ranges[0] = new Range(0, 1);
+        ranges[1] = new Range(0, blobs.size(1));
+        ranges[2] = new Range(0, blobs.size(2));
+        ranges[3] = new Range(0, blobs.size(3));
+        Mat blob0 = blobs.submat(ranges).clone();
 
-            Mat rowM = new Mat(1, 20, CvType.CV_8UC1);
-            rowM.put(0, 0, valVec);
-            for (int i = 0; i < 4; i++) {
-                Core.multiply(rowM, new Scalar(i), targetChannels[i] = new Mat());
-            }
+        ranges[0] = new Range(1, 2);
+        Mat blob1 = blobs.submat(ranges).clone();
 
-            Mat targetImg = new Mat();
-            Core.merge(Arrays.asList(targetChannels), targetImg);
-            Size targetSize = new Size(20, 20);
-
-            Image2BlobParams params = new Image2BlobParams();
-            params.set_size(targetSize);
-            params.set_paddingmode(Dnn.DNN_PMODE_LETTERBOX);
-            Mat blob = Dnn.blobFromImageWithParams(img, params);
-            Mat targetBlob = Dnn.blobFromImage(targetImg, 1.0, targetSize); // only convert data from uint8 to float32.
-
-            assertEquals(0, Core.norm(targetBlob, blob, Core.NORM_INF), EPS);
-        }
-
-        // https://github.com/opencv/opencv/issues/27264
-        public void testBlobFromImageWithParams4chMultiImage()
-        {
-            /*
-            Mat img = new Mat(10, 10, CvType.CV_8UC4, new Scalar(0, 1, 2, 3));
-
-            Scalar scalefactor = new Scalar(0.1, 0.2, 0.3, 0.4);
-
-            Image2BlobParams param = new Image2BlobParams();
-            param.set_scalefactor(scalefactor);
-            param.set_datalayout(Core.DATA_LAYOUT_NHWC);
-            return;
-
-            List<Mat> images = new ArrayList<>();
-            images.add(img);
-            Mat img2 = new Mat();
-            Core.multiply(img, Scalar.all(2), img2);
-            images.add(img2);
-
-            Mat blobs = Dnn.blobFromImagesWithParams(images, param);
-
-            Range[] ranges = new Range[4];
-            ranges[0] = new Range(0, 1);
-            ranges[1] = new Range(0, blobs.size(1));
-            ranges[2] = new Range(0, blobs.size(2));
-            ranges[3] = new Range(0, blobs.size(3));
-
-            Mat blob0 = blobs.submat(ranges).clone();
-
-            ranges[0] = new Range(1, 2);
-            Mat blob1 = blobs.submat(ranges).clone();
-
-            Core.multiply(blob0, Scalar.all(2), blob0);
-
-            assertEquals(0, Core.norm(blob0, blob1, Core.NORM_INF), EPS);
-            */
-        }
+        // img2 = 2 * img, so blob1 must equal 2 * blob0
+        Core.multiply(blob0, Scalar.all(2), blob0);
+        assertEquals(0.0, Core.norm(blob0, blob1, Core.NORM_INF), 1e-5);
+    }
 }

--- a/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
+++ b/modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java
@@ -26,15 +26,6 @@ public class DnnBlobFromImageWithParamsTest extends OpenCVTestCase {
             assertEquals(5, Core.DATA_LAYOUT_NDHWC);
             assertEquals(6, Core.DATA_LAYOUT_PLANAR);
             assertEquals(7, Core.DATA_LAYOUT_BLOCK);
-
-            assertEquals(Core.DATA_LAYOUT_UNKNOWN, Core.DNN_LAYOUT_UNKNOWN);
-            assertEquals(Core.DATA_LAYOUT_ND,      Core.DNN_LAYOUT_ND);
-            assertEquals(Core.DATA_LAYOUT_NCHW,    Core.DNN_LAYOUT_NCHW);
-            assertEquals(Core.DATA_LAYOUT_NCDHW,   Core.DNN_LAYOUT_NCDHW);
-            assertEquals(Core.DATA_LAYOUT_NHWC,    Core.DNN_LAYOUT_NHWC);
-            assertEquals(Core.DATA_LAYOUT_NDHWC,   Core.DNN_LAYOUT_NDHWC);
-            assertEquals(Core.DATA_LAYOUT_PLANAR,  Core.DNN_LAYOUT_PLANAR);
-            assertEquals(Core.DATA_LAYOUT_BLOCK,   Core.DNN_LAYOUT_BLOCK);
         }
 
         public void testBlobFromImageWithParamsNHWCScalarScale()


### PR DESCRIPTION
- Added DATA_LAYOUT_* constants to missing_consts so they
  are manually injected into Core.java (same approach used for CV_8U, FILLED etc.)
- Added DataLayout entry to type_dict so the generator correctly maps
  DataLayout 

### Tests

modules/dnn/misc/java/test/DnnBlobFromImageWithParamsTest.java:

New test added:
- testDataLayoutConstants: verifies all DATA_LAYOUT_*  constants are accessible from Core
  
Pre-existing tests enabled (were commented out earlier):
- testBlobFromImageWithParamsNHWCScalarScale: verifies blobFromImageWithParams
  produces correct output with DATA_LAYOUT_NHWC and per-channel scalar scaling
- testBlobFromImageWithParams4chMultiImage: verifies blobFromImagesWithParams
  correctly handles a batch of images with DATA_LAYOUT_NHWC layout
  
  
Closes : #27264 

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake