### PR TITLE
Get CV_DISABLE_UBSAN to compile with older compilers

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -695,9 +695,15 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #endif
 
 #if defined(__clang__) || defined(__GNUC__)
-  #define CV_DISABLE_UBSAN __attribute__((no_sanitize("undefined")))
-#else
-  #define CV_DISABLE_UBSAN
+#  if defined(__has_attribute)
+#    if __has_attribute(no_sanitize)
+#      define CV_DISABLE_UBSAN __attribute__((no_sanitize("undefined")))
+#    endif
+#  endif
+#endif
+
+#ifndef CV_DISABLE_UBSAN
+#  define CV_DISABLE_UBSAN
 #endif
 
 /****************************************************************************************\


### PR DESCRIPTION
THis fixes what is mentioned in https://github.com/opencv/opencv/pull/28951.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
