### PR TITLE
Fix MaskedNormInf_SIMD<float, float>

### DIFF
--- a/modules/core/src/norm.simd.hpp
+++ b/modules/core/src/norm.simd.hpp
@@ -1290,7 +1290,7 @@ struct MaskedNormInf_SIMD<float, float> {
             v_float32 acc = vx_setzero_f32();
 
             for (; i <= len - vstep; i += vstep) {
-                v_uint32 m = v_reinterpret_as_u32(vx_load_expand(mask + i));
+                v_uint32 m = vx_load_expand_q(mask + i);
                 v_uint32 cmp = v_gt(m, vx_setzero_u32());
                 v_float32 s = vx_load(src + i);
                 s = v_abs(s);


### PR DESCRIPTION
Right now, the following test fails on my M4 Mac:

```bash
mkdir build
cd build
cmake ..
cmake --build . --target opencv_test_core
./bin/opencv_test_core --gtest_filter=OCL_Arithm/Norm.NORM_INF_2args_mask/40
```

This is caused by a bug in #28610. The `uchar` mask (8 bit) needs to be expanded 4 times to match `float`'s 32 bit. Not sure why this was not caught by CI.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
