### PR TITLE
reject nd-matrix dim count above CV_MAX_DIM in FileStorage read

### DIFF
--- a/modules/core/src/persistence_types.cpp
+++ b/modules/core/src/persistence_types.cpp
@@ -142,6 +142,7 @@ void read(const FileNode& node, Mat& m, const Mat& default_mat)
         CV_Assert( !sizes_node.empty() );
 
         dims = (int)sizes_node.size();
+        CV_Assert( dims > 0 && dims <= CV_MAX_DIM );
         sizes_node.readRaw("i", sizes, dims*sizeof(sizes[0]));
 
         m.create(dims, sizes, elem_type);
@@ -180,6 +181,7 @@ void read( const FileNode& node, SparseMat& m, const SparseMat& default_mat )
     CV_Assert( !sizes_node.empty() );
 
     int dims = (int)sizes_node.size();
+    CV_Assert( dims > 0 && dims <= CV_MAX_DIM );
     sizes_node.readRaw("i", sizes, dims*sizeof(sizes[0]));
 
     m.create(dims, sizes, elem_type);

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -807,6 +807,35 @@ TEST(Core_InputOutput, filestorage_heap_overflow)
     EXPECT_EQ(0, remove(name.c_str()));
 }
 
+TEST(Core_InputOutput, filestorage_nd_matrix_too_many_dims)
+{
+    // A declared dimension count above CV_MAX_DIM used to write the sizes list
+    // past the fixed-size sizes[CV_MAX_DIM] stack buffer in cv::read().
+    std::string sizes;
+    for (int i = 0; i < CV_MAX_DIM + 8; i++)
+        sizes += "2, ";
+    sizes += "2";
+
+    const std::string content =
+        "%YAML:1.0\n---\n"
+        "m: !!opencv-nd-matrix\n"
+        "   sizes: [ " + sizes + " ]\n"
+        "   dt: f\n"
+        "   data: [ 0., 0. ]\n"
+        "sm: !!opencv-sparse-matrix\n"
+        "   sizes: [ " + sizes + " ]\n"
+        "   dt: f\n"
+        "   data: [ ]\n";
+
+    FileStorage fs(content, FileStorage::READ | FileStorage::MEMORY);
+
+    Mat m;
+    EXPECT_ANY_THROW(fs["m"] >> m);
+
+    SparseMat sm;
+    EXPECT_ANY_THROW(fs["sm"] >> sm);
+}
+
 TEST(Core_InputOutput, filestorage_base64_valid_call)
 {
     const ::testing::TestInfo* const test_info = ::testing::UnitTest::GetInstance()->current_test_info();


### PR DESCRIPTION
cv::read() for a Mat or SparseMat takes the dimension count straight from the `sizes` sequence of an `opencv-nd-matrix` / `opencv-sparse-matrix` node, then hands it to `FileNode::readRaw()`, which writes that many ints into a fixed `int sizes[CV_MAX_DIM]` on the stack. A FileStorage file whose `sizes` list holds more than CV_MAX_DIM (32) entries writes past the array before `m.create()` ever gets to reject the count. Reading such a .yml/.xml/.json with `fs[...] >> mat` trips an ASan stack-buffer-overflow inside `readRaw`.

Before: the dim count was only checked inside `m.create()`, which runs after the out-of-bounds write. After: both `read()` overloads validate `dims` against CV_MAX_DIM right before the `readRaw()` call, so the bound lives at the layer that owns the stack buffer, and the same check covers the `idx[CV_MAX_DIM]` writes in the sparse path. The tradeoff is that a file declaring more than 32 dimensions is now refused with an exception instead of corrupting the stack, but OpenCV cannot represent such a matrix anyway.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
