### PR TITLE
objdetect: rescue valid Charuco boards under tough perspective (#25850)

### DIFF
--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -80,6 +80,82 @@ struct CharucoDetector::CharucoDetectorImpl {
         return true;
     }
 
+    /** Verify the detected board against the MARKERS (not the interpolated chessboard corners).
+     *
+     * checkBoard() compares raw pixel distances of interpolated charuco corners, which assumes a
+     * near-orthographic view and false-rejects valid boards under strong perspective (issue #25850).
+     * Re-deriving a geometric test from the charuco corners is circular: those corners are produced
+     * from the board model, so under a camera pose they are a single-plane projection that fits any
+     * homography. The markers, in contrast, carry absolute identity (their ArUco ids) and image
+     * positions independent of the board layout, so they discriminate a wrong board where corner
+     * geometry cannot.
+     *
+     * Two signals, both required to keep:
+     *  - Completeness: every detected board-dictionary marker must belong to the configured board.
+     *    A wrong-size/transposed board leaves "orphan" markers whose ids are outside its layout.
+     *  - Planar consistency: the configured object positions of the matched markers must fit one
+     *    homography to their detected image corners with small reprojection error. A wrong board
+     *    that happens to have no orphans (e.g. a strict sub-grid sharing an id range) still fails
+     *    this because its object<->image marker correspondences are inconsistent.
+     *
+     * Additive rescue: returns true only on a confident match; abstains (false) on too few markers
+     * or a failed fit, leaving checkBoard()'s verdict in place. */
+    bool checkBoardWithMarkers(InputArrayOfArrays markerCorners, InputArray markerIds) {
+        const float reprojThreshold = 0.10f;    // scale-relative MEAN marker-corner reprojection error
+        const float maxReprojThreshold = 0.30f; // scale-relative MAX single-corner error (anti-averaging)
+        // A homography has 8 DOF and fits any 4 generic points exactly, so very few markers can
+        // overfit. Require enough markers that the fit is over-determined and a wrong board cannot
+        // hide behind a degenerate solution.
+        const int minMarkers = 6;
+
+        vector<Mat> mCorners;
+        markerCorners.getMatVector(mCorners);
+        const Mat mIds = markerIds.getMat();
+        if (mIds.total() < (size_t)minMarkers)
+            return false;
+
+        const vector<int>& boardIds = board.getIds();
+        const vector<vector<Point3f> >& objPts3d = board.getObjPoints();
+
+        vector<Point2f> objPts, imgPts;
+        for (size_t i = 0; i < mIds.total(); i++) {
+            int id = mIds.ptr<int>(0)[i];
+            auto it = find(boardIds.begin(), boardIds.end(), id);
+            if (it == boardIds.end())
+                return false;   // orphan marker: detected id not part of this board -> wrong board
+            size_t bi = (size_t)(it - boardIds.begin());
+            for (int c = 0; c < 4; c++) {
+                objPts.push_back(Point2f(objPts3d[bi][c].x, objPts3d[bi][c].y));
+                imgPts.push_back(mCorners[i].ptr<Point2f>(0)[c]);
+            }
+        }
+        if (imgPts.size() < (size_t)minMarkers * 4)
+            return false;
+
+        Mat H = findHomography(objPts, imgPts, 0);
+        if (H.empty())
+            return false;
+        vector<Point2f> proj;
+        perspectiveTransform(objPts, proj, H);
+        Point2f centroid(0.f, 0.f);
+        for (const Point2f& p : imgPts) centroid += p;
+        centroid *= 1.f / imgPts.size();
+        double err = 0.0, maxErr = 0.0, scaleSq = 0.0;
+        for (size_t i = 0; i < imgPts.size(); i++) {
+            double e = sqrt(normL2Sqr<float>(proj[i] - imgPts[i]));
+            err += e;
+            maxErr = max(maxErr, e);
+            scaleSq += normL2Sqr<float>(imgPts[i] - centroid);
+        }
+        double scale = sqrt(scaleSq / imgPts.size());
+        if (scale < 1e-6)
+            return false;
+        // Both the mean error and the worst single-corner error must be small. The max-error cap
+        // stops a wrong board from passing by averaging one badly-placed marker corner away.
+        return (err / imgPts.size()) / scale <= reprojThreshold
+            && maxErr / scale <= maxReprojThreshold;
+    }
+
     /** Calculate the maximum window sizes for corner refinement for each charuco corner based on the distance
      * to their closest markers */
     vector<Size> getMaximumSubPixWindowSizes(InputArrayOfArrays markerCorners, InputArray markerIds,
@@ -344,7 +420,15 @@ struct CharucoDetector::CharucoDetectorImpl {
         InputOutputArrayOfArrays _markerCorners = markerCorners.needed() ? markerCorners : _InputOutputArray(tmpMarkerCorners);
         InputOutputArray _markerIds = markerIds.needed() ? markerIds : _InputOutputArray(tmpMarkerIds);
         detectBoard(image, charucoCorners, charucoIds, _markerCorners, _markerIds);
-        if (charucoParameters.checkMarkers && checkBoard(_markerCorners, _markerIds, charucoCorners, charucoIds) == false) {
+        // checkBoard()'s nearest-marker heuristic false-rejects valid boards under strong perspective
+        // (issue #25850). Rescue such a detection only if the MARKERS confirm the board: all detected
+        // markers belong to it and their object positions fit one homography. This uses marker identity
+        // (not the interpolated charuco corners, which are circular on the camera-pose path), so it
+        // still rejects wrong-size/transposed boards. checkBoardWithMarkers() abstains on weak input,
+        // so the verdict can only change from reject to keep, never the reverse.
+        if (charucoParameters.checkMarkers
+                && checkBoard(_markerCorners, _markerIds, charucoCorners, charucoIds) == false
+                && checkBoardWithMarkers(_markerCorners, _markerIds) == false) {
             CV_LOG_DEBUG(NULL, "ChArUco board is built incorrectly");
             charucoCorners.release();
             charucoIds.release();

--- a/modules/objdetect/src/aruco/charuco_detector.cpp
+++ b/modules/objdetect/src/aruco/charuco_detector.cpp
@@ -132,28 +132,39 @@ struct CharucoDetector::CharucoDetectorImpl {
         if (imgPts.size() < (size_t)minMarkers * 4)
             return false;
 
-        Mat H = findHomography(objPts, imgPts, 0);
+        vector<Point2f> points = imgPts;
+        if (!charucoParameters.cameraMatrix.empty()) {
+            undistortPoints(imgPts, points, charucoParameters.cameraMatrix,
+                            charucoParameters.distCoeffs, noArray(), charucoParameters.cameraMatrix,
+                            TermCriteria(TermCriteria::MAX_ITER | TermCriteria::EPS, 30, 1e-12));
+        }
+
+        Mat H = findHomography(objPts, points, 0);
         if (H.empty())
             return false;
         vector<Point2f> proj;
         perspectiveTransform(objPts, proj, H);
-        Point2f centroid(0.f, 0.f);
-        for (const Point2f& p : imgPts) centroid += p;
-        centroid *= 1.f / imgPts.size();
-        double err = 0.0, maxErr = 0.0, scaleSq = 0.0;
-        for (size_t i = 0; i < imgPts.size(); i++) {
-            double e = sqrt(normL2Sqr<float>(proj[i] - imgPts[i]));
-            err += e;
-            maxErr = max(maxErr, e);
-            scaleSq += normL2Sqr<float>(imgPts[i] - centroid);
+
+        double err = 0.0, maxErr = 0.0;
+        for (size_t marker = 0; marker < mIds.total(); marker++) {
+            double scale = std::numeric_limits<double>::max();
+            for (int c = 0; c < 4; c++) {
+                size_t idx = marker * 4 + c;
+                size_t nextIdx = marker * 4 + (c + 1) % 4;
+                scale = min(scale, norm(points[idx] - points[nextIdx]));
+            }
+            if (scale < 1e-6)
+                return false;
+
+            for (int c = 0; c < 4; c++) {
+                size_t idx = marker * 4 + c;
+                double e = sqrt(normL2Sqr<float>(proj[idx] - points[idx])) / scale;
+                err += e;
+                maxErr = max(maxErr, e);
+            }
         }
-        double scale = sqrt(scaleSq / imgPts.size());
-        if (scale < 1e-6)
-            return false;
-        // Both the mean error and the worst single-corner error must be small. The max-error cap
-        // stops a wrong board from passing by averaging one badly-placed marker corner away.
-        return (err / imgPts.size()) / scale <= reprojThreshold
-            && maxErr / scale <= maxReprojThreshold;
+        // Marker-relative errors do not become smaller when the board contains more markers.
+        return err / points.size() <= reprojThreshold && maxErr <= maxReprojThreshold;
     }
 
     /** Calculate the maximum window sizes for corner refinement for each charuco corner based on the distance

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -811,6 +811,85 @@ TEST_P(CharucoBoard, testWrongSizeDetection)
 }
 
 
+// Regression test for issue #25850: CharucoDetector::detectBoard() must not drop a valid board
+// seen under strong perspective. The regression is triggered specifically when a cameraMatrix and
+// distortion coefficients are supplied (the reporter's case): pose-based corner refinement then
+// shifts corners enough that the nearest-marker heuristic in checkBoard() false-rejects the board
+// and detectBoard() returns no charuco corners. The homography-consistency rescue keeps it.
+// (Mirrors the issue's exact reproducer: large image, low-focal camera matrix, small distortion,
+// and the same 4-point homography warp; without the camera matrix the bug does NOT reproduce.)
+TEST(CharucoDetection, toughPerspectiveIssue25850)
+{
+    aruco::CharucoBoard board(Size(17, 11), 8.f, 4.f, aruco::getPredefinedDictionary(aruco::DICT_5X5_100));
+    const Size imgSize(6560, 4160);
+    Mat boardImage;
+    board.generateImage(imgSize, boardImage);
+    cvtColor(boardImage, boardImage, COLOR_GRAY2BGR);
+
+    // Reporter's warp: nudge the four board-extent corners by a few pixels and warp.
+    const float bw = 136.f, bh = 88.f;
+    vector<Point2f> oldPts = { {-bw, -bh}, {bw, -bh}, {-bw, bh}, {bw, bh} };
+    vector<Point2f> newPts = { oldPts[0] + Point2f(-2.f, -2.f), oldPts[1] + Point2f(0.f, -1.f),
+                               oldPts[2] + Point2f(3.f, -0.4f), oldPts[3] };
+    Mat H = findHomography(newPts, oldPts);
+    Mat warped;
+    warpPerspective(boardImage, warped, H, imgSize, INTER_LINEAR, BORDER_CONSTANT, Scalar::all(255));
+
+    Matx33d cameraMatrix(300, 0, imgSize.width / 2.0,
+                         0, 300, imgSize.height / 2.0,
+                         0, 0, 1);
+    Matx<double, 1, 5> distCoeffs(-5.7e-7, 1.7e-8, -2e-7, -3.8e-7, -1.4e-10);
+
+    aruco::CharucoParameters params;  // defaults: checkMarkers == true
+    params.cameraMatrix = Mat(cameraMatrix);
+    params.distCoeffs = Mat(distCoeffs);
+    params.tryRefineMarkers = true;
+    aruco::CharucoDetector detector(board, params);
+    vector<int> charucoIds;
+    vector<Point2f> charucoCorners;
+    detector.detectBoard(warped, charucoCorners, charucoIds);
+
+    EXPECT_FALSE(charucoCorners.empty());
+    EXPECT_GT(charucoCorners.size(), 4u);
+    EXPECT_EQ(charucoCorners.size(), charucoIds.size());
+}
+
+// The marker-based rescue (issue #25850) must NOT resurrect genuinely wrong boards. On the
+// cameraMatrix path the interpolated charuco corners are a single-pose plane projection, so a
+// check built from them is near-tautological; checkBoardWithMarkers() instead verifies the
+// detected markers (their ids and image positions). A wrong-size board leaves markers whose ids
+// are outside its layout, and/or its markers do not fit one homography, so it is still rejected.
+TEST(CharucoDetection, markerCheckRejectsWrongBoard)
+{
+    aruco::Dictionary dict = aruco::getPredefinedDictionary(aruco::DICT_7X7_250);
+    aruco::CharucoBoard trueBoard(Size(8, 5), 1.f, 0.7f, dict);
+    Mat boardImage;
+    trueBoard.generateImage(Size(8 * 80, 5 * 80), boardImage);
+    cvtColor(boardImage, boardImage, COLOR_GRAY2BGR);
+
+    Matx33d cameraMatrix(300, 0, boardImage.cols / 2.0,
+                         0, 300, boardImage.rows / 2.0,
+                         0, 0, 1);
+    Matx<double, 1, 5> distCoeffs(-5.7e-7, 1.7e-8, -2e-7, -3.8e-7, -1.4e-10);
+
+    // Wrong-size (7x5) and transposed (5x8) layouts: both must yield NO charuco corners.
+    for (Size wrongSize : {Size(7, 5), Size(5, 8)}) {
+        aruco::CharucoBoard wrongBoard(wrongSize, 1.f, 0.7f, dict);
+        aruco::CharucoParameters params;  // checkMarkers == true
+        params.cameraMatrix = Mat(cameraMatrix);
+        params.distCoeffs = Mat(distCoeffs);
+        params.tryRefineMarkers = true;
+        aruco::CharucoDetector detector(wrongBoard, params);
+        vector<int> charucoIds;
+        vector<Point2f> charucoCorners;
+        detector.detectBoard(boardImage, charucoCorners, charucoIds);
+        EXPECT_TRUE(charucoCorners.empty())
+            << "wrong board " << wrongSize << " produced " << charucoCorners.size() << " corners";
+        EXPECT_TRUE(charucoIds.empty());
+    }
+}
+
+
 typedef testing::TestWithParam<std::tuple<cv::Size, float, cv::Size, int>> CharucoBoardGenerate;
 INSTANTIATE_TEST_CASE_P(/**/, CharucoBoardGenerate, testing::Values(make_tuple(Size(7, 4), 13.f, Size(400, 300), 24),
                                                                     make_tuple(Size(12, 2), 13.f, Size(200, 150), 1),

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -849,7 +849,6 @@ TEST(CharucoDetection, toughPerspectiveIssue25850)
     vector<Point2f> charucoCorners;
     detector.detectBoard(warped, charucoCorners, charucoIds);
 
-    EXPECT_FALSE(charucoCorners.empty());
     EXPECT_GT(charucoCorners.size(), 4u);
     EXPECT_EQ(charucoCorners.size(), charucoIds.size());
 }

--- a/modules/objdetect/test/test_charucodetection.cpp
+++ b/modules/objdetect/test/test_charucodetection.cpp
@@ -888,6 +888,34 @@ TEST(CharucoDetection, markerCheckRejectsWrongBoard)
     }
 }
 
+// Marker swaps must be rejected independently of the board dimensions.
+TEST(CharucoDetection, markerCheckRejectsSwappedMarkerIdsOnLargeBoard)
+{
+    aruco::Dictionary dict = aruco::getPredefinedDictionary(aruco::DICT_5X5_1000);
+    const Size boardSize(30, 20);
+    aruco::CharucoBoard trueBoard(boardSize, 1.f, 0.6f, dict);
+    vector<vector<Point2f>> markerCorners;
+    for (const vector<Point3f>& marker : trueBoard.getObjPoints()) {
+        vector<Point2f> corners;
+        for (const Point3f& p : marker)
+            corners.emplace_back(50.f * p.x + 100.f, 50.f * p.y + 100.f);
+        markerCorners.push_back(corners);
+    }
+
+    const vector<int>& trueIds = trueBoard.getIds();
+    vector<int> wrongIds = trueIds;
+    swap(wrongIds[0], wrongIds[1]);
+    aruco::CharucoBoard wrongBoard(boardSize, 1.f, 0.6f, dict, wrongIds);
+    aruco::CharucoDetector detector(wrongBoard);
+    Mat image(1200, 1700, CV_8UC1, Scalar::all(255));
+    vector<Point2f> charucoCorners;
+    vector<int> charucoIds;
+    detector.detectBoard(image, charucoCorners, charucoIds, markerCorners, trueIds);
+
+    EXPECT_TRUE(charucoCorners.empty());
+    EXPECT_TRUE(charucoIds.empty());
+}
+
 
 typedef testing::TestWithParam<std::tuple<cv::Size, float, cv::Size, int>> CharucoBoardGenerate;
 INSTANTIATE_TEST_CASE_P(/**/, CharucoBoardGenerate, testing::Values(make_tuple(Size(7, 4), 13.f, Size(400, 300), 24),


### PR DESCRIPTION
Fixes #25850.

`CharucoDetector::detectBoard()` returns no corners on strongly perspective views when a cameraMatrix is set. The post-detection `checkBoard()` heuristic compares raw pixel distances of the interpolated charuco corners, which assumes a near head-on view, so foreshortening makes it reject valid boards.

A check re-derived from the charuco corners cannot fix this: on the cameraMatrix path those corners are a single-pose projection of a flat board (a homography by construction), so any corner-based geometric test also accepts wrong boards.

This adds `checkBoardWithMarkers()`, an additive rescue that runs only after `checkBoard()` has rejected, so it can only turn a reject into a keep. It checks the markers, whose ids and image positions are independent of the board layout. A board is kept only if both hold:
- every detected board-dictionary marker belongs to the configured board (no stray ids), and
- the markers' configured object positions fit one homography to their detected image positions with low mean and worst-corner error (min 6 markers).

Wrong-size and transposed boards still produce no corners.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
