### PR TITLE
imgcodecs: fix SunRaster IMREAD_GRAYSCALE returning black image

### DIFF
--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -159,7 +159,7 @@ bool  SunRasterDecoder::readData( Mat& img )
     AutoBuffer<uchar> _src(src_pitch + 32);
     uchar* src = _src.data();
 
-    if( !color && m_maptype == RMT_EQUAL_RGB )
+    if( !color )
         CvtPaletteToGray( m_palette, gray_palette, 1 << m_bpp );
 
     try

--- a/modules/imgcodecs/src/grfmt_sunras.cpp
+++ b/modules/imgcodecs/src/grfmt_sunras.cpp
@@ -147,7 +147,7 @@ bool  SunRasterDecoder::readData( Mat& img )
     AutoBuffer<uchar> _src(src_pitch + 32);
     uchar* src = _src.data();
 
-    if( !color && m_maptype == RMT_EQUAL_RGB )
+    if( !color )
         CvtPaletteToGray( m_palette, gray_palette, 1 << m_bpp );
 
     try

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -264,7 +264,6 @@ TEST_P(Imgcodecs_Image, read_write_GRAYSCALE)
 
     if (false
         || ext == "ppm"  // grayscale is not implemented
-        || ext == "ras"  // broken (black result)
     )
         throw SkipTestException("GRAYSCALE mode is not supported");
 
@@ -290,6 +289,38 @@ TEST_P(Imgcodecs_Image, read_write_GRAYSCALE)
 }
 
 INSTANTIATE_TEST_CASE_P(imgcodecs, Imgcodecs_Image, testing::ValuesIn(exts));
+
+#ifdef HAVE_IMGCODEC_SUNRASTER
+// Regression test: imread(file, IMREAD_GRAYSCALE) for a .ras file written by
+// imwrite() used to return an all-black image because gray_palette[] was never
+// populated when the file has no color palette (RMT_NONE, which is what
+// SunRasterEncoder always writes).
+TEST(Imgcodecs_SunRaster, imread_grayscale_roundtrip)
+{
+    // Build a 16x16 ramp covering all 256 values so a silent all-zero result
+    // is immediately obvious.
+    Mat src(16, 16, CV_8UC1);
+    for (int i = 0; i < src.rows; i++)
+        for (int j = 0; j < src.cols; j++)
+            src.at<uchar>(i, j) = (uchar)(i * src.cols + j);
+
+    const string fname = cv::tempfile(".ras");
+    ASSERT_TRUE(imwrite(fname, src)) << "imwrite failed for .ras";
+
+    Mat dst = imread(fname, IMREAD_GRAYSCALE);
+    ASSERT_FALSE(dst.empty()) << "imread returned empty Mat";
+    ASSERT_EQ(src.size(), dst.size());
+    ASSERT_EQ(src.type(), dst.type());
+
+    // Before the fix every pixel read back as 0 (black), so norm would equal
+    // the sum of all original values instead of 0.
+    EXPECT_EQ(0, cvtest::norm(src, dst, NORM_INF))
+        << "imread(IMREAD_GRAYSCALE) returned wrong pixel values for .ras — "
+           "expected exact roundtrip, got all-zero (black) image";
+
+    EXPECT_EQ(0, remove(fname.c_str()));
+}
+#endif
 
 TEST(Imgcodecs_Image, regression_9376)
 {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake

## Bug

`imread("file.ras", IMREAD_GRAYSCALE)` silently returns an all-black image (every pixel = 0) for any `.ras` (Sun Raster) file written by OpenCV. No error or warning is raised.

```cpp
Mat gray(16, 16, CV_8UC1);
// ... fill with non-zero values ...
imwrite("out.ras", gray);

Mat back = imread("out.ras", IMREAD_GRAYSCALE);
// back is all zeros — every pixel is black
```

The bug was already acknowledged in the test suite:
```cpp
|| ext == "ras"  // broken (black result)
```

## Root Cause

`SunRasterDecoder::readData()` uses `FillGrayRow8()` to decode 8-bit grayscale pixels. `FillGrayRow8` is a palette lookup: `dst[i] = gray_palette[src[i]]`. If `gray_palette[]` is all-zero, every pixel maps to 0.

`gray_palette` is populated by `CvtPaletteToGray()`, but the call was guarded by:

```cpp
if (!color && m_maptype == RMT_EQUAL_RGB)   // wrong condition
    CvtPaletteToGray(m_palette, gray_palette, 1 << m_bpp);
```

`RMT_EQUAL_RGB` means a color palette is stored in the file. However, `SunRasterEncoder::write()` always writes `RMT_NONE` (no palette), so this condition is never true for files written by OpenCV. `gray_palette` stays zero-initialized and all pixels decode to 0.

`readHeader()` correctly calls `FillGrayPalette(m_palette, m_bpp)` for the `RMT_NONE` case, so `m_palette` holds the right grayscale ramp — it just never gets converted into `gray_palette`.

## Fix

Remove the `m_maptype == RMT_EQUAL_RGB` guard:

```cpp
// Before
if (!color && m_maptype == RMT_EQUAL_RGB)
    CvtPaletteToGray(m_palette, gray_palette, 1 << m_bpp);

// After
if (!color)
    CvtPaletteToGray(m_palette, gray_palette, 1 << m_bpp);
```

Both cases (`RMT_EQUAL_RGB` and `RMT_NONE`) already have `m_palette` filled correctly by `readHeader()`, so `CvtPaletteToGray` produces the right result for both.

## Test

Added `Imgcodecs_SunRaster.imread_grayscale_roundtrip`: writes a synthetic 16x16 image covering all 256 grayscale values, reads it back with `IMREAD_GRAYSCALE`, and asserts `NORM_INF == 0`. Without the fix, `NORM_INF == 255` (all-black result). The existing `read_write_GRAYSCALE` skip for `"ras"` is also removed.