### PR TITLE
gapi: optimize Fluid Select kernel using Universal Intrinsics

### DIFF
--- a/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
+++ b/modules/gapi/perf/cpu/gapi_core_perf_tests_fluid.cpp
@@ -159,7 +159,8 @@ INSTANTIATE_TEST_CASE_P(BitwiseNotPerfTestFluid, BitwiseNotPerfTest,
 INSTANTIATE_TEST_CASE_P(SelectPerfTestFluid, SelectPerfTest,
     Combine(Values(AbsExact().to_compare_f()),
             Values(szSmall128, szVGA, sz720p, sz1080p),
-            Values(CV_8UC1, CV_8UC3, CV_16UC1, CV_16SC1),
+            Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
+                   CV_16UC1, CV_16UC3, CV_16SC1, CV_16SC3),
             Values(cv::compile_args(CORE_FLUID))));
 
 INSTANTIATE_TEST_CASE_P(MinPerfTestFluid, MinPerfTest,

--- a/modules/gapi/src/backends/fluid/gfluidcore.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore.cpp
@@ -2195,63 +2195,27 @@ GAPI_FLUID_KERNEL(GFluidInRange, cv::gapi::core::GInRange, false)
 //
 //----------------------
 
-// manually vectored function for important case if RGB/BGR image
-static void run_select_row3(int width, uchar out[], uchar in1[], uchar in2[], uchar in3[])
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+
+template<typename SRC>
+static CV_ALWAYS_INLINE
+typename std::enable_if<std::is_integral<SRC>::value, int>::type
+call_select_simd(const SRC in1[], const SRC in2[], const uchar in3[],
+                 SRC out[], int width, int chan)
 {
-    int w = 0; // cycle index
+    return select_simd(in1, in2, in3, out, width, chan);
+}
 
-#if CV_SIMD128
-    for (; w <= width-16; w+=16)
-    {
-        v_uint8x16 a1, b1, c1;
-        v_uint8x16 a2, b2, c2;
-        v_uint8x16 mask;
-        v_uint8x16 a, b, c;
 
-        v_load_deinterleave(&in1[3*w], a1, b1, c1);
-        v_load_deinterleave(&in2[3*w], a2, b2, c2);
-
-        mask = v_load(&in3[w]);
-        mask = v_ne(mask, v_setzero_u8());
-
-        a = v_select(mask, a1, a2);
-        b = v_select(mask, b1, b2);
-        c = v_select(mask, c1, c2);
-
-        v_store_interleave(&out[3*w], a, b, c);
-    }
+template<typename SRC>
+static CV_ALWAYS_INLINE
+typename std::enable_if<!std::is_integral<SRC>::value, int>::type
+call_select_simd(const SRC[], const SRC[], const uchar[],
+                 SRC[], int, int)
+{
+    return 0;
+}
 #endif
-
-    for (; w < width; w++)
-    {
-        out[3*w    ] = in3[w]? in1[3*w    ]: in2[3*w    ];
-        out[3*w + 1] = in3[w]? in1[3*w + 1]: in2[3*w + 1];
-        out[3*w + 2] = in3[w]? in1[3*w + 2]: in2[3*w + 2];
-    }
-}
-
-// parameter chan is compile-time known constant, normally chan=1..4
-template<int chan, typename DST, typename SRC1, typename SRC2, typename SRC3>
-static void run_select_row(int width, DST out[], SRC1 in1[], SRC2 in2[], SRC3 in3[])
-{
-    if (std::is_same<DST,uchar>::value && chan==3)
-    {
-        // manually vectored function for important case if RGB/BGR image
-        run_select_row3(width, (uchar*)out, (uchar*)in1, (uchar*)in2, (uchar*)in3);
-        return;
-    }
-
-    // because `chan` is template parameter, its value is known at compilation time,
-    // so that modern compilers would efficiently vectorize this cycle if chan==1
-    // (if chan>1, compilers may need help with de-interleaving of the channels)
-    for (int w=0; w < width; w++)
-    {
-        for (int c=0; c < chan; c++)
-        {
-            out[w*chan + c] = in3[w]? in1[w*chan + c]: in2[w*chan + c];
-        }
-    }
-}
 
 template<typename DST, typename SRC1, typename SRC2, typename SRC3>
 static void run_select(Buffer &dst, const View &src1, const View &src2, const View &src3)
@@ -2261,7 +2225,6 @@ static void run_select(Buffer &dst, const View &src1, const View &src2, const Vi
     static_assert(std::is_same<uchar, SRC3>::value, "wrong types");
 
     auto *out = dst.OutLine<DST>();
-
     const auto *in1 = src1.InLine<SRC1>(0);
     const auto *in2 = src2.InLine<SRC2>(0);
     const auto *in3 = src3.InLine<SRC3>(0);
@@ -2269,13 +2232,18 @@ static void run_select(Buffer &dst, const View &src1, const View &src2, const Vi
     int width = dst.length();
     int chan  = dst.meta().chan;
 
-    switch (chan)
+    int w = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    w = call_select_simd(in1, in2, in3, out, width, chan);
+#endif
+
+    for (; w < width; w++)
     {
-    case 1: run_select_row<1>(width, out, in1, in2, in3); break;
-    case 2: run_select_row<2>(width, out, in1, in2, in3); break;
-    case 3: run_select_row<3>(width, out, in1, in2, in3); break;
-    case 4: run_select_row<4>(width, out, in1, in2, in3); break;
-    default: CV_Error(cv::Error::StsBadArg, "unsupported number of channels");
+        for (int c = 0; c < chan; c++)
+        {
+            out[w*chan + c] = in3[w] ? in1[w*chan + c] : in2[w*chan + c];
+        }
     }
 }
 

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.dispatch.cpp
@@ -420,8 +420,30 @@ INRANGE_SIMD(short)
 
 #undef INRANGE_SIMD
 
+//-----------------------------------
+//
+// Fluid kernels: Select
+//
+//-----------------------------------
+
+#define DISPATCH_SELECT_SIMD(SRC)                                                   \
+int select_simd(const SRC in1[], const SRC in2[], const uchar in3[],                \
+                SRC out[], const int length, const int chan)                        \
+{                                                                                   \
+    CV_CPU_DISPATCH(select_simd, (in1, in2, in3, out, length, chan),                \
+                    CV_CPU_DISPATCH_MODES_ALL);                                     \
+}
+
+DISPATCH_SELECT_SIMD(uchar)
+DISPATCH_SELECT_SIMD(ushort)
+DISPATCH_SELECT_SIMD(short)
+
+#undef DISPATCH_SELECT_SIMD
+
 } // namespace fluid
 } // namespace gapi
 } // namespace cv
+
+
 #endif // CV_SIMD
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.hpp
@@ -331,8 +331,26 @@ INRANGE_SIMD(short)
 
 #undef INRANGE_SIMD
 
+//-----------------------------------
+//
+// Fluid kernels: Select
+//
+//-----------------------------------
+#define SELECT_SIMD(SRC)                                                            \
+int select_simd(const SRC in1[], const SRC in2[], const uchar in3[],                \
+                SRC out[], const int length, const int chan);
+
+SELECT_SIMD(uchar)
+SELECT_SIMD(ushort)
+SELECT_SIMD(short)
+
+#undef SELECT_SIMD
+
 }  // namespace fluid
 }  // namespace gapi
 }  // namespace cv
+
+
+
 
 #endif // !defined(GAPI_STANDALONE)

--- a/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
+++ b/modules/gapi/src/backends/fluid/gfluidcore_func.simd.hpp
@@ -347,6 +347,18 @@ int merge4_simd(const uchar in1[], const uchar in2[], const uchar in3[],
                 const uchar in4[], uchar out[], const int width);
 
 
+
+#define DECLARE_SELECT_SIMD(SRC)                                                    \
+int select_simd(const SRC in1[], const SRC in2[], const uchar in3[],                \
+                SRC out[], const int length, const int chan);
+
+DECLARE_SELECT_SIMD(uchar)
+DECLARE_SELECT_SIMD(ushort)
+DECLARE_SELECT_SIMD(short)
+
+#undef DECLARE_SELECT_SIMD
+
+
 #ifndef CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 
 #define SRC_SHORT_OR_USHORT std::is_same<SRC, short>::value || std::is_same<SRC, ushort>::value
@@ -3378,6 +3390,163 @@ INRANGE_SIMD(ushort)
 INRANGE_SIMD(short)
 
 #undef INRANGE_SIMD
+
+//-----------------------------------
+//
+// Fluid kernels: Select
+//
+//-----------------------------------
+
+
+
+CV_ALWAYS_INLINE int select_simd_impl(const uchar in1[], const uchar in2[], const uchar in3[],
+                                      uchar out[], const int length, const int chan)
+{
+    const int nlanes = VTraits<v_uint8>::vlanes();
+    if (length < nlanes) return 0;
+
+    int x = 0;
+    for (;;)
+    {
+        for (; x <= length - nlanes; x += nlanes)
+        {
+            v_uint8 m = vx_load(&in3[x]);
+            m = v_ne(m, vx_setzero_u8());
+            if (chan == 1)
+            {
+                v_uint8 a = vx_load(&in1[x]);
+                v_uint8 b = vx_load(&in2[x]);
+                v_store(&out[x], v_select(m, a, b));
+            }
+            else if (chan == 2)
+            {
+                v_uint8 a0, a1, b0, b1;
+                v_load_deinterleave(&in1[2 * x], a0, a1);
+                v_load_deinterleave(&in2[2 * x], b0, b1);
+                v_store_interleave(&out[2 * x], v_select(m, a0, b0),
+                                                v_select(m, a1, b1));
+            }
+            else if (chan == 3)
+            {
+                v_uint8 a0, a1, a2, b0, b1, b2;
+                v_load_deinterleave(&in1[3 * x], a0, a1, a2);
+                v_load_deinterleave(&in2[3 * x], b0, b1, b2);
+                v_store_interleave(&out[3 * x], v_select(m, a0, b0),
+                                                v_select(m, a1, b1),
+                                                v_select(m, a2, b2));
+            }
+            else if (chan == 4)
+            {
+                v_uint8 a0, a1, a2, a3, b0, b1, b2, b3;
+                v_load_deinterleave(&in1[4 * x], a0, a1, a2, a3);
+                v_load_deinterleave(&in2[4 * x], b0, b1, b2, b3);
+                v_store_interleave(&out[4 * x], v_select(m, a0, b0),
+                                                v_select(m, a1, b1),
+                                                v_select(m, a2, b2),
+                                                v_select(m, a3, b3));
+            }
+        }
+
+        if (x < length) { x = length - nlanes; continue; }
+        break;
+    }
+    return x;
+}
+
+
+CV_ALWAYS_INLINE int select_simd_impl(const ushort in1[], const ushort in2[], const uchar in3[],
+                                      ushort out[], const int length, const int chan)
+{
+    const int nlanes = VTraits<v_uint16>::vlanes();
+    if (length < nlanes) return 0;
+    int x = 0;
+    for (;;)
+    {
+        for (; x <= length - nlanes; x += nlanes)
+        {
+            v_uint16 m = vx_load_expand(&in3[x]);
+            m = v_ne(m, vx_setzero_u16());
+
+            if (chan == 1) {
+                v_uint16 a = vx_load(&in1[x]);
+                v_uint16 b = vx_load(&in2[x]);
+                v_store(&out[x], v_select(m, a, b));
+            } else if (chan == 2) {
+                v_uint16 a0, a1, b0, b1;
+                v_load_deinterleave(&in1[2 * x], a0, a1);
+                v_load_deinterleave(&in2[2 * x], b0, b1);
+                v_store_interleave(&out[2 * x], v_select(m, a0, b0), v_select(m, a1, b1));
+            } else if (chan == 3) {
+                v_uint16 a0, a1, a2, b0, b1, b2;
+                v_load_deinterleave(&in1[3 * x], a0, a1, a2);
+                v_load_deinterleave(&in2[3 * x], b0, b1, b2);
+                v_store_interleave(&out[3 * x], v_select(m, a0, b0), v_select(m, a1, b1), v_select(m, a2, b2));
+            } else if (chan == 4) {
+                v_uint16 a0, a1, a2, a3, b0, b1, b2, b3;
+                v_load_deinterleave(&in1[4 * x], a0, a1, a2, a3);
+                v_load_deinterleave(&in2[4 * x], b0, b1, b2, b3);
+                v_store_interleave(&out[4 * x], v_select(m, a0, b0), v_select(m, a1, b1), v_select(m, a2, b2), v_select(m, a3, b3));
+            }
+        }
+        if (x < length) { x = length - nlanes; continue; }
+        break;
+    }
+    return x;
+}
+
+CV_ALWAYS_INLINE int select_simd_impl(const short in1[], const short in2[], const uchar in3[],
+                                      short out[], const int length, const int chan)
+{
+    const int nlanes = VTraits<v_int16>::vlanes();
+    if (length < nlanes) return 0;
+    int x = 0;
+    for (;;)
+    {
+        for (; x <= length - nlanes; x += nlanes)
+        {
+            v_int16 m = v_reinterpret_as_s16(vx_load_expand(&in3[x]));
+            m = v_ne(m, vx_setzero_s16());
+
+            if (chan == 1) {
+                v_int16 a = vx_load(&in1[x]);
+                v_int16 b = vx_load(&in2[x]);
+                v_store(&out[x], v_select(m, a, b));
+            } else if (chan == 2) {
+                v_int16 a0, a1, b0, b1;
+                v_load_deinterleave(&in1[2 * x], a0, a1);
+                v_load_deinterleave(&in2[2 * x], b0, b1);
+                v_store_interleave(&out[2 * x], v_select(m, a0, b0), v_select(m, a1, b1));
+            } else if (chan == 3) {
+                v_int16 a0, a1, a2, b0, b1, b2;
+                v_load_deinterleave(&in1[3 * x], a0, a1, a2);
+                v_load_deinterleave(&in2[3 * x], b0, b1, b2);
+                v_store_interleave(&out[3 * x], v_select(m, a0, b0), v_select(m, a1, b1), v_select(m, a2, b2));
+            } else if (chan == 4) {
+                v_int16 a0, a1, a2, a3, b0, b1, b2, b3;
+                v_load_deinterleave(&in1[4 * x], a0, a1, a2, a3);
+                v_load_deinterleave(&in2[4 * x], b0, b1, b2, b3);
+                v_store_interleave(&out[4 * x], v_select(m, a0, b0), v_select(m, a1, b1), v_select(m, a2, b2), v_select(m, a3, b3));
+            }
+        }
+        if (x < length) { x = length - nlanes; continue; }
+        break;
+    }
+    return x;
+}
+
+
+#define SELECT_SIMD(SRC)                                                            \
+int select_simd(const SRC in1[], const SRC in2[], const uchar in3[],                \
+                SRC out[], const int length, const int chan)                        \
+{                                                                                   \
+    return select_simd_impl(in1, in2, in3, out, length, chan);                      \
+}
+
+SELECT_SIMD(uchar)
+SELECT_SIMD(ushort)
+SELECT_SIMD(short)
+
+#undef SELECT_SIMD
 
 #endif  // CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 

--- a/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
+++ b/modules/gapi/test/cpu/gapi_core_tests_fluid.cpp
@@ -240,10 +240,11 @@ INSTANTIATE_TEST_CASE_P(DISABLED_CropTestFluid, CropTest,
                                 Values(cv::Rect(10, 8, 20, 35), cv::Rect(4, 10, 37, 50))));
 
 INSTANTIATE_TEST_CASE_P(SelectTestFluid, SelectTest,
-                        Combine(Values(CV_8UC3, CV_8UC1, CV_16UC1, CV_16SC1),
-                                ValuesIn(in_sizes),
-                                Values(-1),
-                                Values(CORE_FLUID)));
+                        Combine(Values(CV_8UC1, CV_8UC2, CV_8UC3, CV_8UC4,
+                                CV_16UC1, CV_16UC3, CV_16SC1, CV_16SC3),
+                        ValuesIn(in_sizes),
+                        Values(-1),
+                        Values(CORE_FLUID)));
 
 INSTANTIATE_TEST_CASE_P(Polar2CartFluid, Polar2CartTest,
                         Combine(Values(CV_32FC1),


### PR DESCRIPTION
### Problem

The G-API fluid backend's `Select` kernel lacked scalable SIMD support:
- `CV_8UC3` relied on a legacy, fixed-width `CV_SIMD128` implementation.
- All other channel and depth configurations (e.g., `CV_8UC2/4`, `CV_16UC*`, `CV_16SC*`) fell through to a scalar fallback loop. 
- The scalar loop used a ternary operator (`out = mask ? a : b`), which caused pipeline branch mispredictions and prevented compiler auto-vectorization due to channel interleaving.

### Solution

- **Universal Intrinsics API**: Implemented `select_simd()` using `CV_SIMD` / `CV_SIMD_SCALABLE`, extending hardware acceleration to all integral types (`uchar`, `ushort`, `short`) and channels (1/2/3/4).
- **Branchless Masking**: Replaced the scalar ternary conditions with `v_select` instructions to resolve branch misprediction bottlenecks.
- **Mixed-Bitwidth Handling**: Used `vx_load_expand` and `v_reinterpret_as_s16` to zero-extend the 8-bit mask to 16-bit vectors on the fly, matching the 16-bit image data width for `ushort` and `short` types without scalar degradation.
- **Dynamic Scalability**: Adopted `vlanes()` to replace the fixed 16-byte step, scaling automatically on wider architectures like AVX2/AVX-512.
- **Testing**: Added corresponding multi-channel and 16-bit test cases in `gapi_core_tests_fluid.cpp` and `gapi_core_perf_tests_fluid.cpp`.

### Performance (Local Machine, AVX2, 1920x1080)

| Type | Before (ms) | After (ms) | Speedup |
| :--- | :--- | :--- | :--- |
| `CV_8UC1`  | 0.52 | 0.19 | **2.74x** |
| `CV_8UC2`  | 1.02 | 0.54 | **1.89x** |
| `CV_8UC3`  | 1.23 | 0.78 | **1.58x** |
| `CV_8UC4`  | 2.54 | 1.10 | **2.31x** |
| `CV_16UC1` | 0.64 | 0.56 | **1.14x** |
| `CV_16UC3` | 2.58 | 1.35 | **1.91x** |
| `CV_16SC1` | 1.10 | 0.46 | **2.39x** |
| `CV_16SC3` | 2.98 | 1.39 | **2.14x** |

*(Note: Explicit `v_select` outperformed compiler auto-vectorization on C1 types, and the scalable step improved the performance over the legacy CV_SIMD128 on CV_8UC3.)*

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
