### PR TITLE
fix: videoio test hang on win11 from issue #27400

### DIFF
--- a/modules/videoio/src/cap_msmf.cpp
+++ b/modules/videoio/src/cap_msmf.cpp
@@ -1633,7 +1633,9 @@ bool CvCapture_MSMF::configureAudioFrame()
             chunkLengthOfBytes = bufferAudioData.size();
             audioSamplePos += chunkLengthOfBytes/bytesPerSample;
         }
-        CV_Check((double)chunkLengthOfBytes, chunkLengthOfBytes >= INT_MIN || chunkLengthOfBytes <= INT_MAX, "MSMF: The chunkLengthOfBytes is out of the allowed range");
+        if ((LONGLONG)bufferAudioData.size() < chunkLengthOfBytes)
+            chunkLengthOfBytes = (LONGLONG)bufferAudioData.size();
+        CV_Check((double)chunkLengthOfBytes, chunkLengthOfBytes >= INT_MIN && chunkLengthOfBytes <= INT_MAX, "MSMF: The chunkLengthOfBytes is out of the allowed range");
         copy(bufferAudioData.begin(), bufferAudioData.begin() + (int)chunkLengthOfBytes, std::back_inserter(audioDataInUse));
         bufferAudioData.erase(bufferAudioData.begin(), bufferAudioData.begin() + (int)chunkLengthOfBytes);
         if (audioFrame.empty())


### PR DESCRIPTION
Fixes #27400 
Issue #27400 shows that on Windows 11, running `opencv_test_videoio.exe` would cause a hang. I reproduced in the latest version and fixed it.
## cause
In `opencv\opencv\modules\videoio\src\cap_msmf.cpp`, the `bool CvCapture_MSMF::configureAudioFrame()` result in the problem.
Such code causes the hang:
```
bufferAudioData.erase(bufferAudioData.begin(), bufferAudioData.begin() + (int)chunkLengthOfBytes);
``` 
In the testcase `Media.audio/mp4_1CN_MSMF`, when processing frame 88, there are 1092 elements left in the `bufferAudioData`. However, it tries to erase 2940 elements (`chunkLengthOfBytes`) from that deque. The element-counting size_t underflows to a huge value, and the destructor then iterates over it, freezing the program. 
## solution
Add the code below before the `erase()`
```
if ((LONGLONG)bufferAudioData.size() < chunkLengthOfBytes)
            chunkLengthOfBytes = (LONGLONG)bufferAudioData.size();
```
## verification
With the fix, I rebuilt and ran the tests. They all ran to completion without the program hanging.
## addition
Additionally, I found a conditional expression in this function that evaluates to true in all cases. The logical OR `||` should be replaced with a logical AND `&&` to reflect the original intent.
```
CV_Check((double)chunkLengthOfBytes, chunkLengthOfBytes >= INT_MIN && chunkLengthOfBytes <= INT_MAX, "MSMF: The chunkLengthOfBytes is out of the allowed range");
```
Moreover, this matches the problem described by `[zwassall-gentuity]` in #27438 
## further cause
The further cause of this issue may lie in internal changes to Media Foundation on Windows 11, which result in slightly different alignment behavior for audio/video boundaries compared to Windows 10.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
