### PR TITLE
Fixed gatherND offset calculation

### DIFF
--- a/modules/dnn/src/layers/gatherND.cpp
+++ b/modules/dnn/src/layers/gatherND.cpp
@@ -163,8 +163,16 @@ public:
                 }
 
                 if (batch_dims > 0)
-                    offset += data_strides[batch_dims - 1] * i;
-
+                {
+                    size_t rem = i;
+                    for (int d = q - 2; d >= 0; --d)
+                    {
+                        const size_t coord_d = rem % indices.size[d];
+                        rem /= indices.size[d];
+                        if (d < batch_dims)
+                            offset += coord_d * data_strides[d];
+                    }
+                }
                 // copy data from data to out
                 for (size_t j = 0; j < inner_size; ++j)
                 {

--- a/modules/dnn/src/layers/gatherND.cpp
+++ b/modules/dnn/src/layers/gatherND.cpp
@@ -151,6 +151,10 @@ public:
         const int inner_size = out.total() / outer_size;
         const int nstripes =  outer_size * inner_size / 1024;
 
+        size_t num_slices_per_batch = 1;
+        for (int d = batch_dims; d < static_cast<int>(q) - 1; ++d)
+            num_slices_per_batch *= indices.size[d];
+
         parallel_for_(Range(0, outer_size), [&](const Range& range) {
             for (size_t i = range.start; i < range.end; ++i)
             {
@@ -164,14 +168,8 @@ public:
 
                 if (batch_dims > 0)
                 {
-                    size_t rem = i;
-                    for (int d = q - 2; d >= 0; --d)
-                    {
-                        const size_t coord_d = rem % indices.size[d];
-                        rem /= indices.size[d];
-                        if (d < batch_dims)
-                            offset += coord_d * data_strides[d];
-                    }
+                    const int batch_idx = i / num_slices_per_batch;
+                    offset += (size_t)batch_idx * data_strides[batch_dims - 1];
                 }
                 // copy data from data to out
                 for (size_t j = 0; j < inner_size; ++j)


### PR DESCRIPTION
Bug fix: fixed segmentation fault when running ALIKED onnx model with ENGINE_NEW.

### Description
issue: when running ALIKED onnx model with ENGINE_NEW, segmentation fault happens during the inference.

fix: fixed the offset calculation in gatherND.cpp, so gather does not access out-of-bound memory.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

