### PR TITLE
little but important fix in bicubic warping 1-channel case

### DIFF
--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -7535,10 +7535,10 @@ CV_ALWAYS_INLINE v_float32 v_fma(const v_int32& a, const v_float32& b, const v_f
 #define FETCH_INLIERS_C1_DEFAULT(row) \
     for (int j = 0; j < BATCH; j++) { \
         const chtype* srcj = (const chtype*)((const uint8_t*)src + row*srcstep + tl_ofs[j]); \
-        pixbuf[0][j] = buftype(srcj[1]); \
-        pixbuf[0][j + BATCH] = buftype(srcj[2]); \
-        pixbuf[0][j + BATCH*2] = buftype(srcj[3]); \
-        pixbuf[0][j + BATCH*3] = buftype(srcj[4]); \
+        pixbuf[0][j] = buftype(srcj[0]); \
+        pixbuf[0][j + BATCH] = buftype(srcj[1]); \
+        pixbuf[0][j + BATCH*2] = buftype(srcj[2]); \
+        pixbuf[0][j + BATCH*3] = buftype(srcj[3]); \
     } \
     R0 = vx_load(&pixbuf[0][0]); \
     R1 = vx_load(&pixbuf[0][BATCH]); \


### PR DESCRIPTION
merge together with https://github.com/opencv/opencv_contrib/pull/4136

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
