### PR TITLE
cap torch storage size to int to prevent heap overflow

### DIFF
--- a/modules/dnn/src/torch/torch_importer.cpp
+++ b/modules/dnn/src/torch/torch_importer.cpp
@@ -255,6 +255,10 @@ struct TorchImporter
     void readTorchStorage(int index, int type = -1)
     {
         long size = readLong();
+        // size is read as a 64-bit value but Mat::create() takes int columns, so a
+        // value above INT_MAX is truncated for the allocation while the THFile_read*Raw
+        // calls below still consume the full 64-bit count, overflowing the buffer.
+        CV_Assert(size >= 0 && size <= INT_MAX);
         Mat storageMat;
 
         switch (type)


### PR DESCRIPTION
readTorchStorage reads the storage element count with readLong, so on LP64 builds size holds a full 64-bit value taken from the .t7 file. It then calls Mat::create(1, size, ...), which narrows size to int for the column count, while the following THFile_read*Raw calls keep the 64-bit count. A size like 0x100000005 allocates room for 5 floats but the read still consumes 0x100000005 elements, so reading walks past the storage buffer.

Before, the count used for the allocation and the count used for the read could disagree once size exceeded INT_MAX. After, size is validated once before the switch, so create and the readers always size the same buffer. The tradeoff is that storages claiming more than INT_MAX elements are now rejected instead of being silently truncated, which is all Mat::create can represent anyway.