### PR TITLE
Rework IPP Remap to use IW interface

### DIFF
--- a/hal/ipp/include/ipp_hal_imgproc.hpp
+++ b/hal/ipp/include/ipp_hal_imgproc.hpp
@@ -18,6 +18,9 @@
 #if IPP_VERSION_X100 >= 810
 
 #if defined(HAVE_IPP_IW)
+
+#define CV_TYPE(src_type) (src_type & (CV_DEPTH_MAX - 1))
+
 int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width,
                        int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4]);
 
@@ -39,8 +42,6 @@ int ipp_hal_scharr(const uchar* src_data, size_t src_step, uchar* dst_data, size
 #undef cv_hal_scharr
 #define cv_hal_scharr ipp_hal_scharr
 
-#endif
-
 #if IPP_VERSION_X100 >= 202600
 
 int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width,
@@ -52,12 +53,19 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
 
 #endif // IPP_VERSION_X100 >= 202600
 
-#if defined(HAVE_IPP_IW)
 int ipp_hal_resize(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
                    uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
                    double inv_scale_x, double inv_scale_y, int interpolation);
 #undef cv_hal_resize
 #define cv_hal_resize ipp_hal_resize
+
+int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+    uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
+    float* mapx, size_t mapx_step, float* mapy, size_t mapy_step,
+    int interpolation, int border_type, const double border_value[4]);
+#undef cv_hal_remap32f
+#define cv_hal_remap32f ipp_hal_remap32f
+
 #endif // HAVE_IPP_IW
 
 #if defined(HAVE_IPP_IW) && !DISABLE_IPP_BOX_FILTER

--- a/hal/ipp/include/ipp_hal_imgproc.hpp
+++ b/hal/ipp/include/ipp_hal_imgproc.hpp
@@ -27,6 +27,7 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
 // Does not pass tests in 5.x branch
 //#undef cv_hal_warpAffine
 //#define cv_hal_warpAffine ipp_hal_warpAffine
+<<<<<<< HEAD
 
 int ipp_hal_sobel(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step,
                   int width, int height, int src_depth, int dst_depth, int cn,
@@ -41,6 +42,8 @@ int ipp_hal_scharr(const uchar* src_data, size_t src_step, uchar* dst_data, size
                    int dx, int dy, double scale, double delta, int border_type);
 #undef cv_hal_scharr
 #define cv_hal_scharr ipp_hal_scharr
+=======
+>>>>>>> 212a204754 (fixed header file)
 
 #if IPP_VERSION_X100 >= 202600
 

--- a/hal/ipp/include/ipp_hal_imgproc.hpp
+++ b/hal/ipp/include/ipp_hal_imgproc.hpp
@@ -27,7 +27,6 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
 // Does not pass tests in 5.x branch
 //#undef cv_hal_warpAffine
 //#define cv_hal_warpAffine ipp_hal_warpAffine
-<<<<<<< HEAD
 
 int ipp_hal_sobel(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step,
                   int width, int height, int src_depth, int dst_depth, int cn,
@@ -42,8 +41,6 @@ int ipp_hal_scharr(const uchar* src_data, size_t src_step, uchar* dst_data, size
                    int dx, int dy, double scale, double delta, int border_type);
 #undef cv_hal_scharr
 #define cv_hal_scharr ipp_hal_scharr
-=======
->>>>>>> 212a204754 (fixed header file)
 
 #if IPP_VERSION_X100 >= 202600
 

--- a/hal/ipp/src/transforms_ipp.cpp
+++ b/hal/ipp/src/transforms_ipp.cpp
@@ -24,6 +24,7 @@ namespace cv
 int ipp_hal_transpose2d(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step, int src_width,
                         int src_height, int element_size)
 {
+    CV_HAL_CHECK_USE_IPP();
     typedef IppStatus (CV_STDCALL * IppiTranspose)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize);
     typedef IppStatus (CV_STDCALL * IppiTransposeI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize);
     IppiTranspose ippiTranspose = nullptr;
@@ -99,6 +100,7 @@ int ipp_hal_flip(int src_type, const uchar* src_data, size_t src_step, int src_w
                  uchar* dst_data, size_t dst_step, int flip_mode)
 
 {
+    CV_HAL_CHECK_USE_IPP();
     int64_t total = src_step*src_height*CV_ELEM_SIZE(src_type);
     // Details: https://github.com/opencv/opencv/issues/12943
     if (flip_mode <= 0 /* swap rows */
@@ -199,6 +201,7 @@ int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int s
                      float *mapx, size_t mapx_step, float *mapy, size_t mapy_step,
                      int interpolation, int border_type, const double border_value[4])
 {
+    CV_HAL_CHECK_USE_IPP();
     if (!((interpolation == cv::INTER_LINEAR || interpolation == cv::INTER_CUBIC || interpolation == cv::INTER_NEAREST) &&
         (border_type == cv::BORDER_CONSTANT || border_type == cv::BORDER_TRANSPARENT)))
     {

--- a/hal/ipp/src/transforms_ipp.cpp
+++ b/hal/ipp/src/transforms_ipp.cpp
@@ -24,7 +24,6 @@ namespace cv
 int ipp_hal_transpose2d(const uchar* src_data, size_t src_step, uchar* dst_data, size_t dst_step, int src_width,
                         int src_height, int element_size)
 {
-    CV_HAL_CHECK_USE_IPP();
     typedef IppStatus (CV_STDCALL * IppiTranspose)(const void * pSrc, int srcStep, void * pDst, int dstStep, IppiSize roiSize);
     typedef IppStatus (CV_STDCALL * IppiTransposeI)(const void * pSrcDst, int srcDstStep, IppiSize roiSize);
     IppiTranspose ippiTranspose = nullptr;
@@ -100,7 +99,6 @@ int ipp_hal_flip(int src_type, const uchar* src_data, size_t src_step, int src_w
                  uchar* dst_data, size_t dst_step, int flip_mode)
 
 {
-    CV_HAL_CHECK_USE_IPP();
     int64_t total = src_step*src_height*CV_ELEM_SIZE(src_type);
     // Details: https://github.com/opencv/opencv/issues/12943
     if (flip_mode <= 0 /* swap rows */
@@ -133,4 +131,175 @@ int ipp_hal_flip(int src_type, const uchar* src_data, size_t src_step, int src_w
     return CV_HAL_ERROR_OK;
 }
 
+#if IPP_VERSION_X100 >= 202600
+#include <atomic>
+#include "ipp_hal_imgproc.hpp"
+
+typedef IppStatus (CV_STDCALL* ippiSetFunc)(const void*, void *, int, IppiSize);
+
+template <int channels, typename Type>
+bool IPPSetSimple(const double value[4], void *dataPointer, int step, IppiSize &size, ippiSetFunc func)
+{
+    //CV_INSTRUMENT_REGION_IPP();
+
+    Type values[channels];
+    for( int i = 0; i < channels; i++ )
+        values[i] = cv::saturate_cast<Type>(value[i]);
+    return CV_INSTRUMENT_FUN_IPP(func, values, dataPointer, step, size) >= 0;
+}
+
+static bool IPPSet(const double value[4], void *dataPointer, int step, IppiSize &size, int channels, int depth)
+{
+    //CV_INSTRUMENT_REGION_IPP();
+
+    if( channels == 1 )
+    {
+        switch( depth )
+        {
+        case CV_8U:
+            return CV_INSTRUMENT_FUN_IPP(ippiSet_8u_C1R, cv::saturate_cast<Ipp8u>(value[0]), (Ipp8u *)dataPointer, step, size) >= 0;
+        case CV_16U:
+            return CV_INSTRUMENT_FUN_IPP(ippiSet_16u_C1R, cv::saturate_cast<Ipp16u>(value[0]), (Ipp16u *)dataPointer, step, size) >= 0;
+        case CV_32F:
+            return CV_INSTRUMENT_FUN_IPP(ippiSet_32f_C1R, cv::saturate_cast<Ipp32f>(value[0]), (Ipp32f *)dataPointer, step, size) >= 0;
+        }
+    }
+    else
+    {
+        if( channels == 3 )
+        {
+            switch( depth )
+            {
+            case CV_8U:
+                return IPPSetSimple<3, Ipp8u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_8u_C3R);
+            case CV_16U:
+                return IPPSetSimple<3, Ipp16u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_16u_C3R);
+            case CV_32F:
+                return IPPSetSimple<3, Ipp32f>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_32f_C3R);
+            }
+        }
+        else if( channels == 4 )
+        {
+            switch( depth )
+            {
+            case CV_8U:
+                return IPPSetSimple<4, Ipp8u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_8u_C4R);
+            case CV_16U:
+                return IPPSetSimple<4, Ipp16u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_16u_C4R);
+            case CV_32F:
+                return IPPSetSimple<4, Ipp32f>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_32f_C4R);
+            }
+        }
+    }
+    return false;
+}
+
+int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
+                     uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
+                     float *mapx, size_t mapx_step, float *mapy, size_t mapy_step,
+                     int interpolation, int border_type, const double border_value[4])
+{
+    if (!((interpolation == cv::INTER_LINEAR || interpolation == cv::INTER_CUBIC || interpolation == cv::INTER_NEAREST) &&
+        (border_type == cv::BORDER_CONSTANT || border_type == cv::BORDER_TRANSPARENT)))
+    {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    int ippInterpolation = ippiGetInterpolation(interpolation);
+    // Unsupported source type
+    if (src_type !=  CV_8UC1 && src_type !=  CV_8UC3 && src_type !=  CV_8UC4 &&
+        src_type != CV_16UC1 && src_type != CV_16UC3 && src_type != CV_16UC4 &&
+        src_type != CV_32FC1 && src_type != CV_32FC3 && src_type != CV_32FC4)
+    {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+#if defined(IPP_CALLS_ENFORCED)
+                                    /* C1         C2         C3         C4 */
+    char impl[CV_DEPTH_MAX][4][3] = {{{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //8U
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8S
+                                     {{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //16U
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16S
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32S
+                                     {{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //32F
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}};  //64F
+#else // IPP_CALLS_ENFORCED is not defined, results are strictly aligned to OpenCV implementation
+                                    /* C1         C2         C3         C4 */
+    char impl[CV_DEPTH_MAX][4][3] = {{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8U
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8S
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16U
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16S
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32S
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32F
+                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}};  //64F
 #endif
+
+    if (impl[CV_TYPE(src_type)][CV_MAT_CN(src_type)-1][interpolation] == 0)
+    {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    try
+    {
+        std::atomic_bool ok{true};
+        cv::Range cv_range(0, dst_height);
+
+        ::ipp::IwiImage iwSrc, iwMapx, iwMapy; // There are const pointers. So, we need to call an init function
+        iwSrc.Init( IwiSize{src_width, src_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), src_data, IwSize(src_step));
+        iwMapx.Init(IwiSize{dst_width, dst_height}, ippiGetDataType(CV_32FC1), 1, IwiBorderSize(), mapx, IwSize(mapx_step));
+        iwMapy.Init(IwiSize{dst_width, dst_height}, ippiGetDataType(CV_32FC1), 1, IwiBorderSize(), mapy, IwSize(mapy_step));
+        ::ipp::IwiImage iwDst(IwiSize{dst_width, dst_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), dst_data, IwSize(dst_step));
+
+        auto IPPRemapInvokerLambda = [dst_data, border_type, border_value, src_type,
+            &iwSrc, &iwDst, &iwMapx, &iwMapy, ippInterpolation, &ok](const cv::Range& range)
+        {
+            //CV_INSTRUMENT_REGION_IPP();
+            if (!ok.load(std::memory_order_relaxed))
+                return;
+
+            try
+            {
+                IppiSize dstRoiSize = ippiSize(iwDst.m_size.width, range.size());
+                IppiRect srcRoiRect = {0, 0, (int)iwSrc.m_size.width, (int)iwSrc.m_size.height};
+                uchar *dst_roi_data = dst_data + range.start * iwDst.m_step;
+                int depth = CV_MAT_DEPTH(src_type), cn = CV_MAT_CN(src_type);
+
+                if (border_type == cv::BORDER_CONSTANT &&
+                    !IPPSet(border_value, dst_roi_data, iwDst.m_step, dstRoiSize, cn, depth))
+                {
+                    ok.store(false, std::memory_order_relaxed);
+                    return;
+                }
+                ::ipp::IwiTile tile = ::ipp::IwiRoi(0, range.start, iwDst.m_size.width, range.end - range.start);
+                CV_INSTRUMENT_FUN_IPP(::ipp::iwiRemap, iwSrc, iwDst, srcRoiRect, iwMapx, iwMapy, dstRoiSize, ippInterpolation, tile);
+            }
+            catch (const ::ipp::IwException &)
+            {
+                ok.store(false, std::memory_order_relaxed);
+                return;
+            }
+
+            CV_IMPL_ADD(CV_IMPL_IPP|CV_IMPL_MT);
+        };
+
+        int min_payload = 1 << 16; // 64KB shall be minimal per thread to maximize scalability for warping functions
+        const char type_size[CV_DEPTH_MAX] = {1,1,2,2,4,4,8};
+        const int num_threads = ippiSuggestRowThreadsNum(dst_width, dst_height, type_size[CV_TYPE(src_type)]*CV_MAT_CN(src_type), min_payload);
+
+        cv::parallel_for_(cv_range, IPPRemapInvokerLambda, num_threads);
+
+        if (!ok)
+        {
+            return CV_HAL_ERROR_NOT_IMPLEMENTED;
+        }
+    }
+    catch (const ::ipp::IwException &)
+    {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+#endif // IPP_VERSION_X100 >= 202600
+
+#endif // HAVE_IPP_IW

--- a/hal/ipp/src/transforms_ipp.cpp
+++ b/hal/ipp/src/transforms_ipp.cpp
@@ -1,6 +1,7 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
+// Copyright (C) 2026, Intel Corporation, all rights reserved.
 
 #include "ipp_hal_core.hpp"
 #include "precomp_ipp.hpp"

--- a/hal/ipp/src/warp_ipp.cpp
+++ b/hal/ipp/src/warp_ipp.cpp
@@ -1,6 +1,7 @@
 // This file is part of OpenCV project.
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html
+// Copyright (C) 2026, Intel Corporation, all rights reserved.
 
 #include "ipp_hal_imgproc.hpp"
 

--- a/hal/ipp/src/warp_ipp.cpp
+++ b/hal/ipp/src/warp_ipp.cpp
@@ -6,73 +6,12 @@
 
 #if IPP_VERSION_X100 >= 810 // integrated IPP warping/remap ABI is available since IPP v8.1
 
+#include <atomic>
 #include <opencv2/core.hpp>
 #include "precomp_ipp.hpp"
-#include <atomic>
 
 // Uncomment to enforce IPP calls for all supported by IPP configurations
 // #define IPP_CALLS_ENFORCED
-
-#define CV_TYPE(src_type) (src_type & (CV_DEPTH_MAX - 1))
-
-typedef IppStatus (CV_STDCALL* ippiSetFunc)(const void*, void *, int, IppiSize);
-
-template <int channels, typename Type>
-bool IPPSetSimple(const double value[4], void *dataPointer, int step, IppiSize &size, ippiSetFunc func)
-{
-    //CV_INSTRUMENT_REGION_IPP();
-
-    Type values[channels];
-    for( int i = 0; i < channels; i++ )
-        values[i] = cv::saturate_cast<Type>(value[i]);
-    return CV_INSTRUMENT_FUN_IPP(func, values, dataPointer, step, size) >= 0;
-}
-
-static bool IPPSet(const double value[4], void *dataPointer, int step, IppiSize &size, int channels, int depth)
-{
-    //CV_INSTRUMENT_REGION_IPP();
-
-    if( channels == 1 )
-    {
-        switch( depth )
-        {
-        case CV_8U:
-            return CV_INSTRUMENT_FUN_IPP(ippiSet_8u_C1R, cv::saturate_cast<Ipp8u>(value[0]), (Ipp8u *)dataPointer, step, size) >= 0;
-        case CV_16U:
-            return CV_INSTRUMENT_FUN_IPP(ippiSet_16u_C1R, cv::saturate_cast<Ipp16u>(value[0]), (Ipp16u *)dataPointer, step, size) >= 0;
-        case CV_32F:
-            return CV_INSTRUMENT_FUN_IPP(ippiSet_32f_C1R, cv::saturate_cast<Ipp32f>(value[0]), (Ipp32f *)dataPointer, step, size) >= 0;
-        }
-    }
-    else
-    {
-        if( channels == 3 )
-        {
-            switch( depth )
-            {
-            case CV_8U:
-                return IPPSetSimple<3, Ipp8u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_8u_C3R);
-            case CV_16U:
-                return IPPSetSimple<3, Ipp16u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_16u_C3R);
-            case CV_32F:
-                return IPPSetSimple<3, Ipp32f>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_32f_C3R);
-            }
-        }
-        else if( channels == 4 )
-        {
-            switch( depth )
-            {
-            case CV_8U:
-                return IPPSetSimple<4, Ipp8u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_8u_C4R);
-            case CV_16U:
-                return IPPSetSimple<4, Ipp16u>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_16u_C4R);
-            case CV_32F:
-                return IPPSetSimple<4, Ipp32f>(value, dataPointer, step, size, (ippiSetFunc)ippiSet_32f_C4R);
-            }
-        }
-    }
-    return false;
-}
 
 #ifdef HAVE_IPP_IW
 
@@ -128,7 +67,6 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
         iwSrc.Init(IwiSize{src_width, src_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), src_data, IwSize(src_step));
         ::ipp::IwiImage        iwDst(IwiSize{dst_width, dst_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), dst_data, IwSize(dst_step));
         ::ipp::IwiBorderType   ippBorder(ippiGetBorderType(borderType), {borderValue, 4});
-        // OpenCV inverts the affine matrix before calling the HAL (lines 2401-2411 of imgwarp.cpp), so the HAL receives the inverse transform.
         IwTransDirection       iwTransDirection = iwTransInverse;
 
         if ((int)ippBorder == -1)
@@ -165,7 +103,7 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
 
         if (num_threads > 1)
         {
-            parallel_for_(cv_range, IPPWarpAffineInvokerLambda, num_threads);
+            cv::parallel_for_(cv_range, IPPWarpAffineInvokerLambda, num_threads);
         }
         else
         {
@@ -295,7 +233,7 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
 
         if (num_threads > 1)
         {
-            parallel_for_(cv_range, IPPWarpPerspectiveInvokerLambda, num_threads);
+            cv::parallel_for_(cv_range, IPPWarpPerspectiveInvokerLambda, num_threads);
         }
         else
         {
@@ -317,147 +255,5 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
 #endif // IPP_VERSION_X100 >= 202600
 
 #endif // HAVE_IPP_IW
-
-// Remap section
-typedef IppStatus(CV_STDCALL *ippiRemap)(const void *pSrc, IppiSize srcSize, int srcStep, IppiRect srcRoi,
-                                         const Ipp32f *pxMap, int xMapStep, const Ipp32f *pyMap, int yMapStep,
-                                         void *pDst, int dstStep, IppiSize dstRoiSize, int interpolation);
-
-class IPPRemapInvoker : public cv::ParallelLoopBody
-{
-public:
-    IPPRemapInvoker(int _src_type, const uchar *_src_data, size_t _src_step, int _src_width, int _src_height,
-                    uchar *_dst_data, size_t _dst_step, int _dst_width, float *_mapx, size_t _mapx_step, float *_mapy,
-                    size_t _mapy_step, ippiRemap _ippFunc, int _ippInterpolation, int _borderType, const double _borderValue[4], std::atomic_bool *_ok) :
-        src_type(_src_type), src(_src_data), src_step(_src_step), src_width(_src_width), src_height(_src_height),
-        dst(_dst_data), dst_step(_dst_step), dst_width(_dst_width), mapx(_mapx), mapx_step(_mapx_step), mapy(_mapy),
-        mapy_step(_mapy_step), ippFunc(_ippFunc), ippInterpolation(_ippInterpolation), borderType(_borderType), ok(_ok)
-    {
-        memcpy(this->borderValue, _borderValue, sizeof(this->borderValue));
-    }
-
-    virtual void operator()(const cv::Range &range) const
-    {
-        //CV_INSTRUMENT_REGION_IPP();
-        if(!ok->load(std::memory_order_relaxed))
-            return;
-
-        IppiRect srcRoiRect = {0, 0, src_width, src_height};
-        uchar *dst_roi_data = dst + range.start * dst_step;
-        IppiSize dstRoiSize = ippiSize(dst_width, range.size());
-        int depth = CV_MAT_DEPTH(src_type), cn = CV_MAT_CN(src_type);
-
-        if (borderType == cv::BORDER_CONSTANT &&
-            !IPPSet(borderValue, dst_roi_data, (int)dst_step, dstRoiSize, cn, depth))
-        {
-            ok->store(false, std::memory_order_relaxed);
-            return;
-        }
-
-        if (ippStsNoErr != CV_INSTRUMENT_FUN_IPP(ippFunc, src, {src_width, src_height}, (int)src_step, srcRoiRect,
-                                  mapx, (int)mapx_step, mapy, (int)mapy_step,
-                                  dst_roi_data, (int)dst_step, dstRoiSize, ippInterpolation))
-        {
-            ok->store(false, std::memory_order_relaxed);
-            return;
-        }
-
-        CV_IMPL_ADD(CV_IMPL_IPP | CV_IMPL_MT);
-    }
-
-private:
-    int src_type;
-    const uchar *src;
-    size_t src_step;
-    int src_width, src_height;
-    uchar *dst;
-    size_t dst_step;
-    int dst_width;
-    float *mapx;
-    size_t mapx_step;
-    float *mapy;
-    size_t mapy_step;
-    ippiRemap ippFunc;
-    int ippInterpolation, borderType;
-    double borderValue[4];
-    std::atomic_bool *ok;
-};
-
-int ipp_hal_remap32f(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height,
-                     uchar *dst_data, size_t dst_step, int dst_width, int dst_height,
-                     float *mapx, size_t mapx_step, float *mapy, size_t mapy_step,
-                     int interpolation, int border_type, const double border_value[4])
-{
-    CV_HAL_CHECK_USE_IPP();
-
-    if (!((interpolation == cv::INTER_LINEAR || interpolation == cv::INTER_CUBIC || interpolation == cv::INTER_NEAREST) &&
-        (border_type == cv::BORDER_CONSTANT || border_type == cv::BORDER_TRANSPARENT)))
-    {
-        return CV_HAL_ERROR_NOT_IMPLEMENTED;
-    }
-
-    int ippInterpolation = ippiGetInterpolation(interpolation);
-
-#if defined(IPP_CALLS_ENFORCED)
-                                    /* C1         C2         C3         C4 */
-    char impl[CV_DEPTH_MAX][4][3] = {{{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //8U
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8S
-                                     {{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //16U
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16S
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32S
-                                     {{1, 1, 1}, {0, 0, 0}, {1, 1, 1}, {1, 1, 1}},   //32F
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}};  //64F
-#else // IPP_CALLS_ENFORCED is not defined, results are strictly aligned to OpenCV implementation
-                                    /* C1         C2         C3         C4 */
-    char impl[CV_DEPTH_MAX][4][3] = {{{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8U
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //8S
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16U
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //16S
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32S
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}},   //32F
-                                     {{0, 0, 0}, {0, 0, 0}, {0, 0, 0}, {0, 0, 0}}};  //64F
-#endif
-    const char type_size[CV_DEPTH_MAX] = {1,1,2,2,4,4,8};
-
-    if (impl[CV_TYPE(src_type)][CV_MAT_CN(src_type) - 1][interpolation] == 0)
-    {
-        return CV_HAL_ERROR_NOT_IMPLEMENTED;
-    }
-
-    ippiRemap ippFunc =
-        src_type == CV_8UC1  ? (ippiRemap)ippiRemap_8u_C1R :
-        src_type == CV_8UC3  ? (ippiRemap)ippiRemap_8u_C3R :
-        src_type == CV_8UC4  ? (ippiRemap)ippiRemap_8u_C4R :
-        src_type == CV_16UC1 ? (ippiRemap)ippiRemap_16u_C1R :
-        src_type == CV_16UC3 ? (ippiRemap)ippiRemap_16u_C3R :
-        src_type == CV_16UC4 ? (ippiRemap)ippiRemap_16u_C4R :
-        src_type == CV_32FC1 ? (ippiRemap)ippiRemap_32f_C1R :
-        src_type == CV_32FC3 ? (ippiRemap)ippiRemap_32f_C3R :
-        src_type == CV_32FC4 ? (ippiRemap)ippiRemap_32f_C4R : 0;
-
-    if (ippFunc)
-    {
-        std::atomic_bool ok{true};
-
-        IPPRemapInvoker invoker(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width,
-                                mapx, mapx_step, mapy, mapy_step, ippFunc, ippInterpolation, border_type, border_value, &ok);
-        cv::Range range(0, dst_height);
-
-        int min_payload = 1 << 16; // 64KB shall be minimal per thread to maximize scalability for warping functions
-        int num_threads = ippiSuggestRowThreadsNum(dst_width, dst_height, type_size[CV_TYPE(src_type)]*CV_MAT_CN(src_type), min_payload);
-
-        cv::parallel_for_(range, invoker, num_threads);
-
-        if (ok)
-        {
-            CV_IMPL_ADD(CV_IMPL_IPP | CV_IMPL_MT);
-            return CV_HAL_ERROR_OK;
-        }
-    }
-
-    return CV_HAL_ERROR_NOT_IMPLEMENTED;
-}
-
-// End of Remap section
 
 #endif // IPP_VERSION_X100 >= 810

--- a/hal/ipp/src/warp_ipp.cpp
+++ b/hal/ipp/src/warp_ipp.cpp
@@ -130,10 +130,6 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
                             int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4])
 {
     CV_HAL_CHECK_USE_IPP();
-<<<<<<< HEAD
-
-=======
->>>>>>> 492e17e922 (added missed extra function calls)
     //CV_INSTRUMENT_REGION_IPP();
 
     IppiInterpolationType ippInter = ippiGetInterpolation(interpolation);

--- a/hal/ipp/src/warp_ipp.cpp
+++ b/hal/ipp/src/warp_ipp.cpp
@@ -21,7 +21,6 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
                        int dst_width, int dst_height, const double M[6], int interpolation, int borderType, const double borderValue[4])
 {
     CV_HAL_CHECK_USE_IPP();
-
     //CV_INSTRUMENT_REGION_IPP();
 
     IppiInterpolationType ippInter  = ippiGetInterpolation(interpolation);
@@ -67,6 +66,7 @@ int ipp_hal_warpAffine(int src_type, const uchar *src_data, size_t src_step, int
         iwSrc.Init(IwiSize{src_width, src_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), src_data, IwSize(src_step));
         ::ipp::IwiImage        iwDst(IwiSize{dst_width, dst_height}, ippiGetDataType(src_type), CV_MAT_CN(src_type), IwiBorderSize(), dst_data, IwSize(dst_step));
         ::ipp::IwiBorderType   ippBorder(ippiGetBorderType(borderType), {borderValue, 4});
+        // OpenCV inverts the affine matrix before calling the HAL (lines 2401-2411 of imgwarp.cpp), so the HAL receives the inverse transform.
         IwTransDirection       iwTransDirection = iwTransInverse;
 
         if ((int)ippBorder == -1)
@@ -129,7 +129,10 @@ int ipp_hal_warpPerspective(int src_type, const uchar *src_data, size_t src_step
                             int dst_width, int dst_height, const double M[9], int interpolation, int borderType, const double borderValue[4])
 {
     CV_HAL_CHECK_USE_IPP();
+<<<<<<< HEAD
 
+=======
+>>>>>>> 492e17e922 (added missed extra function calls)
     //CV_INSTRUMENT_REGION_IPP();
 
     IppiInterpolationType ippInter = ippiGetInterpolation(interpolation);


### PR DESCRIPTION
- Rewrote `ipp_hal_remap32f` to use the `iwiRemap` IW interface (requires `IPP >= 2026.0`), replacing the legacy low-level `ippiRemap*` API with manual spec/buffer management
- Moved `ipp_hal_remap32f` from `warp_ipp.cpp` to `transforms_ipp.cpp`
- Added `cv::` namespace prefix to `parallel_for_` calls

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
