### PR TITLE
dnn: register RandomNormalLike layer explicitly in init.cpp

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1204,6 +1204,12 @@ CV__DNN_INLINE_NS_BEGIN
         static Ptr<TopKLayer> create(const LayerParams& params);
     };
 
+    class CV_EXPORTS RandomNormalLikeLayer : public Layer
+    {
+    public:
+        static Ptr<RandomNormalLikeLayer> create(const LayerParams& params);
+    };
+
 //! @}
 //! @}
 CV__DNN_INLINE_NS_END

--- a/modules/dnn/src/init.cpp
+++ b/modules/dnn/src/init.cpp
@@ -200,6 +200,7 @@ void initializeLayerFactory()
     CV_DNN_REGISTER_LAYER_CLASS(ScatterND,      ScatterNDLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Tile,           TileLayer);
     CV_DNN_REGISTER_LAYER_CLASS(TopK,           TopKLayer);
+    CV_DNN_REGISTER_LAYER_CLASS(RandomNormalLike, RandomNormalLikeLayer);
 
     CV_DNN_REGISTER_LAYER_CLASS(Quantize,         QuantizeLayer);
     CV_DNN_REGISTER_LAYER_CLASS(Dequantize,       DequantizeLayer);

--- a/modules/dnn/src/layers/randomnormallike_layer.cpp
+++ b/modules/dnn/src/layers/randomnormallike_layer.cpp
@@ -6,12 +6,11 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
-#include <opencv2/dnn/layer.details.hpp>
 #include <cmath>
 
 namespace cv { namespace dnn {
 
-class RandomNormalLikeLayerImpl CV_FINAL : public Layer
+class RandomNormalLikeLayerImpl CV_FINAL : public RandomNormalLikeLayer
 {
 public:
     RandomNormalLikeLayerImpl(const LayerParams& params)
@@ -117,6 +116,9 @@ private:
     int depth;
 };
 
-CV_DNN_REGISTER_LAYER_CLASS_STATIC(RandomNormalLike, RandomNormalLikeLayerImpl);
+Ptr<RandomNormalLikeLayer> RandomNormalLikeLayer::create(const LayerParams& params)
+{
+    return makePtr<RandomNormalLikeLayerImpl>(params);
+}
 
 }} // namespace cv::dnn


### PR DESCRIPTION
Fixes #29072. The RandomNormalLike layer was registered via CV_DNN_REGISTER_LAYER_CLASS_STATIC at file scope, so in static builds (BUILD_SHARED_LIBS=OFF as in the reporter setup) the linker drops the object file and the registration never runs. This patch switches to the standard pattern used by every other DNN layer, with a declaration in all_layers.hpp, a create factory in the cpp, and an explicit CV_DNN_REGISTER_LAYER_CLASS line in init.cpp. The two failing tests pass locally against the patched build and the failure reproduces on the same binary built from main without the patch.
