### PR TITLE
core: fix FileStorage round-trip of integer-valued doubles above INT_MAX 🧑‍💻🤖

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -109,6 +109,17 @@ char* doubleToString( char* buf, size_t bufSize, double value, bool explicitZero
                 ;
             if( *ptr == ',' )
                 *ptr = '.';
+            else if( *ptr == '\0' && (size_t)(ptr - buf) + 3 < bufSize )
+            {
+                // "%g" printed a whole number with no '.' or exponent. This happens
+                // for integer-valued doubles above INT_MAX (e.g. 6662329666); left as
+                // a bare integer the value is read back as an overflowed int, so make
+                // it an unambiguous real, mirroring the "%d."/"%d.0" branch above.
+                *ptr++ = '.';
+                if( explicitZero )
+                    *ptr++ = '0';
+                *ptr = '\0';
+            }
         }
     }
     else

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2152,6 +2152,26 @@ TEST_P(FileStorage_exact_type, long_int)
     }
 }
 
+TEST_P(FileStorage_exact_type, large_real_29363)
+{
+    // Regression #29363: whole-number reals above INT_MAX were serialized without a
+    // decimal point or exponent (e.g. "6662329666") and then read back as an
+    // overflowed 32-bit int. They must round-trip exactly.
+    for (const double expected : std::vector<double>{
+            6662329666.0, 3366945464.0, 45054241452.0,
+            2147483648.0 /* INT_MAX+1 */, 4294967296.0 /* 2^32 */, -9876543210.0, 1.5e20 })
+    {
+        const double value = fsWriteRead(expected, GetParam());
+        EXPECT_EQ(value, expected) << "ext=" << GetParam();
+    }
+    // Scalar floats are written through doubleToString (writeScalar casts to double).
+    for (const float expected : std::vector<float>{ 2147483648.0f, 3000000000.0f, 4000000000.0f })
+    {
+        const float value = fsWriteRead(expected, GetParam());
+        EXPECT_EQ(value, expected) << "ext=" << GetParam();
+    }
+}
+
 INSTANTIATE_TEST_CASE_P(Core_InputOutput,
     FileStorage_exact_type, Values(".yml", ".xml", ".json", ".xml.gz", ".xml.gz0", ".xml.gz9")
 );


### PR DESCRIPTION
### Summary

`cv::FileStorage` cannot round-trip a whole-number `double` whose magnitude
exceeds `INT_MAX` (and is below `2^53`, where doubles are still exact integers).
A value written by `FileStorage` itself is read back as a different, overflowed
number — silently, with no error. This surfaced in opencv/opencv#29272, where a
64-bit `sqsum` max of `6662329666` was stored by `--perf_write_sanity` and read
back as `-1927604926`. Reported as #29363.

### Root cause

`doubleToString()` in `modules/core/src/persistence.cpp`:

```cpp
int ivalue = cvRound(value);          // cvRound returns int (32-bit)
if( ivalue == value )
    snprintf( buf, bufSize, "%d.", ivalue );   // whole number <= INT_MAX -> trailing dot
else
    snprintf( buf, bufSize, "%.17g", value );  // everything else
```

For a whole number above `INT_MAX`, e.g. `6662329666.0`:

1. `cvRound()` overflows `int32`, so `ivalue == value` is false and the `"%d."`
   branch (which appends the decimal point) is skipped.
2. The `"%.17g"` fallback prints a whole number in `[INT_MAX, 1e17)` **without a
   decimal point and without an exponent** → `6662329666`.
3. On read-back the parser sees a token with no `.` and no exponent, classifies
   it as an integer, and parses it into a 32-bit int → it overflows to
   `-1927604926` (`= 6662329666 & 0xFFFFFFFF`).

So the write side preserves the value in text, but that text is ambiguous and the
read side re-types it as `int32`. The boundary is exactly `INT_MAX`: values
`<= INT_MAX` are written as `"N."` (dotted) and round-trip; values `> INT_MAX` are
written dotless and corrupt. Affects XML and YAML; JSON likewise wrote a bare
integer.

### Fix

In the `"%g"` fallback, when the output came out as a bare integer (no `.` and no
exponent), append a decimal point so the value is unambiguously a real — `".0"`
for JSON (which requires a digit after the point) and `"."` for XML/YAML, mirroring
the existing `"%d."`/`"%d.0"` path used for small whole numbers:

```
6662329666  ->  6662329666.   (XML/YAML)   /   6662329666.0   (JSON)
```

These read back exactly.

### `floatToString` is not affected

`floatToString()` uses `"%.9g"`. Every whole `float` above `INT_MAX` has exponent
`>= 9`, which equals the precision, so `"%g"` always emits it in scientific
notation (`3e+09`) — never as a dotless integer. Scalar floats are written through
`doubleToString()` anyway (`writeScalar(float)` casts to `double`). So no change is
needed there, and only `doubleToString()` is touched.

### Test

Adds `large_real_29363` to `modules/core/test/test_io.cpp` — a write→read
round-trip over the existing `FileStorage_exact_type` parameter set (`.xml`,
`.yml`, `.json`, `.xml.gz`, `.xml.gz0`, `.xml.gz9`) for whole-number doubles and
floats above `INT_MAX`. It fails before this fix and passes after.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work (#29363)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable — self-contained regression test in `modules/core/test/test_io.cpp`; no opencv_extra data required
- [ ] The feature is well documented and sample code can be built with the project CMake — N/A (bug fix, no new API)
