### PR TITLE
Make sure pagedAttnAVGemmKernel uses no more than the stack

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/fast_gemm_kernels.default.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_gemm_kernels.default.hpp
@@ -13,7 +13,7 @@
 #include <opencv2/core/utility.hpp> // parallel_for_
 
 #define FAST_GEMM_STORAGE (1<<20) // 2^20
-#define FAST_GEMM_MAX_STACKBUF (1 << 14)
+#define FAST_GEMM_MAX_STACKBUF (1 << 13)
 
 #define FAST_GEMM_F32_MC 64
 #define FAST_GEMM_F32_NC 240

--- a/modules/dnn/src/layers/cpu_kernels/fast_gemm_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_gemm_kernels.simd.hpp
@@ -13,7 +13,7 @@
 #include <opencv2/core/utility.hpp> // parallel_for_
 
 #define FAST_GEMM_STORAGE (1<<20) // 2^20
-#define FAST_GEMM_MAX_STACKBUF (1 << 14)
+#define FAST_GEMM_MAX_STACKBUF (1 << 13)
 
 #if CV_AVX
 #define FAST_GEMM_F32_MC 60


### PR DESCRIPTION
There are two AutoBuffers so each needs to use FAST_GEMM_MAX_STACKBUF / 2

Otherwise, this code does not compile on certain platforms (sorry, I cannot give more info).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
