### PR TITLE
Remove leftover fcvtns assembly

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_neon.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_neon.hpp
@@ -2252,14 +2252,7 @@ inline v_int32x4 v_round(const v_float32x4& a)
 {
     float32x4_t a_ = a.val;
     int32x4_t result;
-#if defined _MSC_VER
     result = vcvtnq_s32_f32(a_);
-#else
-    __asm__ ("fcvtns %0.4s, %1.4s"
-             : "=w"(result)
-             : "w"(a_)
-             : /* No clobbers */);
-#endif
     return v_int32x4(result);
 }
 #else


### PR DESCRIPTION
Nothing in the history justifies this. It can trigger some memory sanitizer that do not support raw assembly.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
