### PR TITLE
fix reversed custom_options size check in tflite custom-op parsers

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -668,7 +668,7 @@ void TFLiteImporter::parsePooling(const Operator& op, const std::string& opcode,
 void TFLiteImporter::parsePoolingWithArgmax(const Operator& op, const std::string& opcode, LayerParams& layerParams) {
     layerParams.type = "Pooling";
 
-    CV_CheckLE(op.custom_options()->size(), sizeof(TfLitePoolParams), "");
+    CV_CheckGE(op.custom_options()->size(), sizeof(TfLitePoolParams), "Truncated custom_options for pooling");
     const auto* params = reinterpret_cast<const TfLitePoolParams*>(op.custom_options()->Data());
     if (params->activation != kTfLiteActNone) {
         CV_Error(Error::StsNotImplemented, "Argmax pooling with fused activation");
@@ -686,7 +686,7 @@ void TFLiteImporter::parsePoolingWithArgmax(const Operator& op, const std::strin
 void TFLiteImporter::parseUnpooling(const Operator& op, const std::string& opcode, LayerParams& layerParams) {
     layerParams.type = "MaxUnpool";
 
-    CV_CheckLE(op.custom_options()->size(), sizeof(TfLitePoolParams), "");
+    CV_CheckGE(op.custom_options()->size(), sizeof(TfLitePoolParams), "Truncated custom_options for pooling");
     const auto* params = reinterpret_cast<const TfLitePoolParams*>(op.custom_options()->Data());
     if (params->activation != kTfLiteActNone) {
         CV_Error(Error::StsNotImplemented, "Unpooling with fused activation");
@@ -950,7 +950,7 @@ int TFLiteImporter::addConstLayer(const Mat& blob, const std::string& name)
 void TFLiteImporter::parseDeconvolution(const Operator& op, const std::string& opcode, LayerParams& layerParams) {
     layerParams.type = "Deconvolution";
 
-    CV_CheckLE(op.custom_options()->size(), sizeof(TfLiteTransposeConvParams), "");
+    CV_CheckGE(op.custom_options()->size(), sizeof(TfLiteTransposeConvParams), "Truncated custom_options for deconvolution");
     const auto* params = reinterpret_cast<const TfLiteTransposeConvParams*>(op.custom_options()->Data());
     if (params->padding != kTfLitePaddingUnknown)
         layerParams.set("pad_mode", params->padding == kTfLitePaddingSame ? "SAME" : "VALID");


### PR DESCRIPTION
parsePoolingWithArgmax, parseUnpooling and parseDeconvolution read a TfLitePoolParams or TfLiteTransposeConvParams struct straight out of an operator's custom_options blob, then guard it with CV_CheckLE(custom_options()->size(), sizeof(params)). That bound accepts any blob up to the struct size, so a MaxPoolingWithArgmax2D, MaxUnpooling2D or Convolution2DTransposeBias op whose custom_options is shorter than the struct passes the check and the following read runs past the end of the buffer. readNetFromTFLite reaches all three parsers on a crafted model.

Before, the bound let an undersized blob through and the reinterpret_cast read out of bounds; after, CV_CheckGE requires the blob to be at least the struct size, so a truncated custom_options is rejected before the struct is dereferenced. The check sits next to the read because the size and the struct layout are tied together there, and keeping it callee-side covers every dispatch entry that maps to these parsers without each caller repeating it. The tradeoff is that an undersized custom_options now fails the import instead of being read speculatively, which matches how the other tflite parsers treat malformed options.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
