### PR TITLE
FFmpeg update for OpenCV 5.0 release.

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,8 +1,8 @@
-# Binaries branch name: ffmpeg/5.x_20241121
-# Binaries were created for OpenCV: ce7c0f0e651dbd7991f2c6a2327f2697f2102296
-ocv_update(FFMPEG_BINARIES_COMMIT "b2b3a3188ebbe73492ce4554c12b416512a5dec3")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "6e9aa1b8796e9ac19fca4278523c5dff")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "0fe534d69035e3801bc88418611019b4")
+# Binaries branch name: ffmpeg/5.x_20260602
+# Binaries were created for OpenCV: a0a660fcb1e58a295e6caa6aee64ed4d369b0181
+ocv_update(FFMPEG_BINARIES_COMMIT "06dc20cad65dc7fcf784f70c95d46750520889a7")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "9cef7a78b6f7ec8cf1a3935c058cfac5")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "a821a1135251859655090c795af05789")
 ocv_update(FFMPEG_FILE_HASH_CMAKE "e09efc33312d1173be8a9446f3b088fe")
 
 function(download_win_ffmpeg script_var)

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -845,8 +845,6 @@ TEST(videoio_ffmpeg, create_with_property_badarg)
     EXPECT_FALSE(cap.isOpened());
 }
 
-// requires FFmpeg wrapper rebuild on Windows
-#ifndef _WIN32
 TEST(videoio_ffmpeg, open_with_format_cv8uc3)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -862,7 +860,6 @@ TEST(videoio_ffmpeg, open_with_format_cv8uc3)
     ASSERT_TRUE(cap.read(frame));
     EXPECT_EQ(frame.channels(), 3);
 }
-#endif
 
 // related issue: https://github.com/opencv/opencv/issues/16821
 TEST(videoio_ffmpeg, DISABLED_open_from_web)
@@ -1049,12 +1046,9 @@ inline static std::string videoio_ffmpeg_mismatch_name_printer(const testing::Te
 
 INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_channel_mismatch, testing::ValuesIn(mismatch_cases), videoio_ffmpeg_mismatch_name_printer);
 
-#ifndef _WIN32
-
 typedef tuple<string, string> AlphaChannelParams;
 typedef testing::TestWithParam< AlphaChannelParams > videoio_ffmpeg_alpha_channel;
 
-// New feature in https://github.com/opencv/opencv/pull/28751 requires FFmpeg wrapper rebuild on Windows
 TEST_P(videoio_ffmpeg_alpha_channel, write_read)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -1116,11 +1110,6 @@ AlphaChannelParams alpha_params[] =
 };
 
 INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_alpha_channel, testing::ValuesIn(alpha_params));
-#endif
-
-// PR: https://github.com/opencv/opencv/pull/27523
-// TODO: Enable the tests back on Windows after FFmpeg plugin rebuild
-#ifndef _WIN32
 
 // related issue: https://github.com/opencv/opencv/issues/23088
 TEST(ffmpeg_cap_properties, set_pos_get_msec)
@@ -1198,6 +1187,5 @@ TEST(videoio_ffmpeg, seek_with_negative_dts)
         EXPECT_GE(cap.get(CAP_PROP_POS_FRAMES), f);
     }
 }
-#endif // _WIN32
 
 }} // namespace

--- a/modules/videoio/test/test_orientation.cpp
+++ b/modules/videoio/test/test_orientation.cpp
@@ -8,10 +8,6 @@ using namespace std;
 
 namespace opencv_test { namespace {
 
-// PR: https://github.com/opencv/opencv/pull/26800
-// TODO: Enable the tests back on Windows after FFmpeg plugin rebuild
-#ifndef _WIN32
-
 struct VideoCaptureAPITests: TestWithParam<cv::VideoCaptureAPIs>
 {
     void SetUp()
@@ -88,7 +84,5 @@ inline static std::string VideoCaptureAPITests_name_printer(const testing::TestP
 }
 
 INSTANTIATE_TEST_CASE_P(videoio, VideoCaptureAPITests, testing::ValuesIn(supported_backends), VideoCaptureAPITests_name_printer);
-
-#endif // WIN32
 
 }} // namespace

--- a/modules/videoio/test/test_video_io.cpp
+++ b/modules/videoio/test/test_video_io.cpp
@@ -65,13 +65,8 @@ public:
             return;
         }
 
-// TODO: Requires FFmpeg wrapper rebuild for Windows
-#ifdef _WIN32
-        if (apiPref != CAP_FFMPEG)
-            EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
-#else
         EXPECT_EQ(CAP_PROP_UNKNOWN, cap.get(CV__CAP_PROP_LATEST));
-#endif
+
         int n_frames = -1;
         EXPECT_NO_THROW(n_frames = (int)cap.get(CAP_PROP_FRAME_COUNT));
         if (n_frames > 0)
@@ -537,13 +532,7 @@ TEST_P(Videoio_Writer, write_nothing)
     EXPECT_NO_THROW(writer.open(video_file, apiPref, fourcc, fps, frame_size, true));
     ASSERT_TRUE(writer.isOpened());
 
-// TODO: Requires FFmpeg wrapper rebuild for Windows
-#ifdef _WIN32
-    if (apiPref != CAP_FFMPEG)
-        EXPECT_EQ(CAP_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
-#else
     EXPECT_EQ(cv::VIDEOWRITER_PROP_UNKNOWN, writer.get(CV__CAP_PROP_LATEST));
-#endif
 
 #if 0  // no frames
     cv::Mat m(frame_size, CV_8UC3, Scalar::all(127));


### PR DESCRIPTION
Binaries update: https://github.com/opencv/opencv_3rdparty/pull/108

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
