### PR TITLE
imgproc: fix missing tipLength validation in arrowedLine

### DIFF
--- a/modules/imgproc/src/drawing.cpp
+++ b/modules/imgproc/src/drawing.cpp
@@ -1844,6 +1844,7 @@ void line( InputOutputArray _img, Point pt1, Point pt2, const Scalar& color,
 void arrowedLine(InputOutputArray img, Point pt1, Point pt2, const Scalar& color,
            int thickness, int line_type, int shift, double tipLength)
 {
+    CV_Assert( tipLength > 0.0 && tipLength <= 1.0 );
     CV_INSTRUMENT_REGION();
 
     const double tipSize = norm(pt1-pt2)*tipLength; // Factor to normalize the size of the tip depending on the length of the arrow

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -1128,4 +1128,24 @@ TEST(Drawing, line_connectivity_regression_26413)
     EXPECT_GT(count4, 15) << "LINE_4 diagonal should have significantly more pixels due to staircase";
 }
 
+//This test ensures that the tipLength geometric ratio is strictly bounded  within the logical range (0.0, 1.0].
+TEST(Imgproc_Drawing, arrowedLine_tipLength_validation)
+{
+    // Create a simple miniature canvas for testing. Added cv:: prefix.
+    cv::Mat img = cv::Mat::zeros(100, 100, CV_8UC3);
+    cv::Point pt1(10, 10), pt2(90, 90);
+
+    // 1. Validate legal parameters: should not throw any exceptions (Normal cases)
+    EXPECT_NO_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, 0.1));
+    EXPECT_NO_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, 1.0));
+
+    // 2. Validate illegal parameters: expect cv::Exception to be thrown (Boundary violations)
+    // Negative ratio (tipLength <= 0.0)
+    EXPECT_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, -0.5), cv::Exception);
+    
+    // Overflow ratio (tipLength > 1.0)
+    EXPECT_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, 1.5), cv::Exception);
+}
+
 }} // namespace
+

--- a/modules/imgproc/test/test_drawing.cpp
+++ b/modules/imgproc/test/test_drawing.cpp
@@ -1142,10 +1142,9 @@ TEST(Imgproc_Drawing, arrowedLine_tipLength_validation)
     // 2. Validate illegal parameters: expect cv::Exception to be thrown (Boundary violations)
     // Negative ratio (tipLength <= 0.0)
     EXPECT_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, -0.5), cv::Exception);
-    
+
     // Overflow ratio (tipLength > 1.0)
     EXPECT_THROW(cv::arrowedLine(img, pt1, pt2, cv::Scalar(255, 255, 255), 1, 8, 0, 1.5), cv::Exception);
 }
 
 }} // namespace
-


### PR DESCRIPTION
### Pull Request Description

**Issue/Bug:**
Currently, the `cv::arrowedLine` function in `modules/imgproc/src/drawing.cpp` lacks boundary validation for the `tipLength` parameter. Passing an invalid ratio (e.g., negative values or values > 1.0) leads to mathematically distorted arrowhead coordinates being silently passed to the underlying `line()` drawing function, resulting in severely deformed output without any warning.

**Solution:**
Added a `CV_Assert` to enforce the geometric contract of `tipLength`, ensuring it strictly falls within the logical bounds `(0.0, 1.0]`. This adheres to the fail-fast principle and prevents silent geometric failures. 

**Testing:**
Successfully built the project locally and added a dedicated regression test (`arrowedLine_tipLength_validation`) using Google Test in `modules/imgproc/test/test_drawing.cpp`. Tested with boundary values (e.g., `tipLength = 1.5` and `-0.5`), and the assertion correctly intercepts the invalid parameters before rasterization.

*(Note: This contribution is part of a university engineering project evaluating open-source workflow and C++ robustness.)*