### PR TITLE
check begin and size have equal length in tensorflow Slice import

### DIFF
--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -1651,6 +1651,7 @@ void TFImporter::parseSlice(tensorflow::GraphDef& net, const tensorflow::NodeDef
     CV_Assert_N(!begins.empty(), !sizes.empty());
     CV_CheckTypeEQ(begins.type(), CV_32SC1, "");
     CV_CheckTypeEQ(sizes.type(), CV_32SC1, "");
+    CV_CheckEQ(begins.total(), sizes.total(), "Slice: 'begin' and 'size' must have equal length");
 
     if (begins.total() == 4 && getDataLayout(name, data_layouts) == DNN_LAYOUT_NHWC)
     {


### PR DESCRIPTION
parseSlice reads the Slice op's begin and size inputs as two independent constant tensors, then enters the NHWC->NCHW reordering branch whenever begins.total() == 4. Inside that branch it swaps elements of both begins and sizes, but the length of size is never checked against begin. A graph whose begin holds 4 ints while size holds fewer makes the swap on sizes.ptr<int32_t>(0, 2) and (0, 3) index past the size buffer. ASan reports a heap-buffer-overflow read/write at tf_importer.cpp:1660 reached straight from readNetFromTensorflow on a crafted .pb.

The check goes next to the existing type checks so begin and size are validated where they are consumed rather than relying on the caller. parseStridedSlice just below already enforces this same equal-length invariant across begin/end/strides; parseSlice was the one sibling missing it. Before, a length mismatch let the 4-element reorder run over a shorter buffer; after, the mismatched Slice is rejected with a clear error. The tradeoff is that a model declaring begin and size of different lengths is now refused instead of silently reordered, which matches the TensorFlow Slice contract that both have the input's rank.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake