### PR TITLE
core: fix signed integer overflow UB in borderInterpolate with BORDER_WRAP

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -938,11 +938,8 @@ int cv::borderInterpolate( int p, int len, int borderType )
     {
         CV_Assert(len > 0);
         if( p < 0 )
-            // Use long long arithmetic to avoid signed integer overflow when p is
-            // close to INT_MIN. The sub-expression (p - len + 1) can underflow if
-            // performed in 32-bit, which is undefined behavior.  The final result
-            // is always in [0, len) and fits safely back in int.
-            p = (int)((long long)p - (((long long)p - len + 1) / len) * (long long)len);
+            // Use int64 to avoid signed integer overflow when p is close to INT_MIN
+            p = (int)((int64)p - (((int64)p - len + 1) / len) * (int64)len);
         if( p >= len )
             p %= len;
     }

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -938,7 +938,11 @@ int cv::borderInterpolate( int p, int len, int borderType )
     {
         CV_Assert(len > 0);
         if( p < 0 )
-            p -= ((p-len+1)/len)*len;
+            // Use long long arithmetic to avoid signed integer overflow when p is
+            // close to INT_MIN. The sub-expression (p - len + 1) can underflow if
+            // performed in 32-bit, which is undefined behavior.  The final result
+            // is always in [0, len) and fits safely back in int.
+            p = (int)((long long)p - (((long long)p - len + 1) / len) * (long long)len);
         if( p >= len )
             p %= len;
     }

--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -938,7 +938,7 @@ int cv::borderInterpolate( int p, int len, int borderType )
     {
         CV_Assert(len > 0);
         if( p < 0 )
-            // Use int64 to avoid signed integer overflow when p is close to INT_MIN
+            // Use int64 arithmetic to avoid signed integer overflow when p is close to INT_MIN
             p = (int)((int64)p - (((int64)p - len + 1) / len) * (int64)len);
         if( p >= len )
             p %= len;

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -952,4 +952,96 @@ TEST_F(TestSetUpSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 
+// ── Tests for cv::borderInterpolate with BORDER_WRAP ──────────────────────
+// Regression tests for signed integer overflow (UB) when the coordinate p
+// is close to INT_MIN.  See https://github.com/opencv/opencv/issues/29232
+//
+// The expected values are derived from mathematical modulo (always >= 0):
+//   result == ((p % len) + len) % len
+
+// Reference helper: 64-bit modulo, always non-negative
+static int borderWrapRef(int p, int len) {
+    long long r = (long long)p % len;
+    return (int)((r + len) % len);
+}
+
+// Basic correctness – small negative coordinates
+TEST(Core_BorderInterpolate, WrapSmallNegative)
+{
+    const int len = 10;
+    for (int p = -50; p < 0; ++p) {
+        int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
+        int exp = borderWrapRef(p, len);
+        EXPECT_EQ(exp, got) << "p=" << p << " len=" << len;
+        EXPECT_GE(got, 0);
+        EXPECT_LT(got, len);
+    }
+}
+
+// Basic correctness – non-negative coordinates (passthrough / modulo path)
+TEST(Core_BorderInterpolate, WrapNonNegative)
+{
+    const int len = 10;
+    for (int p = 0; p < 50; ++p) {
+        int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
+        int exp = borderWrapRef(p, len);
+        EXPECT_EQ(exp, got) << "p=" << p << " len=" << len;
+        EXPECT_GE(got, 0);
+        EXPECT_LT(got, len);
+    }
+}
+
+// Overflow regression – exact PoC from the bug report (issue #29232).
+// p = -2147483583 (near INT_MIN) caused signed integer overflow in the
+// original code: (-2147483583 - 269 + 1) underflows a 32-bit signed int.
+TEST(Core_BorderInterpolate, WrapNearIntMinPoC)
+{
+    const int p   = -2147483583;  // near INT_MIN (-2147483648)
+    const int len = 269;
+    const int exp = borderWrapRef(p, len);  // 176
+    int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
+    EXPECT_EQ(exp, got);
+    EXPECT_GE(got, 0);
+    EXPECT_LT(got, len);
+}
+
+// Overflow regression – INT_MIN itself with various lengths
+TEST(Core_BorderInterpolate, WrapIntMin)
+{
+    const int p = INT_MIN;
+    const int lens[] = {1, 2, 10, 100, 1000, 32768, INT_MAX};
+    for (int len : lens) {
+        int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
+        int exp = borderWrapRef(p, len);
+        EXPECT_EQ(exp, got) << "p=INT_MIN len=" << len;
+        EXPECT_GE(got, 0);
+        EXPECT_LT(got, len);
+    }
+}
+
+// Verify that all results are within [0, len) for a wide range of inputs
+// including values adjacent to INT_MIN.
+TEST(Core_BorderInterpolate, WrapResultInRange)
+{
+    const struct { int p; int len; } cases[] = {
+        {INT_MIN,         1},
+        {INT_MIN,     10000},
+        {INT_MIN,   INT_MAX},
+        {INT_MIN + 1, INT_MAX},
+        {INT_MIN + 2, INT_MAX - 1},
+        {-2147483583,    269},
+        {-2147483583, INT_MAX},
+        {-1,              1},
+        {-1,             10},
+        {INT_MAX,    INT_MAX},  // p == len, should wrap to 0
+    };
+    for (const auto& c : cases) {
+        int got = cv::borderInterpolate(c.p, c.len, cv::BORDER_WRAP);
+        int exp = borderWrapRef(c.p, c.len);
+        EXPECT_EQ(exp, got) << "p=" << c.p << " len=" << c.len;
+        EXPECT_GE(got, 0)      << "p=" << c.p << " len=" << c.len;
+        EXPECT_LT(got, c.len)  << "p=" << c.p << " len=" << c.len;
+    }
+}
+
 }} // namespace

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -952,24 +952,20 @@ TEST_F(TestSetUpSkip, NoBodyRun) {
     FAIL() << "Unreachable code called";
 }
 
-// ── Tests for cv::borderInterpolate with BORDER_WRAP ──────────────────────
-// Regression tests for signed integer overflow (UB) when the coordinate p
-// is close to INT_MIN.  See https://github.com/opencv/opencv/issues/29232
-//
-// The expected values are derived from mathematical modulo (always >= 0):
-//   result == ((p % len) + len) % len
+// See https://github.com/opencv/opencv/issues/29232
+// Regression tests for signed integer overflow in borderInterpolate BORDER_WRAP
 
-// Reference helper: 64-bit modulo, always non-negative
-static int borderWrapRef(int p, int len) {
-    long long r = (long long)p % len;
+static int borderWrapRef(int p, int len)
+{
+    int64 r = (int64)p % len;
     return (int)((r + len) % len);
 }
 
-// Basic correctness – small negative coordinates
 TEST(Core_BorderInterpolate, WrapSmallNegative)
 {
     const int len = 10;
-    for (int p = -50; p < 0; ++p) {
+    for( int p = -50; p < 0; p++ )
+    {
         int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
         int exp = borderWrapRef(p, len);
         EXPECT_EQ(exp, got) << "p=" << p << " len=" << len;
@@ -978,11 +974,11 @@ TEST(Core_BorderInterpolate, WrapSmallNegative)
     }
 }
 
-// Basic correctness – non-negative coordinates (passthrough / modulo path)
 TEST(Core_BorderInterpolate, WrapNonNegative)
 {
     const int len = 10;
-    for (int p = 0; p < 50; ++p) {
+    for( int p = 0; p < 50; p++ )
+    {
         int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
         int exp = borderWrapRef(p, len);
         EXPECT_EQ(exp, got) << "p=" << p << " len=" << len;
@@ -991,36 +987,31 @@ TEST(Core_BorderInterpolate, WrapNonNegative)
     }
 }
 
-// Overflow regression – exact PoC from the bug report (issue #29232).
-// p = -2147483583 (near INT_MIN) caused signed integer overflow in the
-// original code: (-2147483583 - 269 + 1) underflows a 32-bit signed int.
 TEST(Core_BorderInterpolate, WrapNearIntMinPoC)
 {
-    const int p   = -2147483583;  // near INT_MIN (-2147483648)
+    const int p   = -2147483583;
     const int len = 269;
-    const int exp = borderWrapRef(p, len);  // 176
+    const int exp = borderWrapRef(p, len);
     int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
     EXPECT_EQ(exp, got);
     EXPECT_GE(got, 0);
     EXPECT_LT(got, len);
 }
 
-// Overflow regression – INT_MIN itself with various lengths
 TEST(Core_BorderInterpolate, WrapIntMin)
 {
     const int p = INT_MIN;
     const int lens[] = {1, 2, 10, 100, 1000, 32768, INT_MAX};
-    for (int len : lens) {
-        int got = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
-        int exp = borderWrapRef(p, len);
-        EXPECT_EQ(exp, got) << "p=INT_MIN len=" << len;
+    for( int i = 0; i < (int)(sizeof(lens)/sizeof(lens[0])); i++ )
+    {
+        int got = cv::borderInterpolate(p, lens[i], cv::BORDER_WRAP);
+        int exp = borderWrapRef(p, lens[i]);
+        EXPECT_EQ(exp, got) << "p=INT_MIN len=" << lens[i];
         EXPECT_GE(got, 0);
-        EXPECT_LT(got, len);
+        EXPECT_LT(got, lens[i]);
     }
 }
 
-// Verify that all results are within [0, len) for a wide range of inputs
-// including values adjacent to INT_MIN.
 TEST(Core_BorderInterpolate, WrapResultInRange)
 {
     const struct { int p; int len; } cases[] = {
@@ -1033,14 +1024,15 @@ TEST(Core_BorderInterpolate, WrapResultInRange)
         {-2147483583, INT_MAX},
         {-1,              1},
         {-1,             10},
-        {INT_MAX,    INT_MAX},  // p == len, should wrap to 0
+        {INT_MAX,    INT_MAX},
     };
-    for (const auto& c : cases) {
-        int got = cv::borderInterpolate(c.p, c.len, cv::BORDER_WRAP);
-        int exp = borderWrapRef(c.p, c.len);
-        EXPECT_EQ(exp, got) << "p=" << c.p << " len=" << c.len;
-        EXPECT_GE(got, 0)      << "p=" << c.p << " len=" << c.len;
-        EXPECT_LT(got, c.len)  << "p=" << c.p << " len=" << c.len;
+    for( int i = 0; i < (int)(sizeof(cases)/sizeof(cases[0])); i++ )
+    {
+        int got = cv::borderInterpolate(cases[i].p, cases[i].len, cv::BORDER_WRAP);
+        int exp = borderWrapRef(cases[i].p, cases[i].len);
+        EXPECT_EQ(exp, got) << "p=" << cases[i].p << " len=" << cases[i].len;
+        EXPECT_GE(got, 0)      << "p=" << cases[i].p << " len=" << cases[i].len;
+        EXPECT_LT(got, cases[i].len)  << "p=" << cases[i].p << " len=" << cases[i].len;
     }
 }
 

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -953,8 +953,10 @@ TEST_F(TestSetUpSkip, NoBodyRun) {
 }
 
 // See https://github.com/opencv/opencv/issues/29232
-// Regression tests for signed integer overflow in borderInterpolate BORDER_WRAP
+// Regression tests for signed integer overflow (UB) in borderInterpolate
+// when the coordinate p is close to INT_MIN with BORDER_WRAP.
 
+// Reference helper: 64-bit modulo, always non-negative
 static int borderWrapRef(int p, int len)
 {
     int64 r = (int64)p % len;
@@ -989,6 +991,9 @@ TEST(Core_BorderInterpolate, WrapNonNegative)
 
 TEST(Core_BorderInterpolate, WrapNearIntMinPoC)
 {
+    // Exact PoC from the bug report (issue #29232).
+    // p = -2147483583 (near INT_MIN) caused signed integer overflow:
+    // (-2147483583 - 269 + 1) underflows a 32-bit signed int.
     const int p   = -2147483583;
     const int len = 269;
     const int exp = borderWrapRef(p, len);

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -879,7 +879,8 @@ static int borderInterpolate( int p, int len, int borderType )
     else if( borderType == BORDER_WRAP )
     {
         if( p < 0 )
-            p -= ((p-len+1)/len)*len;
+            // Use int64 to avoid signed integer overflow when p is close to INT_MIN
+            p = (int)((int64)p - (((int64)p - len + 1) / len) * (int64)len);
         if( p >= len )
             p %= len;
     }


### PR DESCRIPTION
This PR attempts to fix the issue #29232.

## Problem

In `cv::borderInterpolate` (`modules/core/src/copy.cpp`), the `BORDER_WRAP` branch computes:

```cpp
if( p < 0 )
    p -= ((p-len+1)/len)*len;
```

When `p` is close to `INT_MIN` (e.g. `p = -2147483583`) and `len` is a moderate positive value (e.g. `len = 269`), the sub-expression `p - len + 1` evaluates to a value below `INT_MIN`, which is **signed integer overflow — undefined behavior in C++**.

The API documentation (`core.hpp:238`) explicitly states that negative `p` values are expected:
> `@param p  0-based coordinate of the extrapolated pixel along one of the axes, likely <0 or >= len`

No constraint on `p`'s range is documented, so any `int` value must be handled safely.

**UBSan output (before fix):**
```
modules/core/src/copy.cpp:941:21: runtime error: signed integer overflow:
-2147483583 - 269 cannot be represented in type 'int'
```

## Fix

Lift the intermediate arithmetic to `long long` so neither the subtraction nor the multiplication can overflow. The final result is always in `[0, len)` and fits safely back into `int`:

```cpp
// Before
p -= ((p-len+1)/len)*len;

// After
p = (int)((long long)p - (((long long)p - len + 1) / len) * (long long)len);
```

This preserves the original formula's semantics exactly while eliminating the UB. The `long long` widening adds no measurable overhead (a single extra register move on x86-64).

## Verification

Compiled with `clang -fsanitize=address,undefined -O1`. The PoC:
```cpp
cv::borderInterpolate(-2147483583, 269, cv::BORDER_WRAP);
```
now returns `176` (correct) without any sanitizer error.

## Tests

Added 5 regression tests to `modules/core/test/test_misc.cpp`:

| Test | What it checks |
|------|---------------|
| `WrapSmallNegative` | correctness for `p ∈ [-50, -1]` |
| `WrapNonNegative`   | correctness for `p ∈ [0, 49]` (unchanged path) |
| `WrapNearIntMinPoC` | exact crash input from issue #29232 (`p=-2147483583, len=269`) |
| `WrapIntMin`        | `p = INT_MIN` with several representative lengths |
| `WrapResultInRange` | wide-range check — result always in `[0, len)` |

All pass under ASan + UBSan with `halt_on_error=1`.