### PR TITLE
reject under-length raw exif profile in processRawProfile

### DIFF
--- a/modules/imgcodecs/src/exif.cpp
+++ b/modules/imgcodecs/src/exif.cpp
@@ -160,6 +160,12 @@ bool ExifReader::processRawProfile(const char* profile, size_t profile_len) {
     }
     ++end;
 
+    // the payload starts with a 6-byte "Exif\0\0" header, so a shorter declared
+    // length underflows the size and pointer handed to parseExif() below
+    if (expected_length < 6) {
+        return false;
+    }
+
     // 'end' now points to the profile payload.
     std::string payload = HexStringToBytes(end, expected_length);
     if (payload.size() == 0) return false;


### PR DESCRIPTION
`processRawProfile` reads the ImageMagick raw profile length straight from a PNG `Raw profile type exif`/`APP1` text chunk, then calls `parseExif(payload.c_str() + 6, expected_length - 6)` on the assumption the payload opens with a 6-byte `Exif\0\0` header. A profile that declares a length below 6 makes `expected_length - 6` underflow to a near-`SIZE_MAX` `size_t` while the data pointer already sits past the short payload, so `parseExif`'s `m_data.assign(data, data + size)` runs far out of bounds.

Before: any declared length under 6 reaches the subtraction and the bad pointer/size pair. After: a length below the header size returns early, matching the guard the JPEG path already applies (`grfmt_jpeg.cpp` checks `data_length > EXIF_HEADER_SIZE` before the same `- 6`). Keeping the check in the shared callee covers both the PNG and SPNG readers, which both feed untrusted text chunks here; the tradeoff is that a profile carrying fewer than 6 payload bytes is now dropped, but such a profile has no EXIF body to parse anyway.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
