### PR TITLE
Make sure Truco is launched on non-empty and CV_8UC1 only.

### DIFF
--- a/modules/imgproc/src/contours_new.cpp
+++ b/modules/imgproc/src/contours_new.cpp
@@ -649,7 +649,7 @@ void cv::findContours(InputArray _image,
     }
 
     // Fast path: RETR_LIST without hierarchy → findTRUContours (parallel contour extraction)
-    if (mode == RETR_LIST && !_hierarchy.needed())
+    if (mode == RETR_LIST && !_hierarchy.needed() && _image.type() == CV_8UC1)
     {
         // findTRUContours requires FOREGROUND=255; binarize=true thresholds the padded
         // image in-place, avoiding an extra allocation (findContours accepts any non-zero value)

--- a/modules/imgproc/src/contours_truco.cpp
+++ b/modules/imgproc/src/contours_truco.cpp
@@ -618,7 +618,7 @@ void findTRUContours(InputArray _src, OutputArrayOfArrays _contours, int minSize
 {
     CV_INSTRUMENT_REGION();
     Mat src = _src.getMat();
-    CV_Assert(!src.empty() && src.type() == CV_8UC1);
+    CV_Assert(src.type() == CV_8UC1);
 
     // Buffer handling
     cv::Mat padded;


### PR DESCRIPTION
This is checked in the function:
https://github.com/opencv/opencv/blob/3bb68212dac2e1c42e7910de9daf3a0766eaead8/modules/imgproc/src/contours_truco.cpp#L621

Introduced in https://github.com/opencv/opencv/pull/28773

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
