### PR TITLE
imgproc: re-enable RVV integral optimization for safe cases

### DIFF
--- a/hal/riscv-rvv/include/imgproc.hpp
+++ b/hal/riscv-rvv/include/imgproc.hpp
@@ -236,10 +236,8 @@ int integral(int depth, int sdepth, int sqdepth,
              uchar* tilted_data, [[maybe_unused]] size_t tilted_step,
              int width, int height, int cn);
 
-// Diasbled due to accuracy issue.
-// Details see https://github.com/opencv/opencv/issues/27407.
-//#undef cv_hal_integral
-//#define cv_hal_integral cv::rvv_hal::imgproc::integral
+#undef cv_hal_integral
+#define cv_hal_integral cv::rvv_hal::imgproc::integral
 
 /* ############ laplacian ############ */
 int laplacian(const uint8_t* src_data, size_t src_step,

--- a/hal/riscv-rvv/src/imgproc/integral.cpp
+++ b/hal/riscv-rvv/src/imgproc/integral.cpp
@@ -129,6 +129,11 @@ int integral(int depth, int sdepth, int sqdepth,
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
     }
 
+    // CV_32F sqsum kept on generic path due to accumulation-order sensitivity, see #27407
+    if (sqsum_data && (sdepth == CV_32F || sqdepth == CV_32F)) {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
     // Skip images that are too small
     if (!(width >> 8 || height >> 8)) {
         return CV_HAL_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

## Motivation

The RVV integral HAL implementation exists, but `cv_hal_integral` was disabled due to the accuracy issue tracked by #27407. The failures are concentrated in `integral_sqsum` cases involving `CV_32F`, where floating-point accumulation order is sensitive.

This patch re-enables RVV integral only for safe cases and keeps `CV_32F` sqsum cases on the generic path:

```cpp
if (sqsum_data && (sdepth == CV_32F || sqdepth == CV_32F)) {
    return CV_HAL_ERROR_NOT_IMPLEMENTED;
}
```

So the intended behavior is:

- Risky `CV_32F` sqsum cases: fallback to generic.
- Non-`CV_32F` safe cases: use RVV HAL.
- No generic imgproc code or perf tests are changed.

## Platform
SpacemiT X60 (K1), 8-core RISC-V RVV 1.0, VLEN=256, 16GB RAM, OS: Bianbu Linux (kernel 6.6.63), GCC 13.2.0, Build: OpenCV 4.14.0-pre, Release, HAL: YES (RVV HAL 0.0.1)

## Experiment 1: Risk Cases Do Not Use RVV

Command:

```bash
./build/bin/opencv_perf_imgproc \
  --gtest_filter='Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/1:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/4:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/10:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/13:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/16:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/22:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/25:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/28:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/34' \
  --perf_min_samples=1 \
  --perf_force_samples=1
```

These are the #27407-sensitive cases:

- `640x480`: `8UC1/8UC2/8UC4 + CV_32F`
- `1280x720`: `8UC1/8UC2/8UC4 + CV_32F`
- `1920x1080`: `8UC1/8UC2/8UC4 + CV_32F`

Key result:

```text
[==========] Running 9 tests from 1 test case.
[  PASSED  ] 9 tests.
```

This confirms that the risky `CV_32F` sqsum cases still pass after the patch. These cases are intentionally kept on the generic fallback path.

## Experiment 2: Safe Cases Use RVV And Pass

Command:

```bash
./build/bin/opencv_perf_imgproc \
  --gtest_filter='Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/0:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/2:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/9:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/11:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/24:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/26:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/33:Size_MatType_OutMatDepth_integral_sqsum.integral_sqsum/35' \
  --perf_min_samples=1 \
  --perf_force_samples=1
```

These are non-`CV_32F` `integral_sqsum` cases, so they are not blocked by the new guard and are expected to go through the RVV HAL.

Key result:

```text
[==========] Running 8 tests from 1 test case.
[  PASSED  ] 8 tests.
```

This confirms that the re-enabled safe subset is correct for the tested cases.

## Experiment 3: Performance

The following table compares `integral_sqsum` safe cases before and after re-enabling RVV integral.

| Case | Before, RVV disabled | After, RVV enabled | Speedup |
| --- | ---: | ---: | ---: |
| `640x480, 8UC1, CV_32S` | 3.83 | 4.27 | 0.90x |
| `640x480, 8UC1, CV_64F` | 5.94 | 5.26 | 1.13x |
| `640x480, 8UC4, CV_32S` | 21.53 | 14.53 | 1.48x |
| `640x480, 8UC4, CV_64F` | 23.95 | 17.85 | 1.34x |
| `1920x1080, 8UC1, CV_32S` | 27.67 | 28.02 | 0.99x |
| `1920x1080, 8UC1, CV_64F` | 36.55 | 35.38 | 1.03x |
| `1920x1080, 8UC4, CV_32S` | 152.11 | 97.12 | 1.57x |
| `1920x1080, 8UC4, CV_64F` | 501.17 | 118.51 | 4.23x |

Most selected safe cases improve, especially multi-channel cases. The largest measured gain is `4.23x` for `1920x1080, 8UC4, CV_64F`.

There are small neutral or slightly slower cases for single-channel `CV_32S`, but the important multi-channel safe cases show substantial speedups while #27407-sensitive `CV_32F` sqsum cases remain protected by generic fallback.

Overall, this is a conservative and useful optimization: it restores RVV acceleration for safe integral cases without reintroducing the known `CV_32F` sqsum accuracy issue.