### PR TITLE
core: fix signed integer overflow in borderInterpolate BORDER_WRAP

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -938,7 +938,11 @@ int cv::borderInterpolate( int p, int len, int borderType )
     {
         CV_Assert(len > 0);
         if( p < 0 )
-            p -= ((p-len+1)/len)*len;
+        {
+            int64_t p64 = p;
+            int64_t len64 = len;
+            p = (int)(p64 - ((p64 - len64 + 1) / len64) * len64);
+        }
         if( p >= len )
             p %= len;
     }

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -218,6 +218,20 @@ TEST(Core_Copy, repeat_regression_8972)
                      });
 }
 
+TEST(Core_Copy, borderInterpolate_overflow_wrap)
+{
+    EXPECT_NO_THROW({
+        int val = cv::borderInterpolate(INT_MIN, 10, cv::BORDER_WRAP);
+        EXPECT_GE(val, 0);
+        EXPECT_LT(val, 10);
+    });
+    EXPECT_NO_THROW({
+        int val = cv::borderInterpolate(INT_MIN + 1, 10, cv::BORDER_WRAP);
+        EXPECT_GE(val, 0);
+        EXPECT_LT(val, 10);
+    });
+}
+
 
 class ThrowErrorParallelLoopBody : public cv::ParallelLoopBody
 {

--- a/modules/ts/src/ts_func.cpp
+++ b/modules/ts/src/ts_func.cpp
@@ -879,7 +879,11 @@ static int borderInterpolate( int p, int len, int borderType )
     else if( borderType == BORDER_WRAP )
     {
         if( p < 0 )
-            p -= ((p-len+1)/len)*len;
+        {
+            int64_t p64 = p;
+            int64_t len64 = len;
+            p = (int)(p64 - ((p64 - len64 + 1) / len64) * len64);
+        }
         if( p >= len )
             p %= len;
     }


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or 
      another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (4.x)
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, 
      if applicable. Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Description

Fixes #29232

Signed integer overflow (UB) occurs in `cv::borderInterpolate` when 
`borderType == BORDER_WRAP` and `p` is near `INT_MIN`. The expression 
`p - len + 1` underflows before the division, triggering UBSan.

**Fix:** Cast intermediate arithmetic to `long long` before dividing, 
then cast the result back to `int`.

**Tests added:** `Core_Copy.borderInterpolate_overflow_wrap` in 
`modules/core/test/test_misc.cpp` — both new and existing tests pass.