### PR TITLE
Consistently include `<math.h>` with angle brackets

### DIFF
--- a/modules/calib3d/src/chessboard.cpp
+++ b/modules/calib3d/src/chessboard.cpp
@@ -5,7 +5,7 @@
 #include "precomp.hpp"
 #include "opencv2/flann.hpp"
 #include "chessboard.hpp"
-#include "math.h"
+#include <math.h>
 
 //#define CV_DETECTORS_CHESSBOARD_DEBUG
 #ifdef CV_DETECTORS_CHESSBOARD_DEBUG

--- a/modules/photo/src/npr.hpp
+++ b/modules/photo/src/npr.hpp
@@ -44,7 +44,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <limits>
-#include "math.h"
+#include <math.h>
 
 
 using namespace std;


### PR DESCRIPTION
# Overview

opencv almost always properly includes the Standard header `math.h` with angle brackets, but there are two lines that inconsistently use double quotes (which could pick up something in the local directory). This PR changes opencv to consistently use angle brackets.

(We found this for a complicated reason. I'm the primary maintainer of MSVC's STL, and I'm working with @Codiferous who's implementing `constexpr <cmath>` in the MSVC compiler. This involves "intercepting" inclusions of `math.h` but that only works with angle brackets. In any event, consistently using angle brackets is good for all compilers on all platforms, not just because of our weird reason.)

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
  * I believe 4.x is correct
- [ ] There is a reference to the original bug report and related work
  * Not applicable; no separate bug report, explanation above.
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
  * Not applicable
- [ ] The feature is well documented and sample code can be built with the project CMake
  * Documentation not applicable. CI should verify that this simple change still builds

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
