### PR TITLE
docs_sphinx: enable dnn module

### DIFF
--- a/docs_sphinx/conf.py
+++ b/docs_sphinx/conf.py
@@ -1,0 +1,5 @@
+DOC_MODULES = [
+    m.strip()
+    for m in (_os.environ.get("OPENCV_DOC_MODULES") or "photo,imgproc,dnn").split(",")
+    if m.strip()
+] 


### PR DESCRIPTION
- [ ] `DOC_MODULES` in `opencv/docs_sphinx/conf.py` includes the new module name.
- [ ] `git diff -- opencv/doc opencv/samples` is empty.
- [ ] `cmake --build build --target sphinx` succeeds with no new warnings.
- [ ] Every tutorial page in the new module renders cleanly — no untranslated `@directive`s visible in the body.
- [ ] Front-matter table styled as the `.opencv-meta-table` card.
- [ ] All images in the module load.
- [ ] Left sidebar shows the new module nested; other modules still external `↗` links.
- [ ] Dark mode toggle still works; code blocks remain legible.
- [ ] No new build dependencies; no new CMake switches; no new files inside `opencv/doc/`.
