### PR TITLE
Fix js ximgproc edge drawing

### DIFF
--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -348,7 +348,8 @@ class JSWrapperGenerator(object):
         inner = ret_type[len('Ptr<'):-1].strip()
         if '::' in inner:
             return ret_type
-        if inner == class_info.name:
+        class_basename = class_info.cname.split('::')[-1]
+        if inner == class_info.name or inner == class_basename:
             return 'Ptr<%s>' % class_info.cname
         return ret_type
 

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -348,8 +348,7 @@ class JSWrapperGenerator(object):
         inner = ret_type[len('Ptr<'):-1].strip()
         if '::' in inner:
             return ret_type
-        class_basename = class_info.cname.split('::')[-1]
-        if inner == class_info.name or inner == class_basename:
+        if inner == class_info.name or inner == class_info.cname.split('::')[-1]:
             return 'Ptr<%s>' % class_info.cname
         return ret_type
 

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -342,6 +342,18 @@ class JSWrapperGenerator(object):
         }
         return tp in string_types
 
+    def _qualify_factory_ptr_return_type(self, ret_type, class_info):
+        if class_info is None:
+            return ret_type
+        if not ret_type.startswith('Ptr<') or not ret_type.endswith('>'):
+            return ret_type
+        inner = ret_type[len('Ptr<'):-1].strip()
+        if '::' in inner:
+            return ret_type
+        if inner == class_info.name:
+            return 'Ptr<%s>' % class_info.cname
+        return ret_type
+
     def _generate_class_properties(self, class_info, class_bindings):
         # Generate bindings for properties
         for prop in class_info.props:

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -535,12 +535,8 @@ class JSWrapperGenerator(object):
 
             # Return type
             ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
-            # FIX: Ensure namespaced smart-pointer return types in factory methods, e.g.:
-            #      Ptr<EdgeDrawing> → Ptr<cv::ximgproc::EdgeDrawing>
             if factory and class_info is not None and ret_type.startswith('Ptr<'):
-                inner = ret_type[len('Ptr<'):-1].strip()
-                if '::' not in inner and inner == class_info.name:
-                    ret_type = 'Ptr<%s>' % class_info.cname
+                ret_type = self._qualify_factory_ptr_return_type(ret_type, class_info)
 
             if ret_type.startswith('Ptr'):  # smart pointer
                 ptr_type = ret_type.replace('Ptr<', '').replace('>', '')

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -723,11 +723,8 @@ class JSWrapperGenerator(object):
             ret_type = 'void' if variant.rettype.strip() == '' else variant.rettype
 
             ret_type = ret_type.strip()
-            # Same namespace fix for factory methods: Ptr<EdgeDrawing> -> Ptr<cv::ximgproc::EdgeDrawing>
             if factory and class_info is not None and ret_type.startswith('Ptr<'):
-                inner = ret_type[len('Ptr<'):-1].strip()
-                if '::' not in inner and inner == class_info.name:
-                    ret_type = 'Ptr<%s>' % class_info.cname
+                ret_type = self._qualify_factory_ptr_return_type(ret_type, class_info)
 
             if ret_type.startswith('Ptr'): #smart pointer
                 ptr_type = ret_type.replace('Ptr<', '').replace('>', '')

--- a/modules/js/generator/embindgen.py
+++ b/modules/js/generator/embindgen.py
@@ -343,9 +343,7 @@ class JSWrapperGenerator(object):
         return tp in string_types
 
     def _qualify_factory_ptr_return_type(self, ret_type, class_info):
-        if class_info is None:
-            return ret_type
-        if not ret_type.startswith('Ptr<') or not ret_type.endswith('>'):
+        if class_info is None or not ret_type.startswith('Ptr<') or not ret_type.endswith('>'):
             return ret_type
         inner = ret_type[len('Ptr<'):-1].strip()
         if '::' in inner:


### PR DESCRIPTION
## Summary

This PR fixes OpenCV.js binding generation for factory functions that return `cv::Ptr<T>` where `T` is a namespaced class exported with a module-prefixed JavaScript binding name.

The failure is reproduced with OpenCV.js plus `opencv_contrib/modules/ximgproc`. The generated binding for `cv::ximgproc::EdgeDrawing` currently contains:

```cpp
.constructor(select_overload<Ptr<EdgeDrawing>()>(&cv::ximgproc::createEdgeDrawing))
```

but `EdgeDrawing` is not available in the generated C++ scope as an unqualified type. The generated constructor should use:

```cpp
.constructor(select_overload<Ptr<cv::ximgproc::EdgeDrawing>()>(&cv::ximgproc::createEdgeDrawing))
```

## Related issues

Fixes opencv/opencv_contrib#4161.

Related to #27963, #28130, and #28143.

#28143 added namespace qualification for factory `Ptr<...>` return types when the inner `Ptr` type matches the generator class key. The remaining `ximgproc::EdgeDrawing` case is different:

```text
inner Ptr type:      EdgeDrawing
generator class key: ximgproc_EdgeDrawing
C++ class name:      cv::ximgproc::EdgeDrawing
```

Because `EdgeDrawing` does not match `ximgproc_EdgeDrawing`, the previous condition does not handle this case.

## Fix approach

The JS generator now centralizes factory `Ptr<...>` return-type qualification in a helper used by both generator paths:

* `gen_function_binding_with_wrapper`
* `gen_function_binding`

The helper keeps the existing behavior for already qualified types and for the existing class-key match. It additionally handles the case where the inner `Ptr` type matches the basename of the C++ class name:

```text
cv::ximgproc::EdgeDrawing -> EdgeDrawing
```

This allows the generator to emit `Ptr<cv::ximgproc::EdgeDrawing>` for `createEdgeDrawing()` without changing generated files directly.

## Necessity as an opencv code change

The failing API is exposed by `opencv_contrib/modules/ximgproc`, but the invalid C++ line is emitted by OpenCV core's JavaScript binding generator in `modules/js/generator/embindgen.py`.

A contrib-only workaround would have to change the `ximgproc` public declaration or special-case the JS export list for `createEdgeDrawing`. That would only work around one symbol and would not fix the generator's handling of namespaced factory `Ptr` return types. The generator already has the class metadata needed to produce the correct fully qualified C++ type, so the fix belongs in OpenCV core.

## Verification

Tested with:

* OpenCV core `4.x`
* opencv_contrib `4.x`
* Emscripten `6.0.1`
* CMake generator: Ninja
* Build list: `core,imgproc,imgcodecs,video,calib3d,ximgproc,js`

Generator target:

```bash
emcmake cmake \
  -S /path/to/opencv \
  -B /path/to/build \
  -G Ninja \
  -DCMAKE_BUILD_TYPE=Release \
  -DCMAKE_CXX_STANDARD=17 \
  -DOPENCV_EXTRA_MODULES_PATH=/path/to/opencv_contrib/modules \
  -DBUILD_LIST=core,imgproc,imgcodecs,video,calib3d,ximgproc,js \
  -DBUILD_SHARED_LIBS=OFF \
  -DBUILD_opencv_js=ON \
  -DBUILD_TESTS=OFF \
  -DBUILD_PERF_TESTS=OFF \
  -DBUILD_EXAMPLES=OFF \
  -DBUILD_DOCS=OFF

ninja -C /path/to/build gen_opencv_js_source
```

This generated the expected binding:

```cpp
.constructor(select_overload<Ptr<cv::ximgproc::EdgeDrawing>()>(&cv::ximgproc::createEdgeDrawing))
.smart_ptr<Ptr<cv::ximgproc::EdgeDrawing>>("Ptr<ximgproc_EdgeDrawing>")
```

The same patch was also verified with the full OpenCV.js target:

```bash
ninja -C /path/to/build opencv.js
```
