### PR TITLE
core: FileStorage reads integers above INT_MAX into float/double without truncation 🧑‍💻🤖

### DIFF
--- a/modules/core/src/persistence.cpp
+++ b/modules/core/src/persistence.cpp
@@ -2376,7 +2376,7 @@ FileNode::operator float() const
 
     if( type == INT )
     {
-        return (float)readInt(p);
+        return (float)readLong(p);
     }
     else if( type == REAL )
     {
@@ -2397,7 +2397,7 @@ FileNode::operator double() const
 
     if( type == INT )
     {
-        return (double)readInt(p);
+        return (double)readLong(p);
     }
     else if( type == REAL )
     {

--- a/modules/core/test/test_io.cpp
+++ b/modules/core/test/test_io.cpp
@@ -2099,6 +2099,24 @@ TEST(Core_InputOutput, FileStorage_int64_26829)
     }
 }
 
+TEST(Core_InputOutput, FileStorage_read_bigint_as_real_29363)
+{
+    // An integer above INT_MAX (e.g. from externally-produced json/yaml/xml) must
+    // convert to float/double without truncating to int32. Regression for #29363.
+    String content =
+        "%YAML:1.0\n"
+        "a: 6662329666\n"   // ~6.6e9, exact in double
+        "b: -9876543210\n"
+        "c: 4294967296\n";  // 2^32, exact in double and float
+    FileStorage fs(content, FileStorage::READ | FileStorage::MEMORY);
+
+    EXPECT_EQ(6662329666.0,  (double)fs["a"]);
+    EXPECT_EQ(-9876543210.0, (double)fs["b"]);
+    EXPECT_EQ(4294967296.0,  (double)fs["c"]);
+    EXPECT_EQ(4294967296.0f, (float)fs["c"]);
+    EXPECT_EQ((int64_t)6662329666LL, (int64_t)fs["a"]);  // int64 path unchanged
+}
+
 template <typename T>
 T fsWriteRead(const T& expectedValue, const char* ext)
 {


### PR DESCRIPTION
### Summary

`cv::FileStorage` reads an integer above `INT_MAX` into a `float`/`double` as an
**overflowed int32**. For example an integer `6662329666` in a `.json`/`.yaml`/`.xml`
file (e.g. one produced by an external Python/JS writer) is read back as
`-1927604926` when accessed as a real:

```cpp
FileStorage fs(file, FileStorage::READ);
double v = (double)fs["x"];   // x = 6662329666  ->  v = -1927604926
```

### Root cause

A `FileNode` stores an integer payload as `int64` (8 bytes), and
`FileNode::operator int64_t()` reads it correctly via `readLong()`. But
`operator double()` and `operator float()` read it via `readInt()` (32-bit):

```cpp
FileNode::operator double() const {
    ...
    if( type == INT )
        return (double)readInt(p);   // low 32 bits only -> truncates values > INT_MAX
    ...
}
```

So the full value is present in the node but discarded during the floating-point
conversion. (`setValue()` reserves 8 bytes for an INT node and stores the full
`int64`, so reading it as `int64` is always valid.)

### Fix

Use `readLong()` in `operator double()` and `operator float()`, matching
`operator int64_t()`. For values that fit in `int32` the result is unchanged (the
`int64` is sign-extended); larger values are now read correctly. `operator int()`
is intentionally left as `readInt()` — truncation is expected when reading into a
32-bit `int`.

### Test

Adds `FileStorage_read_bigint_as_real_29363` to `modules/core/test/test_io.cpp`:
reads integers above `INT_MAX` from an in-memory store and checks the
`double`/`float` conversions are not truncated, while small values and the `int64`
path are unaffected. Fails before the fix, passes after.

### Note

This is the **reader** side of #29363. The **writer** side (FileStorage emitting a
dotless whole-number real that read back as int32) was handled in #29364; this PR
additionally covers integers above `INT_MAX` arriving from external producers,
which the writer-side change cannot.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work (#29363, #29364)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable — self-contained regression test in `modules/core/test/test_io.cpp`; no opencv_extra data required
- [ ] The feature is well documented and sample code can be built with the project CMake — N/A (bug fix, no new API)
