### PR TITLE
fix: improve input validation in minEnclosingConvexPolygon

### DIFF
--- a/modules/imgproc/src/min_enclosing_convex_polygon.cpp
+++ b/modules/imgproc/src/min_enclosing_convex_polygon.cpp
@@ -1020,9 +1020,7 @@ double cv::minEnclosingConvexPolygon(cv::InputArray points, cv::OutputArray poly
 {
     int n = (int)points.getMat().checkVector(2);
 
-    CV_Assert(!points.empty());
-    CV_CheckGE(n, 0, "Input must be a valid set of 2D points");
-    CV_CheckGE(n, k, "Number of input points must be >= k");
+    CV_Assert(!points.empty() && n >= k);
     CV_CheckGE(n, 3, "ngon must have 3 or more different points enclosing an area");
     CV_CheckGE(k, 3, "k must be 3 or higher");
 

--- a/modules/imgproc/src/min_enclosing_convex_polygon.cpp
+++ b/modules/imgproc/src/min_enclosing_convex_polygon.cpp
@@ -1020,7 +1020,9 @@ double cv::minEnclosingConvexPolygon(cv::InputArray points, cv::OutputArray poly
 {
     int n = (int)points.getMat().checkVector(2);
 
-    CV_Assert(!points.empty() && n >= k);
+    CV_Assert(!points.empty());
+    CV_CheckGE(n, 0, "Input must be a valid set of 2D points");
+    CV_CheckGE(n, k, "Number of input points must be >= k");
     CV_CheckGE(n, 3, "ngon must have 3 or more different points enclosing an area");
     CV_CheckGE(k, 3, "k must be 3 or higher");
 

--- a/modules/imgproc/src/min_enclosing_triangle.cpp
+++ b/modules/imgproc/src/min_enclosing_triangle.cpp
@@ -325,6 +325,13 @@ static void findMinEnclosingTriangle(cv::InputArray points,
     std::vector<cv::Point2f> resultingTriangle;
     cv::Mat polygon;
     convexHull(points, polygon, true, true);
+
+    double hullArea = cv::contourArea(polygon);
+    if (hullArea < MIN_ENCLOSING_TRIANGLE_EPSILON) {
+        CV_Error(cv::Error::StsBadArg, 
+                 "Input points are collinear - cannot form a triangle");
+    }
+
     findMinEnclosingTriangle(polygon, resultingTriangle, area);
     cv::Mat(resultingTriangle).copyTo(triangle);
 }

--- a/modules/imgproc/src/min_enclosing_triangle.cpp
+++ b/modules/imgproc/src/min_enclosing_triangle.cpp
@@ -318,6 +318,10 @@ namespace minEnclosingTriangle {
 static void findMinEnclosingTriangle(cv::InputArray points,
                                      CV_OUT cv::OutputArray triangle, CV_OUT double &area) {
     CV_Assert(!points.empty());
+
+    int n = points.getMat().checkVector(2);
+    CV_CheckGE(n, 3, "At least 3 points are required to form a triangle");
+
     std::vector<cv::Point2f> resultingTriangle;
     cv::Mat polygon;
     convexHull(points, polygon, true, true);


### PR DESCRIPTION
with separate checks to properly detect invalid point sets.

- Add CV_CheckGE(n, 0, ...) to reject malformed 2D point arrays
- Keep existing checks for n >= k and n >= 3
- Provides clearer error messages for invalid inputs

Previously, passing a non-2D Mat (n == -1) could bypass the assertion and cause a crash in convexHull() rather than a proper error.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
