### PR TITLE
Unified imreadXXX functions flags.

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -404,22 +404,23 @@ embedded in the file (such as EXIF, XMP, etc.), depending on file format support
 @param filename Name of the file to be loaded.
 @param metadataTypes Output vector with types of metadata chunks returned in metadata, see ImageMetadataType.
 @param metadata Output vector of vectors or vector of matrices to store the retrieved metadata.
-@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
+@param flags Flag that can take values of cv::ImreadModes.
 
 @return The loaded image as a cv::Mat object. If the image cannot be read, the function returns an empty matrix.
 */
 CV_EXPORTS_W Mat imreadWithMetadata( const String& filename, CV_OUT std::vector<int>& metadataTypes,
-                                     OutputArrayOfArrays metadata, int flags = IMREAD_ANYCOLOR);
+                                     OutputArrayOfArrays metadata, int flags);
 
 /** @brief Loads a multi-page image from a file.
 
 The function imreadmulti loads a multi-page image from the specified file into a vector of Mat objects.
 @param filename Name of file to be loaded.
 @param mats A vector of Mat objects holding each page.
-@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
+@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_COLOR_BGR.
+@note The default flags value was changed from cv::IMREAD_ANYCOLOR to cv::IMREAD_COLOR_BGR for unification.
 @sa cv::imread
 */
-CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, int flags = IMREAD_ANYCOLOR);
+CV_EXPORTS_W bool imreadmulti(const String& filename, CV_OUT std::vector<Mat>& mats, int flags = IMREAD_COLOR_BGR);
 
 /** @brief Loads images of a multi-page image from a file.
 
@@ -503,10 +504,11 @@ CV_EXPORTS_W bool imencodeanimation(const String& ext, const Animation& animatio
 The function imcount returns the number of pages in a multi-page image (e.g. TIFF), the number of frames in an animation (e.g. AVIF), and 1 otherwise.
 If the image cannot be decoded, 0 is returned.
 @param filename Name of file to be loaded.
-@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
+@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_COLOR_BGR.
+@note The default flags value was changed from cv::IMREAD_ANYCOLOR to cv::IMREAD_COLOR_BGR for unification.
 @todo when cv::IMREAD_LOAD_GDAL flag used the return value will be 0 or 1 because OpenCV's GDAL decoder doesn't support multi-page reading yet.
 */
-CV_EXPORTS_W size_t imcount(const String& filename, int flags = IMREAD_ANYCOLOR);
+CV_EXPORTS_W size_t imcount(const String& filename, int flags = IMREAD_COLOR_BGR);
 
 /** @brief Saves an image to a specified file.
 
@@ -620,12 +622,12 @@ See cv::imread for the list of supported formats and flags description.
 @param buf Input array or vector of bytes containing the encoded image data.
 @param metadataTypes Output vector with types of metadata chucks returned in metadata, see cv::ImageMetadataType
 @param metadata Output vector of vectors or vector of matrices to store the retrieved metadata
-@param flags Flag that can take values of cv::ImreadModes, default with cv::IMREAD_ANYCOLOR.
+@param flags Flag that can take values of cv::ImreadModes.
 
 @return The decoded image as a cv::Mat object. If decoding fails, the function returns an empty matrix.
 */
 CV_EXPORTS_W Mat imdecodeWithMetadata( InputArray buf, CV_OUT std::vector<int>& metadataTypes,
-                                       OutputArrayOfArrays metadata, int flags = IMREAD_ANYCOLOR );
+                                       OutputArrayOfArrays metadata, int flags );
 
 /** @overload
 @param buf Input array or vector of bytes.

--- a/modules/imgcodecs/test/test_animation.cpp
+++ b/modules/imgcodecs/test/test_animation.cpp
@@ -482,7 +482,7 @@ TEST(Imgcodecs_APNG, imwritemulti_gray)
     string output = cv::tempfile(".png");
     EXPECT_TRUE(imwrite(output, s_animation.frames));
     vector<Mat> read_frames;
-    EXPECT_TRUE(imreadmulti(output, read_frames));
+    EXPECT_TRUE(imreadmulti(output, read_frames, cv::IMREAD_ANYCOLOR));
     EXPECT_EQ(1, read_frames[0].channels());
     read_frames.clear();
     EXPECT_TRUE(imreadmulti(output, read_frames, IMREAD_UNCHANGED));

--- a/modules/imgcodecs/test/test_exif.cpp
+++ b/modules/imgcodecs/test/test_exif.cpp
@@ -593,11 +593,11 @@ TEST_P(ReadExif_Sanity, Check)
 
     std::vector<int> metadata_types, metadata_types2;
     std::vector<std::vector<uchar> >  metadata, metadata2;
-    Mat img = imreadWithMetadata(filename, metadata_types, metadata);
+    Mat img = imreadWithMetadata(filename, metadata_types, metadata, cv::IMREAD_ANYCOLOR);
 
     std::vector<uchar> compressed;
     imencodeWithMetadata(".jpg", img, metadata_types, metadata, compressed);
-    img = imdecodeWithMetadata(compressed, metadata_types2, metadata2);
+    img = imdecodeWithMetadata(compressed, metadata_types2, metadata2, cv::IMREAD_ANYCOLOR);
 
     EXPECT_EQ(metadata_types, metadata_types2);
     EXPECT_EQ(metadata, metadata2);

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -1102,7 +1102,7 @@ TEST(Imgcodecs_Tiff_Modes, write_multipage)
     ASSERT_TRUE(res);
 
     vector<Mat> read_pages;
-    imreadmulti(tmp_filename, read_pages);
+    imreadmulti(tmp_filename, read_pages, cv::IMREAD_ANYCOLOR);
     for (size_t i = 0; i < page_count; i++)
     {
         EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), read_pages[i], pages[i]);

--- a/modules/python/test/test_imread.py
+++ b/modules/python/test/test_imread.py
@@ -24,13 +24,13 @@ class imread_test(NewOpenCVTests):
 
     def test_imread_with_meta(self):
         path = self.extraTestDataPath + '/highgui/readwrite/testExifOrientation_1.jpg'
-        img, meta_types, meta_data = cv.imreadWithMetadata(path)
+        img, meta_types, meta_data = cv.imreadWithMetadata(path, flags=cv.IMREAD_ANYCOLOR)
         self.assertTrue(img is not None)
         self.assertTrue(meta_types is not None)
         self.assertTrue(meta_data is not None)
 
         path = self.extraTestDataPath + '/highgui/readwrite/testExifOrientation_1.png'
-        img, meta_types, meta_data = cv.imreadWithMetadata(path)
+        img, meta_types, meta_data = cv.imreadWithMetadata(path, flags=cv.IMREAD_ANYCOLOR)
         self.assertTrue(img is not None)
         self.assertTrue(meta_types is not None)
         self.assertTrue(meta_data is not None)


### PR DESCRIPTION
1. Use IMREAD_COLOR_BGR for all image reading functions
2. Request user flags in imreadwithmeta

Fixes https://github.com/opencv/opencv/issues/22090
Partially address https://github.com/opencv/opencv/issues/26449

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
