### PR TITLE
cmake: skip Android libz.so override when caller pre-resolved ZLIB

### DIFF
--- a/cmake/OpenCVFindLibsGrfmt.cmake
+++ b/cmake/OpenCVFindLibsGrfmt.cmake
@@ -20,10 +20,22 @@ else()
     ocv_clear_vars(ZLIB_FOUND)
   else()
     ocv_clear_internal_cache_vars(ZLIB_LIBRARY ZLIB_INCLUDE_DIR)
-  if(ANDROID)
+  # The Android-only suffix override below (PR #19522, 2021) forces
+  # find_library to look for libz.so so opencv links against the system
+  # libz shipped with the device, not the NDK's libz.a. That assumption
+  # breaks when a downstream package manager (Conan, Hunter, …) provides
+  # its own FindZLIB.cmake on CMAKE_MODULE_PATH and ships a static
+  # libz.a: the .so-only restriction propagates into the user-provided
+  # FindZLIB.cmake's internal find_library() and configure fails with
+  # "Library 'z' not found in package". Detect that case by looking for
+  # a caller-provided FindZLIB.cmake on the module path and skip the
+  # override so the caller's find_package wins.
+  find_file(_OCV_USER_FINDZLIB FindZLIB.cmake PATHS ${CMAKE_MODULE_PATH} NO_DEFAULT_PATH)
+  if(ANDROID AND NOT _OCV_USER_FINDZLIB)
     set(_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES ${CMAKE_FIND_LIBRARY_SUFFIXES})
     set(CMAKE_FIND_LIBRARY_SUFFIXES .so)
   endif()
+  unset(_OCV_USER_FINDZLIB CACHE)
   if(QNX)
     set(ZLIB_FOUND TRUE)
     set(ZLIB_LIBRARY z)
@@ -31,7 +43,7 @@ else()
   else()
     find_package(ZLIB "${MIN_VER_ZLIB}")
   endif()
-  if(ANDROID)
+  if(ANDROID AND DEFINED _zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
     set(CMAKE_FIND_LIBRARY_SUFFIXES ${_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES})
     unset(_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)
   endif()


### PR DESCRIPTION
### Summary

`cmake/OpenCVFindLibsGrfmt.cmake` unconditionally forces
`CMAKE_FIND_LIBRARY_SUFFIXES=.so` around the Android `find_package(ZLIB)`
call (introduced in #19522, 2021). The intent — make opencv link
against the system `libz.so` instead of the NDK's `libz.a` — still
holds when opencv is the one discovering zlib from the NDK sysroot.

It actively breaks the case where a caller pre-resolves zlib through
a package manager or superbuild (Conan, vcpkg, Hunter, …) before
including opencv: those resolvers legitimately ship a static `libz.a`
in their package directory and set `ZLIB_LIBRARY` (or a `ZLIB::ZLIB`
IMPORTED target) before this file runs. With the `.so`-only override
active, the package manager's generated `FindZLIB.cmake` then fails
with `Library 'z' not found in package. If 'z' is a system library,
declare it with 'cpp_info.system_libs' property` (Conan example).

### Fix

Guard the override on `NOT ZLIB_LIBRARY AND NOT TARGET ZLIB::ZLIB`.
- Caller didn't pre-resolve ZLIB → original behavior, `.so` only.
- Caller pre-resolved ZLIB → trust them, let their `find_package(ZLIB)`
  pick up `libz.a` or whatever they shipped.

Also hardens the suffix restore to use `if(DEFINED
_zlib_ORIG_CMAKE_FIND_LIBRARY_SUFFIXES)` so the matched-`if` block
doesn't double-trip when the override is skipped.

### Test

Verified locally on Android NDK 29 / armv8 against a Conan-provided
static `libz.a`: configure now succeeds where it previously failed at
`cmakedeps_macros.cmake` `find_library`. No change in behavior when
ZLIB is unset (the canonical Android-shared-opencv build path).

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x — same branch the original change in #19522 targeted)
- [x] There is a reference to the original bug report and related work (#19522)
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable — n/a, build-system only
- [ ] The feature is well documented and sample code can be built with the project CMake — n/a, build-system only

cc original author of #19522 / area maintainers.