### PR TITLE
Define MlasGemmSupported under MLAS_GEMM_ONLY

### DIFF
--- a/3rdparty/mlas/lib/platform.cpp
+++ b/3rdparty/mlas/lib/platform.cpp
@@ -420,6 +420,17 @@ MLAS_PLATFORM::MLAS_PLATFORM(void)
     // calls MlasSgemmKernelZero / MlasSgemmKernelAdd directly without going
     // through GetMlasPlatform().GemmFloatKernel.
 }
+
+// FP16 HGemm kernels aren't vendored (MLAS_GEMM_ONLY) but compute.cpp references this probe; define it so static links resolve. See opencv/opencv#29342.
+bool
+MLASCALL
+MlasHGemmSupported(
+    CBLAS_TRANSPOSE /*TransA*/,
+    CBLAS_TRANSPOSE /*TransB*/
+    )
+{
+    return false;
+}
 #else  // !MLAS_GEMM_ONLY
 MLAS_PLATFORM::MLAS_PLATFORM(
     void
@@ -881,7 +892,7 @@ Return Value:
         }
         else{
             this->ErfFP16KernelRoutine = MlasNeonErfFP16Kernel;
-            this->GeluFP16KernelRoutine = MlasNeonGeluFP16Kernel; 
+            this->GeluFP16KernelRoutine = MlasNeonGeluFP16Kernel;
         }
     #else
         this->ErfFP16KernelRoutine = MlasNeonErfFP16Kernel;


### PR DESCRIPTION
Closes : [29342](https://github.com/opencv/opencv/issues/29342)

**Cause.** The vendored MLAS subset (`MLAS_GEMM_ONLY`) imports `lib/compute.cpp` whole, whose
`MlasGQASupported<MLAS_FP16>` specialization references `MlasHGemmSupported`. That function is
declared in `inc/mlas.h` but defined only in the FP16 HGemm kernel sources, which are intentionally
not vendored , so the symbol is referenced but never defined. Shared builds hide it because their
link uses `--gc-sections` (drops the unused FP16 path); static links must resolve it and fail.

**Fix.** Define `MlasHGemmSupported()` to return `false` in the existing `MLAS_GEMM_ONLY` block of
`platform.cpp`.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
