### PR TITLE
imgproc(hough): fix min_theta/max_theta ignored in OpenCL HoughLines path

### DIFF
--- a/modules/imgproc/src/hough.cpp
+++ b/modules/imgproc/src/hough.cpp
@@ -762,7 +762,7 @@ static bool ocl_makePointsList(InputArray _src, OutputArray _pointsList, InputOu
     return pointListKernel.run(2, globalThreads, localThreads, false);
 }
 
-static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle)
+static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_points, double rho, double theta, int numrho, int numangle, double min_theta)
 {
     UMat pointsList = _pointsList.getUMat();
     _accum.create(numangle + 2, numrho + 2, CV_32SC1);
@@ -786,7 +786,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
             return false;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, numrho, numangle, (float) min_theta);
         return fillAccumKernel.run(2, globalThreads, NULL, false);
     }
     else
@@ -798,7 +798,7 @@ static bool ocl_fillAccum(InputArray _pointsList, OutputArray _accum, int total_
         localThreads[0] = workgroup_size; localThreads[1] = 1;
         globalThreads[0] = workgroup_size; globalThreads[1] = numangle+2;
         fillAccumKernel.args(ocl::KernelArg::ReadOnlyNoSize(pointsList), ocl::KernelArg::WriteOnlyNoSize(accum),
-                        total_points, irho, (float) theta, numrho, numangle);
+                        total_points, irho, (float) theta, numrho, numangle, (float) min_theta);
         return fillAccumKernel.run(2, globalThreads, localThreads, false);
     }
 }
@@ -836,7 +836,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, min_theta))
         return false;
 
     const int pixPerWI = 8;
@@ -849,7 +849,7 @@ static bool ocl_HoughLines(InputArray _src, OutputArray _lines, double rho, doub
     UMat lines(linesMax, 1, CV_32FC2);
 
     getLinesKernel.args(ocl::KernelArg::ReadOnly(accum), ocl::KernelArg::WriteOnlyNoSize(lines),
-                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta);
+                        ocl::KernelArg::PtrWriteOnly(counters), linesMax, threshold, (float) rho, (float) theta, (float) min_theta);
 
     size_t globalThreads[2] = { ((size_t)numrho + pixPerWI - 1)/pixPerWI, (size_t)numangle };
     if (!getLinesKernel.run(2, globalThreads, NULL, false))
@@ -890,7 +890,7 @@ static bool ocl_HoughLinesP(InputArray _src, OutputArray _lines, double rho, dou
     }
 
     UMat accum;
-    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle))
+    if (!ocl_fillAccum(pointsList, accum, total_points, rho, theta, numrho, numangle, 0.0))
         return false;
 
     ocl::Kernel getLinesKernel("get_lines", ocl::imgproc::hough_lines_oclsrc,

--- a/modules/imgproc/src/opencl/hough_lines.cl
+++ b/modules/imgproc/src/opencl/hough_lines.cl
@@ -58,13 +58,13 @@ __kernel void make_point_list(__global const uchar * src_ptr, int src_step, int 
 
 __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, int list_offset,
                                 __global uchar * accum_ptr, int accum_step, int accum_offset,
-                                int total_points, float irho, float theta, int numrho, int numangle)
+                                int total_points, float irho, float theta, int numrho, int numangle, float min_theta)
 {
     int theta_idx = get_global_id(1);
     int count_idx = get_global_id(0);
     int glob_size = get_global_size(0);
     float cosVal;
-    float sinVal = sincos(theta * ((float)theta_idx), &cosVal);
+    float sinVal = sincos(min_theta + theta * ((float)theta_idx), &cosVal);
     sinVal *= irho;
     cosVal *= irho;
 
@@ -90,7 +90,7 @@ __kernel void fill_accum_global(__global const uchar * list_ptr, int list_step, 
 
 __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, int list_offset,
                                __global uchar * accum_ptr, int accum_step, int accum_offset,
-                               int total_points, float irho, float theta, int numrho, int numangle)
+                               int total_points, float irho, float theta, int numrho, int numangle, float min_theta)
 {
     int theta_idx = get_group_id(1);
     int count_idx = get_local_id(0);
@@ -99,7 +99,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
     if (theta_idx > 0 && theta_idx < numangle + 1)
     {
         float cosVal;
-        float sinVal = sincos(theta * (float) (theta_idx-1), &cosVal);
+        float sinVal = sincos(min_theta + theta * (float) (theta_idx-1), &cosVal);
         sinVal *= irho;
         cosVal *= irho;
 
@@ -139,7 +139,7 @@ __kernel void fill_accum_local(__global const uchar * list_ptr, int list_step, i
 
 __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_offset, int accum_rows, int accum_cols,
                          __global uchar * lines_ptr, int lines_step, int lines_offset, __global int* lines_index_ptr,
-                         int linesMax, int threshold, float rho, float theta)
+                         int linesMax, int threshold, float rho, float theta, float min_theta)
 {
     int x0 = get_global_id(0);
     int y = get_global_id(1);
@@ -163,7 +163,7 @@ __kernel void get_lines(__global uchar * accum_ptr, int accum_step, int accum_of
                 if (index < linesMax)
                 {
                     float radius = (x - (accum_cols - 3) / 2) * rho;
-                    float angle = y * theta;
+                    float angle = min_theta + y * theta;
 
                     lines[index] = (float2)(radius, angle);
                 }

--- a/modules/imgproc/test/ocl/test_houghlines.cpp
+++ b/modules/imgproc/test/ocl/test_houghlines.cpp
@@ -91,6 +91,46 @@ OCL_TEST_P(HoughLines, RealImage)
     Near(1e-5);
 }
 
+OCL_TEST(HoughLines, MinMaxTheta)
+{
+    Mat src(400, 400, CV_8UC1, Scalar(0));
+    line(src, Point(0, 200), Point(399, 200), Scalar::all(255), 1);
+    UMat usrc;
+    src.copyTo(usrc);
+
+    const double rho = 1.0;
+    const double theta = CV_PI / 360.0;
+    const int thresh = 100;
+    const double min_theta = CV_PI / 2 - 0.2;
+    const double max_theta = CV_PI / 2 + 0.2;
+
+    Mat dst;
+    UMat udst;
+    OCL_OFF(cv::HoughLines(src, dst, rho, theta, thresh, 0, 0, min_theta, max_theta));
+    OCL_ON(cv::HoughLines(usrc, udst, rho, theta, thresh, 0, 0, min_theta, max_theta));
+
+    ASSERT_EQ(dst.size(), udst.size());
+
+    if (dst.total() > 0)
+    {
+        Mat lines_cpu, lines_gpu;
+        dst.copyTo(lines_cpu);
+        udst.copyTo(lines_gpu);
+
+        std::sort(lines_cpu.begin<Vec2f>(), lines_cpu.end<Vec2f>(), Vec2fComparator());
+        std::sort(lines_gpu.begin<Vec2f>(), lines_gpu.end<Vec2f>(), Vec2fComparator());
+
+        EXPECT_LE(TestUtils::checkNorm2(lines_cpu, lines_gpu), 1e-5);
+
+        for (int i = 0; i < lines_cpu.rows; ++i)
+        {
+            float angle = lines_cpu.at<Vec2f>(i)[1];
+            EXPECT_GE(angle, (float)min_theta);
+            EXPECT_LE(angle, (float)max_theta);
+        }
+    }
+}
+
 OCL_TEST_P(HoughLines, GeneratedImage)
 {
     for (int j = 0; j < test_loop_times; j++)

--- a/modules/imgproc/test/test_houghlines.cpp
+++ b/modules/imgproc/test/test_houghlines.cpp
@@ -329,6 +329,25 @@ TEST(HoughLinesPointSet, regression_21029)
     EXPECT_TRUE(lines.empty());
 }
 
+TEST(HoughLines, minMaxTheta)
+{
+    Mat img(200, 200, CV_8UC1, Scalar(0));
+    line(img, Point(0, 100), Point(199, 100), Scalar(255));
+
+    const double min_theta = CV_PI / 2 - 0.2;
+    const double max_theta = CV_PI / 2 + 0.2;
+
+    std::vector<Vec2f> lines;
+    HoughLines(img, lines, 1, CV_PI / 180, 100, 0, 0, min_theta, max_theta);
+
+    ASSERT_FALSE(lines.empty());
+    for (const auto& l : lines)
+    {
+        EXPECT_GE(l[1], (float)min_theta);
+        EXPECT_LE(l[1], (float)max_theta);
+    }
+}
+
 TEST(HoughLines, regression_21983)
 {
     Mat img(200, 200, CV_8UC1, Scalar(0));


### PR DESCRIPTION
### Problem

`cv::HoughLines` with the OpenCL backend ignores `min_theta` and `max_theta` parameters. The OCL kernels `fill_accum_global`, `fill_accum_local`, and `get_lines` computed angles starting from 0 instead of `min_theta`, producing incorrect accumulator votes and wrong output angles whenever `min_theta > 0`.

Fixes #28036

### Solution

- Added `min_theta` parameter to `ocl_fillAccum` and threaded it through to both fill kernels and `getLinesKernel.args`
- Applied `min_theta` as an angle offset in all three OCL kernels
- `ocl_HoughLinesP` always uses the full `[0, π]` range and passes `0.0` explicitly

### Tests

- `HoughLines.minMaxTheta` — CPU path: asserts all detected angles lie within `[min_theta, max_theta]`
- `OCL_HoughLines.MinMaxTheta` — verifies OCL output matches CPU when `min_theta > 0`, with per-line angle range assertion

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake