### PR TITLE
ximgproc: remove CV_NEON macro guard in bin_loop function

### DIFF
--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -399,7 +399,7 @@ static void bin_loop(const T1* src1, size_t step1, const T1* src2, size_t step2,
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     typedef bin_loader<OP, T1, Tvec> ldr;
     const int wide_step = VTraits<Tvec>::vlanes();
-    #if !CV_NEON && CV_SIMD_WIDTH == 16
+    #if CV_SIMD_WIDTH == 16
         const int wide_step_l = wide_step * 2;
     #else
         const int wide_step_l = wide_step;
@@ -415,7 +415,7 @@ static void bin_loop(const T1* src1, size_t step1, const T1* src2, size_t step2,
         int x = 0;
 
     #if (CV_SIMD || CV_SIMD_SCALABLE)
-        #if !CV_NEON && !CV_MSA
+        #if !CV_MSA
         if (is_aligned(src1, src2, dst))
         {
             for (; x <= width - wide_step_l; x += wide_step_l)
@@ -431,7 +431,7 @@ static void bin_loop(const T1* src1, size_t step1, const T1* src2, size_t step2,
             for (; x <= width - wide_step_l; x += wide_step_l)
             {
                 ldr::l(src1 + x, src2 + x, dst + x);
-                #if !CV_NEON && CV_SIMD_WIDTH == 16
+                #if CV_SIMD_WIDTH == 16
                 ldr::l(src1 + x + wide_step, src2 + x + wide_step, dst + x + wide_step);
                 #endif
             }


### PR DESCRIPTION
- This PR improves the performance of FastHoughTransform by enabling wider SIMD processing on ARM64 platforms.
- **Key Optimizations:**
  - Removed NEON-specific conditions and enabled the optimized code path.
  - Increased the number of elements processed per iteration when CV_SIMD_WIDTH == 16.
  - Preserved existing functionality and output accuracy across all supported platforms.

**Performance Benchmarks:**

The optimization improves the performance of FastHough function on Windows-ARM64.

<img width="1318" height="251" alt="image" src="https://github.com/user-attachments/assets/6270a6a0-76a3-4aa6-821b-ce1d5af5a3bd" />


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch