### PR TITLE
feat(rvv-hal): optimize FAST pre-screen with deferred u8mf2 widening

### DIFF
--- a/hal/riscv-rvv/src/features2d/fast.cpp
+++ b/hal/riscv-rvv/src/features2d/fast.cpp
@@ -56,31 +56,34 @@ inline int fast_16(const uchar* src_data, size_t src_step,
             size_t vl;
             for (; j < width - 3; j += vl, ptr += vl)
             {
-                vl = __riscv_vsetvl_e16m1(width - 3 - j);
+                /* u8mf2 pre-screen: same VL as i16m1, defer vzext until needed */
+                vl = __riscv_vsetvl_e8mf2(width - 3 - j);
+                vuint8mf2_t vcen_8 = __riscv_vle8_v_u8mf2(ptr, vl);
+                vuint8mf2_t vlo_8  = __riscv_vssubu_vx_u8mf2(vcen_8, (uint8_t)threshold, vl);
+                vuint8mf2_t vhi_8  = __riscv_vsaddu_vx_u8mf2(vcen_8, (uint8_t)threshold, vl);
+                vuint8mf2_t vk0_8  = __riscv_vle8_v_u8mf2(ptr + pixel[0],  vl);
+                vuint8mf2_t vk4_8  = __riscv_vle8_v_u8mf2(ptr + pixel[4],  vl);
+                vuint8mf2_t vk8_8  = __riscv_vle8_v_u8mf2(ptr + pixel[8],  vl);
+                vuint8mf2_t vk12_8 = __riscv_vle8_v_u8mf2(ptr + pixel[12], vl);
 
-                /* Load center pixel and widen to int16 */
-                vint16m1_t vcen = __riscv_vreinterpret_v_u16m1_i16m1(
-                    __riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr, vl), vl));
-                vint16m1_t vlo = __riscv_vsub_vx_i16m1(vcen, threshold, vl);
-                vint16m1_t vhi = __riscv_vadd_vx_i16m1(vcen, threshold, vl);
-
-                /* 4-direction quick reject */
-                vint16m1_t vk0  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr + pixel[0],  vl), vl));
-                vint16m1_t vk4  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr + pixel[4],  vl), vl));
-                vint16m1_t vk8  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr + pixel[8],  vl), vl));
-                vint16m1_t vk12 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr + pixel[12], vl), vl));
-
-                vbool16_t bright = __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vk0, vhi, vl), __riscv_vmsgt_vv_i16m1_b16(vk4, vhi, vl), vl);
-                vbool16_t dark   = __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vlo, vk0, vl),  __riscv_vmsgt_vv_i16m1_b16(vlo, vk4, vl),  vl);
-                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vk4,  vhi, vl), __riscv_vmsgt_vv_i16m1_b16(vk8,  vhi, vl), vl), vl);
-                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vlo, vk4, vl),  __riscv_vmsgt_vv_i16m1_b16(vlo, vk8, vl),  vl), vl);
-                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vk8,  vhi, vl), __riscv_vmsgt_vv_i16m1_b16(vk12, vhi, vl), vl), vl);
-                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vlo, vk8, vl),  __riscv_vmsgt_vv_i16m1_b16(vlo, vk12, vl), vl), vl);
-                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vk12, vhi, vl), __riscv_vmsgt_vv_i16m1_b16(vk0,  vhi, vl), vl), vl);
-                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgt_vv_i16m1_b16(vlo, vk12, vl), __riscv_vmsgt_vv_i16m1_b16(vlo, vk0,  vl), vl), vl);
+                vbool16_t bright = __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vk0_8, vhi_8, vl), __riscv_vmsgtu_vv_u8mf2_b16(vk4_8, vhi_8, vl), vl);
+                vbool16_t dark   = __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk0_8, vl),  __riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk4_8, vl),  vl);
+                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vk4_8,  vhi_8, vl), __riscv_vmsgtu_vv_u8mf2_b16(vk8_8,  vhi_8, vl), vl), vl);
+                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk4_8, vl),  __riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk8_8, vl),  vl), vl);
+                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vk8_8,  vhi_8, vl), __riscv_vmsgtu_vv_u8mf2_b16(vk12_8, vhi_8, vl), vl), vl);
+                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk8_8, vl),  __riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk12_8, vl), vl), vl);
+                bright = __riscv_vmor_mm_b16(bright, __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vk12_8, vhi_8, vl), __riscv_vmsgtu_vv_u8mf2_b16(vk0_8,  vhi_8, vl), vl), vl);
+                dark   = __riscv_vmor_mm_b16(dark,   __riscv_vmand_mm_b16(__riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk12_8, vl),  __riscv_vmsgtu_vv_u8mf2_b16(vlo_8, vk0_8,  vl), vl), vl);
 
                 if (__riscv_vfirst_m_b16(__riscv_vmor_mm_b16(bright, dark, vl), vl) < 0)
                     continue;
+
+                /* Widen pre-loaded u8mf2 to i16m1 for score computation */
+                vint16m1_t vcen = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(vcen_8, vl));
+                vint16m1_t vk0  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(vk0_8,  vl));
+                vint16m1_t vk4  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(vk4_8,  vl));
+                vint16m1_t vk8  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(vk8_8,  vl));
+                vint16m1_t vk12 = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(vk12_8, vl));
 
                 /* Load remaining 12 neighbors */
                 vint16m1_t vk1  = __riscv_vreinterpret_v_u16m1_i16m1(__riscv_vzext_vf2(__riscv_vle8_v_u8mf2(ptr + pixel[1],  vl), vl));


### PR DESCRIPTION
## Summary

Optimize the RVV HAL FAST-9/16 corner detection pre-screen phase by deferring the u8→i16 widening (`vzext`) until after the quick-reject check passes.

### Before (i16m1 pre-screen)
1. Load 5 values as `u8mf2`
2. Widen all 5 to `i16m1` (`vzext_vf2`) — **always executed, even when rejected**
3. Compute bounds with `vsub`/`vadd`
4. Compare with `vmsgt_vv_i16m1`
5. If rejected → `continue` (wasted widenings)

### After (u8mf2 pre-screen)
1. Load 5 values as `u8mf2` (same loads)
2. Compute bounds with `vssubu`/`vsaddu` (saturating, correct for u8)
3. Compare with `vmsgtu_vv_u8mf2` — **no widening needed**
4. If rejected → `continue` (**saved 5 × `vzext`**)
5. If passed → widen the already-loaded `u8mf2` variables to `i16m1` (deferred, reusing loaded data)

The `u8mf2` type has the same VL as `i16m1` (`VLEN/16`), so there is no change in vector length or loop structure. The only difference is the order of operations: compare-then-widen instead of widen-then-compare.

### Why it helps
At the default threshold=20, ~70-80% of pixel-strips are rejected by the pre-screen. Each rejection now skips 5 `vzext_vf2` instructions. The pre-screen block has ~30 vector instructions total, so saving 5 is ~15% of the pre-screen phase. Combined with the ~75% rejection rate, this yields 5-8% overall improvement.

## Performance Results

Tested on Banana Pi BPI-F3 (SpacemiT K1, 8-core RISC-V with RVV 1.0, VLEN=256), GCC 14.2.0, `-O2`.

### Fast_Params_detect (median, ms)

| Threshold | NMS | Image | i16 | u8mf2 | Speedup |
|-----------|-----|-------|-----|-------|---------|
| 20 | false | orig.png (512×480) | 2.18 | 2.04 | **1.07x** |
| 20 | false | chess9.png | 8.93 | 8.26 | **1.08x** |
| 20 | true | orig.png | 1.88 | 1.79 | **1.05x** |
| 20 | true | chess9.png | 8.50 | 7.93 | **1.07x** |
| 30 | false | orig.png | 1.56 | 1.43 | **1.09x** |
| 30 | false | chess9.png | 8.39 | 7.73 | **1.09x** |
| 30 | true | orig.png | 1.42 | 1.28 | **1.11x** |
| 30 | true | chess9.png | 8.16 | 7.56 | **1.08x** |
| 100 | false | orig.png | 0.86 | 0.73 | **1.18x** |
| 100 | false | chess9.png | 4.98 | 4.23 | **1.18x** |
| 100 | true | orig.png | 0.85 | 0.72 | **1.18x** |
| 100 | true | chess9.png | 4.99 | 4.26 | **1.17x** |

### feature2d_detect FAST-9/16 (median, ms)

| Test | Image | i16 | u8mf2 | Speedup |
|------|-------|-----|-------|---------|
| FAST_DEFAULT | leuven/img1.png | 8.32 | 8.15 | **1.02x** |
| FAST_DEFAULT | stitching/a3.png | 6.13 | 5.93 | **1.03x** |
| FAST_DEFAULT | stitching/s2.jpg | 22.64 | 22.43 | **1.01x** |
| FAST_20_TRUE_TYPE9_16 | leuven/img1.png | 5.77 | 5.56 | **1.04x** |
| FAST_20_TRUE_TYPE9_16 | stitching/a3.png | 3.84 | 3.63 | **1.06x** |
| FAST_20_TRUE_TYPE9_16 | stitching/s2.jpg | 19.45 | 19.08 | **1.02x** |
| FAST_20_FALSE_TYPE9_16 | leuven/img1.png | 6.14 | 5.96 | **1.03x** |
| FAST_20_FALSE_TYPE9_16 | stitching/a3.png | 4.30 | 4.10 | **1.05x** |
| FAST_20_FALSE_TYPE9_16 | stitching/s2.jpg | 22.20 | 21.71 | **1.02x** |

No performance regression observed at any threshold.

## Test plan

- [x] `opencv_perf_features2d` passes with `Fast_Params_detect*` filter
- [x] `opencv_perf_features2d` passes with `feature2d_detect*` FAST-9/16 filters
- [x] Correctness verified: same keypoints detected as the original i16 implementation
- [ ] CI passes on other RISC-V platforms (Muse Pi, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)