### PR TITLE
Deprecate CUDA's convertFp16() in favor of convertTo() with CV_16F

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -1327,15 +1327,6 @@ private:
 CV_EXPORTS_W void printCudaDeviceInfo(int device);
 CV_EXPORTS_W void printShortCudaDeviceInfo(int device);
 
-/** @brief Converts an array to half precision floating number.
-
-@param _src input array.
-@param _dst output array.
-@param stream Stream for the asynchronous version.
-@sa cv::Mat::convertTo
-*/
-CV_EXPORTS void convertFp16(InputArray _src, OutputArray _dst, Stream& stream = Stream::Null());
-
 //! @} cudacore_init
 
 }} // namespace cv { namespace cuda {

--- a/modules/core/src/cuda/gpu_mat.cu
+++ b/modules/core/src/cuda/gpu_mat.cu
@@ -565,9 +565,9 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, Stream& stream) co
         {convertToNoScale<ushort, uchar>, convertToNoScale<ushort, schar>, 0, convertToNoScale<ushort, short>, convertToNoScale<ushort, int>, convertToNoScale<ushort, float>, convertToNoScale<ushort, double>, 0, 0, 0, convertToNoScale<ushort, uint64_t>, convertToNoScale<ushort, int64_t>, convertToNoScale<ushort, uint32_t>},
         {convertToNoScale<short, uchar>, convertToNoScale<short, schar>, convertToNoScale<short, ushort>, 0, convertToNoScale<short, int>, convertToNoScale<short, float>, convertToNoScale<short, double>, 0, 0, 0, convertToNoScale<short, uint64_t>, convertToNoScale<short, int64_t>, convertToNoScale<short, uint32_t>},
         {convertToNoScale<int, uchar>, convertToNoScale<int, schar>, convertToNoScale<int, ushort>, convertToNoScale<int, short>, 0, convertToNoScale<int, float>, convertToNoScale<int, double>, 0, 0, 0, convertToNoScale<int, uint64_t>, convertToNoScale<int, int64_t>, convertToNoScale<int, uint32_t>},
-        {convertToNoScale<float, uchar>, convertToNoScale<float, schar>, convertToNoScale<float, ushort>, convertToNoScale<float, short>, convertToNoScale<float, int>, 0, convertToNoScale<float, double>, 0, 0, 0, convertToNoScale<float, uint64_t>, convertToNoScale<float, int64_t>, convertToNoScale<float, uint32_t>},
+        {convertToNoScale<float, uchar>, convertToNoScale<float, schar>, convertToNoScale<float, ushort>, convertToNoScale<float, short>, convertToNoScale<float, int>, 0, convertToNoScale<float, double>, convertScaleHalf<float, short>, 0, 0, convertToNoScale<float, uint64_t>, convertToNoScale<float, int64_t>, convertToNoScale<float, uint32_t>},
         {convertToNoScale<double, uchar>, convertToNoScale<double, schar>, convertToNoScale<double, ushort>, convertToNoScale<double, short>, convertToNoScale<double, int>, convertToNoScale<double, float>, 0, 0, 0, 0, convertToNoScale<double, uint64_t>, convertToNoScale<double, int64_t>, convertToNoScale<double, uint32_t>},
-        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+        {0, 0, 0, 0, 0, convertScaleHalf<short, float>, 0, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
         {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
         {convertToNoScale<uint64_t, uchar>, convertToNoScale<uint64_t, schar>, convertToNoScale<uint64_t, ushort>, convertToNoScale<uint64_t, short>, convertToNoScale<uint64_t, int>, convertToNoScale<uint64_t, float>, convertToNoScale<uint64_t, double>, 0, 0, 0, 0, convertToNoScale<uint64_t, int64_t>, convertToNoScale<uint64_t, uint32_t>},
@@ -617,40 +617,6 @@ void cv::cuda::GpuMat::convertTo(OutputArray _dst, int rtype, double alpha, doub
     CV_Assert(func);
 
     func(src.reshape(1), dst.reshape(1), alpha, beta, stream);
-}
-
-void cv::cuda::convertFp16(InputArray _src, OutputArray _dst, Stream& stream)
-{
-    GpuMat src = _src.getGpuMat();
-    int ddepth = 0;
-
-    switch(src.depth())
-    {
-    case CV_32F:
-        ddepth = CV_16F;
-        break;
-    case CV_16F:
-        ddepth = CV_32F;
-        break;
-    default:
-        CV_Error(Error::StsUnsupportedFormat, "Unsupported input depth");
-        return;
-    }
-    int type = CV_MAKE_TYPE(CV_MAT_DEPTH(ddepth), src.channels());
-    _dst.create(src.size(), type);
-    GpuMat dst = _dst.getGpuMat();
-
-    typedef void (*func_t)(const GpuMat& src, const GpuMat& dst, Stream& stream);
-    static const func_t funcs[] =
-    {
-        0, 0, 0,
-        0, 0, convertScaleHalf<short, float>,
-        0, convertScaleHalf<float, short>, 0,
-    };
-
-    func_t func = funcs[ddepth];
-    CV_Assert(func);
-    func(src.reshape(1), dst.reshape(1), stream);
 }
 
 #endif

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -1977,7 +1977,6 @@ static void test_20279(FileStorage& fs)
         m32fc1.at<float>((int)i) = v * 0.5f;
     }
     Mat m16fc1;
-    // produces CV_16S output: convertFp16(m32fc1, m16fc1);
     m32fc1.convertTo(m16fc1, CV_16FC1);
     EXPECT_EQ(CV_16FC1, m16fc1.type()) << typeToString(m16fc1.type());
     //std::cout << m16fc1 << std::endl;


### PR DESCRIPTION
openCv Contrib: https://github.com/opencv/opencv_contrib/pull/4122

### Pull Request Readiness Checklist

Resolves https://github.com/opencv/opencv/issues/24909
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
