### PR TITLE
imgproc: fix SIGFPE in applyColorMap on empty input, add tests

### DIFF
--- a/modules/imgproc/src/colormap.cpp
+++ b/modules/imgproc/src/colormap.cpp
@@ -736,6 +736,7 @@ namespace colormap
             CV_Error(Error::StsBadArg, "cv::ColorMap only supports source images of type CV_8UC1 or CV_8UC3");
 
         CV_CheckEQ(src.dims, 2, "Not supported");
+        CV_Assert(!src.empty());
 
         CV_Assert(_lut.isContinuous());
         const int lut_type = _lut.type();

--- a/modules/imgproc/test/test_colormap.cpp
+++ b/modules/imgproc/test/test_colormap.cpp
@@ -1,0 +1,210 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+// All built-in colormap IDs
+static const int all_colormaps[] = {
+    COLORMAP_AUTUMN, COLORMAP_BONE, COLORMAP_CIVIDIS, COLORMAP_COOL,
+    COLORMAP_DEEPGREEN, COLORMAP_HOT, COLORMAP_HSV, COLORMAP_INFERNO,
+    COLORMAP_JET, COLORMAP_MAGMA, COLORMAP_OCEAN, COLORMAP_PARULA,
+    COLORMAP_PINK, COLORMAP_PLASMA, COLORMAP_RAINBOW, COLORMAP_SPRING,
+    COLORMAP_SUMMER, COLORMAP_TURBO, COLORMAP_TWILIGHT,
+    COLORMAP_TWILIGHT_SHIFTED, COLORMAP_VIRIDIS, COLORMAP_WINTER
+};
+
+// ---------------------------------------------------------------------------
+// Test 1: All built-in colormaps run without error on a normal grayscale image
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, AllColormapsRun)
+{
+    Mat src(64, 64, CV_8UC1);
+    // fill with a ramp 0..255
+    for (int i = 0; i < src.rows; i++)
+        for (int j = 0; j < src.cols; j++)
+            src.at<uchar>(i, j) = (uchar)((i * src.cols + j) * 255 / (src.rows * src.cols));
+
+    for (int cm : all_colormaps)
+    {
+        Mat dst;
+        EXPECT_NO_THROW(applyColorMap(src, dst, cm))
+            << "colormap id=" << cm << " threw an exception";
+        EXPECT_FALSE(dst.empty())   << "colormap id=" << cm << " produced empty output";
+        EXPECT_EQ(dst.type(), CV_8UC3) << "colormap id=" << cm << " output is not CV_8UC3";
+        EXPECT_EQ(dst.size(), src.size()) << "colormap id=" << cm << " output size mismatch";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 2: Output is CV_8UC3 regardless of input size
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, OutputType)
+{
+    Mat src(100, 200, CV_8UC1, Scalar(128));
+    Mat dst;
+    applyColorMap(src, dst, COLORMAP_JET);
+    EXPECT_EQ(dst.type(), CV_8UC3);
+    EXPECT_EQ(dst.rows, 100);
+    EXPECT_EQ(dst.cols, 200);
+}
+
+// ---------------------------------------------------------------------------
+// Test 3: 1x1 image (minimal size edge case)
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, SinglePixel)
+{
+    Mat src(1, 1, CV_8UC1, Scalar(0));
+    Mat dst;
+    EXPECT_NO_THROW(applyColorMap(src, dst, COLORMAP_JET));
+    EXPECT_EQ(dst.rows, 1);
+    EXPECT_EQ(dst.cols, 1);
+    EXPECT_EQ(dst.type(), CV_8UC3);
+
+    // pixel 0 and pixel 255 should produce different colors (non-trivial map)
+    Mat src2(1, 1, CV_8UC1, Scalar(255));
+    Mat dst2;
+    applyColorMap(src2, dst2, COLORMAP_JET);
+    EXPECT_NE(dst.at<Vec3b>(0,0), dst2.at<Vec3b>(0,0))
+        << "JET(0) and JET(255) should produce different colors";
+}
+
+// ---------------------------------------------------------------------------
+// Test 4: Invalid colormap ID throws cv::Exception
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, InvalidColormapThrows)
+{
+    Mat src(10, 10, CV_8UC1, Scalar(128));
+    Mat dst;
+    EXPECT_THROW(applyColorMap(src, dst, -1),      cv::Exception);
+    EXPECT_THROW(applyColorMap(src, dst, 9999),    cv::Exception);
+}
+
+// ---------------------------------------------------------------------------
+// Test 5: 3-channel input is accepted and produces 3-channel output
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, ThreeChannelInput)
+{
+    Mat src(32, 32, CV_8UC3, Scalar(100, 150, 200));
+    Mat dst;
+    EXPECT_NO_THROW(applyColorMap(src, dst, COLORMAP_HOT));
+    EXPECT_EQ(dst.type(), CV_8UC3);
+    EXPECT_EQ(dst.size(), src.size());
+}
+
+// ---------------------------------------------------------------------------
+// Test 6: User-defined colormap (CV_8UC3 lookup table, 256 entries)
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, UserColorMapBGR)
+{
+    // Build a simple identity-like LUT: gray -> (v, v, v)
+    Mat lut(256, 1, CV_8UC3);
+    for (int i = 0; i < 256; i++)
+        lut.at<Vec3b>(i, 0) = Vec3b((uchar)i, (uchar)i, (uchar)i);
+
+    Mat src(32, 32, CV_8UC1);
+    for (int i = 0; i < src.rows; i++)
+        for (int j = 0; j < src.cols; j++)
+            src.at<uchar>(i, j) = (uchar)(i * 8);
+
+    Mat dst;
+    EXPECT_NO_THROW(applyColorMap(src, dst, lut));
+    EXPECT_EQ(dst.type(), CV_8UC3);
+
+    // For an identity gray LUT, each output pixel should be (v, v, v)
+    for (int i = 0; i < src.rows; i++)
+        for (int j = 0; j < src.cols; j++)
+        {
+            uchar v = src.at<uchar>(i, j);
+            Vec3b expected(v, v, v);
+            EXPECT_EQ(dst.at<Vec3b>(i, j), expected)
+                << "mismatch at (" << i << "," << j << ")";
+        }
+}
+
+// ---------------------------------------------------------------------------
+// Test 7: User-defined colormap with wrong size throws
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, UserColorMapWrongSizeThrows)
+{
+    Mat bad_lut(128, 1, CV_8UC3, Scalar(0, 0, 0));  // 128 entries, not 256
+    Mat src(10, 10, CV_8UC1, Scalar(0));
+    Mat dst;
+    EXPECT_THROW(applyColorMap(src, dst, bad_lut), cv::Exception);
+}
+
+// ---------------------------------------------------------------------------
+// Test 8: User-defined colormap with wrong type throws
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, UserColorMapWrongTypeThrows)
+{
+    Mat bad_lut(256, 1, CV_32FC3, Scalar(0, 0, 0));  // float, not uchar
+    Mat src(10, 10, CV_8UC1, Scalar(0));
+    Mat dst;
+    EXPECT_THROW(applyColorMap(src, dst, bad_lut), cv::Exception);
+}
+
+// ---------------------------------------------------------------------------
+// Test 9: Deterministic output — same input always gives same output
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, Deterministic)
+{
+    Mat src(32, 32, CV_8UC1);
+    randu(src, 0, 256);
+
+    Mat dst1, dst2;
+    applyColorMap(src, dst1, COLORMAP_VIRIDIS);
+    applyColorMap(src, dst2, COLORMAP_VIRIDIS);
+
+    EXPECT_DOUBLE_EQ(0.0, cv::norm(dst1, dst2, NORM_L1))
+        << "applyColorMap is not deterministic";
+}
+
+// ---------------------------------------------------------------------------
+// Test 10: Known pixel values for COLORMAP_JET (ground truth / regression)
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, PixelValueCorrectness)
+{
+    // JET is a well-known colormap; these values are fixed by the LUT in colormap.cpp.
+    // If someone accidentally edits the LUT table, this test will catch it.
+    struct { uchar input; Vec3b expected_bgr; } cases[] = {
+        { 0,   Vec3b(128,   0,   0) },  // JET(0)   = dark blue
+        { 128, Vec3b(126, 255, 130) },  // JET(128) = green
+        { 255, Vec3b(  0,   0, 128) },  // JET(255) = dark red
+    };
+
+    for (auto& c : cases)
+    {
+        Mat src(1, 1, CV_8UC1, Scalar(c.input));
+        Mat dst;
+        applyColorMap(src, dst, COLORMAP_JET);
+        EXPECT_EQ(dst.at<Vec3b>(0, 0), c.expected_bgr)
+            << "JET(" << (int)c.input << ") produced wrong color";
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 11: Empty input Mat throws cv::Exception
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, EmptyInputThrows)
+{
+    Mat empty;
+    Mat dst;
+    EXPECT_THROW(applyColorMap(empty, dst, COLORMAP_JET), cv::Exception);
+}
+
+// ---------------------------------------------------------------------------
+// Test 12: Zero-size Mat(0,0) should throw, not crash
+// Previously caused SIGFPE (division by zero at cols=0 in ColorMap::operator()).
+// Fixed by adding CV_Assert(!src.empty()) in colormap.cpp.
+// ---------------------------------------------------------------------------
+TEST(ApplyColorMap, ZeroSizeInputThrows)
+{
+    Mat zero(0, 0, CV_8UC1);
+    Mat dst;
+    EXPECT_THROW(applyColorMap(zero, dst, COLORMAP_JET), cv::Exception);
+}
+
+}} // namespace opencv_test


### PR DESCRIPTION
applyColorMap() crashed with SIGFPE (division by zero) when given a zero-size Mat such as Mat(0,0) or a zero-width/height ROI. The crash occurred at ColorMap::operator() line 759:

  const int rowsPerPacket = std::max(1, minimalPixelsPerPacket / cols);

where cols=0 causes integer division by zero. The existing guard CV_CheckEQ(src.dims, 2) only catches default-constructed Mat() with dims=0, but not Mat(0,0) which has dims=2.

Fix: add CV_Assert(!src.empty()) after the dims check.

How to Reproduce                                                                                                                                                                           
     1 #include <opencv2/core.hpp>                                                                                                                                                            
     2 #include <opencv2/imgproc.hpp>                                                                                                                                                         
     3                                                                                                                                                                                        
     4 int main()                                                                                                                                                                             
     5 {                                                                                                                                                                                      
     6     cv::Mat depth_map(480, 640, CV_8UC1, cv::Scalar(128));                                                                                                                             
     7                                                                                                                                                                                        
     8     // Zero-width bounding box — common output from object detectors                                                                                                                   
     9     cv::Rect roi_rect(100, 100, 0, 50);                                                                                                                                                
    10     cv::Mat roi = depth_map(roi_rect);  // succeeds, no error here
    11                             
    12     cv::Mat heatmap;        
    13     cv::applyColorMap(roi, heatmap, cv::COLORMAP_JET);  // SIGFPE crash                                                                                                               
    14     return 0;                                                                                                                                                                          
    15 }              
            
   Environment                                                                                                                                                                                
                                                                                                                                                                                              
   - OS: Ubuntu 24.04.3 LTS (x86_64)                                                                                                                                                          
   - Kernel: 6.17.0-23-generic                                                                                                                                                               
   - Compiler: GCC 16.0.1                                                                                                                                                                     
   - OpenCV: 4.14.0-pre 
                                                                                                                                                            
   Before fix: Floating point exception (core dumped) — cryptic OS signal, no location, no message.                                                                                                                                                                                                                                       
   After fix: Assertion failed (!src.empty()) in ColorMap::operator() — clear and actionable.  

Also add modules/imgproc/test/test_colormap.cpp — the first test file for applyColorMap, covering all 22 built-in colormaps, output type, 1x1 input, invalid colormap IDs, user-defined LUT validation, pixel value correctness (COLORMAP_JET regression), and empty/zero-size input.

   - All 22 built-in colormaps run without error                                                                                                                                              
   - Output is always CV_8UC3 with correct size                                                                                                                                               
   - 1×1 input (minimal edge case)                                
   - Invalid colormap ID throws cv::Exception
   - 3-channel input accepted
   - User-defined LUT pixel-level correctness
   - User-defined LUT wrong size/type throws
   - Deterministic output
   - Known pixel values for COLORMAP_JET (regression guard)
   - Empty Mat() throws
   - Zero-size Mat(0,0) throws instead of crashing


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
