### PR TITLE
features2d: improve detector parameter validation

### DIFF
--- a/modules/features2d/src/agast.cpp
+++ b/modules/features2d/src/agast.cpp
@@ -8052,6 +8052,9 @@ void AGAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, boo
       case AgastFeatureDetector::OAST_9_16:
         OAST_9_16(_img, kpts, threshold);
         break;
+      default:
+        CV_Error_(Error::StsBadArg,
+                  ("Unknown AgastFeatureDetector detector type: %d", static_cast<int>(type)));
     }
 
     cv::Mat img = _img.getMat();

--- a/modules/features2d/src/brisk.cpp
+++ b/modules/features2d/src/brisk.cpp
@@ -104,6 +104,8 @@ public:
     }
     virtual void setPatternScale(float _patternScale) CV_OVERRIDE
     {
+      CV_CheckGT(_patternScale, 0.f, "patternScale must be positive");
+
       patternScale = _patternScale;
       std::vector<float> rList;
       std::vector<int> nList;

--- a/modules/features2d/src/fast.cpp
+++ b/modules/features2d/src/fast.cpp
@@ -441,6 +441,14 @@ void FAST(InputArray _img, std::vector<KeyPoint>& keypoints, int threshold, bool
 {
     CV_INSTRUMENT_REGION();
 
+    if (type != FastFeatureDetector::TYPE_5_8 &&
+        type != FastFeatureDetector::TYPE_7_12 &&
+        type != FastFeatureDetector::TYPE_9_16)
+    {
+        CV_Error_(Error::StsBadArg,
+                  ("Unknown FastFeatureDetector detector type: %d", static_cast<int>(type)));
+    }
+
     const size_t max_fast_features = std::max(_img.total()/100, size_t(1000)); // Simple heuristic that depends on resolution.
 
     CV_OCL_RUN(_img.isUMat() && type == FastFeatureDetector::TYPE_9_16,
@@ -549,7 +557,7 @@ public:
         else if(prop == FAST_N)
             type = static_cast<FastFeatureDetector::DetectorType>(cvRound(value));
         else
-            CV_Error(Error::StsBadArg, "");
+            CV_Error_(Error::StsBadArg, ("Unknown FastFeatureDetector property: %d", prop));
     }
 
     double get(int prop) const
@@ -560,7 +568,7 @@ public:
             return nonmaxSuppression;
         if(prop == FAST_N)
             return static_cast<int>(type);
-        CV_Error(Error::StsBadArg, "");
+        CV_Error_(Error::StsBadArg, ("Unknown FastFeatureDetector property: %d", prop));
         return 0;
     }
 

--- a/modules/features2d/src/orb.cpp
+++ b/modules/features2d/src/orb.cpp
@@ -1266,7 +1266,25 @@ void ORB_Impl::detectAndCompute( InputArray _image, InputArray _mask,
 Ptr<ORB> ORB::create(int nfeatures, float scaleFactor, int nlevels, int edgeThreshold,
            int firstLevel, int wta_k, ORB::ScoreType scoreType, int patchSize, int fastThreshold)
 {
-    CV_Assert(firstLevel >= 0);
+    CV_CheckGE(nfeatures, 0, "nfeatures must be non-negative");
+    CV_CheckGT(scaleFactor, 1.f, "scaleFactor must be greater than 1");
+    CV_CheckGT(nlevels, 0, "nlevels must be positive");
+    CV_CheckGE(edgeThreshold, 0, "edgeThreshold must be non-negative");
+    CV_CheckGE(firstLevel, 0, "firstLevel must be non-negative");
+    CV_CheckGE(patchSize, 2, "patchSize must be at least 2");
+
+    if (wta_k != 2 && wta_k != 3 && wta_k != 4)
+    {
+        CV_Error_(Error::StsBadArg,
+                  ("wta_k must be 2, 3, or 4, but got %d", wta_k));
+    }
+
+    if (scoreType != ORB::HARRIS_SCORE && scoreType != ORB::FAST_SCORE)
+    {
+        CV_Error_(Error::StsBadArg,
+                  ("Unknown ORB score type: %d", static_cast<int>(scoreType)));
+    }
+
     return makePtr<ORB_Impl>(nfeatures, scaleFactor, nlevels, edgeThreshold,
                              firstLevel, wta_k, scoreType, patchSize, fastThreshold);
 }

--- a/modules/features2d/test/test_agast.cpp
+++ b/modules/features2d/test/test_agast.cpp
@@ -135,4 +135,14 @@ void CV_AgastTest::run( int )
 
 TEST(Features2d_AGAST, regression) { CV_AgastTest test; test.safe_run(); }
 
+TEST(Features2d_AGAST, invalidDetectorType)
+{
+    Mat img = Mat::zeros(16, 16, CV_8UC1);
+    vector<KeyPoint> keypoints;
+
+    EXPECT_THROW(AGAST(img, keypoints, 10, true,
+                       static_cast<AgastFeatureDetector::DetectorType>(-1)),
+                 cv::Exception);
+}
+
 }} // namespace

--- a/modules/features2d/test/test_brisk.cpp
+++ b/modules/features2d/test/test_brisk.cpp
@@ -105,4 +105,10 @@ void CV_BRISKTest::run( int )
 
 TEST(Features2d_BRISK, regression) { CV_BRISKTest test; test.safe_run(); }
 
+TEST(Features2d_BRISK, invalidCreateParameters)
+{
+    EXPECT_THROW(BRISK::create(30, 3, 0.0f), cv::Exception);
+    EXPECT_THROW(BRISK::create(30, 3, -1.0f), cv::Exception);
+}
+
 }} // namespace

--- a/modules/features2d/test/test_fast.cpp
+++ b/modules/features2d/test/test_fast.cpp
@@ -165,4 +165,14 @@ TEST(Features2d_FAST, noNMS)
     ASSERT_EQ( 0, cvtest::norm(gt_kps, kps, NORM_L2));
 }
 
+TEST(Features2d_FAST, invalidDetectorType)
+{
+    Mat img = Mat::zeros(16, 16, CV_8UC1);
+    vector<KeyPoint> keypoints;
+
+    EXPECT_THROW(FAST(img, keypoints, 10, true,
+                      static_cast<FastFeatureDetector::DetectorType>(-1)),
+                 cv::Exception);
+}
+
 }} // namespace

--- a/modules/features2d/test/test_orb.cpp
+++ b/modules/features2d/test/test_orb.cpp
@@ -195,4 +195,15 @@ TEST(Features2D_ORB, MaskValue)
     ASSERT_EQ(countNonZero(diff), 0);
 }
 
+TEST(Features2D_ORB, invalidCreateParameters)
+{
+    EXPECT_THROW(ORB::create(500, 1.0f), cv::Exception);
+    EXPECT_THROW(ORB::create(500, 1.2f, 0), cv::Exception);
+    EXPECT_THROW(ORB::create(500, 1.2f, 8, 31, 0, 5), cv::Exception);
+    EXPECT_THROW(ORB::create(500, 1.2f, 8, 31, 0, 2,
+                             static_cast<ORB::ScoreType>(-1)), cv::Exception);
+    EXPECT_THROW(ORB::create(500, 1.2f, 8, 31, 0, 2,
+                             ORB::HARRIS_SCORE, 1), cv::Exception);
+}
+
 }} // namespace

--- a/samples/cpp/morphology2.cpp
+++ b/samples/cpp/morphology2.cpp
@@ -10,7 +10,7 @@ using namespace cv;
 static void help(char** argv)
 {
 
-printf("\nShow off image morphology: erosion, dialation, open and close\n"
+printf("\nShow off image morphology: erosion, dilation, opening and closing\n"
     "Call:\n   %s [image]\n"
     "This program also shows use of rect, ellipse, cross and diamond kernels\n\n", argv[0]);
 printf( "Hot keys: \n"


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable.
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description

This PR improves parameter validation and error diagnostics in the `features2d` module.

Changes include:
- Add explicit invalid detector type checks for FAST.
- Add a default invalid detector type branch for AGAST.
- Add validation for BRISK `patternScale`.
- Add create-time parameter checks for ORB.
- Improve empty FAST property error messages.
- Add regression tests for invalid FAST, AGAST, BRISK, and ORB parameters.
- Fix a typo in the morphology sample help text.

### Tests

Built and ran targeted tests locally:

```bash
ninja opencv_test_features2d

./bin/opencv_test_features2d --gtest_filter=Features2d_FAST.invalidDetectorType:Features2d_AGAST.invalidDetectorType:Features2d_BRISK.invalidCreateParameters:Features2D_ORB.invalidCreateParameters
Result:
[  PASSED  ] 4 tests.