### PR TITLE
imgproc: fix floodFill simple path never being used (small fix)

### DIFF
--- a/modules/imgproc/src/floodfill.cpp
+++ b/modules/imgproc/src/floodfill.cpp
@@ -494,7 +494,8 @@ int cv::floodFill( InputOutputArray _image, InputOutputArray _mask,
     if( connectivity != 0 && connectivity != 4 && connectivity != 8 )
         CV_Error( cv::Error::StsBadFlag, "Connectivity must be 4, 0(=4) or 8" );
 
-    if( _mask.empty() )
+    bool noUserMask = _mask.empty();
+    if( noUserMask )
     {
         _mask.create( size.height + 2, size.width + 2, CV_8UC1 );
         _mask.setTo(0);
@@ -508,7 +509,7 @@ int cv::floodFill( InputOutputArray _image, InputOutputArray _mask,
     Mat mask_inner = mask( Rect(1, 1, mask.cols - 2, mask.rows - 2) );
     copyMakeBorder( mask_inner, mask, 1, 1, 1, 1, BORDER_ISOLATED | BORDER_CONSTANT, Scalar(1) );
 
-    bool is_simple = mask.empty() && (flags & FLOODFILL_MASK_ONLY) == 0;
+    bool is_simple = noUserMask && (flags & FLOODFILL_MASK_ONLY) == 0;
 
     for( i = 0; i < cn; i++ )
     {


### PR DESCRIPTION
  The is_simple check used mask.empty() after the default mask
  had already been created, making it always false. This caused
  the fast path (floodFill_CnIR) to be dead code — every call
  went through the slower gradient-based path (floodFillGrad_CnIR).

  Fix: save _mask.empty() result before auto-creating the default
  mask and use it for the is_simple check.

imgproc: fix floodFill simple path never being used

### Problem

In `cv::floodFill()`, the `is_simple` flag determines whether to take the fast path
(`floodFill_CnIR`, pixel equality check) or the slow path (`floodFillGrad_CnIR`,
gradient-based with diff functors). However, `is_simple` was always `false` because
the check `mask.empty()` was evaluated **after** the default mask had already been
auto-created:

    if( _mask.empty() )                    // user didn't pass a mask
    {
        _mask.create(...);                 // auto-creates one
        _mask.setTo(0);
    }
    mask = _mask.getMat();
    // ...
    bool is_simple = mask.empty() && ...;  // always false! mask is never empty here

This made the fast path (`floodFill_CnIR`) **dead code** — even when the user called
the 7-parameter API with `loDiff=upDiff=0` (ideal conditions for the simple path),
every call went through the expensive gradient path.

### Verification

Added a debug `fprintf` before the `if(is_simple)` branch on the original code:

    is_simple=0 (mask.empty=0, flags&MASK_ONLY=0, loDiff=upDiff=0? 1)

`loDiff=upDiff=0? 1` shows the business condition was fully satisfied, but
`mask.empty=0` forced `is_simple` to 0.

Performance test on 2000x2000 uniform image (100 iterations, Release build):

    |                        | Before fix | After fix |
    |------------------------|------------|-----------|
    | Simple (loDiff=upDiff=0) |   7.0 ms  |   3.2 ms  |
    | Gradient (loDiff=1)     |   6.9 ms  |   6.3 ms  |
    | Ratio                   |   ~1.0x   |   ~2.0x   |

Before fix: both paths take ~7ms (same slow path).
After fix:  simple path correctly uses floodFill_CnIR, ~2x faster.

### Fix

Save `_mask.empty()` **before** auto-creating the default mask, and use it for
the `is_simple` check:

    bool noUserMask = _mask.empty();       // save original state
    if( noUserMask )
    {
        _mask.create(...);
    }
    // ...
    bool is_simple = noUserMask && ...;    // use saved state

2 lines changed in `modules/imgproc/src/floodfill.cpp`.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch