### PR TITLE
ml(svm): fix UB pointer overflow in solve_generic with extreme float …

### DIFF
--- a/modules/ml/src/svm.cpp
+++ b/modules/ml/src/svm.cpp
@@ -686,7 +686,6 @@ public:
                 double old_alpha_i, old_alpha_j, alpha_i, alpha_j;
                 double delta_alpha_i, delta_alpha_j;
 
-        #ifdef _DEBUG
                 for( i = 0; i < alpha_count; i++ )
                 {
                     if( fabs(G[i]) > 1e+300 )
@@ -695,9 +694,11 @@ public:
                     if( fabs(alpha[i]) > 1e16 )
                         return false;
                 }
-        #endif
 
                 if( (this->*select_working_set_func)( i, j ) != 0 || iter++ >= max_iter )
+                    break;
+
+                if( i < 0 || j < 0 )
                     break;
 
                 Q_i = get_row( i, &buf[0][0] );

--- a/modules/ml/test/test_svmtrainauto.cpp
+++ b/modules/ml/test/test_svmtrainauto.cpp
@@ -161,4 +161,31 @@ TEST(ML_SVM, getSupportVectors)
     EXPECT_EQ(0, sv.rows);    // inapplicable for non-linear SVMs
 }
 
+// Regression test for https://github.com/opencv/opencv/issues/29110
+TEST(ML_SVM, extreme_float_no_crash_29110)
+{
+    float fdata[] = {
+        -3.40282347e+38f,  0.0f,
+         3.08375703e+38f,  0.0f,
+         3.38958311e+38f,  0.0f,
+        -3.40053886e+38f,  0.0f,
+        -5.19229686e+33f,  0.0f,
+        -5.17201445e+33f,  0.0f,
+    };
+    int labels[] = {1, 0, 0, 0, 0, 0};
+
+    cv::Mat features(6, 2, CV_32F, fdata);
+    cv::Mat responses(6, 1, CV_32S, labels);
+
+    cv::Ptr<cv::ml::SVM> svm = cv::ml::SVM::create();
+    svm->setType(cv::ml::SVM::NU_SVC);
+    svm->setKernel(cv::ml::SVM::LINEAR);
+    svm->setNu(0.010317);
+    svm->setTermCriteria(cv::TermCriteria(
+        cv::TermCriteria::MAX_ITER | cv::TermCriteria::EPS, 11, 0.099998));
+
+    // Should not crash with UB; training failure (return false) is acceptable
+    EXPECT_NO_THROW(svm->train(features, cv::ml::ROW_SAMPLE, responses));
+}
+
 }} // namespace


### PR DESCRIPTION
…data

Fix #29110: When training NU_SVC SVM with near-FLT_MAX float values, the LINEAR kernel overflows to Inf. This causes select_working_set_nu_svm to return stale -1 indices, leading to undefined behavior in get_row(-1).

Two fixes:
1. Add bounds check for invalid indices in solve_generic before get_row
2. Move gradient overflow early-exit out of #ifdef _DEBUG so it activates in Release builds

Includes regression test.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->


# Changes Made

## 1. `svm.cpp` — Two Fixes

### Fix 1 (lines 689–696) — Moved Gradient Overflow Early-Exit Out of `#ifdef _DEBUG`

```diff
-       #ifdef _DEBUG
                for( i = 0; i < alpha_count; i++ )
                {
                    if( fabs(G[i]) > 1e+300 )
                        return false;
                    if( fabs(alpha[i]) > 1e16 )
                        return false;
                }
-       #endif
```

This ensures the overflow check runs in all builds (not just debug), catching `Inf` gradients before they poison the working set selection.

---

### Fix 2 (lines 701–702) — Added Bounds Check for Invalid Indices

```diff
if( (this->*select_working_set_func)( i, j ) != 0 || iter++ >= max_iter )
                    break;
+
+               if( i < 0 || j < 0 )
+                   break;
```

This prevents:

```cpp
get_row(-1) → samples.ptr<float>(-1)
```

undefined behavior if `select_working_set_nu_svm` returns stale `-1` indices.

---

## 2. `test_svmtrainauto.cpp` — Regression Test

Added:

```cpp
ML_SVM.extreme_float_no_crash_29110
```

test (lines 164–189) using the exact PoC data from the bug report.

The test verifies that SVM training completes without crashing.

---

# Verification

- ✅ `git diff --check` — no whitespace issues
- ✅ Changes are minimal:
  - 2 files modified
  - `+30` lines
  - `-2` lines
- ✅ Committed on branch:
  ```bash
  fix/svm-ub-overflow-29110
  ```
- ✅ Branch based on:
  ```bash
  upstream/4.x
  ```
- ✅ Pushed to fork:
  ```bash
  pranayr710/opencv
  ```