### PR TITLE
ml(svm): fix UB pointer overflow in solve_generic with extreme float data

### DIFF
--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -686,7 +686,6 @@ public:
                 double old_alpha_i, old_alpha_j, alpha_i, alpha_j;
                 double delta_alpha_i, delta_alpha_j;
 
-        #ifdef _DEBUG
                 for( i = 0; i < alpha_count; i++ )
                 {
                     if( fabs(G[i]) > 1e+300 )
@@ -695,9 +694,11 @@ public:
                     if( fabs(alpha[i]) > 1e16 )
                         return false;
                 }
-        #endif
 
                 if( (this->*select_working_set_func)( i, j ) != 0 || iter++ >= max_iter )
+                    break;
+
+                if( i < 0 || j < 0 )
                     break;
 
                 Q_i = get_row( i, &buf[0][0] );

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -161,4 +161,30 @@ TEST(ML_SVM, getSupportVectors)
     EXPECT_EQ(0, sv.rows);    // inapplicable for non-linear SVMs
 }
 
+TEST(ML_SVM, nu_svc_extreme_float_no_crash)
+{
+    float fdata[] = {
+        -3.40282347e+38f, 0.0f,
+         3.08375703e+38f, 0.0f,
+         3.38958311e+38f, 0.0f,
+        -3.40053886e+38f, 0.0f,
+        -5.19229686e+33f, 0.0f,
+        -5.17201445e+33f, 0.0f,
+    };
+    int labels[] = {1, 0, 0, 0, 0, 0};
+
+    Mat features(6, 2, CV_32FC1, fdata);
+    Mat responses(6, 1, CV_32SC1, labels);
+
+    Ptr<SVM> svm = SVM::create();
+    ASSERT_TRUE(svm);
+    svm->setType(SVM::NU_SVC);
+    svm->setKernel(SVM::LINEAR);
+    svm->setNu(0.010317);
+    svm->setTermCriteria(TermCriteria(
+        TermCriteria::MAX_ITER | TermCriteria::EPS, 11, 0.099998f));
+
+    EXPECT_NO_THROW(svm->train(features, cv::ml::ROW_SAMPLE, responses));
+}
+
 }} // namespace


### PR DESCRIPTION
## Summary

Fixes a UBSan pointer arithmetic overflow in `cv::ml::SVMImpl::Solver::solve_generic` when training a `NU_SVC` SVM with training data containing near-`FLT_MAX` float values. Fix issue #29110 .

## Root Cause

Two combined flaws in `modules/ml/src/svm.cpp`:

**Flaw 1** — `select_working_set_nu_svm` can return index `-1` with return code `0`.  
The function initializes all four candidate indices to `-1`. When all gradients `G[]` are `Inf` (due to float overflow in the LINEAR kernel dot-product `~3.4e38 * ~3.4e38`), no comparison succeeds and indices remain at `-1`. The convergence check `Inf < eps` is `false`, so the function returns `0` ("not converged") with stale `-1` indices.

**Flaw 2** — `solve_generic` passes the index to `get_row` without validation.  
After the working-set selector returns, `solve_generic` calls `get_row(i, ...)` unconditionally. `get_row(-1)` calls `samples.ptr<float>(-1)`, triggering UB pointer arithmetic overflow.

The Release-build guard that would catch Inf gradients is inside `#ifdef _DEBUG` and therefore inactive in production.

## Changes

**Fix 1 (primary)** — Guard against stale `-1` indices in `solve_generic` before calling `get_row`:

```diff
+                if( i < 0 || j < 0 )
+                    break;
+
                 Q_i = get_row( i, &buf[0][0] );
```

**Fix 2 (defense-in-depth)** — Remove the `#ifdef _DEBUG` guard around the gradient/alpha overflow check so it is active in Release builds:

```diff
-        #ifdef _DEBUG
                 for( i = 0; i < alpha_count; i++ )
                 {
                     if( fabs(G[i]) > 1e+300 )
                         return false;
                     if( fabs(alpha[i]) > 1e16 )
                         return false;
                 }
-        #endif
```

## Verification

Tested with a minimal PoC using `NU_SVC` + `LINEAR` kernel on 6 samples with near-`FLT_MAX` float values, compiled with `-fsanitize=address,undefined`.  
Before fix: UBSan reports `addition of unsigned offset overflowed` in `Mat::ptr<float>(int)`.  
After fix: PoC exits cleanly with no sanitizer errors.

## Stack Trace (before fix)

```
modules/core/include/opencv2/core/mat.inl.hpp:734:24:
    runtime error: addition of unsigned offset to 0x... overflowed to 0x...
    #0  float* cv::Mat::ptr<float>(int)                     mat.inl.hpp:734
    #1  cv::ml::SVMImpl::Solver::get_row_base(int, bool*)   svm.cpp:564
    #2  cv::ml::SVMImpl::Solver::get_row(int, float*)       svm.cpp:632
    #3  cv::ml::SVMImpl::Solver::solve_generic(...)         svm.cpp:703
    #4  cv::ml::SVMImpl::Solver::solve_nu_svc(...)          svm.cpp:1072
```

Reported-by: FuzzAnything &lt;fuzzanything@gmail.com&gt;
Signed-off-by: FuzzAnything &lt;fuzzanything@gmail.com&gt;