### PR TITLE
Fix pca.project() and gemm() problem

### DIFF
--- a/modules/core/src/matmul.dispatch.cpp
+++ b/modules/core/src/matmul.dispatch.cpp
@@ -59,13 +59,26 @@ namespace cv
 *                                         GEMM                                           *
 \****************************************************************************************/
 
+#if defined(HAVE_CLAMDBLAS) || defined(HAVE_OPENCL)
+static inline bool gemm_has_addend(InputArray matC, double beta)
+{
+    if (matC.kind() == cv::_InputArray::NONE)
+        return false;
+
+    if (beta == 0.0 && matC.empty())
+        return false;
+
+    return true;
+}
+#endif
+
 #ifdef HAVE_CLAMDBLAS
 
 static bool ocl_gemm_amdblas( InputArray matA, InputArray matB, double alpha,
                       InputArray matC, double beta, OutputArray matD, int flags )
 {
     int type = matA.type(), esz = CV_ELEM_SIZE(type);
-    bool haveC = matC.kind() != cv::_InputArray::NONE;
+    bool haveC = gemm_has_addend(matC, beta);
     Size sizeA = matA.size(), sizeB = matB.size(), sizeC = haveC ? matC.size() : Size(0, 0);
     bool atrans = (flags & GEMM_1_T) != 0, btrans = (flags & GEMM_2_T) != 0, ctrans = (flags & GEMM_3_T) != 0;
 
@@ -170,7 +183,7 @@ static bool ocl_gemm( InputArray matA, InputArray matB, double alpha,
     if (!doubleSupport && depth == CV_64F)
         return false;
 
-    bool haveC = matC.kind() != cv::_InputArray::NONE;
+    bool haveC = gemm_has_addend(matC, beta);
     Size sizeA = matA.size(), sizeB = matB.size(), sizeC = haveC ? matC.size() : Size(0, 0);
     bool atrans = (flags & GEMM_1_T) != 0, btrans = (flags & GEMM_2_T) != 0, ctrans = (flags & GEMM_3_T) != 0;
 

--- a/modules/core/test/ocl/test_gemm.cpp
+++ b/modules/core/test/ocl/test_gemm.cpp
@@ -53,6 +53,40 @@ namespace ocl {
 ////////////////////////////////////////////////////////////////////////////
 // GEMM
 
+namespace {
+
+static int gemmErrorCallback(int, const char*, const char*, const char*, int, void* data)
+{
+    ++*static_cast<int*>(data);
+    return 0;
+}
+
+struct GemmErrorRedirector
+{
+    explicit GemmErrorRedirector(int& errorCount)
+        : oldUserData(0),
+          oldCallback(cv::redirectError((cv::ErrorCallback)gemmErrorCallback, &errorCount, &oldUserData))
+    {
+    }
+
+    ~GemmErrorRedirector()
+    {
+        cv::redirectError(oldCallback, oldUserData);
+    }
+
+    void* oldUserData;
+    cv::ErrorCallback oldCallback;
+};
+
+static void requireOpenCL()
+{
+    cv::ocl::setUseOpenCL(true);
+    if (!cv::ocl::useOpenCL())
+        throw cvtest::SkipTestException("OpenCL is not available");
+}
+
+}
+
 PARAM_TEST_CASE(Gemm,
                 MatType,
                 bool, // GEMM_1_T
@@ -158,6 +192,83 @@ OCL_TEST(Gemm, small)
     OCL_ON(cv::gemm(A, B, 1, noArray(), 0, uC, GEMM_2_T));
 
     EXPECT_LE(cvtest::norm(C, uC, cv::NORM_INF), 1e-5);
+}
+
+OCL_TEST(Gemm, emptyMatCZeroBeta)
+{
+    Mat A(16, 12, CV_32FC1), B(12, 16, CV_32FC1);
+    randu(A, -1, 1);
+    randu(B, -1, 1);
+
+    UMat uA, uB, uD;
+    A.copyTo(uA);
+    B.copyTo(uB);
+
+    Mat ref;
+    OCL_OFF(cv::gemm(A, B, 1.0, noArray(), 0.0, ref, 0));
+
+    Mat emptyC;
+    int errorCount = 0;
+    {
+        GemmErrorRedirector redirector(errorCount);
+        requireOpenCL();
+        cv::gemm(uA, uB, 1.0, emptyC, 0.0, uD, 0);
+    }
+
+    EXPECT_EQ(0, errorCount);
+    EXPECT_LE(cvtest::norm(ref, uD, cv::NORM_INF), 1e-5);
+}
+
+OCL_TEST(Gemm, emptyMatCNonZeroBeta)
+{
+    Mat A(16, 12, CV_32FC1), B(12, 16, CV_32FC1);
+    randu(A, -1, 1);
+    randu(B, -1, 1);
+
+    UMat uA, uB, uD;
+    A.copyTo(uA);
+    B.copyTo(uB);
+
+    Mat emptyC;
+    int errorCount = 0;
+    {
+        GemmErrorRedirector redirector(errorCount);
+        requireOpenCL();
+        try
+        {
+            cv::gemm(uA, uB, 1.0, emptyC, 1.0, uD, 0);
+        }
+        catch (const cv::Exception&)
+        {
+        }
+    }
+
+    EXPECT_GT(errorCount, 0);
+}
+
+OCL_TEST(Gemm, emptyMatCZeroBetaTranspose)
+{
+    Mat A(16, 12, CV_32FC1), B(16, 12, CV_32FC1);
+    randu(A, -1, 1);
+    randu(B, -1, 1);
+
+    UMat uA, uB, uD;
+    A.copyTo(uA);
+    B.copyTo(uB);
+
+    Mat ref;
+    OCL_OFF(cv::gemm(A, B, 1.0, noArray(), 0.0, ref, GEMM_2_T));
+
+    Mat emptyC;
+    int errorCount = 0;
+    {
+        GemmErrorRedirector redirector(errorCount);
+        requireOpenCL();
+        cv::gemm(uA, uB, 1.0, emptyC, 0.0, uD, GEMM_2_T);
+    }
+
+    EXPECT_EQ(0, errorCount);
+    EXPECT_LE(cvtest::norm(ref, uD, cv::NORM_INF), 1e-5);
 }
 
 } } // namespace opencv_test::ocl


### PR DESCRIPTION
### Description

Fixes #29007.

This PR fixes an issue in `PCA::project()` when it is used with `UMat` and OpenCL enabled.

The original problem is that calling `PCA::project()` with a `UMat` output may trigger an error in the OpenCL `gemm()` path due to an unexpected input/output type mismatch.

The error reported in the issue is similar to:

```
OpenCV Error: Unspecified error
(expected: 'type == matC.type()')
'type' is CV_32FC1
'matC.type()' is CV_8UC1
in cv::ocl_gemm(...)
```

No documentation update is required because this is a bug fix and does not introduce a new public API or change documented API behavior.

The Doxygen target was also checked locally. It completed with existing documentation warnings unrelated to this patch.

### Solution

The fix updates the PCA projection path to avoid passing an empty `Mat()` placeholder into the related `gemm()` call when no optional matrix is required.

Instead, `noArray()` is used for the optional input, so the OpenCL `gemm()` implementation does not treat the placeholder as a real matrix with an incompatible type.

This affects the following core code paths:

- `modules/core/src/pca.cpp`
- `modules/core/src/matmul.dispatch.cpp`

A regression test was also added/updated for the affected GEMM/OpenCL behavior:

- `modules/core/test/ocl/test_gemm.cpp`

### Tests

Built and ran the core test suite locally.

Build command:

- `cmake --build . --target opencv_test_core -j$(nproc)`

Test data:

- `OPENCV_TEST_DATA_PATH` was set to the corresponding `opencv_extra/testdata` directory.

Test command:

- `./bin/opencv_test_core`

Result:

- All tests passed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
