### PR TITLE
Upgrade WBUF_SIZE/SUMBUF to static constexpr for MSVC 19.29

### DIFF
--- a/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
+++ b/modules/dnn/src/int8layers/conv2_int8_kernels.simd.hpp
@@ -1164,7 +1164,7 @@ static void convInt8BlockDepthwise(const void* inp_, const void* residual_,
     int ntiles = (planeblocks_ + TILE - 1) / TILE;
     int total_tasks = N * K1 * ntiles;
 #if CV_AVX2 && (defined(__x86_64__) || defined(_M_X64))
-    constexpr int WBUF_SIZE = 128 * 8;  // 128 * K0, K0=8; named for MSVC
+    static constexpr int WBUF_SIZE = 128 * 8;  // 128 * K0, K0=8; static for MSVC 19.29
 #endif
 
     parallel_for_(Range(0, total_tasks), [&](const Range& range) {
@@ -1587,7 +1587,7 @@ void convInt8Block(const void* inp_, const void* residual_,
 
     int total_blocks = N * ngroups * Kblk;
 #if CV_AVX2
-    constexpr int SUMBUF_SIZE = 8 * 8;  // SPAT_BLOCK_SIZE * K0, both=8; named for MSVC
+    static constexpr int SUMBUF_SIZE = 8 * 8;  // SPAT_BLOCK_SIZE * K0, both=8; static for MSVC 19.29
 #endif
 
     parallel_for_(Range(0, total_blocks), [&](const Range& range) {


### PR DESCRIPTION
### Description

Plain `constexpr` local variables in the enclosing function scope are still captured via `this` by MSVC 19.29 (VS 2019 as in CI machine) inside lambdas,
causing `C2131: expression did not evaluate to a constant` on `alignas` array declarations.
 `static constexpr` has static storage duration and is never captured by a lambda, so MSVC 19.29 can evaluate it as a
compile-time constant correctly.

**Changed** `WBUF_SIZE` and `SUMBUF_SIZE` in`conv2_int8_kernels.simd.hpp` 
from `constexpr` to `static constexpr`,fixing the remaining C2131 failures with MSVC 19.29 (VS 2019 16.x)
that were not resolved by the plain `constexpr` rename in #29156.

Related : https://github.com/opencv/opencv/actions/runs/26456728664/job/78011116479?pr=29126


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
