### PR TITLE
fix MSVC error: use name constexp for alignas array size in INT8 kernel

### DIFF
--- a/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
+++ b/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
@@ -1163,7 +1163,9 @@ static void convInt8BlockDepthwise(const void* inp_, const void* residual_,
         ((planeblocks_ + nthreads * 4 - 1) / (nthreads * 4) + SB_TILE - 1) & ~(SB_TILE - 1));
     int ntiles = (planeblocks_ + TILE - 1) / TILE;
     int total_tasks = N * K1 * ntiles;
-    constexpr int WBUF_SIZE = 128 * 8;  // 128 * K0, K0=8; named constant for MSVC compatibility
+#if CV_AVX2 && (defined(__x86_64__) || defined(_M_X64))
+    constexpr int WBUF_SIZE = 128 * 8;  // 128 * K0, K0=8; named for MSVC
+#endif
 
     parallel_for_(Range(0, total_tasks), [&](const Range& range) {
         int H = H_, W = W_;
@@ -1194,7 +1196,6 @@ static void convInt8BlockDepthwise(const void* inp_, const void* residual_,
             if (ksize <= 128) {
                 int n_g = g_end - g_start;
                 constexpr int SB = 8;
-
                 // Pre-gather weights for this group block into wbuf[ksize * K0].
                 alignas(32) int8_t wbuf[WBUF_SIZE];
                 for (int i = 0; i < ksize; i++) {
@@ -1585,7 +1586,9 @@ void convInt8Block(const void* inp_, const void* residual_,
     }
 
     int total_blocks = N * ngroups * Kblk;
-    constexpr int SUMBUF_SIZE = 8 * 8;  // SPAT_BLOCK_SIZE * K0, both=8; named constant for MSVC compatibility
+#if CV_AVX2
+    constexpr int SUMBUF_SIZE = 8 * 8;  // SPAT_BLOCK_SIZE * K0, both=8; named for MSVC
+#endif
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
         constexpr int C0 = 8, K0 = 8;

--- a/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
+++ b/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
@@ -1163,6 +1163,7 @@ static void convInt8BlockDepthwise(const void* inp_, const void* residual_,
         ((planeblocks_ + nthreads * 4 - 1) / (nthreads * 4) + SB_TILE - 1) & ~(SB_TILE - 1));
     int ntiles = (planeblocks_ + TILE - 1) / TILE;
     int total_tasks = N * K1 * ntiles;
+    constexpr int WBUF_SIZE = 128 * 8;  // 128 * K0, K0=8; named constant for MSVC compatibility
 
     parallel_for_(Range(0, total_tasks), [&](const Range& range) {
         int H = H_, W = W_;
@@ -1195,7 +1196,7 @@ static void convInt8BlockDepthwise(const void* inp_, const void* residual_,
                 constexpr int SB = 8;
 
                 // Pre-gather weights for this group block into wbuf[ksize * K0].
-                alignas(32) int8_t wbuf[128 * K0];
+                alignas(32) int8_t wbuf[WBUF_SIZE];
                 for (int i = 0; i < ksize; i++) {
                     for (int j = 0; j < n_g; j++) {
                         int g  = g_start + j;
@@ -1584,13 +1585,14 @@ void convInt8Block(const void* inp_, const void* residual_,
     }
 
     int total_blocks = N * ngroups * Kblk;
+    constexpr int SUMBUF_SIZE = 8 * 8;  // SPAT_BLOCK_SIZE * K0, both=8; named constant for MSVC compatibility
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {
         constexpr int C0 = 8, K0 = 8;
         constexpr int C0shift = 3;
 #if CV_AVX2
         constexpr int SPAT_BLOCK_SIZE = 8;
-        alignas(32) int32_t sumbuf[SPAT_BLOCK_SIZE * K0];
+        alignas(32) int32_t sumbuf[SUMBUF_SIZE];
 #endif
         const uint8_t xor_val = inputIsU8 ? 0x80 : 0;
 


### PR DESCRIPTION
### Problem
Windows CI fails with MSVC error C2131 in `conv2_int8_kernels.simd.hpp`:

    error C2131: expression did not evaluate to a constant
    failure was caused by a read of a variable outside its lifetime
    see usage of 'this'

Two array declarations inside `parallel_for_` lambdas used `constexpr`
variables defined inside the lambda body as array sizes:

    alignas(32) int8_t  wbuf[128 * K0];          // K0 defined inside lambda
    alignas(32) int32_t sumbuf[SPAT_BLOCK_SIZE * K0];  // both defined inside lambda


### Fix
Move the combined size constants to function scope (before the lambda),
where they are true compile-time constants with no `this` involvement:

    constexpr int WBUF_SIZE   = 128 * 8;  // 128 * K0
    constexpr int SUMBUF_SIZE = 8 * 8;    // SPAT_BLOCK_SIZE * K0



### Related
Fixes Windows CI failure introduced by #29126.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
