### PR TITLE
added a low overhead roi for Mat and GpuMat

### DIFF
--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -303,6 +303,29 @@ public:
     GpuMat operator ()(Range rowRange, Range colRange) const;
     GpuMat operator ()(Rect roi) const;
 
+    //! returns a new GpuMat header for the specified row
+    //! faster than row() but weaker (original data should say alive)
+    CV_WRAP GpuMat row_weak(int y) const;
+
+    //! returns a new GpuMat header for the specified column
+    //! faster than col() but weaker (original data should say alive)
+    CV_WRAP GpuMat col_weak(int x) const;
+
+    //! ... for the specified row span
+    //! faster than rowRange() but weaker (original data should say alive)
+    CV_WRAP GpuMat rowRange_weak(int startrow, int endrow) const;
+    CV_WRAP GpuMat rowRange_weak(Range r) const;
+
+    //! ... for the specified column span
+    //! faster than colRange() but weaker (original data should say alive)
+    CV_WRAP GpuMat colRange_weak(int startcol, int endcol) const;
+    CV_WRAP GpuMat colRange_weak(Range r) const;
+
+    //! extracts a rectangular sub-GpuMat (this is a generalized form of row, rowRange etc.)
+    //! faster than operator()(Range, Range) or operator(Rect) but weaker (original data should say alive)
+    CV_WRAP GpuMat roi_weak(Range rowRange, Range colRange) const;
+    CV_WRAP GpuMat roi_weak(Rect roi) const;
+
     //! creates alternative GpuMat header for the same data, with different
     //! number of channels and/or different number of rows
     CV_WRAP GpuMat reshape(int cn, int rows = 0) const;

--- a/modules/core/include/opencv2/core/cuda.hpp
+++ b/modules/core/include/opencv2/core/cuda.hpp
@@ -304,25 +304,25 @@ public:
     GpuMat operator ()(Rect roi) const;
 
     //! returns a new GpuMat header for the specified row
-    //! faster than row() but weaker (original data should say alive)
+    //! faster than row() but weaker (original data should stay alive)
     CV_WRAP GpuMat row_weak(int y) const;
 
     //! returns a new GpuMat header for the specified column
-    //! faster than col() but weaker (original data should say alive)
+    //! faster than col() but weaker (original data should stay alive)
     CV_WRAP GpuMat col_weak(int x) const;
 
     //! ... for the specified row span
-    //! faster than rowRange() but weaker (original data should say alive)
+    //! faster than rowRange() but weaker (original data should stay alive)
     CV_WRAP GpuMat rowRange_weak(int startrow, int endrow) const;
     CV_WRAP GpuMat rowRange_weak(Range r) const;
 
     //! ... for the specified column span
-    //! faster than colRange() but weaker (original data should say alive)
+    //! faster than colRange() but weaker (original data should stay alive)
     CV_WRAP GpuMat colRange_weak(int startcol, int endcol) const;
     CV_WRAP GpuMat colRange_weak(Range r) const;
 
     //! extracts a rectangular sub-GpuMat (this is a generalized form of row, rowRange etc.)
-    //! faster than operator()(Range, Range) or operator(Rect) but weaker (original data should say alive)
+    //! faster than operator()(Range, Range) or operator(Rect) but weaker (original data should stay alive)
     CV_WRAP GpuMat roi_weak(Range rowRange, Range colRange) const;
     CV_WRAP GpuMat roi_weak(Rect roi) const;
 

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -314,6 +314,66 @@ GpuMat GpuMat::operator ()(Rect roi) const
 }
 
 inline
+GpuMat GpuMat::row_weak(int y) const
+{
+    CV_Assert( (y >= 0) && (y < rows) );
+    return GpuMat(1, cols, type(), const_cast<unsigned char*>(ptr<unsigned char>(y)), step);
+}
+
+inline
+GpuMat GpuMat::col_weak(int x) const
+{
+    CV_Assert( (x >= 0) && (x < cols) );
+    return GpuMat(rows, 1, type(), const_cast<unsigned char*>(data)+x*elemSize(), step);
+}
+
+inline
+GpuMat GpuMat::rowRange_weak(int startrow, int endrow) const
+{
+    CV_Assert( (startrow >= 0) && (endrow <= rows) && (startrow <= endrow) );
+    return GpuMat(endrow-startrow, cols, type(), const_cast<unsigned char*>(ptr<unsigned char>(startrow)), step);
+}
+
+inline
+GpuMat GpuMat::rowRange_weak(Range r) const
+{
+    return rowRange_weak(r.start, r.end);
+}
+
+inline
+GpuMat GpuMat::colRange_weak(int startcol, int endcol) const
+{
+    CV_Assert( (startcol >= 0) && (endcol <= cols) && (startcol <= endcol) );
+    return GpuMat(rows, endcol-startcol, type(), const_cast<unsigned char*>(data)+startcol*elemSize(), step);
+}
+
+inline
+GpuMat GpuMat::colRange_weak(Range r) const
+{
+    return colRange_weak(r.start, r.end);
+}
+
+inline
+GpuMat GpuMat::roi_weak(Range rowRange_, Range colRange_) const
+{
+    CV_Assert( (rowRange_.start >= 0) && (rowRange_.end <= rows) && (rowRange_.start <= rowRange_.end) );
+    CV_Assert( (colRange_.start >= 0) && (colRange_.end <= cols) && (colRange_.start <= colRange_.end) );
+    return GpuMat(rowRange_.size(), colRange_.size(), type(),
+                  const_cast<unsigned char*>(ptr<unsigned char>(rowRange_.start))+colRange_.start*elemSize(),
+                  step);
+}
+
+inline
+GpuMat GpuMat::roi_weak(Rect roi) const
+{
+    CV_Assert( (roi.y >= 0) && (roi.y+roi.height <= rows) );
+    CV_Assert( (roi.x >= 0) && (roi.x+roi.width <= cols) );
+    return GpuMat(roi.height, roi.width, type(),
+        const_cast<unsigned char*>(ptr<unsigned char>(roi.y))+roi.x*elemSize(),
+        step);
+}
+
+inline
 bool GpuMat::isContinuous() const
 {
     return (flags & Mat::CONTINUOUS_FLAG) != 0;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1156,7 +1156,7 @@ public:
      */
     Mat row(int y) const;
 
-    //! faster than row() but weaker (original data should say alive)
+    //! faster than row() but weaker (original data should stay alive)
     CV_WRAP Mat row_weak(int y) const;
 
     /** @brief Creates a matrix header for the specified matrix column.
@@ -1168,7 +1168,7 @@ public:
      */
     Mat col(int x) const;
 
-    //! faster than row() but weaker (original data should say alive)
+    //! faster than row() but weaker (original data should stay alive)
     CV_WRAP Mat col_weak(int x) const;
 
     /** @brief Creates a matrix header for the specified row span.
@@ -1180,7 +1180,7 @@ public:
      */
     Mat rowRange(int startrow, int endrow) const;
 
-    //! faster than rowRange() but weaker (original data should say alive)
+    //! faster than rowRange() but weaker (original data should stay alive)
     Mat rowRange_weak(int startrow, int endrow) const;
 
     /** @overload
@@ -1188,7 +1188,7 @@ public:
     */
     Mat rowRange(const Range& r) const;
 
-    //! faster than rowRange() but weaker (original data should say alive)
+    //! faster than rowRange() but weaker (original data should stay alive)
     Mat rowRange_weak(const Range& r) const;
 
     /** @brief Creates a matrix header for the specified column span.
@@ -1200,7 +1200,7 @@ public:
      */
     Mat colRange(int startcol, int endcol) const;
 
-    //! faster than colRange() but weaker (original data should say alive)
+    //! faster than colRange() but weaker (original data should stay alive)
     Mat colRange_weak(int startcol, int endcol) const;
 
     /** @overload
@@ -1208,7 +1208,7 @@ public:
     */
     Mat colRange(const Range& r) const;
 
-    //! faster than colRange() but weaker (original data should say alive)
+    //! faster than colRange() but weaker (original data should stay alive)
     Mat colRange_weak(const Range& r) const;
 
     /** @brief Extracts a diagonal from a matrix
@@ -1757,7 +1757,7 @@ public:
      */
     Mat operator()( Range rowRange, Range colRange ) const;
 
-    //! faster than operator()(Range, Range) but weaker (original data should say alive)
+    //! faster than operator()(Range, Range) but weaker (original data should stay alive)
     Mat roi_weak( Range rowRange, Range colRange ) const;
 
     /** @overload
@@ -1765,7 +1765,7 @@ public:
     */
     Mat operator()( const Rect& roi ) const;
 
-    //! faster than operator()(const Rect&) but weaker (original data should say alive)
+    //! faster than operator()(const Rect&) but weaker (original data should stay alive)
     Mat roi_weak( const Rect& roi ) const;
 
     /** @overload
@@ -1773,7 +1773,7 @@ public:
     */
     Mat operator()( const Range* ranges ) const;
 
-    //! faster than operator()(const Range*) but weaker (original data should say alive)
+    //! faster than operator()(const Range*) but weaker (original data should stay alive)
     Mat roi_weak( const Range* ranges ) const;
 
     /** @overload
@@ -1781,7 +1781,7 @@ public:
     */
     Mat operator()(const std::vector<Range>& ranges) const;
 
-    //! faster than operator()(const std::vector<Range>&) but weaker (original data should say alive)
+    //! faster than operator()(const std::vector<Range>&) but weaker (original data should stay alive)
     Mat roi_weak( const std::vector<Range>& ranges ) const;
 
     template<typename _Tp> operator std::vector<_Tp>() const;

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -1156,6 +1156,9 @@ public:
      */
     Mat row(int y) const;
 
+    //! faster than row() but weaker (original data should say alive)
+    CV_WRAP Mat row_weak(int y) const;
+
     /** @brief Creates a matrix header for the specified matrix column.
 
     The method makes a new header for the specified matrix column and returns it. This is an O(1)
@@ -1164,6 +1167,9 @@ public:
     @param x A 0-based column index.
      */
     Mat col(int x) const;
+
+    //! faster than row() but weaker (original data should say alive)
+    CV_WRAP Mat col_weak(int x) const;
 
     /** @brief Creates a matrix header for the specified row span.
 
@@ -1174,10 +1180,16 @@ public:
      */
     Mat rowRange(int startrow, int endrow) const;
 
+    //! faster than rowRange() but weaker (original data should say alive)
+    Mat rowRange_weak(int startrow, int endrow) const;
+
     /** @overload
     @param r Range structure containing both the start and the end indices.
     */
     Mat rowRange(const Range& r) const;
+
+    //! faster than rowRange() but weaker (original data should say alive)
+    Mat rowRange_weak(const Range& r) const;
 
     /** @brief Creates a matrix header for the specified column span.
 
@@ -1188,10 +1200,16 @@ public:
      */
     Mat colRange(int startcol, int endcol) const;
 
+    //! faster than colRange() but weaker (original data should say alive)
+    Mat colRange_weak(int startcol, int endcol) const;
+
     /** @overload
     @param r Range structure containing both the start and the end indices.
     */
     Mat colRange(const Range& r) const;
+
+    //! faster than colRange() but weaker (original data should say alive)
+    Mat colRange_weak(const Range& r) const;
 
     /** @brief Extracts a diagonal from a matrix
 
@@ -1739,20 +1757,32 @@ public:
      */
     Mat operator()( Range rowRange, Range colRange ) const;
 
+    //! faster than operator()(Range, Range) but weaker (original data should say alive)
+    Mat roi_weak( Range rowRange, Range colRange ) const;
+
     /** @overload
     @param roi Extracted submatrix specified as a rectangle.
     */
     Mat operator()( const Rect& roi ) const;
+
+    //! faster than operator()(const Rect&) but weaker (original data should say alive)
+    Mat roi_weak( const Rect& roi ) const;
 
     /** @overload
     @param ranges Array of selected ranges along each array dimension.
     */
     Mat operator()( const Range* ranges ) const;
 
+    //! faster than operator()(const Range*) but weaker (original data should say alive)
+    Mat roi_weak( const Range* ranges ) const;
+
     /** @overload
     @param ranges Array of selected ranges along each array dimension.
     */
     Mat operator()(const std::vector<Range>& ranges) const;
+
+    //! faster than operator()(const std::vector<Range>&) but weaker (original data should say alive)
+    Mat roi_weak( const std::vector<Range>& ranges ) const;
 
     template<typename _Tp> operator std::vector<_Tp>() const;
     template<typename _Tp, int n> operator Vec<_Tp, n>() const;

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -747,7 +747,7 @@ Mat Mat::roi_weak(const Range* ranges) const
 inline
 Mat Mat::roi_weak(const std::vector<Range>& ranges) const
 {
-    CV_Assert( ranges.size() == dims );
+    CV_Assert( (int)ranges.size() == dims );
     return roi_weak(ranges.data());
 }
 

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -670,6 +670,88 @@ Mat Mat::operator()(const std::vector<Range>& ranges) const
 }
 
 inline
+Mat Mat::row_weak(int y) const
+{
+    CV_Assert( (y >= 0) && (y < rows) );
+    return Mat(1, cols, type(), const_cast<unsigned char*>(ptr<unsigned char>(y)), step);
+}
+
+inline
+Mat Mat::col_weak(int x) const
+{
+    CV_Assert( (x >= 0) && (x < cols) );
+    return Mat(rows, 1, type(), const_cast<unsigned char*>(data)+x*elemSize(), step);
+}
+
+inline
+Mat Mat::rowRange_weak(int startrow, int endrow) const
+{
+    CV_Assert( (startrow >= 0) && (endrow <= rows) && (startrow <= endrow) );
+    return Mat(endrow-startrow, cols, type(), const_cast<unsigned char*>(ptr<unsigned char>(startrow)), step);
+}
+
+inline
+Mat Mat::rowRange_weak(const Range& r) const
+{
+    return rowRange_weak(r.start, r.end);
+}
+
+inline
+Mat Mat::colRange_weak(int startcol, int endcol) const
+{
+    CV_Assert( (startcol >= 0) && (endcol <= cols) && (startcol <= endcol) );
+    return Mat(rows, endcol-startcol, type(), const_cast<unsigned char*>(data)+startcol*elemSize(), step);
+}
+
+inline
+Mat Mat::colRange_weak(const Range& r) const
+{
+    return colRange_weak(r.start, r.end);
+}
+
+inline
+Mat Mat::roi_weak( Range _rowRange, Range _colRange ) const
+{
+    CV_Assert( (_rowRange.start >= 0) && (_rowRange.end <= rows) && (_rowRange.start <= _rowRange.end) );
+    CV_Assert( (_colRange.start >= 0) && (_colRange.end <= cols) && (_colRange.start <= _colRange.end) );
+    return Mat(_rowRange.size(), _colRange.size(), type(),
+        const_cast<unsigned char*>(ptr<unsigned char>(_rowRange.start))+_colRange.start*elemSize(),
+        step);
+}
+
+inline
+Mat Mat::roi_weak( const Rect& roi ) const
+{
+    CV_Assert( (roi.y >= 0) && (roi.y+roi.height <= rows) );
+    CV_Assert( (roi.x >= 0) && (roi.x+roi.width <= cols) );
+    return Mat(roi.height, roi.width, type(),
+        const_cast<unsigned char*>(ptr<unsigned char>(roi.y))+roi.x*elemSize(),
+        step);
+}
+
+inline
+Mat Mat::roi_weak(const Range* ranges) const
+{
+    CV_Assert( ranges != nullptr );
+    int subSizes[CV_MAX_DIM];
+    const unsigned char* subData = data;
+    for(int k = 0 ; k<dims ; ++k)
+    {
+      const Range& r = ranges[k];
+      subSizes[k] = r.size();
+      subData += r.start*((k+1<dims) ? step[k] : elemSize());
+    }
+    return Mat(dims, subSizes, type(), const_cast<unsigned char*>(subData), step.p);
+}
+
+inline
+Mat Mat::roi_weak(const std::vector<Range>& ranges) const
+{
+    CV_Assert( ranges.size() == dims );
+    return roi_weak(ranges.data());
+}
+
+inline
 bool Mat::isContinuous() const
 {
     return (flags & CONTINUOUS_FLAG) != 0;


### PR DESCRIPTION
When an ROI is needed for a Mat or a GpuMat, but only for a limited scope, it is less expensive to create a wrapper of "external data" (`cv::Mat(x, y, type, data, step)`) rather than a regular Mat ROI with reference counting.

The original data must stay alive, but there is a small speed gain.

The current PR adds a few methods like` row_weak()`, `col_weak()` to explicitely opt-in for such an ROI.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [X] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [X] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
