### PR TITLE
Fix undefined behavior with pointer alignment

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -3060,39 +3060,25 @@ inline v_float64x2 v_cvt_f64(const v_int64x2& v)
 
 inline v_int8x16 v_lut(const schar* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int8x16(_mm_setr_epi8(tab[idx[0]], tab[idx[1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]],
-                                   tab[idx[8]], tab[idx[9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]]));
-#else
-    return v_int8x16(_mm_setr_epi64(
-                        _mm_setr_pi8(tab[idx[0]], tab[idx[1]], tab[idx[ 2]], tab[idx[ 3]], tab[idx[ 4]], tab[idx[ 5]], tab[idx[ 6]], tab[idx[ 7]]),
-                        _mm_setr_pi8(tab[idx[8]], tab[idx[9]], tab[idx[10]], tab[idx[11]], tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]])
-                    ));
-#endif
+    return v_int8x16(tab[idx[0]], tab[idx[1]], tab[idx[2]], tab[idx[3]],
+                     tab[idx[4]], tab[idx[5]], tab[idx[6]], tab[idx[7]],
+                     tab[idx[8]], tab[idx[9]], tab[idx[10]], tab[idx[11]],
+                     tab[idx[12]], tab[idx[13]], tab[idx[14]], tab[idx[15]]);
 }
 inline v_int8x16 v_lut_pairs(const schar* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int8x16(_mm_setr_epi16(*(const short*)(tab + idx[0]), *(const short*)(tab + idx[1]), *(const short*)(tab + idx[2]), *(const short*)(tab + idx[3]),
-                                    *(const short*)(tab + idx[4]), *(const short*)(tab + idx[5]), *(const short*)(tab + idx[6]), *(const short*)(tab + idx[7])));
-#else
-    return v_int8x16(_mm_setr_epi64(
-                        _mm_setr_pi16(*(const short*)(tab + idx[0]), *(const short*)(tab + idx[1]), *(const short*)(tab + idx[2]), *(const short*)(tab + idx[3])),
-                        _mm_setr_pi16(*(const short*)(tab + idx[4]), *(const short*)(tab + idx[5]), *(const short*)(tab + idx[6]), *(const short*)(tab + idx[7]))
-                    ));
-#endif
+    return v_int8x16(tab[idx[0]], tab[idx[0] + 1], tab[idx[1]], tab[idx[1] + 1],
+                     tab[idx[2]], tab[idx[2] + 1], tab[idx[3]], tab[idx[3] + 1],
+                     tab[idx[4]], tab[idx[4] + 1], tab[idx[5]], tab[idx[5] + 1],
+                     tab[idx[6]], tab[idx[6] + 1], tab[idx[7]], tab[idx[7] + 1]);
 }
 inline v_int8x16 v_lut_quads(const schar* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int8x16(_mm_setr_epi32(*(const int*)(tab + idx[0]), *(const int*)(tab + idx[1]),
-                                    *(const int*)(tab + idx[2]), *(const int*)(tab + idx[3])));
-#else
-    return v_int8x16(_mm_setr_epi64(
-                        _mm_setr_pi32(*(const int*)(tab + idx[0]), *(const int*)(tab + idx[1])),
-                        _mm_setr_pi32(*(const int*)(tab + idx[2]), *(const int*)(tab + idx[3]))
-                    ));
-#endif
+    return v_int8x16(
+        tab[idx[0]], tab[idx[0] + 1], tab[idx[0] + 2], tab[idx[0] + 3],
+        tab[idx[1]], tab[idx[1] + 1], tab[idx[1] + 2], tab[idx[1] + 3],
+        tab[idx[2]], tab[idx[2] + 1], tab[idx[2] + 2], tab[idx[2] + 3],
+        tab[idx[3]], tab[idx[3] + 1], tab[idx[3] + 2], tab[idx[3] + 3]);
 }
 inline v_uint8x16 v_lut(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v_lut((const schar *)tab, idx)); }
 inline v_uint8x16 v_lut_pairs(const uchar* tab, const int* idx) { return v_reinterpret_as_u8(v_lut_pairs((const schar *)tab, idx)); }
@@ -3100,31 +3086,19 @@ inline v_uint8x16 v_lut_quads(const uchar* tab, const int* idx) { return v_reint
 
 inline v_int16x8 v_lut(const short* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int16x8(_mm_setr_epi16(tab[idx[0]], tab[idx[1]], tab[idx[2]], tab[idx[3]],
-                                    tab[idx[4]], tab[idx[5]], tab[idx[6]], tab[idx[7]]));
-#else
-    return v_int16x8(_mm_setr_epi64(
-                        _mm_setr_pi16(tab[idx[0]], tab[idx[1]], tab[idx[2]], tab[idx[3]]),
-                        _mm_setr_pi16(tab[idx[4]], tab[idx[5]], tab[idx[6]], tab[idx[7]])
-                    ));
-#endif
+    return v_int16x8(tab[idx[0]], tab[idx[1]], tab[idx[2]], tab[idx[3]],
+                     tab[idx[4]], tab[idx[5]], tab[idx[6]], tab[idx[7]]);
 }
 inline v_int16x8 v_lut_pairs(const short* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int16x8(_mm_setr_epi32(*(const int*)(tab + idx[0]), *(const int*)(tab + idx[1]),
-                                    *(const int*)(tab + idx[2]), *(const int*)(tab + idx[3])));
-#else
-    return v_int16x8(_mm_setr_epi64(
-                        _mm_setr_pi32(*(const int*)(tab + idx[0]), *(const int*)(tab + idx[1])),
-                        _mm_setr_pi32(*(const int*)(tab + idx[2]), *(const int*)(tab + idx[3]))
-                    ));
-#endif
+    return v_int16x8(tab[idx[0]], tab[idx[0] + 1], tab[idx[1]], tab[idx[1] + 1],
+                     tab[idx[2]], tab[idx[2] + 1], tab[idx[3]], tab[idx[3] + 1]);
 }
 inline v_int16x8 v_lut_quads(const short* tab, const int* idx)
 {
-    return v_int16x8(_mm_set_epi64x(*(const int64_t*)(tab + idx[1]), *(const int64_t*)(tab + idx[0])));
+    return v_int16x8(tab[idx[0]], tab[idx[0] + 1], tab[idx[0] + 2],
+                     tab[idx[0] + 3], tab[idx[1]], tab[idx[1] + 1],
+                     tab[idx[1] + 2], tab[idx[1] + 3]);
 }
 inline v_uint16x8 v_lut(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v_lut((const short *)tab, idx)); }
 inline v_uint16x8 v_lut_pairs(const ushort* tab, const int* idx) { return v_reinterpret_as_u16(v_lut_pairs((const short *)tab, idx)); }
@@ -3132,15 +3106,7 @@ inline v_uint16x8 v_lut_quads(const ushort* tab, const int* idx) { return v_rein
 
 inline v_int32x4 v_lut(const int* tab, const int* idx)
 {
-#if defined(_MSC_VER)
-    return v_int32x4(_mm_setr_epi32(tab[idx[0]], tab[idx[1]],
-                                    tab[idx[2]], tab[idx[3]]));
-#else
-    return v_int32x4(_mm_setr_epi64(
-                        _mm_setr_pi32(tab[idx[0]], tab[idx[1]]),
-                        _mm_setr_pi32(tab[idx[2]], tab[idx[3]])
-                    ));
-#endif
+    return v_int32x4(tab[idx[0]], tab[idx[1]], tab[idx[2]], tab[idx[3]]);
 }
 inline v_int32x4 v_lut_pairs(const int* tab, const int* idx)
 {


### PR DESCRIPTION
While at it, replace MMX _mm_setr_epi64 to not do the MMX to XMM move.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
