### PR TITLE
Disable several HAL cases for cv_hal_meanStdDev

### DIFF
--- a/hal/ipp/include/ipp_hal_core.hpp
+++ b/hal/ipp/include/ipp_hal_core.hpp
@@ -12,8 +12,10 @@
 int ipp_hal_meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                        double* mean_val, double* stddev_val, uchar* mask, size_t mask_step);
 
-#undef cv_hal_meanStdDev
-#define cv_hal_meanStdDev ipp_hal_meanStdDev
+// IPP version is less efficient than implementation with universtal intrinsics
+// See https://github.com/opencv/opencv/pull/29339
+//#undef cv_hal_meanStdDev
+//#define cv_hal_meanStdDev ipp_hal_meanStdDev
 
 int ipp_hal_minMaxIdxMaskStep(const uchar* src_data, size_t src_step, int width, int height, int depth,
                               double* _minVal, double* _maxVal, int* _minIdx, int* _maxIdx, uchar* mask, size_t mask_step);

--- a/hal/riscv-rvv/src/core/mean.cpp
+++ b/hal/riscv-rvv/src/core/mean.cpp
@@ -19,6 +19,14 @@ inline int meanStdDev_32FC1(const uchar* src_data, size_t src_step, int width, i
 
 int meanStdDev(const uchar* src_data, size_t src_step, int width, int height, int src_type,
                double* mean_val, double* stddev_val, uchar* mask, size_t mask_step) {
+
+    // NOTE: The OpenCV imlementation with universal intrinscs is more efficient
+    // See https://github.com/opencv/opencv/pull/29339#issuecomment-4778104352
+    if (!mask && !stddev_val)
+    {
+        return CV_HAL_ERROR_NOT_IMPLEMENTED;
+    }
+
     switch (src_type)
     {
     case CV_8UC1:


### PR DESCRIPTION
See performance reports in https://github.com/opencv/opencv/pull/29339

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

