### PR TITLE
core(ocl): fix out-of-bounds read and SIGFPE in predictOptimalVectorWidth for new depths

### DIFF
--- a/modules/core/src/ocl.cpp
+++ b/modules/core/src/ocl.cpp
@@ -7229,10 +7229,17 @@ int predictOptimalVectorWidth(InputArray src1, InputArray src2, InputArray src3,
 {
     const ocl::Device & d = ocl::Device::getDefault();
 
-    int vectorWidths[] = { d.preferredVectorWidthChar(), d.preferredVectorWidthChar(),
-        d.preferredVectorWidthShort(), d.preferredVectorWidthShort(),
-        d.preferredVectorWidthInt(), d.preferredVectorWidthFloat(),
-        d.preferredVectorWidthDouble(), d.preferredVectorWidthHalf() };
+    // Indexed by depth: must span CV_DEPTH_MAX. bf16 has no OpenCL vector type.
+    int vectorWidths[CV_DEPTH_MAX] = {
+        d.preferredVectorWidthChar(), d.preferredVectorWidthChar(),   // CV_8U,  CV_8S
+        d.preferredVectorWidthShort(), d.preferredVectorWidthShort(), // CV_16U, CV_16S
+        d.preferredVectorWidthInt(), d.preferredVectorWidthFloat(),   // CV_32S, CV_32F
+        d.preferredVectorWidthDouble(), d.preferredVectorWidthHalf(), // CV_64F, CV_16F
+        1,                                                            // CV_16BF
+        d.preferredVectorWidthChar(),                                 // CV_Bool
+        d.preferredVectorWidthLong(), d.preferredVectorWidthLong(),   // CV_64U, CV_64S
+        d.preferredVectorWidthInt()                                   // CV_32U
+    };
 
     // if the device says don't use vectors
     if (vectorWidths[0] == 1)

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -2124,6 +2124,30 @@ OCL_TEST(Normalize, DISABLED_regression_5876_inplace_change_type)
     EXPECT_EQ(0, cvtest::norm(um, uresult, NORM_INF));
 }
 
+// Regression: predictOptimalVectorWidth() must handle every depth without
+// reading past its per-depth table.
+OCL_TEST(Arithm, predictOptimalVectorWidth_all_depths)
+{
+    if (!cv::ocl::useOpenCL())
+        return;
+
+    const int depths[] = { CV_8U, CV_8S, CV_16U, CV_16S, CV_32S, CV_32F, CV_64F,
+                           CV_16F, CV_16BF, CV_Bool, CV_64U, CV_64S, CV_32U };
+    for (size_t i = 0; i < sizeof(depths) / sizeof(depths[0]); ++i)
+    {
+        const int depth = depths[i];
+        for (int cn = 1; cn <= 4; ++cn)
+        {
+            const int type = CV_MAKE_TYPE(depth, cn);
+            UMat a(11, 13, type), b(11, 13, type);
+            EXPECT_GE(cv::ocl::predictOptimalVectorWidth(a), 1)
+                << "depth=" << depth << " cn=" << cn;
+            EXPECT_GE(cv::ocl::predictOptimalVectorWidth(a, b), 1)
+                << "depth=" << depth << " cn=" << cn;
+        }
+    }
+}
+
 } } // namespace opencv_test::ocl
 
 #endif // HAVE_OPENCL


### PR DESCRIPTION
predictOptimalVectorWidth() built its `vectorWidths` table with exactly 8 entries (depths CV_8U..CV_16F). checkOptimalVectorWidth() indexes it by depth via `vectorWidths[cdepth]`. The 5.x depth enum added CV_16BF(8), CV_Bool(9), CV_64U(10), CV_64S(11) and CV_32U(12), so for those depths the lookup reads past the end of the array.

The out-of-bounds value can be positive (slipping past the `ckercn <= 0` scalar-fallback guard) and not a power of two, after which the divider normalization loop shifts the divider to zero and `offsets[i] % dividers[i]` raises SIGFPE. Because the value comes from the stack, the failure is allocation dependent and shows up as a sequence-dependent crash, e.g. in the OpenCL Norm tests for CV_32U (cv::norm on a UMat reaches this code through ocl_sum, which calls predictOptimalVectorWidth before its own depth guard bails out).

Fix: size the table to CV_DEPTH_MAX so every valid depth is in bounds, and give the new fixed-size integer depths their natural OpenCL vector widths (uint/ulong/long/uchar); CV_16BF has no OpenCL vector type and stays scalar. The initializers for the existing 8 depths are unchanged.

Adds a regression test (OCL_Arithm.predictOptimalVectorWidth_all_depths) exercising every depth, including the 5.x additions.

Closes #29355.

#### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable: the test requires only an OpenCL device; no opencv_extra data is needed.
