### PR TITLE
imgproc: vectorize integral() sum-of-squares for 8-bit input — all output types & channel counts 🧑‍💻🤖

### DIFF
--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -79,8 +79,12 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum,
 
     TEST_CYCLE() integral(src, sum, sqsum, sdepth);
 
-    SANITY_CHECK(sum, 1e-6);
-    SANITY_CHECK(sqsum, 1e-6);
+    // A CV_32F sum/sqsum above 2^24 carries a float32 ULP that depends on the SIMD
+    // width and accumulation order (the SIMD path now runs here where it used to fall
+    // back to scalar), so compare those relatively; CV_32S/CV_64F outputs stay exact.
+    // Mirrors the tilted check below.
+    SANITY_CHECK(sum,   1e-6, sum.depth()   > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
+    SANITY_CHECK(sqsum, 1e-6, sqsum.depth() > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
 }
 
 static std::vector<std::tuple<MatType, IntegralOutputDepths>> GetFullSqsumDepthPairs() {

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -159,4 +159,32 @@ PERF_TEST_P( Size_MatType_OutMatDepth, integral_sqsum_tilted,
     SANITY_CHECK(tilted, 1e-6, tilted.depth() > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
 }
 
+// sum=CV_32S, sqsum=CV_64F: the default output types of cv::integral(src, sum, sqsum)
+// for an 8-bit image. The integral_sqsum test above pairs sum and sqsum at the same
+// depth, so this common combination was not measured.
+PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum_64f,
+            testing::Combine(
+                testing::Values(TYPICAL_MAT_SIZES),
+                testing::Values(CV_8UC1, CV_8UC3),
+                testing::Values(CV_32S)
+                )
+            )
+{
+    Size sz = get<0>(GetParam());
+    int matType = get<1>(GetParam());
+    int sdepth = get<2>(GetParam());
+
+    Mat src(sz, matType);
+    Mat sum(sz, sdepth);
+    Mat sqsum(sz, CV_64F);
+
+    declare.in(src, WARMUP_RNG).out(sum, sqsum);
+    declare.time(100);
+
+    TEST_CYCLE() integral(src, sum, sqsum, sdepth, CV_64F);
+
+    SANITY_CHECK(sum, 1e-6);
+    SANITY_CHECK(sqsum, 1e-6);
+}
+
 } // namespace

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -187,4 +187,43 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum_64f,
     SANITY_CHECK(sqsum, 1e-6);
 }
 
+// Enabled coverage for the combinations the widened 8-bit integral sqsum path
+// vectorizes: 8-bit source, every channel count, and every sum/sqsum output-depth
+// pair that now has a SIMD path. (The full 12-combo matrix lives in the DISABLED
+// test above; this curated subset is cheap enough to run by default.) Correctness
+// is covered by the Imgproc_Integral.accuracy test.
+static std::vector<std::tuple<MatType, IntegralOutputDepths>> GetSqsum8UDepthPairs() {
+    static int pairs[5] = { DEPTH_32S_64F, DEPTH_32S_32F, DEPTH_32S_32S, DEPTH_32F_64F, DEPTH_64F_64F };
+    std::vector<std::tuple<MatType, IntegralOutputDepths>> valid_pairs;
+    for (int cn = 1; cn <= 4; cn++)
+        for (int p = 0; p < 5; p++)
+            valid_pairs.emplace_back(CV_MAKETYPE(CV_8U, cn), pairs[p]);
+    return valid_pairs;
+}
+
+PERF_TEST_P(Size_MatType_OutMatDepthArray, integral_sqsum_8u,
+            testing::Combine(
+                testing::Values(TYPICAL_MAT_SIZES),
+                testing::ValuesIn(GetSqsum8UDepthPairs())
+                )
+            )
+{
+    Size sz = get<0>(GetParam());
+    auto depths = get<1>(GetParam());
+    int matType = get<0>(depths);
+    int sdepth  = extraOutputDepths[get<1>(depths)][0];
+    int sqdepth = extraOutputDepths[get<1>(depths)][1];
+
+    Mat src(sz, matType);
+    Mat sum(sz, sdepth);
+    Mat sqsum(sz, sqdepth);
+
+    declare.in(src, WARMUP_RNG).out(sum, sqsum);
+    declare.time(100);
+
+    TEST_CYCLE() integral(src, sum, sqsum, sdepth, sqdepth);
+
+    SANITY_CHECK_NOTHING();
+}
+
 } // namespace

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -193,10 +193,10 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum_64f,
 // test above; this curated subset is cheap enough to run by default.) Correctness
 // is covered by the Imgproc_Integral.accuracy test.
 static std::vector<std::tuple<MatType, IntegralOutputDepths>> GetSqsum8UDepthPairs() {
-    static int pairs[5] = { DEPTH_32S_64F, DEPTH_32S_32F, DEPTH_32S_32S, DEPTH_32F_64F, DEPTH_64F_64F };
+    static int pairs[6] = { DEPTH_32S_64F, DEPTH_32S_32F, DEPTH_32S_32S, DEPTH_32F_64F, DEPTH_32F_32F, DEPTH_64F_64F };
     std::vector<std::tuple<MatType, IntegralOutputDepths>> valid_pairs;
     for (int cn = 1; cn <= 4; cn++)
-        for (int p = 0; p < 5; p++)
+        for (int p = 0; p < 6; p++)
             valid_pairs.emplace_back(CV_MAKETYPE(CV_8U, cn), pairs[p]);
     return valid_pairs;
 }

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -187,10 +187,10 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum_64f,
 
     TEST_CYCLE() integral(src, sum, sqsum, sdepth, CV_64F);
 
-    // No SANITY_CHECK: the CV_64F sqsum max exceeds INT_MAX, and FileStorage cannot
-    // round-trip such whole-number doubles (written without a decimal point, then read
-    // back as an overflowed int32). Correctness is covered by Imgproc_Integral.accuracy.
-    SANITY_CHECK_NOTHING();
+    // The CV_64F sqsum can exceed INT_MAX; round-tripping such whole-number doubles
+    // through FileStorage is fixed by opencv#29368, so the regression baseline is usable.
+    SANITY_CHECK(sum,   1e-6, sum.depth()   > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
+    SANITY_CHECK(sqsum, 1e-6, sqsum.depth() > CV_32S ? ERROR_RELATIVE : ERROR_ABSOLUTE);
 }
 
 // Enabled coverage for the combinations the widened 8-bit integral sqsum path

--- a/modules/imgproc/perf/perf_integral.cpp
+++ b/modules/imgproc/perf/perf_integral.cpp
@@ -183,8 +183,10 @@ PERF_TEST_P(Size_MatType_OutMatDepth, integral_sqsum_64f,
 
     TEST_CYCLE() integral(src, sum, sqsum, sdepth, CV_64F);
 
-    SANITY_CHECK(sum, 1e-6);
-    SANITY_CHECK(sqsum, 1e-6);
+    // No SANITY_CHECK: the CV_64F sqsum max exceeds INT_MAX, and FileStorage cannot
+    // round-trip such whole-number doubles (written without a decimal point, then read
+    // back as an overflowed int32). Correctness is covered by Imgproc_Integral.accuracy.
+    SANITY_CHECK_NOTHING();
 }
 
 // Enabled coverage for the combinations the widened 8-bit integral sqsum path

--- a/modules/imgproc/src/sumpixels.dispatch.cpp
+++ b/modules/imgproc/src/sumpixels.dispatch.cpp
@@ -362,6 +362,47 @@ static bool integral_SIMD(
         CV_CPU_DISPATCH_MODES_ALL);
 }
 
+// --- Autotuned single-channel (cn==1) sqsum path selection --------------------
+// On wide out-of-order cores (e.g. Cortex-A76) the scalar single-channel sqsum
+// integral outruns the universal-intrinsic SIMD path: the per-row prefix is a
+// serial recurrence such cores already pipeline at high IPC, and the kernel is
+// store-bandwidth-bound, so the extra SIMD work is pure overhead. On in-order
+// cores (Cortex-A55) and Apple Silicon the SIMD path wins. These cannot be told
+// apart by CPU feature flags, so on first use we time both paths once on a
+// representative buffer and cache the faster choice (process-global, thread-safe).
+static bool tune_cn1_sqsum_prefer_scalar()
+{
+    const int W = 1280, H = 720, cn = 1;
+    std::vector<uchar>  src((size_t)W * H);
+    for (size_t i = 0; i < src.size(); ++i)
+        src[i] = (uchar)((i * 1103515245u + 12345u) >> 16);
+    std::vector<int>    sumb((size_t)(W + 1) * (H + 1));
+    std::vector<double> sqb ((size_t)(W + 1) * (H + 1));
+    const size_t srcstep = (size_t)W;
+    const size_t sumstep = (size_t)(W + 1) * sizeof(int);
+    const size_t sqstep  = (size_t)(W + 1) * sizeof(double);
+    auto run_simd = [&]{
+        integral_SIMD(CV_8U, CV_32S, CV_64F, src.data(), srcstep,
+            (uchar*)sumb.data(), sumstep, (uchar*)sqb.data(), sqstep,
+            (uchar*)0, 0, W, H, cn);
+    };
+    auto run_scalar = [&]{
+        integral_<uchar, int, double>(src.data(), srcstep, sumb.data(), sumstep,
+            sqb.data(), sqstep, (int*)0, 0, W, H, cn);
+    };
+    run_simd(); run_scalar();   // warmup (page-in + frequency ramp)
+    double tsimd = DBL_MAX, tscal = DBL_MAX;
+    for (int k = 0; k < 4; ++k) { int64 t = cv::getTickCount(); run_simd();   tsimd = std::min(tsimd, (double)(cv::getTickCount() - t)); }
+    for (int k = 0; k < 4; ++k) { int64 t = cv::getTickCount(); run_scalar(); tscal = std::min(tscal, (double)(cv::getTickCount() - t)); }
+    return tscal < tsimd;
+}
+
+static inline bool cn1_sqsum_prefer_scalar()
+{
+    static const bool prefer = tune_cn1_sqsum_prefer_scalar();
+    return prefer;
+}
+
 void integral(
         int depth, int sdepth, int sqdepth,
         const uchar* src, size_t srcstep,
@@ -375,7 +416,14 @@ void integral(
     CALL_HAL(integral, cv_hal_integral, depth, sdepth, sqdepth, src, srcstep, sum, sumstep, sqsum, sqsumstep, tilted, tstep, width, height, cn);
     CV_IPP_RUN_FAST(ipp_integral(depth, sdepth, sqdepth, src, srcstep, sum, sumstep, sqsum, sqsumstep, tilted, tstep, width, height, cn));
 
-    if (integral_SIMD(depth, sdepth, sqdepth, src, srcstep, sum, sumstep, sqsum, sqsumstep, tilted, tstep, width, height, cn))
+    // Single-channel 8-bit sqsum: let the one-time autotune decide SIMD vs scalar
+    // (the SIMD path regresses on wide OoO cores like Cortex-A76 but wins on A55 /
+    // Apple Silicon; CPU feature flags can't distinguish them).
+    bool useSimd = true;
+    if (depth == CV_8U && sqsum && cn == 1 && tilted == 0)
+        useSimd = !cn1_sqsum_prefer_scalar();
+
+    if (useSimd && integral_SIMD(depth, sdepth, sqdepth, src, srcstep, sum, sumstep, sqsum, sqsumstep, tilted, tstep, width, height, cn))
         return;
 
 #define ONE_CALL(A, B, C) integral_<A, B, C>((const A*)src, srcstep, (B*)sum, sumstep, (C*)sqsum, sqsumstep, (B*)tilted, tstep, width, height, cn)

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -605,20 +605,21 @@ struct Integral_SIMD<uchar, int, QT>
     }
 };
 
-template <>
-struct Integral_SIMD<uchar, float, double>
+template <typename QT>
+struct Integral_SIMD<uchar, float, QT>
 {
     Integral_SIMD() {}
 
     bool operator()(const uchar * src, size_t _srcstep,
         float * sum, size_t _sumstep,
-        double * sqsum, size_t _sqsumstep,
+        QT * sqsum, size_t _sqsumstep,
         float * tilted, size_t,
         int width, int height, int cn) const
     {
-        // sqsum is vectorized for single-channel only; other channel counts and
-        // the tilted case still fall back to the scalar path.
-        if ((sqsum && cn != 1) || tilted || cn > 4)
+        // sqsum is vectorized for cn 1..3 at any SIMD width, and cn==4 only at
+        // 128-bit width; wider cn==4 sqsum and the tilted case fall back to scalar.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 
         width *= cn;
@@ -626,7 +627,7 @@ struct Integral_SIMD<uchar, float, double>
         // the first iteration
         memset(sum, 0, (width + cn) * sizeof(float));
         if (sqsum)
-            memset(sqsum, 0, (width + cn) * sizeof(double));
+            memset(sqsum, 0, (width + cn) * sizeof(QT));
 
         if (cn == 1)
         {
@@ -639,8 +640,8 @@ struct Integral_SIMD<uchar, float, double>
 
                 sum_row[-1] = 0;
 
-                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
-                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
                 if (sqsum)
                     sqsum_row[-1] = 0;
 
@@ -691,11 +692,11 @@ struct Integral_SIMD<uchar, float, double>
                     sum_row[jt] = (v += src_row[jt]) + prev_sum_row[jt];
                 if (sqsum)
                 {
-                    double s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
                     for ( ; j < width; ++j)
                     {
                         int it = src_row[j];
-                        s += (double)it * it;
+                        s += (QT)it * it;
                         sqsum_row[j] = s + prev_sqsum_row[j];
                     }
                 }
@@ -713,13 +714,33 @@ struct Integral_SIMD<uchar, float, double>
 
                 sum_row[-1] = sum_row[-2] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = 0;
+
                 v_float32 prev_1 = vx_setzero_f32(), prev_2 = vx_setzero_f32();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32();
                 int j = 0;
                 for (; j + VTraits<v_uint16>::vlanes() * cn <= width; j += VTraits<v_uint16>::vlanes() * cn)
                 {
                     v_int16 v_src_row = v_reinterpret_as_s16(vx_load(src_row + j));
                     v_int16 el8_1 = v_and(v_src_row, mask);
                     v_int16 el8_2 = v_reinterpret_as_s16(v_shr<8>(v_reinterpret_as_u16(v_src_row)));
+
+                    if (sqsum)
+                    {
+                        v_int32 sqlo_1, sqhi_1, sqlo_2, sqhi_2;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sqlo_1, sqhi_1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sqlo_2, sqhi_2);
+                        v_int32 z1, z2, z3, z4;
+                        v_zip(sqlo_1, sqlo_2, z1, z2);
+                        v_zip(sqhi_1, sqhi_2, z3, z4);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_sqsum_block(sqsum_row + j,          prev_sqsum_row + j,          z1, z2);
+                        v_store_sqsum_block(sqsum_row + j + 2 * vl, prev_sqsum_row + j + 2 * vl, z3, z4);
+                    }
+
                     v_float32 el4l_1, el4h_1, el4l_2, el4h_2;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -767,11 +788,25 @@ struct Integral_SIMD<uchar, float, double>
                     v_store(sum_row + j + VTraits<v_float32>::vlanes() * 3, v_add(el4_4, vx_load(prev_sum_row + j + VTraits<v_float32>::vlanes() * 3)));
                 }
 
-                for (float v2 = sum_row[j - 1] - prev_sum_row[j - 1],
-                           v1 = sum_row[j - 2] - prev_sum_row[j - 2]; j < width; j += 2)
+                int jt = j;
+                for (float v2 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                           v1 = sum_row[jt - 2] - prev_sum_row[jt - 2]; jt < width; jt += 2)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                }
+                if (sqsum)
+                {
+                    QT sq2 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT sq1 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    for ( ; j < width; j += 2)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1];
+                        sq1 += (QT)i1 * i1;
+                        sq2 += (QT)i2 * i2;
+                        sqsum_row[j]     = sq1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = sq2 + prev_sqsum_row[j + 1];
+                    }
                 }
             }
         }
@@ -784,11 +819,19 @@ struct Integral_SIMD<uchar, float, double>
                 float * prev_sum_row = (float *)((uchar *)sum + _sumstep * i) + cn;
                 float * sum_row = (float *)((uchar *)sum + _sumstep * (i + 1)) + cn;
                 float row_cache[VTraits<v_float32>::max_nlanes * 6];
+                int sq_cache[VTraits<v_int32>::max_nlanes * 6];
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = 0;
+
                 v_float32 prev_1 = vx_setzero_f32(), prev_2 = vx_setzero_f32(),
                           prev_3 = vx_setzero_f32();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32(),
+                        prev_sq_3 = vx_setzero_s32();
                 int j = 0;
                 const int j_max =
                         ((_srcstep * i + (width - VTraits<v_uint16>::vlanes() * cn + VTraits<v_uint8>::vlanes() * cn)) >= _srcstep * height)
@@ -801,6 +844,24 @@ struct Integral_SIMD<uchar, float, double>
                     v_int16 el8_1 = v_reinterpret_as_s16(v_expand_low(v_src_row_1));
                     v_int16 el8_2 = v_reinterpret_as_s16(v_expand_low(v_src_row_2));
                     v_int16 el8_3 = v_reinterpret_as_s16(v_expand_low(v_src_row_3));
+
+                    if (sqsum)
+                    {
+                        v_int32 sl1, sh1, sl2, sh2, sl3, sh3;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sl1, sh1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sl2, sh2);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_3), prev_sq_3, sl3, sh3);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_interleave(sq_cache         , sl1, sl2, sl3);
+                        v_store_interleave(sq_cache + vl * 3, sh1, sh2, sh3);
+                        v_int32 z0 = vx_load(sq_cache         ), z1 = vx_load(sq_cache + vl    );
+                        v_int32 z2 = vx_load(sq_cache + vl * 2), z3 = vx_load(sq_cache + vl * 3);
+                        v_int32 z4 = vx_load(sq_cache + vl * 4), z5 = vx_load(sq_cache + vl * 5);
+                        v_store_sqsum_block(sqsum_row + j         , prev_sqsum_row + j         , z0, z1);
+                        v_store_sqsum_block(sqsum_row + j + 2 * vl, prev_sqsum_row + j + 2 * vl, z2, z3);
+                        v_store_sqsum_block(sqsum_row + j + 4 * vl, prev_sqsum_row + j + 4 * vl, z4, z5);
+                    }
+
                     v_float32 el4l_1, el4h_1, el4l_2, el4h_2, el4l_3, el4h_3;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -869,13 +930,28 @@ struct Integral_SIMD<uchar, float, double>
                     v_store(sum_row + j + VTraits<v_float32>::vlanes() * 5, v_add(el4h_3, vx_load(prev_sum_row + j + VTraits<v_float32>::vlanes() * 5)));
                 }
 
-                for (float v3 = sum_row[j - 1] - prev_sum_row[j - 1],
-                           v2 = sum_row[j - 2] - prev_sum_row[j - 2],
-                           v1 = sum_row[j - 3] - prev_sum_row[j - 3]; j < width; j += 3)
+                int jt = j;
+                for (float v3 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                           v2 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                           v1 = sum_row[jt - 3] - prev_sum_row[jt - 3]; jt < width; jt += 3)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                }
+                if (sqsum)
+                {
+                    QT s3 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s2 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    QT s1 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    for ( ; j < width; j += 3)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2];
+                        s1 += (QT)i1 * i1; s2 += (QT)i2 * i2; s3 += (QT)i3 * i3;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                    }
                 }
             }
         }
@@ -890,12 +966,34 @@ struct Integral_SIMD<uchar, float, double>
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = sum_row[-4] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = sqsum_row[-4] = 0;
+
                 v_float32 prev = vx_setzero_f32();
+#if CV_SIMD_WIDTH == 16
+                v_int32 prev_sq = vx_setzero_s32();
+#endif
                 int j = 0;
                 for ( ; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_float32 el4l, el4h;
+#if CV_SIMD_WIDTH == 16
+                    if (sqsum)
+                    {
+                        v_uint32 sq_lo_u, sq_hi_u;
+                        v_mul_expand(px, px, sq_lo_u, sq_hi_u);
+                        v_int32 sq_l = v_reinterpret_as_s32(sq_lo_u);
+                        v_int32 sq_h = v_reinterpret_as_s32(sq_hi_u);
+                        sq_l = v_add(sq_l, prev_sq);
+                        sq_h = v_add(sq_h, sq_l);
+                        prev_sq = sq_h;
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sq_l, sq_h);
+                    }
+#endif
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 8));
                     el4l.val = _mm256_add_ps(_mm256_cvtepi32_ps(_mm256_cvtepi16_epi32(_v256_extract_low(vsum))), prev.val);
@@ -926,15 +1024,32 @@ struct Integral_SIMD<uchar, float, double>
                     v_store(sum_row + j + VTraits<v_float32>::vlanes(), v_add(el4h, vx_load(prev_sum_row + j + VTraits<v_float32>::vlanes())));
                 }
 
-                for (float v4 = sum_row[j - 1] - prev_sum_row[j - 1],
-                           v3 = sum_row[j - 2] - prev_sum_row[j - 2],
-                           v2 = sum_row[j - 3] - prev_sum_row[j - 3],
-                           v1 = sum_row[j - 4] - prev_sum_row[j - 4]; j < width; j += 4)
+                int jt = j;
+                for (float v4 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                           v3 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                           v2 = sum_row[jt - 3] - prev_sum_row[jt - 3],
+                           v1 = sum_row[jt - 4] - prev_sum_row[jt - 4]; jt < width; jt += 4)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
-                    sum_row[j + 3] = (v4 += src_row[j + 3]) + prev_sum_row[j + 3];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                    sum_row[jt + 3] = (v4 += src_row[jt + 3]) + prev_sum_row[jt + 3];
+                }
+                if (sqsum)
+                {
+                    QT s4 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s3 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    QT s2 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    QT s1 = sqsum_row[j - 4] - prev_sqsum_row[j - 4];
+                    for ( ; j < width; j += 4)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2], i4 = src_row[j + 3];
+                        s1 += (QT)i1 * i1; s2 += (QT)i2 * i2; s3 += (QT)i3 * i3; s4 += (QT)i4 * i4;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                        sqsum_row[j + 3] = s4 + prev_sqsum_row[j + 3];
+                    }
                 }
             }
         }
@@ -969,9 +1084,11 @@ struct Integral_SIMD<uchar, double, double>
 #else
         CV_UNUSED(_sqsumstep);
 #endif
-        // sqsum is vectorized for single-channel only (the AVX-512 path above covers
-        // the multi-channel case); other channel counts fall back to scalar here.
-        if ((sqsum && cn != 1) || tilted || cn > 4)
+        // sqsum is vectorized for cn 1..3 at any SIMD width and cn==4 at 128-bit
+        // width (the AVX-512 path above already covers the multi-channel case);
+        // wider cn==4 sqsum and the tilted case fall back to scalar here.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 
         width *= cn;
@@ -1075,13 +1192,33 @@ struct Integral_SIMD<uchar, double, double>
 
                 sum_row[-1] = sum_row[-2] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = 0;
+
                 v_float64 prev_1 = vx_setzero_f64(), prev_2 = vx_setzero_f64();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32();
                 int j = 0;
                 for (; j + VTraits<v_uint16>::vlanes() * cn <= width; j += VTraits<v_uint16>::vlanes() * cn)
                 {
                     v_int16 v_src_row = v_reinterpret_as_s16(vx_load(src_row + j));
                     v_int16 el8_1 = v_and(v_src_row, mask);
                     v_int16 el8_2 = v_reinterpret_as_s16(v_shr<8>(v_reinterpret_as_u16(v_src_row)));
+
+                    if (sqsum)
+                    {
+                        v_int32 sqlo_1, sqhi_1, sqlo_2, sqhi_2;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sqlo_1, sqhi_1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sqlo_2, sqhi_2);
+                        v_int32 z1, z2, z3, z4;
+                        v_zip(sqlo_1, sqlo_2, z1, z2);
+                        v_zip(sqhi_1, sqhi_2, z3, z4);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_sqsum_block(sqsum_row + j,          prev_sqsum_row + j,          z1, z2);
+                        v_store_sqsum_block(sqsum_row + j + 2 * vl, prev_sqsum_row + j + 2 * vl, z3, z4);
+                    }
+
                     v_float64 el4ll_1, el4lh_1, el4hl_1, el4hh_1, el4ll_2, el4lh_2, el4hl_2, el4hh_2;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -1150,11 +1287,25 @@ struct Integral_SIMD<uchar, double, double>
                     v_store(sum_row + j + VTraits<v_float64>::vlanes() * 7, v_add(el4_8, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes() * 7)));
                 }
 
-                for (double v2 = sum_row[j - 1] - prev_sum_row[j - 1],
-                            v1 = sum_row[j - 2] - prev_sum_row[j - 2]; j < width; j += 2)
+                int jt = j;
+                for (double v2 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                            v1 = sum_row[jt - 2] - prev_sum_row[jt - 2]; jt < width; jt += 2)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                }
+                if (sqsum)
+                {
+                    double sq2 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    double sq1 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    for ( ; j < width; j += 2)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1];
+                        sq1 += (double)i1 * i1;
+                        sq2 += (double)i2 * i2;
+                        sqsum_row[j]     = sq1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = sq2 + prev_sqsum_row[j + 1];
+                    }
                 }
             }
         }
@@ -1167,11 +1318,19 @@ struct Integral_SIMD<uchar, double, double>
                 double * prev_sum_row = (double *)((uchar *)sum + _sumstep * i) + cn;
                 double * sum_row = (double *)((uchar *)sum + _sumstep * (i + 1)) + cn;
                 double row_cache[VTraits<v_float64>::max_nlanes * 12];
+                int sq_cache[VTraits<v_int32>::max_nlanes * 6];
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = 0;
+
                 v_float64 prev_1 = vx_setzero_f64(), prev_2 = vx_setzero_f64(),
                           prev_3 = vx_setzero_f64();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32(),
+                        prev_sq_3 = vx_setzero_s32();
                 int j = 0;
                 const int j_max =
                         ((_srcstep * i + (width - VTraits<v_uint16>::vlanes() * cn + VTraits<v_uint8>::vlanes() * cn)) >= _srcstep * height)
@@ -1184,6 +1343,24 @@ struct Integral_SIMD<uchar, double, double>
                     v_int16 el8_1 = v_reinterpret_as_s16(v_expand_low(v_src_row_1));
                     v_int16 el8_2 = v_reinterpret_as_s16(v_expand_low(v_src_row_2));
                     v_int16 el8_3 = v_reinterpret_as_s16(v_expand_low(v_src_row_3));
+
+                    if (sqsum)
+                    {
+                        v_int32 sl1, sh1, sl2, sh2, sl3, sh3;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sl1, sh1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sl2, sh2);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_3), prev_sq_3, sl3, sh3);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_interleave(sq_cache         , sl1, sl2, sl3);
+                        v_store_interleave(sq_cache + vl * 3, sh1, sh2, sh3);
+                        v_int32 z0 = vx_load(sq_cache         ), z1 = vx_load(sq_cache + vl    );
+                        v_int32 z2 = vx_load(sq_cache + vl * 2), z3 = vx_load(sq_cache + vl * 3);
+                        v_int32 z4 = vx_load(sq_cache + vl * 4), z5 = vx_load(sq_cache + vl * 5);
+                        v_store_sqsum_block(sqsum_row + j         , prev_sqsum_row + j         , z0, z1);
+                        v_store_sqsum_block(sqsum_row + j + 2 * vl, prev_sqsum_row + j + 2 * vl, z2, z3);
+                        v_store_sqsum_block(sqsum_row + j + 4 * vl, prev_sqsum_row + j + 4 * vl, z4, z5);
+                    }
+
                     v_float64 el4ll_1, el4lh_1, el4hl_1, el4hh_1, el4ll_2, el4lh_2, el4hl_2, el4hh_2, el4ll_3, el4lh_3, el4hl_3, el4hh_3;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -1289,13 +1466,28 @@ struct Integral_SIMD<uchar, double, double>
                     v_store(sum_row + j + VTraits<v_float64>::vlanes() * 11, v_add(el4hh_3, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes() * 11)));
                 }
 
-                for (double v3 = sum_row[j - 1] - prev_sum_row[j - 1],
-                            v2 = sum_row[j - 2] - prev_sum_row[j - 2],
-                            v1 = sum_row[j - 3] - prev_sum_row[j - 3]; j < width; j += 3)
+                int jt = j;
+                for (double v3 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                            v2 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                            v1 = sum_row[jt - 3] - prev_sum_row[jt - 3]; jt < width; jt += 3)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                }
+                if (sqsum)
+                {
+                    double s3 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    double s2 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    double s1 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    for ( ; j < width; j += 3)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2];
+                        s1 += (double)i1 * i1; s2 += (double)i2 * i2; s3 += (double)i3 * i3;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                    }
                 }
             }
         }
@@ -1310,12 +1502,34 @@ struct Integral_SIMD<uchar, double, double>
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = sum_row[-4] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = sqsum_row[-4] = 0;
+
                 v_float64 prev_1 = vx_setzero_f64(), prev_2 = vx_setzero_f64();
+#if CV_SIMD_WIDTH == 16
+                v_int32 prev_sq = vx_setzero_s32();
+#endif
                 int j = 0;
                 for ( ; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_float64 el4ll, el4lh, el4hl, el4hh;
+#if CV_SIMD_WIDTH == 16
+                    if (sqsum)
+                    {
+                        v_uint32 sq_lo_u, sq_hi_u;
+                        v_mul_expand(px, px, sq_lo_u, sq_hi_u);
+                        v_int32 sq_l = v_reinterpret_as_s32(sq_lo_u);
+                        v_int32 sq_h = v_reinterpret_as_s32(sq_hi_u);
+                        sq_l = v_add(sq_l, prev_sq);
+                        sq_h = v_add(sq_h, sq_l);
+                        prev_sq = sq_h;
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sq_l, sq_h);
+                    }
+#endif
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 8));
                     __m256i el4l_32 = _mm256_cvtepi16_epi32(_v256_extract_low(vsum));
@@ -1353,15 +1567,32 @@ struct Integral_SIMD<uchar, double, double>
                     v_store(sum_row + j + VTraits<v_float64>::vlanes() * 3, v_add(el4hh, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes() * 3)));
                 }
 
-                for (double v4 = sum_row[j - 1] - prev_sum_row[j - 1],
-                            v3 = sum_row[j - 2] - prev_sum_row[j - 2],
-                            v2 = sum_row[j - 3] - prev_sum_row[j - 3],
-                            v1 = sum_row[j - 4] - prev_sum_row[j - 4]; j < width; j += 4)
+                int jt = j;
+                for (double v4 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                            v3 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                            v2 = sum_row[jt - 3] - prev_sum_row[jt - 3],
+                            v1 = sum_row[jt - 4] - prev_sum_row[jt - 4]; jt < width; jt += 4)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
-                    sum_row[j + 3] = (v4 += src_row[j + 3]) + prev_sum_row[j + 3];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                    sum_row[jt + 3] = (v4 += src_row[jt + 3]) + prev_sum_row[jt + 3];
+                }
+                if (sqsum)
+                {
+                    double s4 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    double s3 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    double s2 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    double s1 = sqsum_row[j - 4] - prev_sqsum_row[j - 4];
+                    for ( ; j < width; j += 4)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2], i4 = src_row[j + 3];
+                        s1 += (double)i1 * i1; s2 += (double)i2 * i2; s3 += (double)i3 * i3; s4 += (double)i4 * i4;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                        sqsum_row[j + 3] = s4 + prev_sqsum_row[j + 3];
+                    }
                 }
             }
         }

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -82,15 +82,24 @@ struct Integral_SIMD
 // here it is converted to the sqsum output type and added to the integral row above.
 // Overloaded on the output element type so the same int32 prefix feeds CV_64F /
 // CV_32F / CV_32S sqsum outputs (Integral_SIMD<uchar,int,QT> below).
+#if CV_SIMD_64F
 static inline void v_store_sqsum_block(double* dst, const double* prev,
                                        const v_int32& lo, const v_int32& hi)
 {
     const int vl = VTraits<v_float64>::vlanes();
-    v_store(dst,            v_add(v_cvt_f64(lo),      vx_load(prev)));
-    v_store(dst +     vl,   v_add(v_cvt_f64_high(lo), vx_load(prev +     vl)));
-    v_store(dst + 2 * vl,   v_add(v_cvt_f64(hi),      vx_load(prev + 2 * vl)));
-    v_store(dst + 3 * vl,   v_add(v_cvt_f64_high(hi), vx_load(prev + 3 * vl)));
+    // Convert the int32 squared prefix to f64 via int64. v_cvt_f64(v_int32) goes
+    // through float32 on AArch64 NEON (vcvt_f64_f32(vcvt_f32_s32(...))) and loses
+    // precision once the prefix exceeds 2^24 (~16.7M, reached well within one HD
+    // row of squares); the int64 round-trip keeps it exact on every backend.
+    v_int64 lo0, lo1, hi0, hi1;
+    v_expand(lo, lo0, lo1);
+    v_expand(hi, hi0, hi1);
+    v_store(dst,            v_add(v_cvt_f64(lo0), vx_load(prev)));
+    v_store(dst +     vl,   v_add(v_cvt_f64(lo1), vx_load(prev +     vl)));
+    v_store(dst + 2 * vl,   v_add(v_cvt_f64(hi0), vx_load(prev + 2 * vl)));
+    v_store(dst + 3 * vl,   v_add(v_cvt_f64(hi1), vx_load(prev + 3 * vl)));
 }
+#endif // CV_SIMD_64F
 static inline void v_store_sqsum_block(float* dst, const float* prev,
                                        const v_int32& lo, const v_int32& hi)
 {
@@ -1632,13 +1641,21 @@ bool integral_SIMD(
     return Integral_SIMD<T, ST, QT>()((const T*)src, srcstep, (ST*)sum, sumstep, (QT*)sqsum, sqsumstep, (ST*)tilted, tstep, width, height, cn)
 
     if( depth == CV_8U && sdepth == CV_32S && sqdepth == CV_64F )
-        ONE_CALL(uchar, int, double);
+#if CV_SIMD_64F
+        ONE_CALL(uchar, int, double);   // f64 sqsum: needs 64-bit-float SIMD
+#else
+        return false;                   // e.g. 32-bit ARMv7 NEON -> scalar path
+#endif
     else if( depth == CV_8U && sdepth == CV_32S && sqdepth == CV_32F )
         ONE_CALL(uchar, int, float);
     else if( depth == CV_8U && sdepth == CV_32S && sqdepth == CV_32S )
         ONE_CALL(uchar, int, int);
     else if( depth == CV_8U && sdepth == CV_32F && sqdepth == CV_64F )
+#if CV_SIMD_64F
         ONE_CALL(uchar, float, double);
+#else
+        return false;
+#endif
     else if( depth == CV_8U && sdepth == CV_32F && sqdepth == CV_32F )
         ONE_CALL(uchar, float, float);
     else if( depth == CV_8U && sdepth == CV_64F && sqdepth == CV_64F )

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -84,11 +84,13 @@ struct Integral_SIMD<uchar, int, double>
 
     bool operator()(const uchar * src, size_t _srcstep,
                     int * sum, size_t _sumstep,
-                    double * sqsum, size_t,
+                    double * sqsum, size_t _sqsumstep,
                     int * tilted, size_t,
                     int width, int height, int cn) const
     {
-        if (sqsum || tilted || cn > 4)
+        // sqsum is vectorized for single-channel only (see below); other channel
+        // counts and the tilted case still fall back to the scalar path.
+        if ((sqsum && cn != 1) || tilted || cn > 4)
             return false;
 #if !CV_SSE4_1 && CV_SSE2
         // 3 channel code is slower for SSE2 & SSE3
@@ -100,6 +102,8 @@ struct Integral_SIMD<uchar, int, double>
 
         // the first iteration
         memset(sum, 0, (width + cn) * sizeof(int));
+        if (sqsum)
+            memset(sqsum, 0, (width + cn) * sizeof(double));
 
         if (cn == 1)
         {
@@ -112,11 +116,18 @@ struct Integral_SIMD<uchar, int, double>
 
                 sum_row[-1] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
+                if (sqsum)
+                    sqsum_row[-1] = 0;
+
                 v_int32 prev = vx_setzero_s32();
+                v_int32 prev_sq = vx_setzero_s32();
                 int j = 0;
                 for ( ; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_int32 el4l, el4h;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 2));
@@ -142,10 +153,53 @@ struct Integral_SIMD<uchar, int, double>
 #endif
                     v_store(sum_row + j                  , v_add(el4l, vx_load(prev_sum_row + j)));
                     v_store(sum_row + j + VTraits<v_int32>::vlanes(), v_add(el4h, vx_load(prev_sum_row + j + VTraits<v_int32>::vlanes())));
+
+                    if (sqsum)
+                    {
+                        // Integral of squared pixels. The per-row running sum of squares
+                        // (<= width * 255^2) fits in int32, so the horizontal prefix sum is
+                        // done in int32 with the same rotate/broadcast idiom as the sum above,
+                        // then accumulated into the double output together with the row above.
+                        v_uint32 sqlo_u, sqhi_u;
+                        v_mul_expand(px, px, sqlo_u, sqhi_u);
+                        v_int32 sqlo = v_reinterpret_as_s32(sqlo_u);
+                        v_int32 sqhi = v_reinterpret_as_s32(sqhi_u);
+                        sqlo = v_add(sqlo, v_rotate_left<1>(sqlo));
+                        sqlo = v_add(sqlo, v_rotate_left<2>(sqlo));
+                        sqhi = v_add(sqhi, v_rotate_left<1>(sqhi));
+                        sqhi = v_add(sqhi, v_rotate_left<2>(sqhi));
+#if CV_SIMD_WIDTH >= 32
+                        sqlo = v_add(sqlo, v_rotate_left<4>(sqlo));
+                        sqhi = v_add(sqhi, v_rotate_left<4>(sqhi));
+#if CV_SIMD_WIDTH == 64
+                        sqlo = v_add(sqlo, v_rotate_left<8>(sqlo));
+                        sqhi = v_add(sqhi, v_rotate_left<8>(sqhi));
+#endif
+#endif
+                        sqlo = v_add(sqlo, prev_sq);
+                        sqhi = v_add(sqhi, v_broadcast_highest(sqlo));
+                        prev_sq = v_broadcast_highest(sqhi);
+                        const int vl64 = VTraits<v_float64>::vlanes();
+                        v_store(sqsum_row + j            , v_add(v_cvt_f64(sqlo),      vx_load(prev_sqsum_row + j)));
+                        v_store(sqsum_row + j +     vl64 , v_add(v_cvt_f64_high(sqlo), vx_load(prev_sqsum_row + j +     vl64)));
+                        v_store(sqsum_row + j + 2 * vl64 , v_add(v_cvt_f64(sqhi),      vx_load(prev_sqsum_row + j + 2 * vl64)));
+                        v_store(sqsum_row + j + 3 * vl64 , v_add(v_cvt_f64_high(sqhi), vx_load(prev_sqsum_row + j + 3 * vl64)));
+                    }
                 }
 
-                for (int v = sum_row[j - 1] - prev_sum_row[j - 1]; j < width; ++j)
-                    sum_row[j] = (v += src_row[j]) + prev_sum_row[j];
+                int jt = j;
+                for (int v = sum_row[jt - 1] - prev_sum_row[jt - 1]; jt < width; ++jt)
+                    sum_row[jt] = (v += src_row[jt]) + prev_sum_row[jt];
+                if (sqsum)
+                {
+                    double s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    for ( ; j < width; ++j)
+                    {
+                        int it = src_row[j];
+                        s += (double)it * it;
+                        sqsum_row[j] = s + prev_sqsum_row[j];
+                    }
+                }
             }
         }
         else if (cn == 2)

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -146,9 +146,11 @@ struct Integral_SIMD<uchar, int, QT>
                     int * tilted, size_t,
                     int width, int height, int cn) const
     {
-        // sqsum is vectorized for 1- and 2-channel (see below); 3/4-channel sqsum
-        // and the tilted case still fall back to the scalar path.
-        if ((sqsum && cn != 1 && cn != 2) || tilted || cn > 4)
+        // sqsum is vectorized for cn 1..3 at any SIMD width, and cn==4 only at
+        // 128-bit width (where the 4 channels map to two pixels per vector). Wider
+        // cn==4 sqsum and the tilted case still fall back to the scalar path.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 #if !CV_SSE4_1 && CV_SSE2
         // 3 channel code is slower for SSE2 & SSE3
@@ -355,11 +357,19 @@ struct Integral_SIMD<uchar, int, QT>
                 int * prev_sum_row = (int *)((uchar *)sum + _sumstep * i) + cn;
                 int * sum_row = (int *)((uchar *)sum + _sumstep * (i + 1)) + cn;
                 int row_cache[VTraits<v_int32>::max_nlanes * 6];
+                int sq_cache[VTraits<v_int32>::max_nlanes * 6];
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = 0;
+
                 v_int32 prev_1 = vx_setzero_s32(), prev_2 = vx_setzero_s32(),
                         prev_3 = vx_setzero_s32();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32(),
+                        prev_sq_3 = vx_setzero_s32();
                 int j = 0;
                 const int j_max =
                         ((_srcstep * i + (width - VTraits<v_uint16>::vlanes() * cn + VTraits<v_uint8>::vlanes() * cn)) >= _srcstep * height)
@@ -372,6 +382,26 @@ struct Integral_SIMD<uchar, int, QT>
                     v_int16 el8_1 = v_reinterpret_as_s16(v_expand_low(v_src_row_1));
                     v_int16 el8_2 = v_reinterpret_as_s16(v_expand_low(v_src_row_2));
                     v_int16 el8_3 = v_reinterpret_as_s16(v_expand_low(v_src_row_3));
+
+                    if (sqsum)
+                    {
+                        // Per-channel squared prefix (el8_x hold raw channel values),
+                        // then re-interleaved through sq_cache like the sum below.
+                        v_int32 sl1, sh1, sl2, sh2, sl3, sh3;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sl1, sh1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sl2, sh2);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_3), prev_sq_3, sl3, sh3);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_interleave(sq_cache         , sl1, sl2, sl3);
+                        v_store_interleave(sq_cache + vl * 3, sh1, sh2, sh3);
+                        v_int32 z0 = vx_load(sq_cache         ), z1 = vx_load(sq_cache + vl    );
+                        v_int32 z2 = vx_load(sq_cache + vl * 2), z3 = vx_load(sq_cache + vl * 3);
+                        v_int32 z4 = vx_load(sq_cache + vl * 4), z5 = vx_load(sq_cache + vl * 5);
+                        v_store_sqsum_block(sqsum_row + j         , prev_sqsum_row + j         , z0, z1);
+                        v_store_sqsum_block(sqsum_row + j + vl * 2, prev_sqsum_row + j + vl * 2, z2, z3);
+                        v_store_sqsum_block(sqsum_row + j + vl * 4, prev_sqsum_row + j + vl * 4, z4, z5);
+                    }
+
                     v_int32 el4l_1, el4h_1, el4l_2, el4h_2, el4l_3, el4h_3;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -439,13 +469,28 @@ struct Integral_SIMD<uchar, int, QT>
                     v_store(sum_row + j + VTraits<v_int32>::vlanes() * 5, v_add(el4h_3, vx_load(prev_sum_row + j + VTraits<v_int32>::vlanes() * 5)));
                 }
 
-                for (int v3 = sum_row[j - 1] - prev_sum_row[j - 1],
-                         v2 = sum_row[j - 2] - prev_sum_row[j - 2],
-                         v1 = sum_row[j - 3] - prev_sum_row[j - 3]; j < width; j += 3)
+                int jt = j;
+                for (int v3 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                         v2 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                         v1 = sum_row[jt - 3] - prev_sum_row[jt - 3]; jt < width; jt += 3)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                }
+                if (sqsum)
+                {
+                    QT s3 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s2 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    QT s1 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    for ( ; j < width; j += 3)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2];
+                        s1 += (QT)i1 * i1; s2 += (QT)i2 * i2; s3 += (QT)i3 * i3;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                    }
                 }
             }
         }
@@ -461,12 +506,37 @@ struct Integral_SIMD<uchar, int, QT>
 
                 sum_row[-1] = sum_row[-2] = sum_row[-3] = sum_row[-4] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = sqsum_row[-3] = sqsum_row[-4] = 0;
+
                 v_int32 prev = vx_setzero_s32();
+#if CV_SIMD_WIDTH == 16
+                v_int32 prev_sq = vx_setzero_s32();
+#endif
                 int j = 0;
                 for ( ; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_int32 el4l, el4h;
+#if CV_SIMD_WIDTH == 16
+                    // cn==4 sqsum is enabled only at 128-bit width (see bail): the 8
+                    // expanded pixels are exactly two 4-channel pixels, so the squared
+                    // prefix is the same two-pixel accumulate as the sum below.
+                    if (sqsum)
+                    {
+                        v_uint32 sq_lo_u, sq_hi_u;
+                        v_mul_expand(px, px, sq_lo_u, sq_hi_u);
+                        v_int32 sq_l = v_reinterpret_as_s32(sq_lo_u);
+                        v_int32 sq_h = v_reinterpret_as_s32(sq_hi_u);
+                        sq_l = v_add(sq_l, prev_sq);
+                        sq_h = v_add(sq_h, sq_l);
+                        prev_sq = sq_h;
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sq_l, sq_h);
+                    }
+#endif
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 8));
                     el4l.val = _mm256_add_epi32(_mm256_cvtepi16_epi32(_v256_extract_low(vsum)), prev.val);
@@ -496,15 +566,32 @@ struct Integral_SIMD<uchar, int, QT>
                     v_store(sum_row + j + VTraits<v_int32>::vlanes(), v_add(el4h, vx_load(prev_sum_row + j + VTraits<v_int32>::vlanes())));
                 }
 
-                for (int v4 = sum_row[j - 1] - prev_sum_row[j - 1],
-                         v3 = sum_row[j - 2] - prev_sum_row[j - 2],
-                         v2 = sum_row[j - 3] - prev_sum_row[j - 3],
-                         v1 = sum_row[j - 4] - prev_sum_row[j - 4]; j < width; j += 4)
+                int jt = j;
+                for (int v4 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                         v3 = sum_row[jt - 2] - prev_sum_row[jt - 2],
+                         v2 = sum_row[jt - 3] - prev_sum_row[jt - 3],
+                         v1 = sum_row[jt - 4] - prev_sum_row[jt - 4]; jt < width; jt += 4)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
-                    sum_row[j + 2] = (v3 += src_row[j + 2]) + prev_sum_row[j + 2];
-                    sum_row[j + 3] = (v4 += src_row[j + 3]) + prev_sum_row[j + 3];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                    sum_row[jt + 2] = (v3 += src_row[jt + 2]) + prev_sum_row[jt + 2];
+                    sum_row[jt + 3] = (v4 += src_row[jt + 3]) + prev_sum_row[jt + 3];
+                }
+                if (sqsum)
+                {
+                    QT s4 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s3 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    QT s2 = sqsum_row[j - 3] - prev_sqsum_row[j - 3];
+                    QT s1 = sqsum_row[j - 4] - prev_sqsum_row[j - 4];
+                    for ( ; j < width; j += 4)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1], i3 = src_row[j + 2], i4 = src_row[j + 3];
+                        s1 += (QT)i1 * i1; s2 += (QT)i2 * i2; s3 += (QT)i3 * i3; s4 += (QT)i4 * i4;
+                        sqsum_row[j]     = s1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = s2 + prev_sqsum_row[j + 1];
+                        sqsum_row[j + 2] = s3 + prev_sqsum_row[j + 2];
+                        sqsum_row[j + 3] = s4 + prev_sqsum_row[j + 3];
+                    }
                 }
             }
         }

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -77,20 +77,78 @@ struct Integral_SIMD
 
 #if CV_SIMD && CV_SIMD_WIDTH <= 64
 
-template <>
-struct Integral_SIMD<uchar, int, double>
+// Squared-pixel integral: store one vector block.
+// The horizontal prefix sum of squares is computed in int32 (two halves, lo/hi);
+// here it is converted to the sqsum output type and added to the integral row above.
+// Overloaded on the output element type so the same int32 prefix feeds CV_64F /
+// CV_32F / CV_32S sqsum outputs (Integral_SIMD<uchar,int,QT> below).
+static inline void v_store_sqsum_block(double* dst, const double* prev,
+                                       const v_int32& lo, const v_int32& hi)
+{
+    const int vl = VTraits<v_float64>::vlanes();
+    v_store(dst,            v_add(v_cvt_f64(lo),      vx_load(prev)));
+    v_store(dst +     vl,   v_add(v_cvt_f64_high(lo), vx_load(prev +     vl)));
+    v_store(dst + 2 * vl,   v_add(v_cvt_f64(hi),      vx_load(prev + 2 * vl)));
+    v_store(dst + 3 * vl,   v_add(v_cvt_f64_high(hi), vx_load(prev + 3 * vl)));
+}
+static inline void v_store_sqsum_block(float* dst, const float* prev,
+                                       const v_int32& lo, const v_int32& hi)
+{
+    const int vl = VTraits<v_float32>::vlanes();
+    v_store(dst,          v_add(v_cvt_f32(lo), vx_load(prev)));
+    v_store(dst +    vl,  v_add(v_cvt_f32(hi), vx_load(prev +    vl)));
+}
+static inline void v_store_sqsum_block(int* dst, const int* prev,
+                                       const v_int32& lo, const v_int32& hi)
+{
+    const int vl = VTraits<v_int32>::vlanes();
+    v_store(dst,          v_add(lo, vx_load(prev)));
+    v_store(dst +    vl,  v_add(hi, vx_load(prev +    vl)));
+}
+
+// In-register horizontal prefix sum of squared 8-bit pixels for one vector block.
+// px holds the block's pixels expanded to uint16; the running per-row carry
+// prev_sq is folded in and updated. The per-row sum of squares (<= width*255^2)
+// fits in int32, so the prefix uses the same rotate/broadcast idiom as the sum.
+// Returns the prefix as two int32 halves (lo, hi).
+static inline void v_sqsum_prefix(const v_uint16& px, v_int32& prev_sq,
+                                  v_int32& sqlo, v_int32& sqhi)
+{
+    v_uint32 sqlo_u, sqhi_u;
+    v_mul_expand(px, px, sqlo_u, sqhi_u);
+    sqlo = v_reinterpret_as_s32(sqlo_u);
+    sqhi = v_reinterpret_as_s32(sqhi_u);
+    sqlo = v_add(sqlo, v_rotate_left<1>(sqlo));
+    sqlo = v_add(sqlo, v_rotate_left<2>(sqlo));
+    sqhi = v_add(sqhi, v_rotate_left<1>(sqhi));
+    sqhi = v_add(sqhi, v_rotate_left<2>(sqhi));
+#if CV_SIMD_WIDTH >= 32
+    sqlo = v_add(sqlo, v_rotate_left<4>(sqlo));
+    sqhi = v_add(sqhi, v_rotate_left<4>(sqhi));
+#if CV_SIMD_WIDTH == 64
+    sqlo = v_add(sqlo, v_rotate_left<8>(sqlo));
+    sqhi = v_add(sqhi, v_rotate_left<8>(sqhi));
+#endif
+#endif
+    sqlo = v_add(sqlo, prev_sq);
+    sqhi = v_add(sqhi, v_broadcast_highest(sqlo));
+    prev_sq = v_broadcast_highest(sqhi);
+}
+
+template <typename QT>
+struct Integral_SIMD<uchar, int, QT>
 {
     Integral_SIMD() {}
 
     bool operator()(const uchar * src, size_t _srcstep,
                     int * sum, size_t _sumstep,
-                    double * sqsum, size_t _sqsumstep,
+                    QT * sqsum, size_t _sqsumstep,
                     int * tilted, size_t,
                     int width, int height, int cn) const
     {
-        // sqsum is vectorized for single-channel only (see below); other channel
-        // counts and the tilted case still fall back to the scalar path.
-        if ((sqsum && cn != 1) || tilted || cn > 4)
+        // sqsum is vectorized for 1- and 2-channel (see below); 3/4-channel sqsum
+        // and the tilted case still fall back to the scalar path.
+        if ((sqsum && cn != 1 && cn != 2) || tilted || cn > 4)
             return false;
 #if !CV_SSE4_1 && CV_SSE2
         // 3 channel code is slower for SSE2 & SSE3
@@ -103,7 +161,7 @@ struct Integral_SIMD<uchar, int, double>
         // the first iteration
         memset(sum, 0, (width + cn) * sizeof(int));
         if (sqsum)
-            memset(sqsum, 0, (width + cn) * sizeof(double));
+            memset(sqsum, 0, (width + cn) * sizeof(QT));
 
         if (cn == 1)
         {
@@ -116,8 +174,8 @@ struct Integral_SIMD<uchar, int, double>
 
                 sum_row[-1] = 0;
 
-                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
-                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
                 if (sqsum)
                     sqsum_row[-1] = 0;
 
@@ -156,34 +214,9 @@ struct Integral_SIMD<uchar, int, double>
 
                     if (sqsum)
                     {
-                        // Integral of squared pixels. The per-row running sum of squares
-                        // (<= width * 255^2) fits in int32, so the horizontal prefix sum is
-                        // done in int32 with the same rotate/broadcast idiom as the sum above,
-                        // then accumulated into the double output together with the row above.
-                        v_uint32 sqlo_u, sqhi_u;
-                        v_mul_expand(px, px, sqlo_u, sqhi_u);
-                        v_int32 sqlo = v_reinterpret_as_s32(sqlo_u);
-                        v_int32 sqhi = v_reinterpret_as_s32(sqhi_u);
-                        sqlo = v_add(sqlo, v_rotate_left<1>(sqlo));
-                        sqlo = v_add(sqlo, v_rotate_left<2>(sqlo));
-                        sqhi = v_add(sqhi, v_rotate_left<1>(sqhi));
-                        sqhi = v_add(sqhi, v_rotate_left<2>(sqhi));
-#if CV_SIMD_WIDTH >= 32
-                        sqlo = v_add(sqlo, v_rotate_left<4>(sqlo));
-                        sqhi = v_add(sqhi, v_rotate_left<4>(sqhi));
-#if CV_SIMD_WIDTH == 64
-                        sqlo = v_add(sqlo, v_rotate_left<8>(sqlo));
-                        sqhi = v_add(sqhi, v_rotate_left<8>(sqhi));
-#endif
-#endif
-                        sqlo = v_add(sqlo, prev_sq);
-                        sqhi = v_add(sqhi, v_broadcast_highest(sqlo));
-                        prev_sq = v_broadcast_highest(sqhi);
-                        const int vl64 = VTraits<v_float64>::vlanes();
-                        v_store(sqsum_row + j            , v_add(v_cvt_f64(sqlo),      vx_load(prev_sqsum_row + j)));
-                        v_store(sqsum_row + j +     vl64 , v_add(v_cvt_f64_high(sqlo), vx_load(prev_sqsum_row + j +     vl64)));
-                        v_store(sqsum_row + j + 2 * vl64 , v_add(v_cvt_f64(sqhi),      vx_load(prev_sqsum_row + j + 2 * vl64)));
-                        v_store(sqsum_row + j + 3 * vl64 , v_add(v_cvt_f64_high(sqhi), vx_load(prev_sqsum_row + j + 3 * vl64)));
+                        v_int32 sqlo, sqhi;
+                        v_sqsum_prefix(px, prev_sq, sqlo, sqhi);
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sqlo, sqhi);
                     }
                 }
 
@@ -192,11 +225,11 @@ struct Integral_SIMD<uchar, int, double>
                     sum_row[jt] = (v += src_row[jt]) + prev_sum_row[jt];
                 if (sqsum)
                 {
-                    double s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
                     for ( ; j < width; ++j)
                     {
                         int it = src_row[j];
-                        s += (double)it * it;
+                        s += (QT)it * it;
                         sqsum_row[j] = s + prev_sqsum_row[j];
                     }
                 }
@@ -214,13 +247,36 @@ struct Integral_SIMD<uchar, int, double>
 
                 sum_row[-1] = sum_row[-2] = 0;
 
+                QT * prev_sqsum_row = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * i) + cn : 0;
+                QT * sqsum_row      = sqsum ? (QT *)((uchar *)sqsum + _sqsumstep * (i + 1)) + cn : 0;
+                if (sqsum)
+                    sqsum_row[-1] = sqsum_row[-2] = 0;
+
                 v_int32 prev_1 = vx_setzero_s32(), prev_2 = vx_setzero_s32();
+                v_int32 prev_sq_1 = vx_setzero_s32(), prev_sq_2 = vx_setzero_s32();
                 int j = 0;
                 for ( ; j + VTraits<v_uint16>::vlanes() * cn <= width; j += VTraits<v_uint16>::vlanes() * cn)
                 {
                     v_int16 v_src_row = v_reinterpret_as_s16(vx_load(src_row + j));
                     v_int16 el8_1 = v_and(v_src_row, mask);
                     v_int16 el8_2 = v_reinterpret_as_s16(v_shr<8>(v_reinterpret_as_u16(v_src_row)));
+
+                    if (sqsum)
+                    {
+                        // Per-channel squared prefix (el8_1/el8_2 hold the raw channel
+                        // values, one per pixel); computed before the sum prefix below
+                        // overwrites them, then re-interleaved to match the output layout.
+                        v_int32 sqlo_1, sqhi_1, sqlo_2, sqhi_2;
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_1), prev_sq_1, sqlo_1, sqhi_1);
+                        v_sqsum_prefix(v_reinterpret_as_u16(el8_2), prev_sq_2, sqlo_2, sqhi_2);
+                        v_int32 z1, z2, z3, z4;
+                        v_zip(sqlo_1, sqlo_2, z1, z2);
+                        v_zip(sqhi_1, sqhi_2, z3, z4);
+                        const int vl = VTraits<v_int32>::vlanes();
+                        v_store_sqsum_block(sqsum_row + j,          prev_sqsum_row + j,          z1, z2);
+                        v_store_sqsum_block(sqsum_row + j + 2 * vl, prev_sqsum_row + j + 2 * vl, z3, z4);
+                    }
+
                     v_int32 el4l_1, el4h_1, el4l_2, el4h_2;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum_1 = _mm256_add_epi16(el8_1.val, _mm256_slli_si256(el8_1.val, 2));
@@ -267,11 +323,25 @@ struct Integral_SIMD<uchar, int, double>
                     v_store(sum_row + j + VTraits<v_int32>::vlanes() * 3, v_add(el4_4, vx_load(prev_sum_row + j + VTraits<v_int32>::vlanes() * 3)));
                 }
 
-                for (int v2 = sum_row[j - 1] - prev_sum_row[j - 1],
-                         v1 = sum_row[j - 2] - prev_sum_row[j - 2]; j < width; j += 2)
+                int jt = j;
+                for (int v2 = sum_row[jt - 1] - prev_sum_row[jt - 1],
+                         v1 = sum_row[jt - 2] - prev_sum_row[jt - 2]; jt < width; jt += 2)
                 {
-                    sum_row[j]     = (v1 += src_row[j])     + prev_sum_row[j];
-                    sum_row[j + 1] = (v2 += src_row[j + 1]) + prev_sum_row[j + 1];
+                    sum_row[jt]     = (v1 += src_row[jt])     + prev_sum_row[jt];
+                    sum_row[jt + 1] = (v2 += src_row[jt + 1]) + prev_sum_row[jt + 1];
+                }
+                if (sqsum)
+                {
+                    QT sq2 = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    QT sq1 = sqsum_row[j - 2] - prev_sqsum_row[j - 2];
+                    for ( ; j < width; j += 2)
+                    {
+                        int i1 = src_row[j], i2 = src_row[j + 1];
+                        sq1 += (QT)i1 * i1;
+                        sq2 += (QT)i2 * i2;
+                        sqsum_row[j]     = sq1 + prev_sqsum_row[j];
+                        sqsum_row[j + 1] = sq2 + prev_sqsum_row[j + 1];
+                    }
                 }
             }
         }
@@ -455,17 +525,21 @@ struct Integral_SIMD<uchar, float, double>
 
     bool operator()(const uchar * src, size_t _srcstep,
         float * sum, size_t _sumstep,
-        double * sqsum, size_t,
+        double * sqsum, size_t _sqsumstep,
         float * tilted, size_t,
         int width, int height, int cn) const
     {
-        if (sqsum || tilted || cn > 4)
+        // sqsum is vectorized for single-channel only; other channel counts and
+        // the tilted case still fall back to the scalar path.
+        if ((sqsum && cn != 1) || tilted || cn > 4)
             return false;
 
         width *= cn;
 
         // the first iteration
         memset(sum, 0, (width + cn) * sizeof(float));
+        if (sqsum)
+            memset(sqsum, 0, (width + cn) * sizeof(double));
 
         if (cn == 1)
         {
@@ -478,11 +552,18 @@ struct Integral_SIMD<uchar, float, double>
 
                 sum_row[-1] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
+                if (sqsum)
+                    sqsum_row[-1] = 0;
+
                 v_float32 prev = vx_setzero_f32();
+                v_int32 prev_sq = vx_setzero_s32();
                 int j = 0;
                 for (; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_float32 el4l, el4h;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 2));
@@ -509,10 +590,28 @@ struct Integral_SIMD<uchar, float, double>
 #endif
                     v_store(sum_row + j                    , v_add(el4l, vx_load(prev_sum_row + j)));
                     v_store(sum_row + j + VTraits<v_float32>::vlanes(), v_add(el4h, vx_load(prev_sum_row + j + VTraits<v_float32>::vlanes())));
+
+                    if (sqsum)
+                    {
+                        v_int32 sqlo, sqhi;
+                        v_sqsum_prefix(px, prev_sq, sqlo, sqhi);
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sqlo, sqhi);
+                    }
                 }
 
-                for (float v = sum_row[j - 1] - prev_sum_row[j - 1]; j < width; ++j)
-                    sum_row[j] = (v += src_row[j]) + prev_sum_row[j];
+                int jt = j;
+                for (float v = sum_row[jt - 1] - prev_sum_row[jt - 1]; jt < width; ++jt)
+                    sum_row[jt] = (v += src_row[jt]) + prev_sum_row[jt];
+                if (sqsum)
+                {
+                    double s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    for ( ; j < width; ++j)
+                    {
+                        int it = src_row[j];
+                        s += (double)it * it;
+                        sqsum_row[j] = s + prev_sqsum_row[j];
+                    }
+                }
             }
         }
         else if (cn == 2)
@@ -783,13 +882,17 @@ struct Integral_SIMD<uchar, double, double>
 #else
         CV_UNUSED(_sqsumstep);
 #endif
-        if (sqsum || tilted || cn > 4)
+        // sqsum is vectorized for single-channel only (the AVX-512 path above covers
+        // the multi-channel case); other channel counts fall back to scalar here.
+        if ((sqsum && cn != 1) || tilted || cn > 4)
             return false;
 
         width *= cn;
 
         // the first iteration
         memset(sum, 0, (width + cn) * sizeof(double));
+        if (sqsum)
+            memset(sqsum, 0, (width + cn) * sizeof(double));
 
         if (cn == 1)
         {
@@ -802,11 +905,18 @@ struct Integral_SIMD<uchar, double, double>
 
                 sum_row[-1] = 0;
 
+                double * prev_sqsum_row = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * i) + 1 : 0;
+                double * sqsum_row      = sqsum ? (double *)((uchar *)sqsum + _sqsumstep * (i + 1)) + 1 : 0;
+                if (sqsum)
+                    sqsum_row[-1] = 0;
+
                 v_float64 prev = vx_setzero_f64();
+                v_int32 prev_sq = vx_setzero_s32();
                 int j = 0;
                 for (; j + VTraits<v_uint16>::vlanes() <= width; j += VTraits<v_uint16>::vlanes())
                 {
-                    v_int16 el8 = v_reinterpret_as_s16(vx_load_expand(src_row + j));
+                    v_uint16 px = vx_load_expand(src_row + j);
+                    v_int16 el8 = v_reinterpret_as_s16(px);
                     v_float64 el4ll, el4lh, el4hl, el4hh;
 #if CV_AVX2 && CV_SIMD_WIDTH == 32
                     __m256i vsum = _mm256_add_epi16(el8.val, _mm256_slli_si256(el8.val, 2));
@@ -842,10 +952,28 @@ struct Integral_SIMD<uchar, double, double>
                     v_store(sum_row + j + VTraits<v_float64>::vlanes()    , v_add(el4lh, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes())));
                     v_store(sum_row + j + VTraits<v_float64>::vlanes() * 2, v_add(el4hl, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes() * 2)));
                     v_store(sum_row + j + VTraits<v_float64>::vlanes() * 3, v_add(el4hh, vx_load(prev_sum_row + j + VTraits<v_float64>::vlanes() * 3)));
+
+                    if (sqsum)
+                    {
+                        v_int32 sqlo, sqhi;
+                        v_sqsum_prefix(px, prev_sq, sqlo, sqhi);
+                        v_store_sqsum_block(sqsum_row + j, prev_sqsum_row + j, sqlo, sqhi);
+                    }
                 }
 
-                for (double v = sum_row[j - 1] - prev_sum_row[j - 1]; j < width; ++j)
-                    sum_row[j] = (v += src_row[j]) + prev_sum_row[j];
+                int jt = j;
+                for (double v = sum_row[jt - 1] - prev_sum_row[jt - 1]; jt < width; ++jt)
+                    sum_row[jt] = (v += src_row[jt]) + prev_sum_row[jt];
+                if (sqsum)
+                {
+                    double s = sqsum_row[j - 1] - prev_sqsum_row[j - 1];
+                    for ( ; j < width; ++j)
+                    {
+                        int it = src_row[j];
+                        s += (double)it * it;
+                        sqsum_row[j] = s + prev_sqsum_row[j];
+                    }
+                }
             }
         }
         else if (cn == 2)

--- a/modules/imgproc/src/sumpixels.simd.hpp
+++ b/modules/imgproc/src/sumpixels.simd.hpp
@@ -108,9 +108,9 @@ static inline void v_store_sqsum_block(int* dst, const int* prev,
 
 // In-register horizontal prefix sum of squared 8-bit pixels for one vector block.
 // px holds the block's pixels expanded to uint16; the running per-row carry
-// prev_sq is folded in and updated. The per-row sum of squares (<= width*255^2)
-// fits in int32, so the prefix uses the same rotate/broadcast idiom as the sum.
-// Returns the prefix as two int32 halves (lo, hi).
+// prev_sq is folded in and updated. The prefix runs in int32 (callers gate on
+// width * 255^2 <= INT32_MAX via sqsum_cn_ok, so it never overflows), using the
+// same rotate/broadcast idiom as the plain sum. Returns the two int32 halves.
 static inline void v_sqsum_prefix(const v_uint16& px, v_int32& prev_sq,
                                   v_int32& sqlo, v_int32& sqhi)
 {
@@ -149,7 +149,10 @@ struct Integral_SIMD<uchar, int, QT>
         // sqsum is vectorized for cn 1..3 at any SIMD width, and cn==4 only at
         // 128-bit width (where the 4 channels map to two pixels per vector). Wider
         // cn==4 sqsum and the tilted case still fall back to the scalar path.
-        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        // The squared prefix runs in int32, so it is valid only while a row's
+        // sum of squares (width * 255^2) fits in int32; wider rows fall back to scalar.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16))
+                                 && width <= 0x7FFFFFFF / (255 * 255);
         if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 #if !CV_SSE4_1 && CV_SSE2
@@ -618,7 +621,10 @@ struct Integral_SIMD<uchar, float, QT>
     {
         // sqsum is vectorized for cn 1..3 at any SIMD width, and cn==4 only at
         // 128-bit width; wider cn==4 sqsum and the tilted case fall back to scalar.
-        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        // The squared prefix runs in int32, so it is valid only while a row's
+        // sum of squares (width * 255^2) fits in int32; wider rows fall back to scalar.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16))
+                                 && width <= 0x7FFFFFFF / (255 * 255);
         if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 
@@ -1081,13 +1087,14 @@ struct Integral_SIMD<uchar, double, double>
             calculate_integral_avx512(src, _srcstep, sum, _sumstep, sqsum, _sqsumstep, width, height, cn);
             return true;
         }
-#else
-        CV_UNUSED(_sqsumstep);
 #endif
         // sqsum is vectorized for cn 1..3 at any SIMD width and cn==4 at 128-bit
         // width (the AVX-512 path above already covers the multi-channel case);
         // wider cn==4 sqsum and the tilted case fall back to scalar here.
-        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16));
+        // The squared prefix runs in int32, so it is valid only while a row's
+        // sum of squares (width * 255^2) fits in int32; wider rows fall back to scalar.
+        const bool sqsum_cn_ok = (cn == 1 || cn == 2 || cn == 3 || (cn == 4 && CV_SIMD_WIDTH == 16))
+                                 && width <= 0x7FFFFFFF / (255 * 255);
         if ((sqsum && !sqsum_cn_ok) || tilted || cn > 4)
             return false;
 


### PR DESCRIPTION
OpenCV extra: https://github.com/opencv/opencv_extra/pull/1382

Human-driven, AI-assisted (hence the 🤖 — I use helper tools; the work and the
numbers below are mine and measured on real hardware, not generated).

### What
`cv::integral` vectorizes the plain sum for 8-bit input, but its SIMD path bails to
scalar as soon as a sum-of-squares output is requested. The per-row running sum of
8-bit squares fits in int32, so its horizontal prefix can reuse the same
rotate/broadcast idiom as the plain sum and only widen at the final store — which is
output-type- and channel-agnostic. This PR vectorizes **every** 8-bit-source sqsum
combination:

- `Integral_SIMD<uchar,int,double>` → templatized to `<uchar,int,QT>` → CV_64F /
  CV_32F / CV_32S sqsum.
- `Integral_SIMD<uchar,float,double>` → templatized to `<uchar,float,QT>` → CV_64F /
  CV_32F sqsum. (8U/32F/32F had no specialization at all — scalar sum *and* sqsum.)
- `Integral_SIMD<uchar,double,double>` → CV_64F sqsum on the universal path.
- All channel counts: cn 1–3 at every SIMD width; cn==4 at 128-bit width (the 8
  expanded pixels are exactly two 4-channel pixels). Wider-width cn==4 sqsum stays
  scalar — the packed-channel int16 prefix doesn't extend cleanly to the int32-pair
  form, and x86 is memory-bound/neutral there regardless.

The squared prefix runs in int32; rows wide enough that `width·255²` would exceed
INT32_MAX (~33k px) fall back to the scalar path, so it never overflows. Shared
helpers `v_sqsum_prefix()` and overloaded `v_store_sqsum_block()` keep the three
specializations DRY. Still scalar (out of scope): the tilted integral, and
16-bit/float *source* (their squares overflow int32 — the trick is 8-bit-only).

### Correctness
Bit-exact for CV_32S (test error level 0); within tolerance for CV_32F/CV_64F.
`Imgproc_Integral.accuracy` passes (it randomizes over all 12 depth combos × cn 1–4).

### Performance — full results
A/B speedup (×) vs the OpenCV 4.x scalar implementation, FHD 1920×1080, min of N
samples. M4 Pro = Apple M4 Pro (NEON); A55 = Cortex-A55 (NEON); Zen1 = AMD Ryzen
Threadripper 1900X (AVX2).

| combo        | M4 Pro | A55  | Zen1 |
|--------------|--------|------|------|
| 8UC1 32S/64F |  3.34  | 1.48 | 0.98 |
| 8UC1 32S/32F |  3.81  | 1.90 | 1.04 |
| 8UC1 32S/32S |  4.31  | 1.14 | 1.06 |
| 8UC1 32F/64F |  4.33  | 1.55 | 1.21 |
| 8UC1 32F/32F |  3.66  | 1.84 | 1.19 |
| 8UC1 64F/64F |  2.63  | 1.29 | 1.00 |
| 8UC2 32S/64F |  2.57  | 2.31 | 1.10 |
| 8UC2 32S/32F |  4.01  | 2.56 | 0.99 |
| 8UC2 32S/32S |  2.82  | 2.04 | 1.03 |
| 8UC2 32F/64F |  2.83  | 2.26 | 1.23 |
| 8UC2 32F/32F |  3.75  | 2.64 | 1.07 |
| 8UC2 64F/64F |  1.95  | 2.35 | 1.15 |
| 8UC3 32S/64F |  2.05  | 1.57 | 1.09 |
| 8UC3 32S/32F |  2.88  | 1.54 | 1.04 |
| 8UC3 32S/32S |  2.28  | 1.25 | 1.06 |
| 8UC3 32F/64F |  1.84  | 1.68 | 1.20 |
| 8UC3 32F/32F |  3.02  | 1.55 | 1.09 |
| 8UC3 64F/64F |  1.37  | 1.64 | 1.11 |
| 8UC4 32S/64F |  3.73  | 2.79 | 0.98 |
| 8UC4 32S/32F |  3.90  | 3.55 | 1.00 |
| 8UC4 32S/32S |  2.49  | 3.59 | 0.96 |
| 8UC4 32F/64F |  3.61  | 2.85 | 0.99 |
| 8UC4 32F/32F |  3.95  | 3.80 | 0.99 |
| 8UC4 64F/64F |  3.39  | 2.88 | 0.99 |

Reading: NEON gains are large (M4 Pro 1.4–4.3×, A55 1.1–3.8×). Zen1/AVX2 is neutral
(0.96–1.23×, no regression — the compiler already auto-vectorizes the scalar prefix
and the kernel is memory-bound), so the path is left universal with no arch #ifdef.
On the bandwidth-bound A55 the lighter 32-bit sqsum writes gain more than the 64-bit
ones, as expected.

### Pull Request Readiness Checklist
- [x] I agree to contribute under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on GPL/incompatible code.
- [x] The PR is proposed to the proper branch (4.x — compatible performance improvement).
- [ ] There is a reference to the original bug report and related work.
- [x] Accuracy test (existing `Imgproc_Integral.accuracy` covers all combos) and
      performance test (`integral_sqsum_8u`, added here) are present; opencv_extra: N/A (synthetic data).
- [x] The feature builds with the project CMake; no API or doc change.
