### PR TITLE
fix(rvv-hal): use upstream (a*scale)/b order in divide to fix rounding mismatch.

### DIFF
--- a/hal/riscv-rvv/src/core/div.cpp
+++ b/hal/riscv-rvv/src/core/div.cpp
@@ -45,28 +45,32 @@ template <> inline
 vint16m2_t div_sat(const vint16m2_t &v1, const vint16m2_t &v2, const float scale, const int vl) {
     auto f1 = __riscv_vfwcvt_f(v1, vl);
     auto f2 = __riscv_vfwcvt_f(v2, vl);
-    auto res = __riscv_vfmul(f1, __riscv_vfmul(common::__riscv_vfrec(f2, vl), scale, vl), vl);
+    auto scaled = __riscv_vfmul(f1, scale, vl);
+    auto res = __riscv_vfdiv(scaled, f2, vl);
     return __riscv_vfncvt_x(res, vl);
 }
 template <> inline
 vuint16m2_t div_sat(const vuint16m2_t &v1, const vuint16m2_t &v2, const float scale, const int vl) {
     auto f1 = __riscv_vfwcvt_f(v1, vl);
     auto f2 = __riscv_vfwcvt_f(v2, vl);
-    auto res = __riscv_vfmul(f1, __riscv_vfmul(common::__riscv_vfrec(f2, vl), scale, vl), vl);
+    auto scaled = __riscv_vfmul(f1, scale, vl);
+    auto res = __riscv_vfdiv(scaled, f2, vl);
     return __riscv_vfncvt_xu(res, vl);
 }
 template <> inline
 vint32m4_t div_sat(const vint32m4_t &v1, const vint32m4_t &v2, const float scale, const int vl) {
     auto f1 = __riscv_vfcvt_f(v1, vl);
     auto f2 = __riscv_vfcvt_f(v2, vl);
-    auto res = __riscv_vfmul(f1, __riscv_vfmul(common::__riscv_vfrec(f2, vl), scale, vl), vl);
+    auto scaled = __riscv_vfmul(f1, scale, vl);
+    auto res = __riscv_vfdiv(scaled, f2, vl);
     return __riscv_vfcvt_x(res, vl);
 }
 template <> inline
 vuint32m4_t div_sat(const vuint32m4_t &v1, const vuint32m4_t &v2, const float scale, const int vl) {
     auto f1 = __riscv_vfcvt_f(v1, vl);
     auto f2 = __riscv_vfcvt_f(v2, vl);
-    auto res = __riscv_vfmul(f1, __riscv_vfmul(common::__riscv_vfrec(f2, vl), scale, vl), vl);
+    auto scaled = __riscv_vfmul(f1, scale, vl);
+    auto res = __riscv_vfdiv(scaled, f2, vl);
     return __riscv_vfcvt_xu(res, vl);
 }
 
@@ -173,7 +177,7 @@ int div(const float *src1, size_t step1, const float *src2, size_t step2,
                 auto v1 = vle(src1_h + w, vl);
                 auto v2 = vle(src2_h + w, vl);
 
-                vse(dst_h + w, __riscv_vfmul(v1, __riscv_vfmul(common::__riscv_vfrec(v2, vl), scale, vl), vl), vl);
+                vse(dst_h + w, __riscv_vfdiv(__riscv_vfmul(v1, scale, vl), v2, vl), vl);
             }
         }
     }


### PR DESCRIPTION
…g mismatch

The RVV HAL div_sat computed `a * (scale / b)` using vfrec+vfmul, but the canonical order in arithm.simd.hpp (both scalar and universal SIMD paths) is `(a * scale) / b`.  These two evaluation orders differ by 1 ULP at floating-point rounding boundaries, which after float-to-int conversion produces 1 LSB differences on .5-boundary pixels.

This caused bit-exact tests that compare cv::divide() with other implementations (e.g. G-API Fluid DivPerfTest) to fail spuriously.

Fix by switching div_sat and float div from vfrec to vfdiv, computing (a * scale) / b.

**Verification:**
- Tested on RISC-V **SpacemiT K3** hardware with `opencv_perf_gapi --gtest_filter="*DivPerfTestFluid/DivPerfTest.*"`: 100/100 passed, AbsExact.
- The G-API Fluid backend also reverted to upstream expression to match.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
