### PR TITLE
Restore some IPP calls that were disabled in #13085 due to the binary size

### DIFF
--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -6,12 +6,6 @@
 #include "opencv2/core/mat.hpp"
 #include "opencl_kernels_core.hpp"
 
-#undef HAVE_IPP
-#undef CV_IPP_RUN_FAST
-#define CV_IPP_RUN_FAST(f, ...)
-#undef CV_IPP_RUN
-#define CV_IPP_RUN(c, f, ...)
-
 /*************************************************************************************************\
                                         Matrix Operations
 \*************************************************************************************************/
@@ -515,6 +509,12 @@ typedef void (*ReduceFunc)( const Mat& src, Mat& dst );
 #ifdef HAVE_IPP
 static inline bool ipp_reduceSumC_8u16u16s32f_64f(const cv::Mat& srcmat, cv::Mat& dstmat)
 {
+    /* IPP processes rows sequentially; OpenCV's reduceC_ uses parallel_for_ which is faster in MT mode */
+    if(cv::getNumThreads() > 1)
+    {
+        return false;
+    }
+
     int sstep = (int)srcmat.step, stype = srcmat.type(),
             ddepth = dstmat.depth();
 
@@ -611,17 +611,22 @@ static inline void reduceSumC_8u16u16s32f_64f(const cv::Mat& srcmat, cv::Mat& ds
 #define reduceSumC16u64f reduceC_<ushort,double,OpAdd<double> >
 #define reduceSumC16s64f reduceC_<short, double,OpAdd<double> >
 #define reduceSumC32f64f reduceC_<float, double,OpAdd<double> >
+#endif
 
 #define reduceSum2C8u64f  reduceC_<uchar, double,OpAddSqr<int>,   OpSqr<int> >
 #define reduceSum2C16u64f reduceC_<ushort,double,OpAddSqr<double>,OpSqr<double> >
 #define reduceSum2C16s64f reduceC_<short, double,OpAddSqr<double>,OpSqr<double> >
 #define reduceSum2C32f64f reduceC_<float, double,OpAddSqr<double>,OpSqr<double> >
-#endif
 
 #ifdef HAVE_IPP
 #define REDUCE_OP(favor, optype, type1, type2) \
 static inline bool ipp_reduce##optype##C##favor(const cv::Mat& srcmat, cv::Mat& dstmat) \
 { \
+    /* IPP processes rows sequentially; OpenCV's reduceC_ uses parallel_for_ which is faster in MT mode */ \
+    if(cv::getNumThreads() > 1) \
+    { \
+        return false; \
+    } \
     if((srcmat.channels() == 1)) \
     { \
         int sstep = (int)srcmat.step; \

--- a/modules/imgproc/src/box_filter.dispatch.cpp
+++ b/modules/imgproc/src/box_filter.dispatch.cpp
@@ -314,7 +314,7 @@ Ptr<FilterEngine> createBoxFilter(int srcType, int dstType, Size ksize,
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
-#if 0 //defined(HAVE_IPP)
+#if defined(HAVE_IPP)
 static bool ipp_boxfilter(Mat &src, Mat &dst, Size ksize, Point anchor, bool normalize, int borderType)
 {
 #ifdef HAVE_IPP_IW
@@ -331,6 +331,26 @@ static bool ipp_boxfilter(Mat &src, Mat &dst, Size ksize, Point anchor, bool nor
 #endif
 
     if(!normalize)
+        return false;
+
+    int depth = src.depth();
+    int cn = src.channels();
+    int kw = ksize.width;
+
+    // IPP could optimize more for 8U C3 all kernel sizes
+    if(depth == CV_8U && cn == 3)
+        return false;
+    // IPP could optimize more for 8U C4 with small/medium kernels (but it's good for ksize 21)
+    if(depth == CV_8U && cn == 4 && kw <= 7)
+        return false;
+    // IPP could optimize more for 8U C1 with ksize >= 5
+    if(depth == CV_8U && cn == 1 && kw >= 5)
+        return false;
+    // IPP could optimize more for 16U/16S C3 with small kernels
+    if((depth == CV_16U || depth == CV_16S) && cn == 3 && kw <= 5)
+        return false;
+    // IPP could optimize more for 16U/16S C4 all kernel sizes
+    if((depth == CV_16U || depth == CV_16S) && cn == 4)
         return false;
 
     if(!ippiCheckAnchor(anchor, ksize))
@@ -401,7 +421,7 @@ void boxFilter(InputArray _src, OutputArray _dst, int ddepth,
              ofs.x, ofs.y, wsz.width - src.cols - ofs.x, wsz.height - src.rows - ofs.y, ksize.width, ksize.height,
              anchor.x, anchor.y, normalize, borderType&~BORDER_ISOLATED);
 
-    //CV_IPP_RUN_FAST(ipp_boxfilter(src, dst, ksize, anchor, normalize, borderType));
+    CV_IPP_RUN_FAST(ipp_boxfilter(src, dst, ksize, anchor, normalize, borderType));
 
     borderType = (borderType&~BORDER_ISOLATED);
 

--- a/modules/imgproc/src/deriv.cpp
+++ b/modules/imgproc/src/deriv.cpp
@@ -182,7 +182,7 @@ cv::Ptr<cv::FilterEngine> cv::createDerivFilter(int srcType, int dstType,
 }
 
 
-#if 0 //defined HAVE_IPP
+#if defined HAVE_IPP
 namespace cv
 {
 
@@ -238,17 +238,22 @@ static bool ipp_Deriv(InputArray _src, OutputArray _dst, int dx, int dy, int ksi
         if(!ippBorder)
             return false;
 
+        // IPP path for 8u->32f does an extra full-image conversion pass, OpenCV's fused sepFilter2D is better
+        if(srcType == ipp8u && dstType == ipp32f)
+            return false;
+
+        // IPP could optimize more for 16s->32f (extra conversion overhead)
+        if(srcType == ipp16s && dstType == ipp32f)
+            return false;
+
+        // IPP extra iwiScale pass for 32f output with scale/delta could be better than OpenCV's fused approach
+        if(useScale && dstType == ipp32f)
+            return false;
+
         if(srcType == ipp8u && dstType == ipp8u)
         {
             iwDstProc.Alloc(iwDst.m_size, ipp16s, channels);
             useScale = true;
-        }
-        else if(srcType == ipp8u && dstType == ipp32f)
-        {
-            iwSrc -= borderSize;
-            iwSrcProc.Alloc(iwSrc.m_size, ipp32f, channels);
-            CV_INSTRUMENT_FUN_IPP(::ipp::iwiScale, iwSrc, iwSrcProc, 1, 0, ::ipp::IwiScaleParams(ippAlgHintFast));
-            iwSrcProc += borderSize;
         }
 
         if(useScharr)
@@ -378,7 +383,7 @@ void cv::Sobel( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
     CALL_HAL(sobel, cv_hal_sobel, src.ptr(), src.step, dst.ptr(), dst.step, src.cols, src.rows, sdepth, ddepth, cn,
              ofs.x, ofs.y, wsz.width - src.cols - ofs.x, wsz.height - src.rows - ofs.y, dx, dy, ksize, scale, delta, borderType&~BORDER_ISOLATED);
 
-    //CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, ksize, scale, delta, borderType));
+    CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, ksize, scale, delta, borderType));
 
     sepFilter2D(src, dst, ddepth, kx, ky, Point(-1, -1), delta, borderType );
 }
@@ -430,7 +435,7 @@ void cv::Scharr( InputArray _src, OutputArray _dst, int ddepth, int dx, int dy,
     CALL_HAL(scharr, cv_hal_scharr, src.ptr(), src.step, dst.ptr(), dst.step, src.cols, src.rows, sdepth, ddepth, cn,
              ofs.x, ofs.y, wsz.width - src.cols - ofs.x, wsz.height - src.rows - ofs.y, dx, dy, scale, delta, borderType&~BORDER_ISOLATED);
 
-    //CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, 0, scale, delta, borderType));
+    CV_IPP_RUN_FAST(ipp_Deriv(src, dst, dx, dy, 0, scale, delta, borderType));
 
     sepFilter2D( src, dst, ddepth, kx, ky, Point(-1, -1), delta, borderType );
 }

--- a/modules/imgproc/src/filter.dispatch.cpp
+++ b/modules/imgproc/src/filter.dispatch.cpp
@@ -1227,7 +1227,7 @@ static bool replacementFilter2D(int stype, int dtype, int kernel_type,
     return success;
 }
 
-#if 0 //defined HAVE_IPP
+#if defined HAVE_IPP
 static bool ippFilter2D(int stype, int dtype, int kernel_type,
               uchar * src_data, size_t src_step,
               uchar * dst_data, size_t dst_step,
@@ -1524,7 +1524,7 @@ void filter2D(int stype, int dtype, int kernel_type,
     if (res)
         return;
 
-    /*CV_IPP_RUN_FAST(ippFilter2D(stype, dtype, kernel_type,
+    CV_IPP_RUN_FAST(ippFilter2D(stype, dtype, kernel_type,
                               src_data, src_step,
                               dst_data, dst_step,
                               width, height,
@@ -1533,7 +1533,7 @@ void filter2D(int stype, int dtype, int kernel_type,
                               kernel_data, kernel_step,
                               kernel_width, kernel_height,
                               anchor_x, anchor_y,
-                              delta, borderType, isSubmatrix))*/
+                              delta, borderType, isSubmatrix));
 
     res = dftFilter2D(stype, dtype, kernel_type,
                       src_data, src_step,

--- a/modules/imgproc/src/median_blur.dispatch.cpp
+++ b/modules/imgproc/src/median_blur.dispatch.cpp
@@ -110,7 +110,7 @@ static bool ocl_medianFilter(InputArray _src, OutputArray _dst, int m)
 
 #endif
 
-#if 0 //defined HAVE_IPP
+#if defined HAVE_IPP
 static bool ipp_medianFilter(Mat &src0, Mat &dst, int ksize)
 {
     CV_INSTRUMENT_REGION_IPP();
@@ -121,11 +121,26 @@ static bool ipp_medianFilter(Mat &src0, Mat &dst, int ksize)
         return false;
 #endif
 
+    int channels = src0.channels();
+    int depth = src0.depth();
+
+    // IPP could be better for C1 large kernels (ksize >= 7)
+    if(channels == 1 && ksize >= 7)
+        return false;
+    // IPP could be better for any channel with very large kernels
+    if(ksize > 7)
+        return false;
+    // IPP could be better for multi-channel ksize == 3 (all types)
+    if(channels >= 3 && ksize == 3)
+        return false;
+    // IPP could be better for 16u/16s C3 ksize == 5
+    if(channels == 3 && ksize == 5 && depth != CV_8U)
+        return false;
+
     {
         int         bufSize;
         IppiSize    dstRoiSize = ippiSize(dst.cols, dst.rows), maskSize = ippiSize(ksize, ksize);
         IppDataType ippType = ippiGetDataType(src0.type());
-        int         channels = src0.channels();
         IppAutoBuffer<Ipp8u> buffer;
 
         if(src0.isSubmatrix())
@@ -207,7 +222,7 @@ void medianBlur( InputArray _src0, OutputArray _dst, int ksize )
     CALL_HAL(medianBlur, cv_hal_medianBlur, src0.data, src0.step, dst.data, dst.step, src0.cols, src0.rows, src0.depth(),
              src0.channels(), ksize);
 
-    //CV_IPP_RUN_FAST(ipp_medianFilter(src0, dst, ksize));
+    CV_IPP_RUN_FAST(ipp_medianFilter(src0, dst, ksize));
 
     CV_CPU_DISPATCH(medianBlur, (src0, dst, ksize),
         CV_CPU_DISPATCH_MODES_ALL);

--- a/modules/imgproc/src/morph.dispatch.cpp
+++ b/modules/imgproc/src/morph.dispatch.cpp
@@ -265,7 +265,7 @@ static bool halMorph(int op, int src_type, int dst_type,
 }
 
 // ===== 2. IPP implementation
-#if 0 //defined HAVE_IPP
+#if defined HAVE_IPP
 #ifdef HAVE_IPP_IW
 static inline IwiMorphologyType ippiGetMorphologyType(int morphOp)
 {
@@ -342,6 +342,26 @@ static bool ippMorph(int op, int src_type, int dst_type,
         return false;
 
     if(iterations > 1 && morphType != iwiMorphErode && morphType != iwiMorphDilate)
+        return false;
+
+    // IPP iterative loop with border copy could be better for small kernels with multiple iterations
+    if(iterations > 1 && kernel_width*kernel_height < 25)
+        return false;
+
+    // IPP could be better for large rectangular (fully-filled) kernels, typically expanded from RECT + iterations > 1
+    if(kernel_width*kernel_height > 100)
+    {
+        bool isRect = true;
+        for(int i = 0; i < kernel_height && isRect; i++)
+            for(int j = 0; j < kernel_width && isRect; j++)
+                if(kernel_data[i*kernel_step + j] == 0)
+                    isRect = false;
+        if(isRect)
+            return false;
+    }
+
+    // In-place path requires extra buffer allocation + copy, OpenCV's direct approach is better
+    if(src_data == dst_data)
         return false;
 
     if(src_type != dst_type)
@@ -539,12 +559,12 @@ void morph(int op, int src_type, int dst_type,
             return;
     }
 
-    /*CV_IPP_RUN_FAST(ippMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
+    CV_IPP_RUN_FAST(ippMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
                             roi_width, roi_height, roi_x, roi_y,
                             roi_width2, roi_height2, roi_x2, roi_y2,
                             kernel_type, kernel_data, kernel_step,
                             kernel_width, kernel_height, anchor_x, anchor_y,
-                            borderType, borderValue, iterations, isSubmatrix));*/
+                            borderType, borderValue, iterations, isSubmatrix));
 
     ocvMorph(op, src_type, dst_type, src_data, src_step, dst_data, dst_step, width, height,
              roi_width, roi_height, roi_x, roi_y,
@@ -1129,7 +1149,7 @@ static bool ocl_morphologyEx(InputArray _src, OutputArray _dst, int op,
 #endif
 
 #define IPP_DISABLE_MORPH_ADV 1
-#if 0 //defined HAVE_IPP
+#if defined HAVE_IPP
 #if !IPP_DISABLE_MORPH_ADV
 static bool ipp_morphologyEx(int op, InputArray _src, OutputArray _dst,
                      InputArray _kernel,
@@ -1226,7 +1246,7 @@ void morphologyEx( InputArray _src, OutputArray _dst, int op,
     Mat dst = _dst.getMat();
 
 #if !IPP_DISABLE_MORPH_ADV
-    //CV_IPP_RUN_FAST(ipp_morphologyEx(op, src, dst, kernel, anchor, iterations, borderType, borderValue));
+    CV_IPP_RUN_FAST(ipp_morphologyEx(op, src, dst, kernel, anchor, iterations, borderType, borderValue));
 #endif
 
     switch( op )


### PR DESCRIPTION
IPP calls were previously disabled in #13085.
Change of size when enabling IPP calls in the PR:

| Library | Old (MB) | New (MB) | Diff (KB) | Change |
|---------|----------|----------|-----------|--------|
| calib3d | 2.85 | 2.85 | 0 | 0.0% |
| **core** | **19.37** | **19.56** | **+194** | **+1.0%** |
| dnn | 12.88 | 13.64 | +779 | +5.9% |
| features2d | 5.15 | 6.06 | +933 | +17.7% |
| flann | 0.71 | 0.71 | 0 | 0.0% |
| highgui | 0.26 | 0.26 | 0 | 0.0% |
| imgcodecs | 4.77 | 5.68 | +933 | +19.1% |
| **imgproc** | **33.84** | **42.81** | **+9,182** | **+26.5%** |
| ml | 0.68 | 0.68 | 0 | 0.0% |
| objdetect | 1.44 | 1.35 | -97 | -6.6% |
| photo | 5.07 | 5.98 | +929 | +17.9% |
| stitching | 0.73 | 0.73 | 0 | 0.0% |
| video | 0.68 | 0.58 | -99 | -14.2% |
| videoio | 0.69 | 0.69 | 0 | 0.0% |
| **Total** | **89.13** | **101.58** | **+12,753** | **+14.0%** |

Changes in the PR also lead to significant improvements in single-threaded and multi-threaded modes both: up to 10-20x for some perf test's cases (checked with ICV 2026.0.0).

Feel free to check and decide whether the PR is good to be merged now or not.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
