### PR TITLE
dnn: vectorize Sigmoid activation kernel using universal intrinsics

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/activation_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/activation_kernels.simd.hpp
@@ -97,12 +97,30 @@ static void activationSigmoid(const void* input, void* output,
     size_t i = 0;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     const int vlanes = VTraits<v_float32>::vlanes();
-    v_float32 one = vx_setall_f32(1.f), z = vx_setzero_f32();
+    const size_t step2 = (size_t)vlanes * 2;
+
+    v_float32 one = vx_setall_f32(1.f);
+    v_float32 min_val = vx_setall_f32(-80.f), max_val = vx_setall_f32(88.f);
+
+    // Using identity: 1 / (1 + exp(-x)) == 1 - (1 / (1 + exp(x))).
+    // Clamping x to [-80.f, 88.f] prevents v_exp overflow and subnormal underflow.
+    for (; i + step2 <= len; i += step2) {
+        v_float32 x0 = vx_load(inp + i);
+        v_float32 x1 = vx_load(inp + i + vlanes);
+
+        x0 = v_min(v_max(x0, min_val), max_val);
+        x1 = v_min(v_max(x1, min_val), max_val);
+
+        v_float32 y0 = v_sub(one, v_div(one, v_add(one, v_exp(x0))));
+        v_float32 y1 = v_sub(one, v_div(one, v_add(one, v_exp(x1))));
+
+        vx_store(out + i, y0);
+        vx_store(out + i + vlanes, y1);
+    }
     for (; i + vlanes <= len; i += vlanes) {
         v_float32 x = vx_load(inp + i);
-        v_float32 t = v_exp(v_sub(z, x));
-        t = v_div(one, v_add(one, t));
-        vx_store(out + i, t);
+        x = v_min(v_max(x, min_val), max_val);
+        vx_store(out + i, v_sub(one, v_div(one, v_add(one, v_exp(x)))));
     }
 #endif
     for (; i < len; i++) {


### PR DESCRIPTION
### Description

Port of #28999 to 5.x, as requested in #29068.

In 4.x, the optimization was implemented in `SigmoidFunctor::apply()`. In 5.x, `SigmoidFunctor` uses the activation function fast path through `getActivationFunc(ACTIV_SIGMOID)`, so the optimization is applied to `activationSigmoid()` in `modules/dnn/src/layers/cpu_kernels/activation_kernels.simd.hpp`.

This patch updates the SIMD path for sigmoid by:
- using a 2-way unrolled universal intrinsics loop;
- clamping input values before `v_exp`;
- keeping a single-vector SIMD tail before the scalar fallback.

### Related

- Original 4.x PR: #28999

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

