### PR TITLE
imgproc: avoid signed left-shift UB in drawing code

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -73,6 +73,17 @@ static void
 FillConvexPoly( Mat& img, const Point2l* v, int npts,
                 const void* color, int line_type, int shift );
 
+// Use multiplication to avoid undefined behavior from left-shifting negative coordinates.
+static inline int64
+ScaleToFixedPoint( int64 v, int shift )
+{
+    CV_Assert( 0 <= shift && shift <= XY_SHIFT );
+    const int64 factor = static_cast<int64>(1) << (XY_SHIFT - shift);
+    CV_DbgAssert( v >= std::numeric_limits<int64>::min() / factor &&
+                  v <= std::numeric_limits<int64>::max() / factor );
+    return v * factor;
+}
+
 /****************************************************************************************\
 *                                   Lines                                                *
 \****************************************************************************************/
@@ -1117,11 +1128,10 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
     else
         delta1 = XY_ONE - 1, delta2 = 0;
 
-    p0 = v[npts - 1];
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
-
     CV_Assert( 0 <= shift && shift <= XY_SHIFT );
+    p0 = v[npts - 1];
+    p0.x = ScaleToFixedPoint(p0.x, shift);
+    p0.y = ScaleToFixedPoint(p0.y, shift);
     xmin = xmax = v[0].x;
     ymin = ymax = v[0].y;
 
@@ -1138,8 +1148,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
         xmax = std::max( xmax, p.x );
         xmin = MIN( xmin, p.x );
 
-        p.x <<= XY_SHIFT - shift;
-        p.y <<= XY_SHIFT - shift;
+        p.x = ScaleToFixedPoint(p.x, shift);
+        p.y = ScaleToFixedPoint(p.y, shift);
 
         if( line_type <= 8 )
         {
@@ -1202,8 +1212,8 @@ FillConvexPoly( Mat& img, const Point2l* v, int npts, const void* color, int lin
                             int64 xe = v[idx].x;
                             if (shift != XY_SHIFT)
                             {
-                                xs <<= XY_SHIFT - shift;
-                                xe <<= XY_SHIFT - shift;
+                                xs = ScaleToFixedPoint(xs, shift);
+                                xe = ScaleToFixedPoint(xe, shift);
                             }
 
                             edge[i].ye = ty;
@@ -1264,7 +1274,7 @@ CollectPolyEdges( Mat& img, const Point2l* v, int count, std::vector<PolyEdge>& 
 {
     int i, delta = offset.y + ((1 << shift) >> 1);
     Point2l pt0 = v[count-1], pt1;
-    pt0.x = (pt0.x + offset.x) << (XY_SHIFT - shift);
+    pt0.x = ScaleToFixedPoint(pt0.x + offset.x, shift);
     pt0.y = (pt0.y + delta) >> shift;
 
     edges.reserve( edges.size() + count );
@@ -1275,7 +1285,7 @@ CollectPolyEdges( Mat& img, const Point2l* v, int count, std::vector<PolyEdge>& 
         PolyEdge edge;
 
         pt1 = v[i];
-        pt1.x = (pt1.x + offset.x) << (XY_SHIFT - shift);
+        pt1.x = ScaleToFixedPoint(pt1.x + offset.x, shift);
         pt1.y = (pt1.y + delta) >> shift;
 
         Point2l pt0c(pt0), pt1c(pt1);
@@ -1301,14 +1311,14 @@ CollectPolyEdges( Mat& img, const Point2l* v, int count, std::vector<PolyEdge>& 
                 }
             }
 
-            pt0c.x = (int64)(t0.x) << XY_SHIFT;
-            pt1c.x = (int64)(t1.x) << XY_SHIFT;
+            pt0c.x = ScaleToFixedPoint(t0.x, 0);
+            pt1c.x = ScaleToFixedPoint(t1.x, 0);
         }
         else
         {
             t0.x = pt0.x; t1.x = pt1.x;
-            t0.y = pt0.y << XY_SHIFT;
-            t1.y = pt1.y << XY_SHIFT;
+            t0.y = ScaleToFixedPoint(pt0.y, 0);
+            t1.y = ScaleToFixedPoint(pt1.y, 0);
             LineAA(img, t0, t1, color);
         }
 
@@ -1659,10 +1669,10 @@ ThickLine( Mat& img, Point2l p0, Point2l p1, const void* color,
         p1 -= offset;
     }
 
-    p0.x <<= XY_SHIFT - shift;
-    p0.y <<= XY_SHIFT - shift;
-    p1.x <<= XY_SHIFT - shift;
-    p1.y <<= XY_SHIFT - shift;
+    p0.x = ScaleToFixedPoint(p0.x, shift);
+    p0.y = ScaleToFixedPoint(p0.y, shift);
+    p1.x = ScaleToFixedPoint(p1.x, shift);
+    p1.y = ScaleToFixedPoint(p1.y, shift);
 
     if( thickness <= 1 )
     {

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -1104,6 +1104,26 @@ TEST(Drawing, contours_filled)
     }
 }
 
+TEST(Drawing, drawContours_negative_offset_regression_28940)
+{
+    Mat roi(80, 80, CV_8UC1, Scalar::all(0));
+    vector<vector<Point> > contours(1);
+    contours[0].push_back(Point(100, 100));
+    contours[0].push_back(Point(160, 100));
+    contours[0].push_back(Point(160, 160));
+    contours[0].push_back(Point(100, 160));
+
+    // Negative offsets are used when drawing full-image contours into an ROI.
+    drawContours(roi, contours, -1, Scalar(255), 2, LINE_8, noArray(), INT_MAX, Point(-120, -120));
+
+    // The contour is shifted to the rectangle with corners (-20, -20) and (40, 40),
+    // so only the bottom and right parts should be visible in the ROI after clipping.
+    EXPECT_NE(0, roi.at<uchar>(20, 40));
+    EXPECT_NE(0, roi.at<uchar>(40, 20));
+    EXPECT_NE(0, roi.at<uchar>(40, 40));
+    EXPECT_EQ(0, countNonZero(roi(Rect(60, 60, 20, 20))));
+}
+
 // Test for LINE_4 vs LINE_8 connectivity behavior
 // Regression test for issue #26413
 TEST(Drawing, line_connectivity_regression_26413)


### PR DESCRIPTION
Fixes #28940

### Summary

This PR fixes undefined behavior in imgproc drawing code when drawing contours with a negative offset.

The issue appears in a realistic ROI drawing workflow: contours are stored in full-image coordinates, but they are rendered into a cropped ROI with a negative `offset`. In that case, `drawContours()` may pass negative coordinates to internal drawing routines. For example, a contour point `(100, 100)` drawn with `offset = (-120, -120)` becomes `(-20, -20)` inside the drawing path.

Some drawing paths converted coordinates to OpenCV's internal fixed-point representation with signed left shifts, for example in `ThickLine()`:

```cpp
p0.x <<= XY_SHIFT - shift;
```

Left-shifting negative signed integers is undefined behavior in C++ and is reported by UBSan.

This patch replaces those signed left shifts with multiplication by the corresponding power-of-two scale factor, preserving the same fixed-point scaling while avoiding undefined behavior for negative coordinates. The affected related paths in `drawing.cpp`, including `ThickLine()`, `FillConvexPoly()`, and `CollectPolyEdges()`, are updated.

### Reproducer

A minimal reproducer is:

```cpp
cv::Mat roi(80, 80, CV_8UC1, cv::Scalar::all(0));

std::vector<std::vector<cv::Point>> contours(1);
contours[0].push_back(cv::Point(100, 100));
contours[0].push_back(cv::Point(160, 100));
contours[0].push_back(cv::Point(160, 160));
contours[0].push_back(cv::Point(100, 160));

cv::drawContours(
    roi, contours, -1, cv::Scalar(255), 2,
    cv::LINE_8, cv::noArray(), INT_MAX, cv::Point(-120, -120));
```

Before this patch, an UBSan build reports:

```text
modules/imgproc/src/drawing.cpp:1662:10: runtime error: left shift of negative value -20
```

After this patch, the reproducer finishes successfully.

### Tests

Added a regression test:

```text
Drawing.drawContours_negative_offset_regression_28940
```

Tested locally with UBSan:

```bash
cmake -S . -B build_ubsan_test_28940 \
  -DCMAKE_BUILD_TYPE=Debug \
  -DBUILD_LIST=core,imgproc,ts \
  -DBUILD_TESTS=ON \
  -DBUILD_PERF_TESTS=OFF \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_SHARED_LIBS=ON \
  -DWITH_IPP=OFF \
  -DWITH_ADE=OFF \
  -DBUILD_opencv_gapi=OFF \
  -DCMAKE_C_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer" \
  -DCMAKE_CXX_FLAGS="-fsanitize=undefined -fno-sanitize-recover=undefined -fno-omit-frame-pointer"

cmake --build build_ubsan_test_28940 --target opencv_test_imgproc --parallel 8

./build_ubsan_test_28940/bin/opencv_test_imgproc \
  --gtest_filter=Drawing.drawContours_negative_offset_regression_28940
```

Result:

```text
[  PASSED  ] 1 test.
```

### Performance

I also compared the original and patched code with repeated `drawContours()` calls for 100, 1000, and 10000 iterations.

For normal positive coordinates, the measured differences were within noise level:

```text
100 iterations:   original best 32.5576 ms, patched best 31.8391 ms
1000 iterations:  original best 327.375 ms, patched best 321.646 ms
10000 iterations: original best 3228.03 ms, patched best 3252.81 ms
```

For the negative-offset path, the measured differences were also small:

```text
100 iterations:   original best 30.3292 ms, patched best 30.7858 ms
1000 iterations:  original best 304.723 ms, patched best 305.115 ms
10000 iterations: original best 2997.3 ms, patched best 3033.59 ms
```

The output checksum was unchanged in these benchmark runs. The measured differences are small and within normal benchmark noise, indicating that this fix does not cause a meaningful performance regression.

No `opencv_extra` test data is required because the regression test uses synthetic contours.

No documentation or sample update is needed because this is a bug fix without API changes.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

