### PR TITLE
add RVV convertScale data type conversions

### DIFF
--- a/hal/riscv-rvv/src/core/convert_scale.cpp
+++ b/hal/riscv-rvv/src/core/convert_scale.cpp
@@ -62,6 +62,141 @@ inline int convertScale_8U32F(const uchar* src, size_t src_step, uchar* dst, siz
     return CV_HAL_ERROR_OK;
 }
 
+inline int convertScale_8U16U(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    if (alpha == 1.0 && beta == 0.0)
+    {
+        for (int i = 0; i < height; i++)
+        {
+            const uchar* src_row = src + i * src_step;
+            ushort* dst_row = reinterpret_cast<ushort*>(dst + i * dst_step);
+            int vl;
+            for (int j = 0; j < width; j += vl)
+            {
+                vl = __riscv_vsetvl_e8m2(width - j);
+                auto vec_src = __riscv_vle8_v_u8m2(src_row + j, vl);
+                auto vec_dst = __riscv_vzext_vf2(vec_src, vl);
+                __riscv_vse16_v_u16m4(dst_row + j, vec_dst, vl);
+            }
+        }
+
+        return CV_HAL_ERROR_OK;
+    }
+
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const uchar* src_row = src + i * src_step;
+        ushort* dst_row = reinterpret_cast<ushort*>(dst + i * dst_step);
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e8m2(width - j);
+            auto vec_src = __riscv_vle8_v_u8m2(src_row + j, vl);
+            auto vec_src_u16 = __riscv_vzext_vf2(vec_src, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src_u16, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            auto vec_dst = __riscv_vfncvt_xu(vec_fma, vl);
+            __riscv_vse16_v_u16m4(dst_row + j, vec_dst, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+inline int convertScale_8U16S(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    if (alpha == 1.0 && beta == 0.0)
+    {
+        for (int i = 0; i < height; i++)
+        {
+            const uchar* src_row = src + i * src_step;
+            short* dst_row = reinterpret_cast<short*>(dst + i * dst_step);
+            int vl;
+            for (int j = 0; j < width; j += vl)
+            {
+                vl = __riscv_vsetvl_e8m2(width - j);
+                auto vec_src = __riscv_vle8_v_u8m2(src_row + j, vl);
+                auto vec_dst = __riscv_vreinterpret_v_u16m4_i16m4(__riscv_vzext_vf2(vec_src, vl));
+                __riscv_vse16_v_i16m4(dst_row + j, vec_dst, vl);
+            }
+        }
+
+        return CV_HAL_ERROR_OK;
+    }
+
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const uchar* src_row = src + i * src_step;
+        short* dst_row = reinterpret_cast<short*>(dst + i * dst_step);
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e8m2(width - j);
+            auto vec_src = __riscv_vle8_v_u8m2(src_row + j, vl);
+            auto vec_src_u16 = __riscv_vzext_vf2(vec_src, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src_u16, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            auto vec_dst = __riscv_vfncvt_x(vec_fma, vl);
+            __riscv_vse16_v_i16m4(dst_row + j, vec_dst, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
+inline int convertScale_16U8U(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    if (alpha == 1.0 && beta == 0.0)
+    {
+        for (int i = 0; i < height; i++)
+        {
+            const ushort* src_row = reinterpret_cast<const ushort*>(src + i * src_step);
+            uchar* dst_row = dst + i * dst_step;
+            int vl;
+            for (int j = 0; j < width; j += vl)
+            {
+                vl = __riscv_vsetvl_e16m4(width - j);
+                auto vec_src = __riscv_vle16_v_u16m4(src_row + j, vl);
+                auto vec_dst = __riscv_vnclipu(vec_src, 0, __RISCV_VXRM_RNU, vl);
+                __riscv_vse8_v_u8m2(dst_row + j, vec_dst, vl);
+            }
+        }
+
+        return CV_HAL_ERROR_OK;
+    }
+
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const ushort* src_row = reinterpret_cast<const ushort*>(src + i * src_step);
+        uchar* dst_row = dst + i * dst_step;
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e16m4(width - j);
+            auto vec_src = __riscv_vle16_v_u16m4(src_row + j, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            auto vec_dst_u16 = __riscv_vfncvt_xu(vec_fma, vl);
+            auto vec_dst = __riscv_vnclipu(vec_dst_u16, 0, __RISCV_VXRM_RNU, vl);
+            __riscv_vse8_v_u8m2(dst_row + j, vec_dst, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
 inline int convertScale_16U32F(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
 {
     int vlmax = __riscv_vsetvlmax_e32m8();
@@ -164,6 +299,13 @@ int convertScale(const uchar* src, size_t src_step, uchar* dst, size_t dst_step,
     if (!dst)
         return CV_HAL_ERROR_OK;
 
+    if ((unsigned)ddepth >= CV_DEPTH_MAX)
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+
+    // Column-shaped sources can target row-shaped continuous vectors.
+    if (width == 1 && height > 1 && dst_step != CV_ELEM_SIZE1(ddepth))
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+
     switch (sdepth)
     {
     case CV_8U:
@@ -171,6 +313,10 @@ int convertScale(const uchar* src, size_t src_step, uchar* dst, size_t dst_step,
         {
         case CV_8U:
             return convertScale_8U8U(src, src_step, dst, dst_step, width, height, alpha, beta);
+        case CV_16U:
+            return convertScale_8U16U(src, src_step, dst, dst_step, width, height, alpha, beta);
+        case CV_16S:
+            return convertScale_8U16S(src, src_step, dst, dst_step, width, height, alpha, beta);
         case CV_32F:
             return convertScale_8U32F(src, src_step, dst, dst_step, width, height, alpha, beta);
         }
@@ -178,6 +324,8 @@ int convertScale(const uchar* src, size_t src_step, uchar* dst, size_t dst_step,
     case CV_16U:
         switch (ddepth)
         {
+        case CV_8U:
+            return convertScale_16U8U(src, src_step, dst, dst_step, width, height, alpha, beta);
         case CV_32F:
             return convertScale_16U32F(src, src_step, dst, dst_step, width, height, alpha, beta);
         }


### PR DESCRIPTION

 ### Summary

  This PR adds RVV HAL `convertScale` implementations for common image conversion pairs:

  - `CV_8U -> CV_16U`
  - `CV_8U -> CV_16S`
  - `CV_16U -> CV_8U`

  These conversions are common in image range expansion, signed intermediate image data, and 16-bit to 8-bit display/export paths.

  ### Implementation Details

  The new kernels follow the existing RVV `convertScale` structure:

  - scaled paths use vectorized float conversion + FMA + saturating conversion
  - no-scale paths (`alpha=1`, `beta=0`) use integer-only fast paths:
    - `8U -> 16U`: zero-extend and store
    - `8U -> 16S`: zero-extend, reinterpret as signed, and store
    - `16U -> 8U`: saturating narrow and store

  The integer fast paths avoid regressing plain `convertTo` calls where floating-point scale/FMA work is unnecessary. Tests on K1 shows around 5% regression if unhandled.

  ### Layout Guard

  The HAL entry receives source-shaped `width`/`height` before OpenCV’s generic path flattens continuous arrays. For column-shaped sources, a destination backed by `std::vector<T>` may be exposed as a row-shaped continuous Mat. The HAL arguments do not include enough destination shape metadata to distinguish that from a real padded column Mat.

  To avoid interpreting ambiguous destination strides incorrectly, RVV HAL now returns `CV_HAL_ERROR_NOT_IMPLEMENTED` for column-shaped inputs where the destination step does not match one destination element. OpenCV then falls back to the generic conversion path, which has full Mat metadata and handles this layout correctly.

  ### Validation

  Tested on SpacemiT K1 with RVV HAL enabled.

```bash
./bin/opencv_test_core \
    --gtest_output=xml:opencv_test_core.xml
```

```text
[==========] 5431 tests from 242 test cases ran. (1298452 ms total)
[  PASSED  ] 5431 tests.

YOU HAVE 14 DISABLED TESTS
```

```bash
./bin/opencv_perf_core \
    --gtest_filter='*convertTo*' \
    --perf_min_samples=20 \
    --perf_force_samples=20 \
    --gtest_output=xml:convertTo_rvv_final.xml
```

  ### Performance


| Conversion | Scale Factor | VGA C1 | VGA C4 | 1080p C1 | 1080p C4 | Geomean |
|------------|--------------|---------|---------|-----------|-----------|---------|
| 8U → 16U | α = 1 | 1.04× | 1.10× | 0.99× | 1.03× | **1.04×** |
| 8U → 16U | α = 1/255 | 1.87× | 1.72× | 1.69× | 1.63× | **1.73×** |
| 8U → 16S | α = 1 | 1.02× | 1.02× | 1.01× | 1.03× | **1.02×** |
| 8U → 16S | α = 1/255 | 1.60× | 1.50× | 1.47× | 1.40× | **1.49×** |
| 16U → 8U | α = 1 | 1.04× | 1.00× | 0.99× | 0.98× | **1.00×** |
| 16U → 8U | α = 1/255 | 2.09× | 2.02× | 2.05× | 2.00× | **2.04×** |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
