### PR TITLE
Fix PCA::project() crash with UMat and OpenCL

### DIFF
--- a/modules/core/src/pca.cpp
+++ b/modules/core/src/pca.cpp
@@ -307,9 +307,9 @@ void PCA::project(InputArray _data, OutputArray result) const
         tmp_data = tmp_mean;
     }
     if( mean.rows == 1 )
-        gemm( tmp_data, eigenvectors, 1, Mat(), 0, result, GEMM_2_T );
+        gemm( tmp_data, eigenvectors, 1, noArray(), 0, result, GEMM_2_T );
     else
-        gemm( eigenvectors, tmp_data, 1, Mat(), 0, result, 0 );
+        gemm( eigenvectors, tmp_data, 1, noArray(), 0, result, 0 );
 }
 
 Mat PCA::project(InputArray data) const


### PR DESCRIPTION
Replace Mat() with noArray() in gemm() delta parameter to avoid type mismatch error (CV_8UC1 vs CV_32FC1) when result is UMat and OpenCL code path is used.

### Issue

[#29007](https://github.com/opencv/opencv/issues/29007): `PCA.project()` generates errors when used with UMat and OpenCL

### Fix

**File**: `modules/core/src/pca.cpp` (lines 310, 312)

Replaced `Mat()` with `noArray()` for the delta parameter in `gemm()` calls.

| Line | Before | After |
|------|--------|-------|
| 310 | `gemm(..., Mat(), ...)` | `gemm(..., noArray(), ...)` |
| 312 | `gemm(..., Mat(), ...)` | `gemm(..., noArray(), ...)` |

### Root Cause

- `Mat()` has default type `CV_8UC1` (value 0)
- The OpenCL code path in `ocl_gemm()` performs type checking (`CV_CheckTypeEQ`) on the delta matrix C. Since `Mat()` is `CV_8UC1` while the input data is `CV_32FC1`, the type check fails and throws an error
- `noArray()` returns `kind() == _InputArray::NONE`. In `ocl_gemm()`, the check `matC.kind() != NONE` determines whether to process delta C. When it is `NONE`, all type checks and processing for delta are skipped entirely, avoiding the error

### Test Environment

| Item | Value |
|------|-------|
| OS | Windows 10.0.26200 AMD64 |
| Compiler | MinGW GCC 15.2.0 |
| CMake | 4.3.2 |
| OpenCV | 4.14.0-pre (cadcb7e4e0-dirty) |
| OpenCL Device | NVIDIA RTX 500 Ada Generation Laptop GPU (OpenCL 3.0 CUDA) |
| Driver Version | 581.95 |

### Existing Unit Test Results

| Test Suite | Cases | Result |
|------------|-------|--------|
| `Core_PCA.accuracy` | 1 | ✅ PASS |
| `Core_GEMM.accuracy` | 1 | ✅ PASS |
| `OCL_Core/Gemm.Accuracy` | 64 (32FC1/32FC2/64FC1/64FC2 × transpose combos × ROI) | ✅ ALL PASS |

### OCL PCA Specific Verification

A standalone OCL PCA test program verified 4 scenarios:

| Test | Description | Result |
|------|-------------|--------|
| Test 1 | `PCA::project()` with `UMat` as `OutputArray` (original crash scenario) | ✅ PASS |
| Test 2 | `PCA::project()` returning `Mat` (existing API regression check) | ✅ PASS |
| Test 3 | CPU vs OCL result comparison (max diff = 1.78e-7) | ✅ PASS |
| Test 4 | `PCA::backProject()` with `UMat` | ✅ PASS |

### Conclusion

The fix is correct. `PCA::project()` no longer crashes when used with UMat and OpenCL. Results match the CPU path (max difference 1.78e-7, within floating-point precision). All regression tests pass.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
