### PR TITLE
Relax G-API GStreamer integration tests as Ubuntu 26.04 produce 1 frame more than expected

### DIFF
--- a/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp
@@ -77,7 +77,7 @@ TEST_P(GStreamerSourceTest, AccuracyTest)
 
     EXPECT_FALSE(ccomp.running());
 
-    EXPECT_EQ(streamLength, framesCount);
+    EXPECT_LE(abs(streamLength-framesCount), 1u);
 }
 
 TEST_P(GStreamerSourceTest, TimestampsTest)
@@ -129,7 +129,7 @@ TEST_P(GStreamerSourceTest, TimestampsTest)
     EXPECT_TRUE(std::is_sorted(allSeqIds.begin(), allSeqIds.end()));
     EXPECT_EQ(allSeqIds.size(), std::set<int64_t>(allSeqIds.begin(), allSeqIds.end()).size());
 
-    EXPECT_EQ(streamLength, allTimestamps.size());
+    EXPECT_LE(abs(streamLength-allTimestamps.size()), 1u);
     EXPECT_TRUE(std::is_sorted(allTimestamps.begin(), allTimestamps.end()));
 }
 
@@ -270,7 +270,7 @@ TEST_P(GStreamerSourceTest, GFrameTest)
 
     EXPECT_FALSE(ccomp.running());
 
-    EXPECT_EQ(streamLength, framesCount);
+    EXPECT_LE(abs(streamLength-framesCount), 1u);
 }
 
 


### PR DESCRIPTION
Similar to https://github.com/opencv/opencv/pull/28946

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
