### PR TITLE
3rdparty(mlas): fix MinGW build by guarding aligned scratch buffer on _WIN32

### DIFF
--- a/3rdparty/mlas/lib/mlasi.h
+++ b/3rdparty/mlas/lib/mlasi.h
@@ -48,6 +48,7 @@ Abstract:
 #endif
 #include <windows.h>
 #include <intrin.h>
+#include <malloc.h>
 #else
 #if defined(__arm__) || defined(__aarch64__)
 #include <arm_neon.h>
@@ -3014,7 +3015,7 @@ MlasReadTimeStampCounter(void)
 
 constexpr size_t ThreadedBufAlignment = 64;
 extern thread_local size_t ThreadedBufSize;
-#ifdef _MSC_VER
+#ifdef _WIN32
 extern thread_local std::unique_ptr<uint8_t, decltype(&_aligned_free)> ThreadedBufHolder;
 #else
 extern thread_local std::unique_ptr<uint8_t, decltype(&free)> ThreadedBufHolder;
@@ -3034,7 +3035,7 @@ void
 MlasThreadedBufAlloc(size_t size)
 {
     if (size > ThreadedBufSize) {
-#ifdef _MSC_VER
+#ifdef _WIN32
         ThreadedBufHolder.reset(
             reinterpret_cast<uint8_t*>(_aligned_malloc(size, ThreadedBufAlignment)));
 #elif (__STDC_VERSION__ >= 201112L) && !defined(__APPLE__)

--- a/3rdparty/mlas/lib/platform.cpp
+++ b/3rdparty/mlas/lib/platform.cpp
@@ -1088,7 +1088,7 @@ MlasPlatformU8S8Overflow(
 
 #endif
 thread_local size_t ThreadedBufSize = 0;
-#ifdef _MSC_VER
+#ifdef _WIN32
 thread_local std::unique_ptr<uint8_t, decltype(&_aligned_free)> ThreadedBufHolder(nullptr, &_aligned_free);
 #else
 thread_local std::unique_ptr<uint8_t, decltype(&free)> ThreadedBufHolder(nullptr, &free);


### PR DESCRIPTION
### Summary

Fixes #29350.

On MinGW (and other non-MSVC Windows toolchains) the build fails in the
vendored MLAS code with:

mlasi.h: In function 'void MlasThreadedBufAlloc(size_t)':
mlasi.h:3046:19: error: 'posix_memalign' was not declared in this scope

`MlasThreadedBufAlloc()` and its `ThreadedBufHolder` selected the aligned
allocator with `#ifdef _MSC_VER`. MinGW does not define `_MSC_VER`, and the
C11 `aligned_alloc` branch is gated on `__STDC_VERSION__` (undefined in C++
translation units), so the code fell through to `posix_memalign()` — which the
Windows CRT does not provide.

### Changes

Guard the GEMM-packing aligned scratch buffer (`ThreadedBufHolder` /
`MlasThreadedBufAlloc`) on `_WIN32` instead of `_MSC_VER`, in both the holder
declaration (`lib/mlasi.h`) and its definition (`lib/platform.cpp`) so the
`unique_ptr` deleter type stays consistent across translation units.

Rationale (previously inline comments, moved here at review request):
- `_aligned_malloc` / `_aligned_free` are the right aligned allocator on every
  Windows toolchain, not just MSVC. `posix_memalign` is not available in the
  Windows CRT, and `aligned_alloc` blocks must be freed with `free()`, which the
  Windows CRT cannot do for aligned memory.
- `<malloc.h>` is included on Windows because MSVC pulls the `_aligned_*`
  declarations in transitively via `<memory>`, but MinGW only exposes them
  through `<malloc.h>`.

The non-Windows `aligned_alloc` / `posix_memalign` fallback is unchanged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`5.x`)
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be demonstrated to work.