### PR TITLE
videoio(mjpeg): fix heap-buffer-overflow in put_bits off-by-one resize guard

### DIFF
--- a/modules/videoio/src/cap_mjpeg_encoder.cpp
+++ b/modules/videoio/src/cap_mjpeg_encoder.cpp
@@ -161,7 +161,7 @@ public:
     inline void put_bits(unsigned bits, int len)
     {
         CV_Assert(len >=0 && len < 32);
-        if((m_pos == (data.size() - 1) && len > bits_free) || m_pos == data.size())
+        if((m_pos == (data.size() - 1) && len >= bits_free) || m_pos == data.size())
         {
             resize(int(2*data.size()));
         }

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -1280,4 +1280,22 @@ VideoCaptureAPIs seekable_backeinds[] = {CAP_FFMPEG, CAP_MSMF, CAP_AVFOUNDATION}
 
 INSTANTIATE_TEST_CASE_P(videoio, PreciseSeekingTest, testing::ValuesIn(seekable_backeinds), safe_capture_name_printer);
 
+// Regression test for heap-buffer-overflow in mjpeg_buffer::put_bits (GitHub issue #29112).
+// When len == bits_free the old guard used strict '>' and skipped the resize, causing
+// an out-of-bounds write after '++m_pos' advanced past data.size().
+TEST(Videoio_MJPEG, put_bits_no_heap_overflow)
+{
+    const std::string filename = cv::tempfile(".avi");
+    uint8_t pixel = 0xff;
+    cv::Mat frame(1, 1, CV_8UC1, &pixel);
+    int fourcc = cv::VideoWriter::fourcc('M', 'J', 'P', 'G');
+    {
+        cv::VideoWriter writer;
+        ASSERT_NO_THROW(writer.open(filename, CAP_OPENCV_MJPEG, fourcc, 25.0, cv::Size(1, 1), false));
+        ASSERT_TRUE(writer.isOpened());
+        EXPECT_NO_THROW(writer.write(frame));
+    }
+    remove(filename.c_str());
+}
+
 } // namespace

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -1286,8 +1286,7 @@ INSTANTIATE_TEST_CASE_P(videoio, PreciseSeekingTest, testing::ValuesIn(seekable_
 TEST(Videoio_MJPEG, put_bits_no_heap_overflow)
 {
     const std::string filename = cv::tempfile(".avi");
-    uint8_t pixel = 0xff;
-    cv::Mat frame(1, 1, CV_8UC1, &pixel);
+    cv::Mat frame(1, 1, CV_8UC1, cv::Scalar::all(255));
     int fourcc = cv::VideoWriter::fourcc('M', 'J', 'P', 'G');
     {
         cv::VideoWriter writer;


### PR DESCRIPTION
### Summary

Fix a heap-buffer-overflow (WRITE of size 4) in the built-in MJPEG encoder detected by AddressSanitizer during fuzzing.

Fixes #29112

### Root Cause

`mjpeg_buffer::put_bits` in `modules/videoio/src/cap_mjpeg_encoder.cpp` guards buffer resize with:

```cpp
if ((m_pos == (data.size() - 1) && len > bits_free) || m_pos == data.size())
    resize(int(2 * data.size()));
```

When `len == bits_free` the guard is **false** (strict `>`), so no resize happens. The subsequent code then:

1. Subtracts `len` from `bits_free`, making it exactly 0.  
2. Enters the `bits_free <= 0` branch and executes `++m_pos`.  
3. Writes `data[m_pos]` — now equal to `data[data.size()]` — **out of bounds**.

### Fix

Change `len > bits_free` to `len >= bits_free` so the buffer is grown whenever the current slot will be exactly or more than consumed.

```diff
-if ((m_pos == (data.size() - 1) && len > bits_free) || m_pos == data.size())
+if ((m_pos == (data.size() - 1) && len >= bits_free) || m_pos == data.size())
```

### Verification

Reproducer (1×1 grayscale frame, `CAP_OPENCV_MJPEG`):

```cpp
uint8_t pixel = 0xff;
cv::Mat frame(1, 1, CV_8UC1, &pixel);
int fourcc = cv::VideoWriter::fourcc('M', 'J', 'P', 'G');
cv::VideoWriter writer;
writer.open("/tmp/poc.avi", cv::CAP_OPENCV_MJPEG, fourcc, 25.0, cv::Size(1,1), false);
writer.write(frame);
```

Ran under `-fsanitize=address,undefined`; exits cleanly with no error after this fix.

### Regression Test

`TEST(Videoio_MJPEG, put_bits_no_heap_overflow)` added to `modules/videoio/test/test_video_io.cpp` — opens a `CAP_OPENCV_MJPEG` VideoWriter for a 1×1 grayscale file and writes one frame; asserts `EXPECT_NO_THROW`.
