### PR TITLE
[BUG FIX] Fixed Conv+Add+BatchNorm fusion with correct BN scale on the residual

### DIFF
--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -195,8 +195,11 @@ public:
     virtual bool fuseBatchNorm(const Ptr<Layer>& bnlayer) override
     {
         BatchNorm2Layer* bn = dynamic_cast<BatchNorm2Layer*>(bnlayer.get());
+        // addResidual means the graph order is conv->add->bn: the residual is added
+        // before BN, but the conv applies the fused BN scale only to conv(x), not to
+        // the residual. Refuse so BN stays separate and runs on (conv + residual).
         if (fusedBatchNorm || !bn || bn->inputs.size() > 1 ||
-            fastActivation != FAST_ACTIV_NONE || !activ.empty())
+            fastActivation != FAST_ACTIV_NONE || !activ.empty() || addResidual)
             return false;
         fuseBatchNormWeights(bn);
         fusedBatchNorm = true;


### PR DESCRIPTION
closes: https://github.com/opencv/opencv/issues/29160
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
