### PR TITLE
Fix typos in tutorial documentation

### DIFF
--- a/doc/js_tutorials/js_core/js_basic_ops/js_basic_ops.markdown
+++ b/doc/js_tutorials/js_core/js_basic_ops/js_basic_ops.markdown
@@ -105,7 +105,7 @@ let mat = new cv.Mat();
 let matVec = new cv.MatVector();
 // Push a Mat back into MatVector
 matVec.push_back(mat);
-// Get a Mat fom MatVector
+// Get a Mat from MatVector
 let cnt = matVec.get(0);
 mat.delete(); matVec.delete(); cnt.delete();
 @endcode

--- a/doc/js_tutorials/js_imgproc/js_morphological_ops/js_morphological_ops.markdown
+++ b/doc/js_tutorials/js_imgproc/js_morphological_ops/js_morphological_ops.markdown
@@ -27,7 +27,7 @@ foreground object (Always try to keep foreground in white). So what it does? The
 through the image (as in 2D convolution). A pixel in the original image (either 1 or 0) will be
 considered 1 only if all the pixels under the kernel is 1, otherwise it is eroded (made to zero).
 
-So what happends is that, all the pixels near boundary will be discarded depending upon the size of
+So what happens is that, all the pixels near boundary will be discarded depending upon the size of
 kernel. So the thickness or size of the foreground object decreases or simply white region decreases
 in the image. It is useful for removing small white noises (as we have seen in colorspace chapter),
 detach two connected objects etc.

--- a/doc/tutorials/app/highgui_wayland_ubuntu.markdown
+++ b/doc/tutorials/app/highgui_wayland_ubuntu.markdown
@@ -103,4 +103,4 @@ int main(void)
 
 Limitation/Known problem
 ------------------------
-- cv::moveWindow() is not implementated. ( See. https://github.com/opencv/opencv/issues/25478 )
+- cv::moveWindow() is not implemented. ( See. https://github.com/opencv/opencv/issues/25478 )

--- a/doc/tutorials/app/orbbec_astra_openni.markdown
+++ b/doc/tutorials/app/orbbec_astra_openni.markdown
@@ -72,8 +72,8 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
 
     @note The last tried version `2.3.0.86_202210111154_4c8f5aa4_beta6` does not work correctly with
     modern Linux, even after libusb rebuild as recommended by the instruction. The last know good
-    configuration is version 2.3.0.63 (tested with Ubuntu 18.04 amd64). It's not provided officialy
-    with the downloading page, but published by Orbbec technical suport on Orbbec community forum
+    configuration is version 2.3.0.63 (tested with Ubuntu 18.04 amd64). It's not provided officially
+    with the downloading page, but published by Orbbec technical support on Orbbec community forum
     [here](https://3dclub.orbbec3d.com/t/universal-download-thread-for-astra-series-cameras/622).
 
 -#  Now you can configure OpenCV with OpenNI support enabled by setting the `WITH_OPENNI2` flag in CMake.
@@ -109,7 +109,7 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
 
 The Astra Pro camera has two sensors -- a depth sensor and a color sensor. The depth sensor
 can be read using the OpenNI interface with @ref cv::VideoCapture class. The video stream is
-not available through OpenNI API and is only provided via the regular caofficiallymera interface.
+not available through OpenNI API and is only provided via the regular camera interface.
 So, to get both depth and color frames, two @ref cv::VideoCapture objects should be created:
 
 @snippetlineno samples/cpp/tutorial_code/videoio/openni_orbbec_astra/openni_orbbec_astra.cpp Open streams

--- a/doc/tutorials/app/orbbec_astra_openni.markdown
+++ b/doc/tutorials/app/orbbec_astra_openni.markdown
@@ -109,7 +109,7 @@ In order to use the Astra camera's depth sensor with OpenCV you should do the fo
 
 The Astra Pro camera has two sensors -- a depth sensor and a color sensor. The depth sensor
 can be read using the OpenNI interface with @ref cv::VideoCapture class. The video stream is
-not available through OpenNI API and is only provided via the regular camera interface.
+not available through OpenNI API and is only provided via the regular caofficiallymera interface.
 So, to get both depth and color frames, two @ref cv::VideoCapture objects should be created:
 
 @snippetlineno samples/cpp/tutorial_code/videoio/openni_orbbec_astra/openni_orbbec_astra.cpp Open streams

--- a/doc/tutorials/calib3d/camera_calibration_pattern/camera_calibration_pattern.markdown
+++ b/doc/tutorials/calib3d/camera_calibration_pattern/camera_calibration_pattern.markdown
@@ -63,7 +63,7 @@ Example code to generate features coordinates for calibration with symmetric gri
         }
     }
 ```
-Example code to generate features corrdinates for calibration with asymmetic grid (object points):
+Example code to generate features coordinates for calibration with asymmetric grid (object points):
 ```
     std::vector<cv::Point3f> objectPoints;
     for (int i = 0; i < boardSize.height; i++) {
@@ -84,7 +84,7 @@ about ArUco pairs. In opposite to the previous pattern partially occluded board 
 corners are labeled. The board is rotation invariant, but set of ArUco markers and their order
 should be known to detector apriori. It cannot detect ChAruco board with predefined size and random
 set of markers.
-Example code to generate features corrdinates for calibration (object points) for board size in units:
+Example code to generate features coordinates for calibration (object points) for board size in units:
 ```
     std::vector<cv::Point3f> objectPoints;
     for (int i = 0; i < boardSize.height-1; ++i) {

--- a/doc/tutorials/dnn/dnn_text_spotting/dnn_text_spotting.markdown
+++ b/doc/tutorials/dnn/dnn_text_spotting/dnn_text_spotting.markdown
@@ -64,25 +64,25 @@ We encourage you to add new algorithms to these APIs.
 
 ```
 crnn.onnx:
-url: https://drive.google.com/uc?export=dowload&id=1ooaLR-rkTl8jdpGy1DoQs0-X0lQsB6Fj
+url: https://drive.google.com/uc?export=download&id=1ooaLR-rkTl8jdpGy1DoQs0-X0lQsB6Fj
 sha: 270d92c9ccb670ada2459a25977e8deeaf8380d3,
-alphabet_36.txt: https://drive.google.com/uc?export=dowload&id=1oPOYx5rQRp8L6XQciUwmwhMCfX0KyO4b
+alphabet_36.txt: https://drive.google.com/uc?export=download&id=1oPOYx5rQRp8L6XQciUwmwhMCfX0KyO4b
 parameter setting: -rgb=0;
 description: The classification number of this model is 36 (0~9 + a~z).
              The training dataset is MJSynth.
 
 crnn_cs.onnx:
-url: https://drive.google.com/uc?export=dowload&id=12diBsVJrS9ZEl6BNUiRp9s0xPALBS7kt
+url: https://drive.google.com/uc?export=download&id=12diBsVJrS9ZEl6BNUiRp9s0xPALBS7kt
 sha: a641e9c57a5147546f7a2dbea4fd322b47197cd5
-alphabet_94.txt: https://drive.google.com/uc?export=dowload&id=1oKXxXKusquimp7XY1mFvj9nwLzldVgBR
+alphabet_94.txt: https://drive.google.com/uc?export=download&id=1oKXxXKusquimp7XY1mFvj9nwLzldVgBR
 parameter setting: -rgb=1;
 description: The classification number of this model is 94 (0~9 + a~z + A~Z + punctuations).
              The training datasets are MJsynth and SynthText.
 
 crnn_cs_CN.onnx:
-url: https://drive.google.com/uc?export=dowload&id=1is4eYEUKH7HR7Gl37Sw4WPXx6Ir8oQEG
+url: https://drive.google.com/uc?export=download&id=1is4eYEUKH7HR7Gl37Sw4WPXx6Ir8oQEG
 sha: 3940942b85761c7f240494cf662dcbf05dc00d14
-alphabet_3944.txt: https://drive.google.com/uc?export=dowload&id=18IZUUdNzJ44heWTndDO6NNfIpJMmN-ul
+alphabet_3944.txt: https://drive.google.com/uc?export=download&id=18IZUUdNzJ44heWTndDO6NNfIpJMmN-ul
 parameter setting: -rgb=1;
 description: The classification number of this model is 3944 (0~9 + a~z + A~Z + Chinese characters + special characters).
              The training dataset is ReCTS (https://rrc.cvc.uab.es/?ch=12).
@@ -96,25 +96,25 @@ You can train more models by [CRNN](https://github.com/meijieru/crnn.pytorch), a
 
 ```
 - DB_IC15_resnet50.onnx:
-url: https://drive.google.com/uc?export=dowload&id=17_ABp79PlFt9yPCxSaarVc_DKTmrSGGf
+url: https://drive.google.com/uc?export=download&id=17_ABp79PlFt9yPCxSaarVc_DKTmrSGGf
 sha: bef233c28947ef6ec8c663d20a2b326302421fa3
 recommended parameter setting: -inputHeight=736, -inputWidth=1280;
 description: This model is trained on ICDAR2015, so it can only detect English text instances.
 
 - DB_IC15_resnet18.onnx:
-url: https://drive.google.com/uc?export=dowload&id=1vY_KsDZZZb_svd5RT6pjyI8BS1nPbBSX
+url: https://drive.google.com/uc?export=download&id=1vY_KsDZZZb_svd5RT6pjyI8BS1nPbBSX
 sha: 19543ce09b2efd35f49705c235cc46d0e22df30b
 recommended parameter setting: -inputHeight=736, -inputWidth=1280;
 description: This model is trained on ICDAR2015, so it can only detect English text instances.
 
 - DB_TD500_resnet50.onnx:
-url: https://drive.google.com/uc?export=dowload&id=19YWhArrNccaoSza0CfkXlA8im4-lAGsR
+url: https://drive.google.com/uc?export=download&id=19YWhArrNccaoSza0CfkXlA8im4-lAGsR
 sha: 1b4dd21a6baa5e3523156776970895bd3db6960a
 recommended parameter setting: -inputHeight=736, -inputWidth=736;
 description: This model is trained on MSRA-TD500, so it can detect both English and Chinese text instances.
 
 - DB_TD500_resnet18.onnx:
-url: https://drive.google.com/uc?export=dowload&id=1sZszH3pEt8hliyBlTmB-iulxHP1dCQWV
+url: https://drive.google.com/uc?export=download&id=1sZszH3pEt8hliyBlTmB-iulxHP1dCQWV
 sha: 8a3700bdc13e00336a815fc7afff5dcc1ce08546
 recommended parameter setting: -inputHeight=736, -inputWidth=736;
 description: This model is trained on MSRA-TD500, so it can detect both English and Chinese text instances.
@@ -133,11 +133,11 @@ This model is based on https://github.com/argman/EAST
 
 ```
 Text Recognition:
-url: https://drive.google.com/uc?export=dowload&id=1nMcEy68zDNpIlqAn6xCk_kYcUTIeSOtN
+url: https://drive.google.com/uc?export=download&id=1nMcEy68zDNpIlqAn6xCk_kYcUTIeSOtN
 sha: 89205612ce8dd2251effa16609342b69bff67ca3
 
 Text Detection:
-url: https://drive.google.com/uc?export=dowload&id=149tAhIcvfCYeyufRoZ9tmc2mZDKE_XrF
+url: https://drive.google.com/uc?export=download&id=149tAhIcvfCYeyufRoZ9tmc2mZDKE_XrF
 sha: ced3c03fb7f8d9608169a913acf7e7b93e07109b
 ```
 

--- a/doc/tutorials/dnn/dnn_yolo/dnn_yolo.markdown
+++ b/doc/tutorials/dnn/dnn_yolo/dnn_yolo.markdown
@@ -129,7 +129,7 @@ than YOLOX) in case it is needed. However, usually each YOLO repository has pred
 
 #### Exporting YOLOv10 model
 
-In oder to run YOLOv10 one needs to cut off postporcessing with dynamic shapes from torch and then convert it to ONNX. If someone is looking for on how to cut off the postprocessing, there is this [forked branch](https://github.com/Abdurrahheem/yolov10/tree/ash/opencv-export) from official YOLOv10. The forked branch cuts of the postprocessing by [returning output](https://github.com/Abdurrahheem/yolov10/blob/4fdaafd912c8891642bfbe85751ea66ec20f05ad/ultralytics/nn/modules/head.py#L522) of the model before postprocessing procedure itself. To convert torch model to ONNX follow this proceduce.
+In order to run YOLOv10 one needs to cut off postprocessing with dynamic shapes from torch and then convert it to ONNX. If someone is looking for on how to cut off the postprocessing, there is this [forked branch](https://github.com/Abdurrahheem/yolov10/tree/ash/opencv-export) from official YOLOv10. The forked branch cuts off the postprocessing by [returning output](https://github.com/Abdurrahheem/yolov10/blob/4fdaafd912c8891642bfbe85751ea66ec20f05ad/ultralytics/nn/modules/head.py#L522) of the model before postprocessing procedure itself. To convert torch model to ONNX follow this procedure.
 
 @code{.bash}
 git clone git@github.com:Abdurrahheem/yolov10.git

--- a/doc/tutorials/objdetect/aruco_faq/aruco_faq.markdown
+++ b/doc/tutorials/objdetect/aruco_faq/aruco_faq.markdown
@@ -167,7 +167,7 @@ for `cv::aruco::Dictionary`. The data member of board classes are public and can
 To do so, you will need to use an external rendering engine library, such as OpenGL. The aruco module
 only provides the functionality to obtain the camera pose, i.e. the rotation and translation vectors,
 which is necessary to create the augmented reality effect. However, you will need to adapt the rotation
-and traslation vectors from the OpenCV format to the format accepted by your 3d rendering library.
+and translation vectors from the OpenCV format to the format accepted by your 3d rendering library.
 The original ArUco library contains examples of how to do it for OpenGL and Ogre3D.
 
 

--- a/doc/tutorials/objdetect/charuco_diamond_detection/charuco_diamond_detection.markdown
+++ b/doc/tutorials/objdetect/charuco_diamond_detection/charuco_diamond_detection.markdown
@@ -12,7 +12,7 @@ It is similar to a ChArUco board in appearance, however they are conceptually di
 In both, ChArUco board and Diamond markers, their detection is based on the previous detected ArUco
 markers. In the ChArUco case, the used markers are selected by directly looking their identifiers. This means
 that if a marker (included in the board) is found on a image, it will be automatically assumed to belong to the board. Furthermore,
-if a marker board is found more than once in the image, it will produce an ambiguity since the system wont
+if a marker board is found more than once in the image, it will produce an ambiguity since the system won't
 be able to know which one should be used for the Board.
 
 On the other hand, the detection of Diamond marker is not based on the identifiers. Instead, their detection


### PR DESCRIPTION
This PR fixes spelling typos across several tutorial documentation files (dnn, calib3d, objdetect, app, js_tutorials), including `export=dowload` -> `export=download` in the DNN text-spotting tutorial's Google Drive URLs.

Documentation-only change; no functional code is affected.

Pull Request Readiness Checklist:

[x] I agree to contribute to the project under Apache 2 License.

[x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.

[x] The PR is proposed to the proper branch (4.x).

[x] Documentation-only change; no accuracy/performance tests or opencv_extra patch are applicable.
