### PR TITLE
 parallelize sort_ using parallel_for_

### DIFF
--- a/modules/core/src/matrix_operations.cpp
+++ b/modules/core/src/matrix_operations.cpp
@@ -992,7 +992,6 @@ namespace cv
 
 template<typename T> static void sort_( const Mat& src, Mat& dst, int flags )
 {
-    AutoBuffer<T> buf;
     int n, len;
     bool sortRows = (flags & 1) == SORT_EVERY_ROW;
     bool inplace = src.data == dst.data;
@@ -1001,43 +1000,47 @@ template<typename T> static void sort_( const Mat& src, Mat& dst, int flags )
     if( sortRows )
         n = src.rows, len = src.cols;
     else
-    {
         n = src.cols, len = src.rows;
-        buf.allocate(len);
-    }
-    T* bptr = buf.data();
-
-    for( int i = 0; i < n; i++ )
+    parallel_for_(Range(0, n), [&](const Range& range)
     {
-        T* ptr = bptr;
-        if( sortRows )
-        {
-            T* dptr = dst.ptr<T>(i);
-            if( !inplace )
-            {
-                const T* sptr = src.ptr<T>(i);
-                memcpy(dptr, sptr, sizeof(T) * len);
-            }
-            ptr = dptr;
-        }
-        else
-        {
-            for( int j = 0; j < len; j++ )
-                ptr[j] = src.ptr<T>(j)[i];
-        }
-
-        std::sort( ptr, ptr + len );
-        if( sortDescending )
-        {
-            for( int j = 0; j < len/2; j++ )
-                std::swap(ptr[j], ptr[len-1-j]);
-        }
-
+        AutoBuffer<T> buf;
         if( !sortRows )
-            for( int j = 0; j < len; j++ )
-                dst.ptr<T>(j)[i] = ptr[j];
-    }
+            buf.allocate(len);
+        T* bptr = buf.data();
+
+        for( int i = range.start; i < range.end; i++ )
+        {
+            T* ptr = bptr;
+            if( sortRows )
+            {
+                T* dptr = dst.ptr<T>(i);
+                if( !inplace )
+                {
+                    const T* sptr = src.ptr<T>(i);
+                    memcpy(dptr, sptr, sizeof(T) * len);
+                }
+                ptr = dptr;
+            }
+            else
+            {
+                for( int j = 0; j < len; j++ )
+                    ptr[j] = src.ptr<T>(j)[i];
+            }
+
+            std::sort( ptr, ptr + len );
+            if( sortDescending )
+            {
+                for( int j = 0; j < len/2; j++ )
+                    std::swap(ptr[j], ptr[len-1-j]);
+            }
+
+            if( !sortRows )
+                for( int j = 0; j < len; j++ )
+                    dst.ptr<T>(j)[i] = ptr[j];
+        }
+    });
 }
+
 
 #ifdef HAVE_IPP
 typedef IppStatus (CV_STDCALL *IppSortFunc)(void  *pSrcDst, int    len, Ipp8u *pBuffer);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->

This PR parallelizes the outer loop of `sort_` in the generic `cv::sort()` implementation using `parallel_for_`.

The main change is limited to:
- replacing the outer serial loop with `parallel_for_`
- moving the temporary buffer used by column sorting into the parallel body, so each task owns its own local buffer

The sorting logic itself is unchanged.

how to run correctness test:
cmake --build build-tests -j --target opencv_test_core
build-tests/bin/opencv_test_core --gtest_filter='*sort*'

run performance test:
cmake --build build-tests -j --target opencv_perf_core
build-tests/bin/opencv_perf_core \
  --gtest_filter='*sortFixture_sort*' \
  --perf_min_samples=10 \
  --perf_force_samples=10

performance improved:
1920x1080, 8UC1, flag=0: 53.76 ms -> 15.17 ms (~3.5x)
1920x1080, 16UC1, flag=0: 61.94 ms -> 6.78 ms (~9.1x)
1920x1080, 16UC1, flag=16: 70.18 ms -> 6.68 ms (~10.5x)
1920x1080, 32FC1, flag=0: 70.40 ms -> 6.81 ms (~10.3x)
1920x1080, 32FC1, flag=16: 71.52 ms -> 6.88 ms (~10.4x)
total 24 performance test :
from 6090 to 2267 ms
 
later I will show you the detailed result ran on my computer by offering comments

