### PR TITLE
imgcodecs: fix Apple conversions build without AVFoundation

### DIFF
--- a/modules/imgcodecs/src/apple_conversions.h
+++ b/modules/imgcodecs/src/apple_conversions.h
@@ -2,10 +2,27 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 
+#ifndef OPENCV_IMGCODECS_APPLE_CONVERSIONS_H
+#define OPENCV_IMGCODECS_APPLE_CONVERSIONS_H
+
 #include "opencv2/core.hpp"
 #import <Accelerate/Accelerate.h>
+
+#include <TargetConditionals.h>
+
+#ifdef HAVE_AVFOUNDATION
 #import <AVFoundation/AVFoundation.h>
+#endif
+
+#if TARGET_OS_IPHONE || (defined(MAC_OS_X_VERSION_MAX_ALLOWED) && MAC_OS_X_VERSION_MAX_ALLOWED >= 1080)
 #import <ImageIO/ImageIO.h>
+#else
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <Foundation/Foundation.h>
+#endif
 
 CV_EXPORTS CGImageRef MatToCGImage(const cv::Mat& image) CF_RETURNS_RETAINED;
 CV_EXPORTS void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist);
+
+#endif // OPENCV_IMGCODECS_APPLE_CONVERSIONS_H

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -5,6 +5,8 @@
 #include "apple_conversions.h"
 #include "precomp.hpp"
 
+#import <Foundation/Foundation.h>
+
 #ifndef __bridge
 #define __bridge
 #endif

--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -5,6 +5,10 @@
 #include "apple_conversions.h"
 #include "precomp.hpp"
 
+#ifndef __bridge
+#define __bridge
+#endif
+
 CGImageRef MatToCGImage(const cv::Mat& image) {
     NSData *data = [NSData dataWithBytes:image.data
                                   length:image.step.p[0] * image.rows];

--- a/modules/imgcodecs/src/macosx_conversions.mm
+++ b/modules/imgcodecs/src/macosx_conversions.mm
@@ -13,8 +13,14 @@ NSImage* MatToNSImage(const cv::Mat& image) {
     CGImageRef imageRef = MatToCGImage(image);
 
     // Getting NSImage from CGImage
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
+    CGFloat width = CGImageGetWidth(imageRef);
+    CGFloat height = CGImageGetHeight(imageRef);
+    NSSize nsSize = NSMakeSize(width, height);
+    NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:nsSize];
+#else
     NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef))];
-    CGImageRelease(imageRef);
+#endif    CGImageRelease(imageRef);
 
     return nsImage;
 }

--- a/modules/imgcodecs/src/macosx_conversions.mm
+++ b/modules/imgcodecs/src/macosx_conversions.mm
@@ -13,14 +13,10 @@ NSImage* MatToNSImage(const cv::Mat& image) {
     CGImageRef imageRef = MatToCGImage(image);
 
     // Getting NSImage from CGImage
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 1080
-    CGFloat width = CGImageGetWidth(imageRef);
-    CGFloat height = CGImageGetHeight(imageRef);
-    NSSize nsSize = NSMakeSize(width, height);
-    NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:nsSize];
-#else
-    NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:CGSizeMake(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef))];
-#endif    CGImageRelease(imageRef);
+    NSSize imageSize = NSMakeSize(CGImageGetWidth(imageRef), CGImageGetHeight(imageRef));
+    NSImage *nsImage = [[NSImage alloc] initWithCGImage:imageRef size:imageSize];
+    CGImageRelease(imageRef);
+
 
     return nsImage;
 }


### PR DESCRIPTION
Fixes #28553.

This PR fixes Apple imgcodecs conversion builds when AVFoundation is disabled or unavailable on older macOS SDKs.

Changes:
- Guard AVFoundation import with HAVE_AVFOUNDATION.
- Use older macOS-compatible framework imports when ImageIO is unavailable.
- Add __bridge compatibility for older Objective-C++ compilers.
- Use NSMakeSize for older macOS instead of passing CGSize to NSImage API.

Testing:
- Not tested locally: no macOS environment available.
- Patch follows the fix confirmed in #28555 discussion.
