### PR TITLE
Added more perf tests for blobFromImage

### DIFF
--- a/modules/dnn/perf/perf_utils.cpp
+++ b/modules/dnn/perf/perf_utils.cpp
@@ -63,4 +63,343 @@ INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImages,
            std::vector<int>{16, 2048, 2048})
 );
 
+// NCHW, 8U->32F, C3, mean+scale+swapRB at 640x640
+using Utils_blobFromImage_8U_NCHW = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_8U_NCHW, MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0/255.0, Size(), Scalar(104, 117, 123), true, false, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_8U_NCHW,
+    Values(std::vector<int>{ 640,  640})
+);
+
+// NHWC, 8U->32F, C3
+using Utils_blobFromImage_8U_NHWC = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_8U_NHWC, SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImageWithParams(input, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImage_8U_NHWC, MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0/255.0);
+    params.mean = Scalar(104, 117, 123);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImageWithParams(input, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_8U_NHWC,
+    Values(std::vector<int>{ 224,  224},
+           std::vector<int>{ 640,  640})
+);
+
+// NHWC, 32F->32F, C3
+using Utils_blobFromImage_32F_NHWC = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_32F_NHWC, SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_32FC3);
+    randu(input, 0.0f, 1.0f);
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImageWithParams(input, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImage_32F_NHWC, MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_32FC3);
+    randu(input, 0.0f, 1.0f);
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0/0.226);
+    params.mean = Scalar(0.485, 0.456, 0.406);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImageWithParams(input, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_32F_NHWC,
+    Values(std::vector<int>{ 224,  224},
+           std::vector<int>{ 640,  640})
+);
+
+// Resize+crop, 8U->32F, C3, mean+scale+swapRB to 640x640
+using Utils_blobFromImage_8U_Resize = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_8U_Resize, NHWC_Crop_MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0/255.0);
+    params.size = Size(640, 640);
+    params.mean = Scalar(104, 117, 123);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+    params.paddingmode = DNN_PMODE_CROP_CENTER;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImageWithParams(input, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImage_8U_Resize, NCHW_Crop_MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0/255.0, Size(640, 640), Scalar(104, 117, 123), true, true, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_8U_Resize,
+    Values(std::vector<int>{  720, 1280},
+           std::vector<int>{ 1080, 1920},
+           std::vector<int>{ 2160, 3840})
+);
+
+// Resize+crop, NCHW, 32F->32F, C3, mean+scale+swapRB to 300x300
+using Utils_blobFromImage_32F_NCHW_Resize = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_32F_NCHW_Resize, Crop_MeanScale_SwapRB_To300) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_32FC3);
+    randu(input, 0.0f, 1.0f);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0/0.226, Size(300, 300), Scalar(0.485, 0.456, 0.406), true, true, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_32F_NCHW_Resize,
+    Values(std::vector<int>{  720, 1280},
+           std::vector<int>{ 1080, 1920})
+);
+
+// Resize+crop, NCHW, 8U->8U, C3
+using Utils_blobFromImage_8U_to_8U_Crop = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_8U_to_8U_Crop, NCHW_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0, Size(640, 640), Scalar(), true, true, CV_8U);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImage_8U_to_8U_Crop, NCHW) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0, Size(640, 640), Scalar(), false, true, CV_8U);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_8U_to_8U_Crop,
+    Values(std::vector<int>{ 1080, 1920},
+           std::vector<int>{ 2160, 3840})
+);
+
+// Resize, NCHW, 8U->8U, C3
+using Utils_blobFromImage_8U_to_8U_Resize = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_8U_to_8U_Resize, NCHW_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_8UC3);
+    randu(input, 0, 255);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0, Size(640, 640), Scalar(), true, false, CV_8U);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_8U_to_8U_Resize,
+    Values(std::vector<int>{ 1080, 1920},
+           std::vector<int>{ 2160, 3840})
+);
+
+// Resize+crop, NCHW, 32F->32F, C1, mean
+using Utils_blobFromImage_32F_NCHW_C1 = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImage_32F_NCHW_C1, Crop_MeanScale_To224) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_32FC1);
+    randu(input, 0.0f, 1.0f);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0/0.226, Size(224, 224), Scalar(0.5), false, true, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImage_32F_NCHW_C1, Crop_MeanScale_To640) {
+    std::vector<int> input_shape = GetParam();
+
+    Mat input(input_shape, CV_32FC1);
+    randu(input, 0.0f, 1.0f);
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImage(input, 1.0/0.226, Size(640, 640), Scalar(0.5), false, true, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImage_32F_NCHW_C1,
+    Values(std::vector<int>{ 1080, 1920},
+           std::vector<int>{ 2160, 3840})
+);
+
+// Batch=8, NHWC, 8U->32F, C3, mean+scale+swapRB
+using Utils_blobFromImages_NoResize = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImages_NoResize, NHWC_MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+    int batch = input_shape.front();
+    std::vector<int> input_shape_no_batch(input_shape.begin()+1, input_shape.end());
+
+    std::vector<Mat> inputs;
+    for (int i = 0; i < batch; i++) {
+        Mat input(input_shape_no_batch, CV_8UC3);
+        randu(input, 0, 255);
+        inputs.push_back(input);
+    }
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0/255.0);
+    params.mean = Scalar(104, 117, 123);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImagesWithParams(inputs, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImages_NoResize,
+    Values(std::vector<int>{8,  640,  640})
+);
+
+// Batch=8, resize+crop to 640x640, 8U->32F, C3, mean+scale+swapRB
+using Utils_blobFromImages_Resize = TestBaseWithParam<std::vector<int>>;
+PERF_TEST_P_(Utils_blobFromImages_Resize, NHWC_Crop_MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+    int batch = input_shape.front();
+    std::vector<int> input_shape_no_batch(input_shape.begin()+1, input_shape.end());
+
+    std::vector<Mat> inputs;
+    for (int i = 0; i < batch; i++) {
+        Mat input(input_shape_no_batch, CV_8UC3);
+        randu(input, 0, 255);
+        inputs.push_back(input);
+    }
+
+    Image2BlobParams params;
+    params.scalefactor = Scalar::all(1.0/255.0);
+    params.size = Size(640, 640);
+    params.mean = Scalar(104, 117, 123);
+    params.swapRB = true;
+    params.datalayout = DNN_LAYOUT_NHWC;
+    params.paddingmode = DNN_PMODE_CROP_CENTER;
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImagesWithParams(inputs, params);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P_(Utils_blobFromImages_Resize, NCHW_Crop_MeanScale_SwapRB) {
+    std::vector<int> input_shape = GetParam();
+    int batch = input_shape.front();
+    std::vector<int> input_shape_no_batch(input_shape.begin()+1, input_shape.end());
+
+    std::vector<Mat> inputs;
+    for (int i = 0; i < batch; i++) {
+        Mat input(input_shape_no_batch, CV_8UC3);
+        randu(input, 0, 255);
+        inputs.push_back(input);
+    }
+
+    TEST_CYCLE() {
+        Mat blob = blobFromImages(inputs, 1.0/255.0, Size(640, 640), Scalar(104, 117, 123), true, true, CV_32F);
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Utils_blobFromImages_Resize,
+    Values(std::vector<int>{8,  720, 1280},
+           std::vector<int>{8, 1080, 1920})
+);
+
 }


### PR DESCRIPTION
Previously there were only trivial cases that showed performance for ~copy operations. Extending performance testing with more combinations of parameters.

Such extending required to show performance benefits for HAL implementation of blobFromImage if any (See https://github.com/opencv/opencv/pull/29216#issuecomment-4658802174)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
