### PR TITLE
Fixed new objdetect warnings on Windows.

### DIFF
--- a/modules/objdetect/src/aruco/aruco_dictionary.cpp
+++ b/modules/objdetect/src/aruco/aruco_dictionary.cpp
@@ -80,7 +80,8 @@ bool Dictionary::identify(const Mat &onlyCellPixelRatio, CV_OUT int &idx, CV_OUT
     const int s = (markerSize * markerSize + 8 - 1) / 8;
     AutoBuffer<uint8_t> temp(4 * s);
     uint8_t* not0 = temp.data(), * not1 = not0 + s;
-    int not0Byte = 0, not1Byte = 0, currentByte = 0, currentBit = 0;
+    uint8_t not0Byte = 0, not1Byte = 0;
+    int currentByte = 0, currentBit = 0;
     for(int j = 0; j < markerSize; j++) {
         const float* cellPixelRatioRow = onlyCellPixelRatio.ptr<float>(j);
         for(int i = 0; i < markerSize; i++) {


### PR DESCRIPTION
Warnings:
```
  Warning: C:\GHA-OCV-3\_work\opencv\opencv\opencv\modules\objdetect\src\aruco\aruco_dictionary.cpp(92,37): warning C4244: '=': conversion from 'int' to 'uint8_t', possible loss of data [C:\GHA-OCV-3\_work\opencv\opencv\build\modules\objdetect\opencv_objdetect.vcxproj]
  Warning: C:\GHA-OCV-3\_work\opencv\opencv\opencv\modules\objdetect\src\aruco\aruco_dictionary.cpp(93,37): warning C4244: '=': conversion from 'int' to 'uint8_t', possible loss of data [C:\GHA-OCV-3\_work\opencv\opencv\build\modules\objdetect\opencv_objdetect.vcxproj]
  Warning: C:\GHA-OCV-3\_work\opencv\opencv\opencv\modules\objdetect\src\aruco\aruco_dictionary.cpp(101,29): warning C4244: '=': conversion from 'int' to 'uint8_t', possible loss of data [C:\GHA-OCV-3\_work\opencv\opencv\build\modules\objdetect\opencv_objdetect.vcxproj]
  Warning: C:\GHA-OCV-3\_work\opencv\opencv\opencv\modules\objdetect\src\aruco\aruco_dictionary.cpp(102,29): warning C4244: '=': conversion from 'int' to 'uint8_t', possible loss of data [C:\GHA-OCV-3\_work\opencv\opencv\build\modules\objdetect\opencv_objdetect.vcxproj]
```

Introduced in https://github.com/opencv/opencv/pull/29267

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
