### PR TITLE
fixed the new chessboard detector by not using OpenCL

### DIFF
--- a/modules/objdetect/src/chessboard.cpp
+++ b/modules/objdetect/src/chessboard.cpp
@@ -704,7 +704,7 @@ void FastX::detectImpl(const cv::Mat& _gray_image,
     CV_CheckTypeEQ(_gray_image.type(), CV_8UC1, "Unsupported image type");
 
     // up-sample if needed
-    cv::UMat gray_image;
+    cv::Mat gray_image;
     const int super_res = int(parameters.super_resolution);
     if(super_res)
         cv::resize(_gray_image,gray_image,cv::Size(),2,2);
@@ -728,9 +728,9 @@ void FastX::detectImpl(const cv::Mat& _gray_image,
             int scale_id = scale-parameters.min_scale;
             int scale_size = int(std::pow(2,scale+1+super_res));
             int scale_size2 = int((scale_size/7)*2+1);
-            std::vector<cv::UMat> images;
+            std::vector<cv::Mat> images;
             images.resize(2*num);
-            cv::UMat rotated,filtered_h,filtered_v;
+            cv::Mat rotated,filtered_h,filtered_v;
             cv::boxFilter(gray_image,images[0],-1,cv::Size(scale_size,scale_size2));
             cv::boxFilter(gray_image,images[num],-1,cv::Size(scale_size2,scale_size));
             for(int i=1;i<num;++i)


### PR DESCRIPTION
This should hopefully fix test failures on macOS x64 builder in the latest 5.x branch.

The code of Chessboard detector (namely, the FastX part) runs tons of different-size box filters on the same image. Optimally, those filters need to be computed all together using once-computed integral image, but instead those multiple box filters, especially given how the current opencl path in box filter is organized, seem to 'overload' our OpenCL cache system and it breaks, at least on macOS. Given that boxfilter is relatively cheap operation, it will unlikely loose much by running on CPU vs GPU. So this is the current solution - switch to CPU path there. Local tests show that even on Apple M4 Max with very fast GPU we get better execution speed on CPU than on GPU.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
