### PR TITLE
core: Add padded buffer for DFT on Windows ARM64 to reduce cache thrashing

### DIFF
--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -3022,7 +3022,90 @@ public:
             return;
         }
 #endif
+#if defined(_M_ARM64)
+        // Fix for CPU cache thrashing on Windows-ARM64 when stride is a power of 2.
+        // Column-wise access with power-of-2 stride maps to very few cache sets,
+        // causing ~97% cache miss rate. Adding one cache line (64 bytes) to the
+        // stride distributes accesses across all cache sets.
+        static const size_t DFT_CACHE_LINE_PAD = 64;
+        static const size_t DFT_PAD_THRESHOLD = 96 * 1024;
 
+        bool needPaddedBuffer = false;
+        size_t padded_step = dst_step;
+        AutoBuffer<uchar> padded_buf;
+
+        if (stages.size() == 2 &&
+            dst_step > 0 && (dst_step & (dst_step - 1)) == 0 &&
+            dst_step * (size_t)height > DFT_PAD_THRESHOLD)
+        {
+            needPaddedBuffer = true;
+            padded_step = dst_step + DFT_CACHE_LINE_PAD;
+            padded_buf.allocate(padded_step * height);
+        }
+
+        for(uint stageIndex = 0; stageIndex < stages.size(); ++stageIndex)
+        {
+            int stage_src_channels = src_channels;
+            int stage_dst_channels = dst_channels;
+
+            if (stageIndex == 1)
+            {
+                if (needPaddedBuffer)
+                {
+                    if (stages[0] == 0)
+                    {
+                        src = padded_buf.data();
+                        src_step = padded_step;
+                    }
+                    else
+                    {
+                        for (int i = 0; i < height; i++)
+                            memcpy(dst + dst_step * i, padded_buf.data() + padded_step * i, dst_step);
+                        src = dst;
+                        src_step = dst_step;
+                    }
+                }
+                else
+                {
+                    src = dst;
+                    src_step = dst_step;
+                }
+                stage_src_channels = stage_dst_channels;
+            }
+
+            int stage = stages[stageIndex];
+            bool isLastStage = (stageIndex + 1 == stages.size());
+            bool isComplex = stage_src_channels != stage_dst_channels;
+
+            if( stage == 0 )
+            {
+                if (needPaddedBuffer && stages[0] == 0)
+                    rowDft(src, src_step, padded_buf.data(), padded_step, isComplex, isLastStage);
+                else
+                    rowDft(src, src_step, dst, dst_step, isComplex, isLastStage);
+            }
+            else
+            {
+                if (needPaddedBuffer)
+                {
+                    if (stages[0] == 1)
+                    {
+                        for (int i = 0; i < height; i++)
+                            memcpy(padded_buf.data() + padded_step * i, src + src_step * i, dst_step);
+                        colDft(padded_buf.data(), padded_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
+                    }
+                    else
+                    {
+                        colDft(src, src_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
+                        for (int i = 0; i < height; i++)
+                            memcpy(dst + dst_step * i, padded_buf.data() + padded_step * i, dst_step);
+                    }
+                }
+                else
+                    colDft(src, src_step, dst, dst_step, stage_src_channels, stage_dst_channels, isLastStage);
+            }
+        }
+#else
         for(uint stageIndex = 0; stageIndex < stages.size(); ++stageIndex)
         {
             int stage_src_channels = src_channels;
@@ -3044,6 +3127,7 @@ public:
             else
                 colDft(src, src_step, dst, dst_step, stage_src_channels, stage_dst_channels, isLastStage);
         }
+#endif
     }
 
 protected:

--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -3022,7 +3022,9 @@ public:
             return;
         }
 #endif
-#if defined(_M_ARM64)
+        uchar* work = dst;
+        size_t work_step = dst_step;
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
         // Fix for CPU cache thrashing on Windows-ARM64 when stride is a power of 2.
         // Column-wise access with power-of-2 stride maps to very few cache sets,
         // causing ~97% cache miss rate. Adding one cache line (64 bytes) to the
@@ -3030,104 +3032,53 @@ public:
         static const size_t DFT_CACHE_LINE_PAD = 64;
         static const size_t DFT_PAD_THRESHOLD = 96 * 1024;
 
-        bool needPaddedBuffer = false;
-        size_t padded_step = dst_step;
         AutoBuffer<uchar> padded_buf;
 
         if (stages.size() == 2 &&
             dst_step > 0 && (dst_step & (dst_step - 1)) == 0 &&
             dst_step * (size_t)height > DFT_PAD_THRESHOLD)
         {
-            needPaddedBuffer = true;
-            padded_step = dst_step + DFT_CACHE_LINE_PAD;
-            if ((padded_step & (padded_step - 1)) == 0)
-                padded_step += DFT_CACHE_LINE_PAD;
-            padded_buf.allocate(padded_step * height);
-        }
-
-        for(uint stageIndex = 0; stageIndex < stages.size(); ++stageIndex)
-        {
-            int stage_src_channels = src_channels;
-            int stage_dst_channels = dst_channels;
-
-            if (stageIndex == 1)
-            {
-                if (needPaddedBuffer)
-                {
-                    if (stages[0] == 0)
-                    {
-                        src = padded_buf.data();
-                        src_step = padded_step;
-                    }
-                    else
-                    {
-                        for (int i = 0; i < height; i++)
-                            memcpy(dst + dst_step * i, padded_buf.data() + padded_step * i, dst_step);
-                        src = dst;
-                        src_step = dst_step;
-                    }
-                }
-                else
-                {
-                    src = dst;
-                    src_step = dst_step;
-                }
-                stage_src_channels = stage_dst_channels;
-            }
-
-            int stage = stages[stageIndex];
-            bool isLastStage = (stageIndex + 1 == stages.size());
-            bool isComplex = stage_src_channels != stage_dst_channels;
-
-            if( stage == 0 )
-            {
-                if (needPaddedBuffer && stages[0] == 0)
-                    rowDft(src, src_step, padded_buf.data(), padded_step, isComplex, isLastStage);
-                else
-                    rowDft(src, src_step, dst, dst_step, isComplex, isLastStage);
-            }
-            else
-            {
-                if (needPaddedBuffer)
-                {
-                    if (stages[0] == 1)
-                    {
-                        colDft(src, src_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
-                    }
-                    else
-                    {
-                        colDft(src, src_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
-                        for (int i = 0; i < height; i++)
-                            memcpy(dst + dst_step * i, padded_buf.data() + padded_step * i, dst_step);
-                    }
-                }
-                else
-                    colDft(src, src_step, dst, dst_step, stage_src_channels, stage_dst_channels, isLastStage);
-            }
-        }
-#else
-        for(uint stageIndex = 0; stageIndex < stages.size(); ++stageIndex)
-        {
-            int stage_src_channels = src_channels;
-            int stage_dst_channels = dst_channels;
-
-            if (stageIndex == 1)
-            {
-                src = dst;
-                src_step = dst_step;
-                stage_src_channels = stage_dst_channels;
-            }
-
-            int stage = stages[stageIndex];
-            bool isLastStage = (stageIndex + 1 == stages.size());
-            bool isComplex = stage_src_channels != stage_dst_channels;
-
-            if( stage == 0 )
-                rowDft(src, src_step, dst, dst_step, isComplex, isLastStage);
-            else
-                colDft(src, src_step, dst, dst_step, stage_src_channels, stage_dst_channels, isLastStage);
+            work_step = dst_step + DFT_CACHE_LINE_PAD;
+            if ((work_step & (work_step - 1)) == 0)
+                work_step += DFT_CACHE_LINE_PAD;
+            padded_buf.allocate(work_step * height);
+            work = padded_buf.data();
         }
 #endif
+
+        bool prevInWork = false;
+        for(uint stageIndex = 0; stageIndex < stages.size(); ++stageIndex)
+        {
+            int stage_src_channels = src_channels;
+            int stage_dst_channels = dst_channels;
+
+            if (stageIndex == 1)
+            {
+                src = prevInWork ? work : dst;
+                src_step = prevInWork ? work_step : dst_step;
+                stage_src_channels = stage_dst_channels;
+            }
+
+            int stage = stages[stageIndex];
+            bool isLastStage = (stageIndex + 1 == stages.size());
+            bool isComplex = stage_src_channels != stage_dst_channels;
+            bool needsWorkBuffer = (stage == 1) || (!isLastStage && stages[stageIndex + 1] == 1);
+            uchar* out = needsWorkBuffer ? work : dst;
+            size_t out_step = needsWorkBuffer ? work_step : dst_step;
+
+            if( stage == 0 )
+                rowDft(src, src_step, out, out_step, isComplex, isLastStage);
+            else
+                colDft(src, src_step, out, out_step, stage_src_channels, stage_dst_channels, isLastStage);
+
+            prevInWork = needsWorkBuffer;
+        }
+
+        if (prevInWork && work != dst)
+        {
+            for (int i = 0; i < height; i++)
+                memcpy(dst + dst_step * i, work + work_step * i, dst_step);
+        }
     }
 
 protected:

--- a/modules/core/src/dxt.cpp
+++ b/modules/core/src/dxt.cpp
@@ -3040,6 +3040,8 @@ public:
         {
             needPaddedBuffer = true;
             padded_step = dst_step + DFT_CACHE_LINE_PAD;
+            if ((padded_step & (padded_step - 1)) == 0)
+                padded_step += DFT_CACHE_LINE_PAD;
             padded_buf.allocate(padded_step * height);
         }
 
@@ -3090,9 +3092,7 @@ public:
                 {
                     if (stages[0] == 1)
                     {
-                        for (int i = 0; i < height; i++)
-                            memcpy(padded_buf.data() + padded_step * i, src + src_step * i, dst_step);
-                        colDft(padded_buf.data(), padded_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
+                        colDft(src, src_step, padded_buf.data(), padded_step, stage_src_channels, stage_dst_channels, isLastStage);
                     }
                     else
                     {


### PR DESCRIPTION
- This PR optimizes DFT on Windows ARM64 by introducing a padded intermediate buffer for specific transform configurations.
- During performance analysis, it was observed that large 2D DFTs with a power-of-two row stride suffer from severe data cache thrashing. 
- Since column-wise accesses repeatedly map to a small number of cache sets, the cache miss rate becomes very high, significantly degrading performance.

<img width="725" height="50" alt="image" src="https://github.com/user-attachments/assets/6c624f08-50c2-485e-8ca0-97f5a53a4dc0" />

- This change is enabled only for Windows ARM64 builds using the MSVC compiler, all other architectures continue to use the existing implementation.

**Performance Benchmarks:**
<img width="949" height="356" alt="image" src="https://github.com/user-attachments/assets/e0c04986-1bfe-4232-8b13-d6a1d24a9b00" />


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
