### PR TITLE
fix fmt_pairs stack overflow in calcElemSize and decodeSimpleFormat

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -266,7 +266,7 @@ int decodeFormat( const char* dt, int* fmt_pairs, int max_len )
 int calcElemSize( const char* dt, int initial_size )
 {
     int size = 0;
-    int fmt_pairs[CV_FS_MAX_FMT_PAIRS], i, fmt_pair_count;
+    int fmt_pairs[CV_FS_MAX_FMT_PAIRS*2], i, fmt_pair_count;
     int comp_size;
 
     fmt_pair_count = decodeFormat( dt, fmt_pairs, CV_FS_MAX_FMT_PAIRS );
@@ -316,7 +316,7 @@ int calcStructSize( const char* dt, int initial_size )
 int decodeSimpleFormat( const char* dt )
 {
     int elem_type = -1;
-    int fmt_pairs[CV_FS_MAX_FMT_PAIRS], fmt_pair_count;
+    int fmt_pairs[CV_FS_MAX_FMT_PAIRS*2], fmt_pair_count;
 
     fmt_pair_count = decodeFormat( dt, fmt_pairs, CV_FS_MAX_FMT_PAIRS );
     if( fmt_pair_count != 1 || fmt_pairs[0] >= CV_CN_MAX)

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -836,6 +836,32 @@ TEST(Core_InputOutput, filestorage_nd_matrix_too_many_dims)
     EXPECT_ANY_THROW(fs["sm"] >> sm);
 }
 
+TEST(Core_InputOutput, filestorage_matrix_dt_too_long)
+{
+    // A "dt" string with many distinct adjacent types makes decodeFormat()
+    // emit more pairs than the caller buffer holds. decodeSimpleFormat() sized
+    // its fmt_pairs buffer as CV_FS_MAX_FMT_PAIRS ints while decodeFormat writes
+    // up to 2*CV_FS_MAX_FMT_PAIRS ints, so a long enough dt wrote past the stack
+    // buffer before the length guard could reject it.
+    // CV_FS_MAX_FMT_PAIRS is 128; well over 2x that many distinct pairs.
+    std::string dt;
+    for (int i = 0; i < 300; i++)
+        dt += (i & 1) ? 'c' : 'u';
+
+    const std::string content =
+        "%YAML:1.0\n---\n"
+        "m: !!opencv-matrix\n"
+        "   rows: 1\n"
+        "   cols: 1\n"
+        "   dt: \"" + dt + "\"\n"
+        "   data: [ 0 ]\n";
+
+    FileStorage fs(content, FileStorage::READ | FileStorage::MEMORY);
+
+    Mat m;
+    EXPECT_ANY_THROW(fs["m"] >> m);
+}
+
 TEST(Core_InputOutput, filestorage_base64_valid_call)
 {
     const ::testing::TestInfo* const test_info = ::testing::UnitTest::GetInstance()->current_test_info();


### PR DESCRIPTION
Repro: read a FileStorage (.yml/.xml/.json) with an opencv-matrix node whose `dt` is a long run of distinct adjacent type codes, e.g. `cucucu...` with more than 64 pairs.
Cause: decodeFormat() treats max_len as a pair count and doubles it internally (max_len *= 2), so it can write up to 2*max_len ints, but calcElemSize() and decodeSimpleFormat() size fmt_pairs as CV_FS_MAX_FMT_PAIRS while the other three callers use CV_FS_MAX_FMT_PAIRS*2.
Fix: size both buffers CV_FS_MAX_FMT_PAIRS*2 so the array matches what decodeFormat() can emit.

Before: a 300-char `dt` overruns the 128-int stack array (ASan reports stack-buffer-overflow write at offset 544 of the 512-byte frame) before the "Too long data type specification" guard fires. The path is reachable from cv::read(FileNode, Mat/SparseMat) via the file-supplied `dt`.
After: the same input reaches that guard and throws cleanly; parsing of valid `dt` strings is unchanged.

The only cost is 512 extra bytes of stack in these two helpers, matching what readRaw() and writeRawData() already reserve.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
