### PR TITLE
objc: Fix VolumeType enum name clash on macOS

### DIFF
--- a/modules/objc/generator/gen_objc.py
+++ b/modules/objc/generator/gen_objc.py
@@ -846,7 +846,11 @@ class ObjectiveCWrapperGenerator(object):
             objc_type = enumType.rsplit(".", 1)[-1]
             if objc_type in enum_ignore_list:
                 return
-            if constinfo.classname in enum_fix:
+            if not constinfo.classname:
+                module_fix = enum_fix.get(self.Module, {})
+                objc_type = module_fix.get(objc_type, objc_type)
+                objc_type = enum_fix.get(objc_type, objc_type)
+            elif constinfo.classname in enum_fix:
                 objc_type = enum_fix[constinfo.classname].get(objc_type, objc_type)
             import_module = constinfo.classname if constinfo.classname and constinfo.classname != objc_type else self.Module
             type_dict[ctype] = { "cast_from" : "int",

--- a/modules/ptcloud/misc/objc/gen_dict.json
+++ b/modules/ptcloud/misc/objc/gen_dict.json
@@ -1,0 +1,7 @@
+{
+  "enum_fix": {
+    "Ptcloud": {
+      "VolumeType": "PtcloudVolumeType"
+    }
+  }
+}


### PR DESCRIPTION
### Pull Request Readiness Checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake

**Problem**
When the ObjC wrapper is generated, the global enum `cv::VolumeType` from the ptcloud module is emitted as `typedef NS_ENUM(int, VolumeType)`. macOS defines `typedef OSType VolumeType` in CoreServices, which leads to a typedef-redefinition error during the framework build.

**Fix**
`add_enum()` in `gen_objc.py` now handles namespace-global enums by falling back to a module-level lookup (`self.Module`) when the enum has no enclosing class. A new `gen_dict.json` entry maps `VolumeType` -> `PtcloudVolumeType`, and the import generation automatically uses the renamed enum.

Fixes #29260
