### PR TITLE
imgproc: Add parameter checks in cv::resize

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -4206,6 +4206,10 @@ void cv::resize( InputArray _src, OutputArray _dst, Size dsize,
     Size ssize = _src.size();
 
     CV_Assert( !ssize.empty() );
+
+    CV_Assert(dsize.width >= 0 && dsize.height >= 0 && "resize: dsize cannot be negative");
+    CV_Assert(interpolation >= 0 && interpolation <= INTER_LANCZOS4 && "resize: invalid interpolation method");
+    
     if( dsize.empty() )
     {
         CV_Assert(inv_scale_x > 0); CV_Assert(inv_scale_y > 0);


### PR DESCRIPTION
This PR adds missing parameter validation in cv::resize function.

Changes:
1. Check that dsize has non-negative width and height
2. Check interpolation method is within valid range (0 ~ INTER_LANCZOS4)

Why:
- Prevent invalid size causing memory allocation failure or crash
- Avoid out-of-bounds access from wrong interpolation enum
- Make function more robust and user-friendly

Test:
- Local build passed
- Normal resize works as before
- Invalid inputs (negative size / bad interpolation) now trigger CV_Assert as expected