### PR TITLE
Disable MLAS on windows

### DIFF
--- a/3rdparty/mlas/CMakeLists.txt
+++ b/3rdparty/mlas/CMakeLists.txt
@@ -71,6 +71,10 @@ set(mlas_platform_srcs)
 set(OPENCV_DNN_MLAS_ENABLED     0  CACHE INTERNAL "" FORCE)
 set(OPENCV_DNN_MLAS_SKIP_REASON "" CACHE INTERNAL "" FORCE)
 
+if(WIN32)
+  return()
+endif()
+
 # Probe ASM language once. check_language(ASM) is a no-op when
 # CMAKE_ASM_COMPILER is already set in cache — and the Android NDK toolchain
 # pre-sets it for every ABI. So on Android the guard falls through to


### PR DESCRIPTION
C++ and Assembly for MLAS on windows can't be built separately hence disabling complete MLAS.

Temporary hack, complete solution would be added later.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
