### PR TITLE
objc: fix conflicting Swift name for LightGlueMatcher.create

### DIFF
--- a/modules/features/misc/objc/gen_dict.json
+++ b/modules/features/misc/objc/gen_dict.json
@@ -17,6 +17,9 @@
         "DescriptorMatcher": {
             "(DescriptorMatcher*)create:(NSString*)descriptorMatcherType" : { "create" : {"name" : "create2"} }
         },
+        "LightGlueMatcher": {
+            "(LightGlueMatcher*)create:(NSString*)modelPath scoreThreshold:(float)scoreThreshold backend:(int)backend target:(int)target" : { "create" : {"name" : "createFromFile"} }
+        },
         "FlannBasedMatcher": {
             "FlannBasedMatcher": { "indexParams" : {"defval" : "cv::makePtr<cv::flann::KDTreeIndexParams>()"}, "searchParams" : {"defval" : "cv::makePtr<cv::flann::SearchParams>()"} }
         },


### PR DESCRIPTION
Fixes #29256

`cv::LightGlueMatcher` (a `DescriptorMatcher` subclass) declares a static
`create(const String& modelPath, ...)` overload. The Objective-C bindings
generator emits it as the selector `+create:`, which is the same selector as
the inherited `DescriptorMatcher::create(MatcherType)` but carries a different
`swift_name`, so clang refuses to build the `opencv2` Objective-C module:

```
LightGlueMatcher.h: error: 'swift_name' and 'swift_name' attributes are not compatible
```

Wrap the file-path overload with `CV_WRAP_AS(createFromFile)` so it gets a
distinct selector, mirroring the sibling `createFromMemory` overload, while
keeping the Swift name `create(modelPath:...)`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
