### PR TITLE
check tflite kernel scale count against output channels

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -442,6 +442,7 @@ void TFLiteImporter::parseConvolution(const Operator& op, const std::string& opc
         if (filterScales->size() == 1) {
             layerParams.blobs[2].setTo(inpScale * filterScales->Get(0) / outScale);
         } else {
+            CV_CheckEQ((int)filterScales->size(), oc, "TFLite: number of filter quantization scales must match the number of output channels");
             for (size_t i = 0; i < filterScales->size(); ++i) {
                 layerParams.blobs[2].at<float>(i) = inpScale * filterScales->Get(i) / outScale;
             }
@@ -504,6 +505,7 @@ void TFLiteImporter::parseDWConvolution(const Operator& op, const std::string& o
         if (filterScales->size() == 1) {
             layerParams.blobs[2].setTo(inpScale * filterScales->Get(0) / outScale);
         } else {
+            CV_CheckEQ((int)filterScales->size(), oc, "TFLite: number of filter quantization scales must match the number of output channels");
             for (size_t i = 0; i < filterScales->size(); ++i) {
                 layerParams.blobs[2].at<float>(i) = inpScale * filterScales->Get(i) / outScale;
             }


### PR DESCRIPTION
`parseConvolution` and `parseDWConvolution` size the per-channel kernel-scale blob from the filter tensor's output channel count (`Mat(oc, 1, CV_32F)`), then fill it by walking the filter tensor's quantization scale array. `oc` and the scale count come from separate fields of an int8 `.tflite`, read independently, so a model whose filter declares one output channel while carrying a longer scale array runs the fill loop past the blob.

Before: the loop trusts `filterScales->size()` and writes that many floats regardless of `oc`, overrunning the heap allocation on a mismatch (AddressSanitizer reports a heap write past the `fastMalloc` region, reachable from `readNetFromTFLite`). After: the count is required to equal `oc` before the writes, the invariant per-axis quantization already holds for well-formed models. The check sits in the importer next to the allocation because that is the only point where both numbers are visible; the convolution layer downstream never sees the raw scale array. The tradeoff is that a per-axis quantized model with a scale count other than the channel count is rejected up front instead of writing out of bounds.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
