### PR TITLE
bound darknet cfg layer and anchor indices before vector reads

### DIFF
--- a/modules/dnn/src/darknet/darknet_io.cpp
+++ b/modules/dnn/src/darknet/darknet_io.cpp
@@ -534,8 +534,10 @@ namespace cv {
                     std::vector<float> usedAnchors(numAnchors * 2);
                     for (int i = 0; i < numAnchors; ++i)
                     {
-                        usedAnchors[i * 2] = anchors[mask[i] * 2];
-                        usedAnchors[i * 2 + 1] = anchors[mask[i] * 2 + 1];
+                        const int m = mask[i];
+                        CV_Assert(m >= 0 && static_cast<size_t>(m) * 2 + 1 < anchors.size());
+                        usedAnchors[i * 2] = anchors[m * 2];
+                        usedAnchors[i * 2 + 1] = anchors[m * 2 + 1];
                     }
 
                     cv::Mat biasData_mat = cv::Mat(1, numAnchors * 2, CV_32F, &usedAnchors[0]).clone();
@@ -835,6 +837,7 @@ namespace cv {
                         tensor_shape[0] = 0;
                         for (size_t k = 0; k < layers_vec.size(); ++k) {
                             layers_vec[k] = layers_vec[k] >= 0 ? layers_vec[k] : (layers_vec[k] + layers_counter);
+                            CV_Assert(layers_vec[k] >= 0 && static_cast<size_t>(layers_vec[k]) < net->out_channels_vec.size());
                             tensor_shape[0] += net->out_channels_vec[layers_vec[k]];
                         }
 


### PR DESCRIPTION
In the Darknet importer the .cfg layer indices are read straight into vectors and then used as subscripts with no range check. A `[yolo]` layer's `mask=` values index the anchors table at `anchors[mask[i]*2]` in `setYolo`, and a `[route]` layer's `layers=` values index `out_channels_vec` in `ReadDarknetFromCfgStream`; the surrounding asserts only validate the anchor count, never the index values. A crafted .cfg handed to `readNetFromDarknet` with a mask/layers entry larger than the table (or negative) reads past the heap buffer, which AddressSanitizer flags as a heap-buffer-overflow read on the anchors path.

Before, the out-of-range index walked off the vector and the leaked floats were copied into the layer's bias blob; after, the index is validated against the vector size so a malformed file is rejected, the same way the neighboring layer-name lookups in this file already fail through `.at()`. Keeping the bound at the subscript site covers every caller that reaches these two layer types instead of trusting the cfg to be well formed. The tradeoff is that a .cfg with deliberately out-of-range indices now throws rather than silently building a garbage model, which is consistent with how the other layer handlers here treat bad references.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake
