### PR TITLE
core: add SIMD specializations for ReduceR_SIMD

### DIFF
--- a/modules/core/perf/perf_reduce.cpp
+++ b/modules/core/perf/perf_reduce.cpp
@@ -1,5 +1,146 @@
 #include "perf_precomp.hpp"
 
+namespace opencv_test {
+using namespace perf;
+
+///////////// reduce() performance tests /////////////
+
+typedef std::tuple<cv::Size, MatType, MatDepth> Size_MatType_OutDepth_t;
+typedef TestBaseWithParam<Size_MatType_OutDepth_t> Size_MatType_OutDepth;
+
+// Test: reduce SUM with float input -> float output (most common case)
+PERF_TEST_P(Size_MatType_OutDepth, reduceSum,
+    testing::Combine(
+        testing::Values(TYPICAL_MAT_SIZES),
+        testing::Values(CV_32FC1),
+        testing::Values(CV_32F)
+    )
+)
+{
+    Size sz = std::get<0>(GetParam());
+    int srcType = std::get<1>(GetParam());
+    int dstDepth = std::get<2>(GetParam());
+
+    Mat src(sz, srcType);
+    Mat dst(1, sz.width, CV_MAKETYPE(dstDepth, 1));
+
+    declare.in(src, WARMUP_RNG).out(dst).iterations(100);
+
+    TEST_CYCLE()
+    {
+        cv::reduce(src, dst, 0, REDUCE_SUM, dstDepth);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+// Test: reduce SUM with uchar input -> int output (tests SIMD widening path)
+PERF_TEST_P(Size_MatType_OutDepth, reduceSum8u32s,
+    testing::Combine(
+        testing::Values(TYPICAL_MAT_SIZES),
+        testing::Values(CV_8UC1, CV_8UC3),
+        testing::Values(CV_32S)
+    )
+)
+{
+    Size sz = std::get<0>(GetParam());
+    int srcType = std::get<1>(GetParam());
+    int dstDepth = std::get<2>(GetParam());
+
+    Mat src(sz, srcType);
+    int cn = CV_MAT_CN(srcType);
+    Mat dst(1, sz.width * cn, CV_MAKETYPE(dstDepth, 1));
+
+    declare.in(src, WARMUP_RNG).out(dst).iterations(100);
+
+    TEST_CYCLE()
+    {
+        cv::reduce(src, dst, 0, REDUCE_SUM, dstDepth);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+// Test: reduce MAX with float input
+PERF_TEST_P(Size_MatType_OutDepth, reduceMax,
+    testing::Combine(
+        testing::Values(TYPICAL_MAT_SIZES),
+        testing::Values(CV_32FC1),
+        testing::Values(CV_32F)
+    )
+)
+{
+    Size sz = std::get<0>(GetParam());
+    int srcType = std::get<1>(GetParam());
+    int dstDepth = std::get<2>(GetParam());
+
+    Mat src(sz, srcType);
+    Mat dst(1, sz.width, CV_MAKETYPE(dstDepth, 1));
+
+    declare.in(src, WARMUP_RNG).out(dst).iterations(100);
+
+    TEST_CYCLE()
+    {
+        cv::reduce(src, dst, 0, REDUCE_MAX, dstDepth);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+// Test: reduce MIN with float input
+PERF_TEST_P(Size_MatType_OutDepth, reduceMin,
+    testing::Combine(
+        testing::Values(TYPICAL_MAT_SIZES),
+        testing::Values(CV_32FC1),
+        testing::Values(CV_32F)
+    )
+)
+{
+    Size sz = std::get<0>(GetParam());
+    int srcType = std::get<1>(GetParam());
+    int dstDepth = std::get<2>(GetParam());
+
+    Mat src(sz, srcType);
+    Mat dst(1, sz.width, CV_MAKETYPE(dstDepth, 1));
+
+    declare.in(src, WARMUP_RNG).out(dst).iterations(100);
+
+    TEST_CYCLE()
+    {
+        cv::reduce(src, dst, 0, REDUCE_MIN, dstDepth);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+// Test: column-wise reduce SUM (reduce to single column)
+PERF_TEST_P(Size_MatType_OutDepth, reduceSumCol,
+    testing::Combine(
+        testing::Values(TYPICAL_MAT_SIZES),
+        testing::Values(CV_32FC1),
+        testing::Values(CV_32F)
+    )
+)
+{
+    Size sz = std::get<0>(GetParam());
+    int srcType = std::get<1>(GetParam());
+    int dstDepth = std::get<2>(GetParam());
+
+    Mat src(sz, srcType);
+    Mat dst(sz.height, 1, CV_MAKETYPE(dstDepth, 1));
+
+    declare.in(src, WARMUP_RNG).out(dst).iterations(100);
+
+    TEST_CYCLE()
+    {
+        cv::reduce(src, dst, 1, REDUCE_SUM, dstDepth);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace opencv_test
+
 namespace opencv_test
 {
 using namespace perf;

--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -354,6 +354,97 @@ struct ReduceR_SIMD
     }
 };
 
+#if CV_SIMD || CV_SIMD_SCALABLE
+
+// SIMD specialization: float sum reduction (reduceSum, type CV_32F -> CV_32F/64F)
+template <>
+struct ReduceR_SIMD<float, float, OpAdd<float>>
+{
+    int operator()(const float* src, int start, int end, float* buf, const OpAdd<float>&) const
+    {
+        int i = start;
+        const int vl = VTraits<v_float32>::vlanes();
+        for (; i <= end - vl; i += vl)
+        {
+            v_float32 v_buf = vx_load(buf + i);
+            v_float32 v_src = vx_load(src + i);
+            v_store(buf + i, v_add(v_buf, v_src));
+        }
+        return i;
+    }
+};
+
+// SIMD specialization: uchar->int sum reduction (reduceSum, type CV_8U -> CV_32S)
+// Load 8-bit values, widen to 32-bit via two-stage expansion, then vector-add.
+template <>
+struct ReduceR_SIMD<uchar, int, OpAdd<int>>
+{
+    int operator()(const uchar* src, int start, int end, int* buf, const OpAdd<int>&) const
+    {
+        int i = start;
+        const int vl8  = VTraits<v_uint8>::vlanes();
+        const int vl32 = VTraits<v_int32>::vlanes();  // vl8 / 4
+        for (; i <= end - vl8; i += vl8)
+        {
+            v_uint8  v_src8 = vx_load(src + i);
+            v_uint16 v_lo16, v_hi16;
+            v_expand(v_src8, v_lo16, v_hi16);
+            // Second-stage widen: 16-bit -> 32-bit
+            v_uint32 v0, v1, v2, v3;
+            v_expand(v_lo16, v0, v1);
+            v_expand(v_hi16, v2, v3);
+            // Load 4 groups of int32 accumulators and add
+            v_int32 b0 = vx_load(buf + i);
+            v_int32 b1 = vx_load(buf + i + vl32);
+            v_int32 b2 = vx_load(buf + i + vl32 * 2);
+            v_int32 b3 = vx_load(buf + i + vl32 * 3);
+            v_store(buf + i,            v_add(b0, v_reinterpret_as_s32(v0)));
+            v_store(buf + i + vl32,     v_add(b1, v_reinterpret_as_s32(v1)));
+            v_store(buf + i + vl32 * 2, v_add(b2, v_reinterpret_as_s32(v2)));
+            v_store(buf + i + vl32 * 3, v_add(b3, v_reinterpret_as_s32(v3)));
+        }
+        return i;
+    }
+};
+
+// SIMD specialization: float max reduction
+template <>
+struct ReduceR_SIMD<float, float, OpMax<float>>
+{
+    int operator()(const float* src, int start, int end, float* buf, const OpMax<float>&) const
+    {
+        int i = start;
+        const int vl = VTraits<v_float32>::vlanes();
+        for (; i <= end - vl; i += vl)
+        {
+            v_float32 v_buf = vx_load(buf + i);
+            v_float32 v_src = vx_load(src + i);
+            v_store(buf + i, v_max(v_buf, v_src));
+        }
+        return i;
+    }
+};
+
+// SIMD specialization: float min reduction
+template <>
+struct ReduceR_SIMD<float, float, OpMin<float>>
+{
+    int operator()(const float* src, int start, int end, float* buf, const OpMin<float>&) const
+    {
+        int i = start;
+        const int vl = VTraits<v_float32>::vlanes();
+        for (; i <= end - vl; i += vl)
+        {
+            v_float32 v_buf = vx_load(buf + i);
+            v_float32 v_src = vx_load(src + i);
+            v_store(buf + i, v_min(v_buf, v_src));
+        }
+        return i;
+    }
+};
+
+#endif // CV_SIMD || CV_SIMD_SCALABLE
+
 
 template<typename T, typename ST, typename WT, class Op, class OpInit>
 class ReduceR_Invoker : public ParallelLoopBody


### PR DESCRIPTION
### Summary

Add universal intrinsic SIMD specializations for row-wise reduce
operations, covering the most common type/op combinations:

- float, float, OpAdd<float>   (v_add, e.g. cv::sum reduction)
- float, float, OpMax<float>   (v_max, e.g. cv::minMaxIdx)
- float, float, OpMin<float>   (v_min)
- uchar, int, OpAdd<int>       (v_expand + v_add, CV_8U -> CV_32S)

Previously ReduceR_SIMD had no specializations and always fell back
to scalar processing. The SIMD path processes VTraits<T>::vlanes()
elements per iteration via vx_load/v_store, automatically mapping
to SSE/AVX/NEON/RVV depending on platform.

Note: This is a new performance optimization (not a bug fix), so no
related issue. Accuracy is covered by existing Core_ReduceTest in
test_mat.cpp. No API change, so no documentation update needed.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
