### PR TITLE
Apple framework: set Xcode C++ language standard so KleidiCV builds

### DIFF
--- a/platforms/ios/build_framework.py
+++ b/platforms/ios/build_framework.py
@@ -218,6 +218,12 @@ class Builder:
             "-DOPENCV_INCLUDE_INSTALL_PATH=include",
             "-DOPENCV_3P_LIB_INSTALL_PATH=lib/3rdparty",
             "-DFRAMEWORK_NAME=%s" % self.framework_name,
+            # With the Xcode generator CMAKE_CXX_STANDARD / per-target
+            # CXX_STANDARD is not translated into CLANG_CXX_LANGUAGE_STANDARD,
+            # so bundled 3rdparty libraries that require C++17 (e.g. KleidiCV)
+            # are compiled at the toolchain default and fail to build. Set the
+            # standard explicitly at the project level.
+            "-DCMAKE_XCODE_ATTRIBUTE_CLANG_CXX_LANGUAGE_STANDARD=gnu++17",
         ]
         if self.dynamic:
             args += [


### PR DESCRIPTION
Fixes #29258

OpenCV requires C++17, and bundled 3rdparty libraries such as KleidiCV
explicitly request `CXX_STANDARD 17`. With the CMake Xcode generator, however,
neither the global `CMAKE_CXX_STANDARD` nor per-target `CXX_STANDARD` is emitted
as `CLANG_CXX_LANGUAGE_STANDARD` in the generated project, so those sources are
compiled at the toolchain default (pre-C++17) and fail, e.g.:

```
kleidicv/include/kleidicv/traits.h: error: no template named 'is_base_of_v' in namespace 'std'
```

Set `CLANG_CXX_LANGUAGE_STANDARD=gnu++17` at the project level via
`CMAKE_XCODE_ATTRIBUTE_*` in the shared `getCMakeArgs()`, so every target in the
generated Xcode project (including 3rdparty subprojects) builds with C++17.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
