### PR TITLE
core: fix GpuMatND move operations with CUDA 10.2

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -500,16 +500,8 @@ public:
     GpuMatND(const GpuMatND&) = default;
     GpuMatND& operator=(const GpuMatND&) = default;
 
-#if defined(__GNUC__) && __GNUC__ < 5
-    // error: function '...' defaulted on its first declaration with an exception-specification
-    // that differs from the implicit declaration '...'
-
     GpuMatND(GpuMatND&&) = default;
     GpuMatND& operator=(GpuMatND&&) = default;
-#else
-    GpuMatND(GpuMatND&&) noexcept = default;
-    GpuMatND& operator=(GpuMatND&&) noexcept = default;
-#endif
 
     void upload(InputArray src);
     void upload(InputArray src, Stream& stream);


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
      Observed on JetPack 4.6 with CUDA 10.2 / GCC 7.5.
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Added CUDA tests for GpuMatND move assignment and swap.
- [x] The feature is well documented and sample code can be built with the project CMake
      Not applicable: build fix only.

Fixes a CUDA 10.2 build failure in GpuMatND move construction and move assignment.
