### PR TITLE
fix MLAS build failure caused by ASM/ASM_NASM dialect conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,16 @@ if(OPENCV_WORKAROUND_CMAKE_20989)
   set(CMAKE_SYSTEM_PROCESSOR ${CMAKE_SYSTEM_PROCESSOR_BACKUP})
 endif()
 
+# Enable generic ASM at top-level scope: enable_language(ASM) from a subdir fails
+# (CMAKE_ASM_COMPILE_OBJECT unset) once ASM_NASM is enabled. Skip on Android (NDK).
+if(NOT ANDROID AND NOT CMAKE_SYSTEM_NAME STREQUAL "Android")
+  include(CheckLanguage)
+  check_language(ASM)
+  if(CMAKE_ASM_COMPILER)
+    enable_language(ASM)
+  endif()
+endif()
+
 enable_testing()
 
 ocv_cmake_hook(POST_CMAKE_BOOTSTRAP)


### PR DESCRIPTION
Fixes: https://github.com/opencv/opencv/pull/28934#issuecomment-4585799066
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
