### PR TITLE
samples: demonstrate SimpleBlobDetector contour collection

### DIFF
--- a/samples/cpp/detect_blob.cpp
+++ b/samples/cpp/detect_blob.cpp
@@ -107,6 +107,8 @@ int main(int argc, char *argv[])
     pDefaultBLOB.filterByConvexity = false;
     pDefaultBLOB.minConvexity = 0.95f;
     pDefaultBLOB.maxConvexity = (float)1e37;
+    // Enable contour collection so we can draw blob outlines (see getBlobContours() below).
+    pDefaultBLOB.collectContours = true;
     // Descriptor array for BLOB
     vector<String> typeDesc;
     // Param array for BLOB
@@ -189,6 +191,11 @@ int main(int argc, char *argv[])
                 int i = 0;
                 for (vector<KeyPoint>::iterator k = keyImg.begin(); k != keyImg.end(); ++k, ++i)
                     circle(result, k->pt, (int)k->size, palette[i % 65536]);
+                // Retrieve the per-blob contours collected during detect() and outline each blob.
+                // Requires SimpleBlobDetector::Params::collectContours to be true.
+                const vector<vector<Point> >& blobContours = sbd->getBlobContours();
+                for (size_t c = 0; c < blobContours.size(); ++c)
+                    drawContours(result, blobContours, (int)c, Scalar(0, 255, 0), 1);
             }
             namedWindow(*itDesc + label, WINDOW_AUTOSIZE);
             imshow(*itDesc + label, result);


### PR DESCRIPTION
### Summary

Updates `samples/cpp/detect_blob.cpp` to exercise the contour-collection API added to `SimpleBlobDetector` in #21942 (`Params::collectContours` + `getBlobContours()`). The sample now enables `collectContours`, fetches the per-blob contours after `detect()`, and outlines each blob with `drawContours` in addition to the existing keypoint-circle visualization.

Addresses the "sample code was not updated" portion of #25904. The Doxygen documentation for these symbols was already added in #28275.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x)
- [x] There is a reference to the original bug report and related work (#25904, #21942, #28275)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (N/A — sample-only change)
- [x] The feature is well documented and sample code can be built with the project CMake

This PR was prepared with assistance from an AI agent (per template instructions, marker added to title).