### PR TITLE
check parameter tensor length in tflite parsePadding and parseResize

### DIFF
--- a/modules/dnn/src/tflite/tflite_importer.cpp
+++ b/modules/dnn/src/tflite/tflite_importer.cpp
@@ -529,16 +529,19 @@ void TFLiteImporter::parsePadding(const Operator& op, const std::string& opcode,
     Mat paddings = allTensors[op.inputs()->Get(1)].clone();
 
     CV_CheckTypeEQ(paddings.type(), CV_32S, "");
-    //  N    H    W    C
-    // 0 1  2 3  4 5  6 7
-    std::swap(paddings.at<int32_t>(2), paddings.at<int32_t>(6));
-    std::swap(paddings.at<int32_t>(3), paddings.at<int32_t>(7));
-    //  N    C    W    H
-    // 0 1  2 3  4 5  6 7
-    std::swap(paddings.at<int32_t>(4), paddings.at<int32_t>(6));
-    std::swap(paddings.at<int32_t>(5), paddings.at<int32_t>(7));
-    //  N    C    H    W
-    // 0 1  2 3  4 5  6 7
+    if (paddings.total() == 8)
+    {
+        //  N    H    W    C
+        // 0 1  2 3  4 5  6 7
+        std::swap(paddings.at<int32_t>(2), paddings.at<int32_t>(6));
+        std::swap(paddings.at<int32_t>(3), paddings.at<int32_t>(7));
+        //  N    C    W    H
+        // 0 1  2 3  4 5  6 7
+        std::swap(paddings.at<int32_t>(4), paddings.at<int32_t>(6));
+        std::swap(paddings.at<int32_t>(5), paddings.at<int32_t>(7));
+        //  N    C    H    W
+        // 0 1  2 3  4 5  6 7
+    }
 
     layerParams.set("paddings", DictValue::arrayInt<int32_t*>((int32_t*)paddings.data, paddings.total()));
     addLayer(layerParams, op);
@@ -828,6 +831,7 @@ void TFLiteImporter::parseResize(const Operator& op, const std::string& opcode, 
         layerParams.set("half_pixel_centers", options->half_pixel_centers());
     }
     Mat shape = allTensors[op.inputs()->Get(1)].reshape(1, 1);
+    CV_CheckGE(shape.total(), (size_t)2, "TFLite Resize: size tensor must hold height and width");
     layerParams.set("height", shape.at<int>(0, 0));
     layerParams.set("width", shape.at<int>(0, 1));
     addLayer(layerParams, op);


### PR DESCRIPTION
parsePadding and parseResize index a parameter tensor from the model at fixed positions after checking only its element type. parsePadding swaps `paddings.at<int32_t>(2..7)` to reorder NHWC to NCHW, which assumes eight values, and parseResize reads height and width from `shape.at<int>(0,0)` and `(0,1)`, which assumes two. A `.tflite` whose PAD paddings tensor has fewer than eight ints, or whose RESIZE size tensor has fewer than two, runs those reads (and, in parsePadding, the swap writes) past the tensor buffer in `readNetFromTFLite`.

parseStridedSlice already gates the same NHWC reorder behind `begins.total() == 4`, so this matches the two siblings to it: the parsePadding swaps now run only when `paddings.total() == 8`, and parseResize requires the size tensor to carry at least two elements. The tradeoff is that a non-eight-element paddings tensor keeps its original order instead of being reordered, which is the safe choice since the reorder is defined only for the 4D NHWC case; doing the check at the read site keeps each layer from trusting the count.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake
