### PR TITLE
Update default YuNet model to new dynamic inputs

### DIFF
--- a/modules/dnn/misc/python/test/test_dnn.py
+++ b/modules/dnn/misc/python/test/test_dnn.py
@@ -286,7 +286,7 @@ class dnn_test(NewOpenCVTests):
 
 
     def test_face_detection(self):
-        model = self.find_dnn_file('dnn/onnx/models/yunet-202303.onnx', required=False)
+        model = self.find_dnn_file('dnn/onnx/models/yunet-202605.onnx', required=False)
         img = self.get_sample('gpu/lbpcascade/er.png')
 
         ref = [[1, 339.62445, 35.32416, 30.754604, 40.202126, 0.9302596],

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -29,9 +29,8 @@ public:
     }
 
     void processNet(std::string weights, std::string proto,
-                    const std::vector<std::tuple<Mat, std::string>>& inputs, const std::string& outputLayer = "",
-                    bool weightsRequired = false){
-        weights = findDataFile(weights, weightsRequired);
+                    const std::vector<std::tuple<Mat, std::string>>& inputs, const std::string& outputLayer = ""){
+        weights = findDataFile(weights, false);
         if (!proto.empty())
             proto = findDataFile(proto);
         net = readNet(weights, proto);
@@ -80,20 +79,18 @@ public:
     }
 
     void processNet(std::string weights, std::string proto,
-                    Mat &input, const std::string& outputLayer = "",
-                    bool weightsRequired = false)
+                    Mat &input, const std::string& outputLayer = "")
     {
-        processNet(weights, proto, {std::make_tuple(input, "")}, outputLayer, weightsRequired);
+        processNet(weights, proto, {std::make_tuple(input, "")}, outputLayer);
     }
 
     void processNet(std::string weights, std::string proto,
-                    Size inpSize, const std::string& outputLayer = "",
-                    bool weightsRequired = false)
+                    Size inpSize, const std::string& outputLayer = "")
     {
         Mat input_data(inpSize, CV_32FC3);
         randu(input_data, 0.0f, 1.0f);
         Mat input = blobFromImage(input_data, 1.0, Size(), Scalar(), false);
-        processNet(weights, proto, input, outputLayer, weightsRequired);
+        processNet(weights, proto, input, outputLayer);
     }
 };
 
@@ -336,15 +333,15 @@ PERF_TEST_P_(DNNTestNetwork, EfficientNet)
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_320) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(320, 320), "", true);
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(320, 320));
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_640) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(640, 640), "", true);
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(640, 640));
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_1280) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(1280, 736), "", true);
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(1280, 736));
 }
 
 PERF_TEST_P_(DNNTestNetwork, SFace) {

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -332,8 +332,16 @@ PERF_TEST_P_(DNNTestNetwork, EfficientNet)
     processNet("dnn/efficientnet-lite4.onnx", "", inp);
 }
 
-PERF_TEST_P_(DNNTestNetwork, YuNet) {
-    processNet("dnn/onnx/models/yunet-202303.onnx", "", cv::Size(640, 640));
+PERF_TEST_P_(DNNTestNetwork, YuNet_320) {
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(320, 320));
+}
+
+PERF_TEST_P_(DNNTestNetwork, YuNet_640) {
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(640, 640));
+}
+
+PERF_TEST_P_(DNNTestNetwork, YuNet_1280) {
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(1280, 736));
 }
 
 PERF_TEST_P_(DNNTestNetwork, SFace) {

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -30,7 +30,7 @@ public:
 
     void processNet(std::string weights, std::string proto,
                     const std::vector<std::tuple<Mat, std::string>>& inputs, const std::string& outputLayer = ""){
-        weights = findDataFile(weights, false);
+        weights = findDataFile(weights);
         if (!proto.empty())
             proto = findDataFile(proto);
         net = readNet(weights, proto);

--- a/modules/dnn/perf/perf_net.cpp
+++ b/modules/dnn/perf/perf_net.cpp
@@ -29,8 +29,9 @@ public:
     }
 
     void processNet(std::string weights, std::string proto,
-                    const std::vector<std::tuple<Mat, std::string>>& inputs, const std::string& outputLayer = ""){
-        weights = findDataFile(weights);
+                    const std::vector<std::tuple<Mat, std::string>>& inputs, const std::string& outputLayer = "",
+                    bool weightsRequired = false){
+        weights = findDataFile(weights, weightsRequired);
         if (!proto.empty())
             proto = findDataFile(proto);
         net = readNet(weights, proto);
@@ -79,18 +80,20 @@ public:
     }
 
     void processNet(std::string weights, std::string proto,
-                    Mat &input, const std::string& outputLayer = "")
+                    Mat &input, const std::string& outputLayer = "",
+                    bool weightsRequired = false)
     {
-        processNet(weights, proto, {std::make_tuple(input, "")}, outputLayer);
+        processNet(weights, proto, {std::make_tuple(input, "")}, outputLayer, weightsRequired);
     }
 
     void processNet(std::string weights, std::string proto,
-                    Size inpSize, const std::string& outputLayer = "")
+                    Size inpSize, const std::string& outputLayer = "",
+                    bool weightsRequired = false)
     {
         Mat input_data(inpSize, CV_32FC3);
         randu(input_data, 0.0f, 1.0f);
         Mat input = blobFromImage(input_data, 1.0, Size(), Scalar(), false);
-        processNet(weights, proto, input, outputLayer);
+        processNet(weights, proto, input, outputLayer, weightsRequired);
     }
 };
 
@@ -333,15 +336,15 @@ PERF_TEST_P_(DNNTestNetwork, EfficientNet)
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_320) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(320, 320));
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(320, 320), "", true);
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_640) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(640, 640));
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(640, 640), "", true);
 }
 
 PERF_TEST_P_(DNNTestNetwork, YuNet_1280) {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(1280, 736));
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", cv::Size(1280, 736), "", true);
 }
 
 PERF_TEST_P_(DNNTestNetwork, SFace) {

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -395,13 +395,10 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 TEST_P(DNNTestNetwork, YuNet)
 {
     Mat img = imread(findDataFile("gpu/lbpcascade/er.png"));
-    for (const auto& sz : {Size(320, 320), Size(640, 480), Size(640, 640)})
-    {
-        Mat resized;
-        resize(img, resized, sz);
-        Mat inp = blobFromImage(resized);
-        processNet("dnn/onnx/models/yunet-202605.onnx", "", inp);
-    }
+    Mat resized;
+    resize(img, resized, Size(320, 320));
+    Mat inp = blobFromImage(resized);
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", inp);
     expectNoFallbacksFromIE(net);
 }
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -33,7 +33,7 @@ public:
         l1 = l1 ? l1 : default_l1;
         lInf = lInf ? lInf : default_lInf;
 
-        weights = findDataFile(weights, false);
+        weights = findDataFile(weights);
         if (!proto.empty())
             proto = findDataFile(proto);
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -395,9 +395,13 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 TEST_P(DNNTestNetwork, YuNet)
 {
     Mat img = imread(findDataFile("gpu/lbpcascade/er.png"));
-    resize(img, img, Size(320, 320));
-    Mat inp = blobFromImage(img);
-    processNet("dnn/onnx/models/yunet-202303.onnx", "", inp);
+    for (const auto& sz : {Size(320, 320), Size(640, 480), Size(640, 640)})
+    {
+        Mat resized;
+        resize(img, resized, sz);
+        Mat inp = blobFromImage(resized);
+        processNet("dnn/onnx/models/yunet-202605.onnx", "", inp);
+    }
     expectNoFallbacksFromIE(net);
 }
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -33,7 +33,7 @@ public:
         l1 = l1 ? l1 : default_l1;
         lInf = lInf ? lInf : default_lInf;
 
-        weights = findDataFile(weights);
+        weights = findDataFile(weights, false);
         if (!proto.empty())
             proto = findDataFile(proto);
 
@@ -394,11 +394,15 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 
 TEST_P(DNNTestNetwork, YuNet)
 {
+    checkBackend();
     Mat img = imread(findDataFile("gpu/lbpcascade/er.png"));
     Mat resized;
     resize(img, resized, Size(320, 320));
-    Mat inp = blobFromImage(resized);
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", inp);
+    net = readNet(findDataFile("dnn/onnx/models/yunet-202605.onnx"));
+    net.setInput(blobFromImage(resized));
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+    net.forward();
     expectNoFallbacksFromIE(net);
 }
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -394,15 +394,7 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 
 TEST_P(DNNTestNetwork, YuNet)
 {
-    checkBackend();
-    Mat img = imread(findDataFile("gpu/lbpcascade/er.png"));
-    Mat resized;
-    resize(img, resized, Size(320, 320));
-    net = readNet(findDataFile("dnn/onnx/models/yunet-202605.onnx"));
-    net.setInput(blobFromImage(resized));
-    net.setPreferableBackend(backend);
-    net.setPreferableTarget(target);
-    net.forward();
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", Size(320, 320));
     expectNoFallbacksFromIE(net);
 }
 

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -394,7 +394,13 @@ TEST_P(DNNTestNetwork, OpenPose_pose_mpi_faster_4_stages)
 
 TEST_P(DNNTestNetwork, YuNet)
 {
-    processNet("dnn/onnx/models/yunet-202605.onnx", "", Size(320, 320));
+    double l1 = 0.0, lInf = 0.0;
+    if (target == DNN_TARGET_CUDA_FP16 || target == DNN_TARGET_OPENCL_FP16 || target == DNN_TARGET_CPU_FP16)
+    {
+        l1 = 0.01;
+        lInf = 0.05;
+    }
+    processNet("dnn/onnx/models/yunet-202605.onnx", "", Size(320, 320), "", l1, lInf);
     expectNoFallbacksFromIE(net);
 }
 

--- a/samples/dnn/face_detect.cpp
+++ b/samples/dnn/face_detect.cpp
@@ -44,7 +44,7 @@ int main(int argc, char** argv)
         "{image2 i2         |            | Path to the input image2. When image1 and image2 parameters given then the program try to find a face on both images and runs face recognition algorithm}"
         "{video v           | 0          | Path to the input video}"
         "{scale sc          | 1.0        | Scale factor used to resize input video frames}"
-        "{fd_model fd       | face_detection_yunet_2023mar.onnx| Path to the model. Download yunet.onnx in https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet}"
+        "{fd_model fd       | face_detection_yunet_2026may.onnx| Path to the model. Download yunet.onnx in https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet}"
         "{fr_model fr       | face_recognition_sface_2021dec.onnx | Path to the face recognition model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface}"
         "{score_threshold   | 0.85       | Filter out faces of score < score_threshold}"
         "{nms_threshold     | 0.3        | Suppress bounding boxes of iou >= nms_threshold}"

--- a/samples/dnn/face_detect.py
+++ b/samples/dnn/face_detect.py
@@ -16,7 +16,7 @@ parser.add_argument('--image1', '-i1', type=str, help='Path to the input image1.
 parser.add_argument('--image2', '-i2', type=str, help='Path to the input image2. When image1 and image2 parameters given then the program try to find a face on both images and runs face recognition algorithm.')
 parser.add_argument('--video', '-v', type=str, help='Path to the input video.')
 parser.add_argument('--scale', '-sc', type=float, default=1.0, help='Scale factor used to resize input video frames.')
-parser.add_argument('--face_detection_model', '-fd', type=str, default='face_detection_yunet_2023mar.onnx', help='Path to the face detection model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet')
+parser.add_argument('--face_detection_model', '-fd', type=str, default='face_detection_yunet_2026may.onnx', help='Path to the face detection model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_detection_yunet')
 parser.add_argument('--face_recognition_model', '-fr', type=str, default='face_recognition_sface_2021dec.onnx', help='Path to the face recognition model. Download the model at https://github.com/opencv/opencv_zoo/tree/master/models/face_recognition_sface')
 parser.add_argument('--score_threshold', type=float, default=0.85, help='Filtering out faces of score < score_threshold.')
 parser.add_argument('--nms_threshold', type=float, default=0.3, help='Suppress bounding boxes of iou >= nms_threshold.')


### PR DESCRIPTION
Update the default model in `face_detect.py` and `face_detect.cpp` to
`face_detection_yunet_2026may.onnx`, which has symbolic `height`/`width` input dims.

## Changes
- `samples/dnn/face_detect.py`: update default `--face_detection_model` to `face_detection_yunet_2026may.onnx`
- `samples/dnn/face_detect.cpp`: update default `fd_model` to `face_detection_yunet_2026may.onnx`

Companion PR : 
- https://github.com/opencv/opencv_zoo/pull/310
- https://github.com/opencv/opencv_extra/pull/1373

 Closes : https://github.com/opencv/opencv/issues/28769
 
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
