### PR TITLE
imgproc: avoid overflow in warpAffine scalar tail

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -2300,8 +2300,8 @@ void warpAffineBlocklineNN(int *adelta, int *bdelta, short* xy, int X0, int Y0, 
 #endif
     for (; x1 < bw; x1++)
     {
-        const int X = (X0 + adelta[x1]) >> AB_BITS;
-        const int Y = (Y0 + bdelta[x1]) >> AB_BITS;
+        const int X = (int)(((int64)X0 + adelta[x1]) >> AB_BITS);
+        const int Y = (int)(((int64)Y0 + bdelta[x1]) >> AB_BITS);
         xy[x1 * 2] = saturate_cast<short>(X);
         xy[x1 * 2 + 1] = saturate_cast<short>(Y);
     }
@@ -2350,8 +2350,8 @@ void warpAffineBlockline(int *adelta, int *bdelta, short* xy, short* alpha, int 
         #endif
         for( ; x1 < bw; x1++ )
         {
-            int X = (X0 + adelta[x1]) >> (AB_BITS - INTER_BITS);
-            int Y = (Y0 + bdelta[x1]) >> (AB_BITS - INTER_BITS);
+            int X = (int)(((int64)X0 + adelta[x1]) >> (AB_BITS - INTER_BITS));
+            int Y = (int)(((int64)Y0 + bdelta[x1]) >> (AB_BITS - INTER_BITS));
             xy[x1*2] = saturate_cast<short>(X >> INTER_BITS);
             xy[x1*2+1] = saturate_cast<short>(Y >> INTER_BITS);
             alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1587,6 +1587,24 @@ TEST(Imgproc_Warp, regression_28554)
     ASSERT_EQ(0.0, cvtest::norm(reference, outMat, NORM_INF));
 }
 
+TEST(Imgproc_Warp, regression_28943)
+{
+    Mat inMat(1, 1, CV_16SC1, Scalar(100));
+    Mat coeffs = (Mat_<double>(2, 3) <<
+            -2097152., 0., -2097152.,
+                    0., 1.,        0.);
+
+    Mat outMat;
+    Mat reference = Mat::zeros(Size(2, 1), inMat.type());
+    EXPECT_NO_THROW(warpAffine(inMat, outMat, coeffs, Size(2, 1),
+            INTER_CUBIC | WARP_INVERSE_MAP, BORDER_CONSTANT, 0.0));
+    EXPECT_EQ(0.0, cvtest::norm(reference, outMat, NORM_INF));
+
+    EXPECT_NO_THROW(warpAffine(inMat, outMat, coeffs, Size(2, 1),
+            INTER_NEAREST | WARP_INVERSE_MAP, BORDER_CONSTANT, 0.0));
+    EXPECT_EQ(0.0, cvtest::norm(reference, outMat, NORM_INF));
+}
+
 
 TEST(Imgproc_GetAffineTransform, singularity)
 {


### PR DESCRIPTION
Fixes #28943

### Summary

This fixes signed integer overflow in the scalar tail paths of `cv::hal::warpAffineBlockline` and `cv::hal::warpAffineBlocklineNN`.

`X0`, `Y0`, `adelta[x]`, and `bdelta[x]` are individually clamped to `int`, but the scalar fallback added those values with signed `int` arithmetic before shifting. With extreme affine coefficients, both operands can be near `INT_MIN`, making the addition undefined behavior.

### Changes

- Promotes scalar-tail coordinate additions to `int64` before shifting.
- Applies the same fix to the nearest-neighbor scalar tail.
- Adds a regression test for issue #28943 covering both `INTER_CUBIC` and `INTER_NEAREST`.

### Validation

All listed checks passed locally:

- `cmake --build build-suhas-imgproc --config Release --target opencv_test_imgproc --parallel 4`
- `build-suhas-imgproc\bin\Release\opencv_test_imgproc.exe --gtest_filter=Imgproc_Warp.regression_28943`
- `build-suhas-imgproc\bin\Release\opencv_test_imgproc.exe --gtest_filter=Imgproc_Warp.regression_19566:Imgproc_Warp.regression_28554:Imgproc_Warp.multichannel`
- `git diff --check`

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch.
- [x] There is a reference to the original bug report and related work.
- [x] There is an accuracy/regression test where applicable; no opencv_extra test data is needed.
- [x] Documentation/sample update is not required because this is an internal bug fix with no public API change.