### PR TITLE
solvePoly warning fix on Windows.

### DIFF
--- a/modules/core/test/test_math.cpp
+++ b/modules/core/test/test_math.cpp
@@ -2698,13 +2698,13 @@ TEST(Core_SolvePoly, degree_2_polynomials)
     cv::Mat_<float> coefs(1,3);
     cv::Mat r;
     double prec;
-    for (int c0 = -20; c0 <= 20; c0++)
+    for (float c0 = -20; c0 <= 20; c0++)
     {
         coefs.at<float>(0) = c0;
-        for (int c1 = -20; c1 <= 20; c1++)
+        for (float c1 = -20; c1 <= 20; c1++)
         {
             coefs.at<float>(1) = c1;
-            for (int c2 = -20; c2 <= 20; c2++)
+            for (float c2 = -20; c2 <= 20; c2++)
             {
                 coefs.at<float>(2) = c2;
                 prec = cv::solvePoly(coefs, r);
@@ -2721,19 +2721,19 @@ TEST(Core_SolvePoly, degree_4_polynomials)
     cv::Mat_<float> coefs(1,5);
     cv::Mat r;
     double prec;
-    for (int c0 = -10; c0 <= 10; c0++)
+    for (float c0 = -10; c0 <= 10; c0++)
     {
         coefs.at<float>(0) = c0;
-        for (int c1 = -10; c1 <= 10; c1++)
+        for (float c1 = -10; c1 <= 10; c1++)
         {
             coefs.at<float>(1) = c1;
-            for (int c2 = -10; c2 <= 10; c2++)
+            for (float c2 = -10; c2 <= 10; c2++)
             {
                 coefs.at<float>(2) = c2;
-                for (int c3 = -10; c3 <= 10; c3++)
+                for (float c3 = -10; c3 <= 10; c3++)
                 {
                     coefs.at<float>(3) = c3;
-                    for (int c4 = -10; c4 <= 10; c4++)
+                    for (float c4 = -10; c4 <= 10; c4++)
                     {
                         coefs.at<float>(4) = c4;
                         prec = cv::solvePoly(coefs, r);
@@ -2750,15 +2750,15 @@ TEST(Core_SolvePoly, different_magnitudes_polynomials)
     cv::Mat_<float> coefs(1,3);
     cv::Mat r;
     double prec;
-    for (int i = -10; i < 10; i++)
+    for (float i = -10; i < 10; i++)
     {
-        coefs.at<float>(0) = pow(2, i);
-        for (int j = -10; j < 10; j++)
+        coefs.at<float>(0) = pow(2.f, i);
+        for (float j = -10; j < 10; j++)
         {
-            coefs.at<float>(1) = pow(2, j);
-            for (int k = -10; k < 10; k++)
+            coefs.at<float>(1) = pow(2.f, j);
+            for (float k = -10; k < 10; k++)
             {
-                coefs.at<float>(2) = pow(2, k);
+                coefs.at<float>(2) = pow(2.f, k);
                 prec = cv::solvePoly(coefs, r);
                 EXPECT_LE(prec, 1e-6);
             }


### PR DESCRIPTION
Warning was introduced in https://github.com/opencv/opencv/pull/29109

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
