### PR TITLE
Fix std lib vs cv2 typing

### DIFF
--- a/modules/python/src2/typing_stubs_generation/generation.py
+++ b/modules/python/src2/typing_stubs_generation/generation.py
@@ -719,6 +719,36 @@ def _write_required_imports(required_imports: Collection[str],
         output_stream.write("\n\n")
 
 
+def _write_typing_module_import_guard(output_stream: StringIO) -> None:
+    output_stream.write(
+        "if __name__ == \"typing\":\n"
+        "    import importlib.util as _importlib_util\n"
+        "    import os as _os\n"
+        "    import sys as _sys\n"
+        "    import sysconfig as _sysconfig\n"
+        "\n"
+        "    _typing_path = _os.path.join(\n"
+        "        _sysconfig.get_path(\"stdlib\"), \"typing.py\"\n"
+        "    )\n"
+        "    _spec = _importlib_util.spec_from_file_location(\n"
+        "        \"typing\", _typing_path\n"
+        "    )\n"
+        "    if _spec is None or _spec.loader is None:\n"
+        "        raise ImportError(\"Unable to load Python stdlib typing module\")\n"
+        "    _module = _importlib_util.module_from_spec(_spec)\n"
+        "    _sys.modules[\"typing\"] = _module\n"
+        "    _spec.loader.exec_module(_module)\n"
+        "else:\n"
+    )
+
+
+def _write_indented_block(output_stream: StringIO, content: str) -> None:
+    for line in content.splitlines(True):
+        if line.strip():
+            output_stream.write("    ")
+        output_stream.write(line)
+
+
 def _generate_typing_module(root: NamespaceNode, output_path: Path) -> None:
     """Generates stub file for typings module.
     Actual module doesn't exist, but it is an appropriate place to define
@@ -832,23 +862,32 @@ def _generate_typing_module(root: NamespaceNode, output_path: Path) -> None:
         for required_import in node.required_definition_imports:
             required_imports.add(required_import)
 
-    output_stream = StringIO()
-    output_stream.write("__all__ = [\n")
+    body_stream = StringIO()
+    body_stream.write("__all__ = [\n")
     for alias_name in aliases:
-        output_stream.write(f'    "{alias_name}",\n')
-    output_stream.write("]\n\n")
+        body_stream.write(f'    "{alias_name}",\n')
+    body_stream.write("]\n\n")
 
-    _write_required_imports(required_imports, output_stream)
+    _write_required_imports(required_imports, body_stream)
 
     # Add type checking time definitions as generated __init__.py content
     for _, type_node in conditional_type_nodes.items():
-        output_stream.write(f"if {type_node.condition}:\n    ")
-        output_stream.write(f"{type_node.typename} = {type_node.positive_branch_type.full_typename}\nelse:\n")
-        output_stream.write(f"    {type_node.typename} = {type_node.negative_branch_type.full_typename}\n\n\n")
+        body_stream.write(f"if {type_node.condition}:\n    ")
+        body_stream.write(
+            f"{type_node.typename} = "
+            f"{type_node.positive_branch_type.full_typename}\nelse:\n"
+        )
+        body_stream.write(
+            f"    {type_node.typename} = "
+            f"{type_node.negative_branch_type.full_typename}\n\n\n"
+        )
 
     for alias_name, alias_type in aliases.items():
-        output_stream.write(f"{alias_name} = {alias_type}\n")
+        body_stream.write(f"{alias_name} = {alias_type}\n")
 
+    output_stream = StringIO()
+    _write_typing_module_import_guard(output_stream)
+    _write_indented_block(output_stream, body_stream.getvalue())
     TypeNode.compatible_to_runtime_usage = False
     (output_path / "__init__.py").write_text(output_stream.getvalue())
 

--- a/modules/python/test/test_typing.py
+++ b/modules/python/test/test_typing.py
@@ -1,0 +1,55 @@
+import os
+import subprocess
+import sys
+import textwrap
+
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+class typing_test(NewOpenCVTests):
+    def test_top_level_typing_not_shadowed_by_cv2_package(self):
+        code = textwrap.dedent(
+            """
+            import importlib.util
+            import pathlib
+            import sys
+
+            cv2_spec = importlib.util.find_spec("cv2")
+            cv2_dir = pathlib.Path(cv2_spec.origin).parent
+            sys.modules.pop("typing", None)
+            sys.path.insert(0, str(cv2_dir))
+
+            import typing
+
+            typing_path = pathlib.Path(typing.__file__).resolve()
+            cv2_typing_dir = (cv2_dir / "typing").resolve()
+            if cv2_typing_dir in typing_path.parents:
+                raise AssertionError(
+                    "stdlib typing shadowed by {}".format(typing_path)
+                )
+            """
+        )
+        env = os.environ.copy()
+        env["PYTHONPATH"] = os.pathsep.join(sys.path)
+        result = subprocess.run(
+            [sys.executable, "-c", code],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True
+        )
+        self.assertEqual(
+            result.returncode, 0,
+            "stdout:\n{}\nstderr:\n{}".format(result.stdout, result.stderr)
+        )
+
+    def test_cv2_typing_is_available(self):
+        import cv2.typing
+
+        self.assertTrue(hasattr(cv.typing, "MatLike"))
+
+
+if __name__ == "__main__":
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
### Summary

Fix `cv2.typing` shadowing Python stdlib `typing` when the `cv2` package directory is inserted at the front of `sys.path`

Original Issue: #28766 

### Details

- Add generated `cv2.typing` import guard for accidental top-level `import typing`
- Redirect shadowed top-level `typing` import to Python stdlib `typing.py`
- Keep normal `import cv2.typing` behavior unchanged.
- Add regression tests for both paths.

### Validation

- Added `modules/python/test/test_typing.py`
- `git diff --check HEAD~2..HEAD` passed

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x)
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (regression tests in python/test in same repo)
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
