### PR TITLE
temporarily disabled RVV intrinsics in several layers of the new DNN …

### DIFF
--- a/modules/dnn/src/layers/avgpool_layer.cpp
+++ b/modules/dnn/src/layers/avgpool_layer.cpp
@@ -52,7 +52,7 @@ static void avgPool32f(const void* inp_, void* out_,
         float* out = (float*)out_ + nc0*planesize;
         float iksize = 1.f/ksize;
 
-#if CV_SIMD || CV_SIMD_SCALABLE
+#if CV_SIMD
         int nlanes = VTraits<v_float32>::vlanes();
         CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
         v_float32 z = vx_setzero_f32();
@@ -68,12 +68,12 @@ static void avgPool32f(const void* inp_, void* out_,
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
 
-                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                #if !(CV_SIMD)
                     memset(out, 0, W*C0*sizeof(out[0]));
                 #endif
 
                     for(;;) {
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
@@ -152,7 +152,7 @@ static void avgPool32f(const void* inp_, void* out_,
                             break;
                         x1 = inner_x1;
 
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;

--- a/modules/dnn/src/layers/batch_norm2_layer.cpp
+++ b/modules/dnn/src/layers/batch_norm2_layer.cpp
@@ -19,7 +19,7 @@ namespace dnn {
 */
 
 #undef CV_SIMD_ONLY
-#if CV_SIMD || CV_SIMD_SCALABLE
+#if CV_SIMD
 #define CV_SIMD_ONLY(expr) expr
 #else
 #define CV_SIMD_ONLY(expr)
@@ -135,7 +135,7 @@ static void batchnorm(const Mat& inp, Mat& out, const Mat& scale,
                     }
                 }
             }
-        #if CV_SIMD || CV_SIMD_SCALABLE
+        #if CV_SIMD
             /*
                 [TODO] support C0 == vlanes/2, maybe C0 == vlanes/4.
                 in this case, load everything into vsc0 and vb0, process

--- a/modules/dnn/src/layers/cpu_kernels/conv2_deconv.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_deconv.cpp
@@ -63,7 +63,7 @@ static void deconvBlock32f(const void* inp__, const void* /*residual*/,
     const float* wdata = (const float*)weights__;
     const float* bias  = bias__;
 
-#if (CV_SIMD || CV_SIMD_SCALABLE)
+#if (CV_SIMD)
     // SIMD path is safe when ngroups==1 or Kg%C0==0; repackDeconvWeights()
     // zero-fills padded lanes.
     const bool simd_ok =
@@ -83,7 +83,7 @@ static void deconvBlock32f(const void* inp__, const void* /*residual*/,
             float* out_k1 = (float*)out__ + ((int64_t)n * K1 + k1) * ospatial * C0;
             const float* inp_n = (const float*)inp__ + (int64_t)n * C1 * ispatial * C0;
 
-#if (CV_SIMD || CV_SIMD_SCALABLE)
+#if (CV_SIMD)
             // Precompute the shared (g, kblk, c1_abs_base) for the SIMD path.
             int simd_g = 0, simd_kblk = 0, simd_c1_abs_base = 0;
             if (simd_ok) {
@@ -115,7 +115,7 @@ static void deconvBlock32f(const void* inp__, const void* /*residual*/,
                     }
                 }
 
-#if (CV_SIMD || CV_SIMD_SCALABLE)
+#if (CV_SIMD)
                 if (simd_ok) {
                     const int VLANES = VTraits<v_float32>::vlanes();
                     const int v_per_block = C0 / VLANES;

--- a/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_depthwise.simd.hpp
@@ -89,7 +89,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
             defaultAlpha = 1.f;
         }
 
-    #if CV_SIMD || CV_SIMD_SCALABLE
+    #if CV_SIMD
         v_float32 v_maxval = vx_setall_f32(maxval);
         v_float32 z = vx_setzero_f32();
         const int nlanes = VTraits<v_float32>::vlanes();
@@ -126,12 +126,12 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
 
-                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                #if !(CV_SIMD)
                     memset(out, 0, W*C0*sizeof(out[0]));
                 #endif
 
                     for(;;) {
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             v_float32 sc0 = vx_load(scalebuf), b0 = vx_load(biasbuf);
                             v_float32 alpha0 = vx_load(alphabuf);
@@ -218,7 +218,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                             break;
                         x1 = inner_x1;
 
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             v_float32 sc0 = vx_load(scalebuf), b0 = vx_load(biasbuf), alpha0 = vx_load(alphabuf);
                             for (; x0 < x1; x0++) {
@@ -335,7 +335,7 @@ static void depthwiseConv32f(const void* inp__, const void* residual__,
                         x1 = W;
                     }
 
-                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                #if !(CV_SIMD)
                     if (residual) {
                         for (int x = 0; x < W*C0; x += C0) {
                             for (int c = 0; c < C0; c++) {

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -50,7 +50,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
         float* out = (float*)out_ + nc0*planesize;
         const float INITVAL = -FLT_MAX;
 
-    #if CV_SIMD || CV_SIMD_SCALABLE
+    #if CV_SIMD
         int nlanes = VTraits<v_float32>::vlanes();
         v_float32 s_min = vx_setall_f32(INITVAL);
         CV_Assert(C0 == nlanes || C0 == nlanes*2 || C0 % (nlanes*4) == 0);
@@ -65,13 +65,13 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                         y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
                     int yi_ = y0*SY - padY0;
 
-                #if !(CV_SIMD || CV_SIMD_SCALABLE)
+                #if !(CV_SIMD)
                     for (int c = 0; c < C0*W; c++)
                         out[c] = INITVAL;
                 #endif
 
                     for(;;) {
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;
@@ -136,7 +136,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
                             break;
                         x1 = inner_x1;
 
-                    #if CV_SIMD || CV_SIMD_SCALABLE
+                    #if CV_SIMD
                         if (nlanes == C0) {
                             for (; x0 < x1; x0++) {
                                 int xi_ = x0*SX - padX0;


### PR DESCRIPTION
tested on musebook K1. kernels will be re-enabled when we find some good solution for the current 'm2' issue in rvv_scalable intrinsics.

This should fix #28852

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
