### PR TITLE
core: fix signed integer overflow in borderInterpolate BORDER_WRAP

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -938,7 +938,7 @@ int cv::borderInterpolate( int p, int len, int borderType )
     {
         CV_Assert(len > 0);
         if( p < 0 )
-            p -= ((p-len+1)/len)*len;
+            p = (int)((long long)p - (((long long)p - len + 1)/len)*len);
         if( p >= len )
             p %= len;
     }

--- a/modules/core/test/test_copy.cpp
+++ b/modules/core/test/test_copy.cpp
@@ -1,0 +1,46 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+// Regression test for https://github.com/opencv/opencv/issues/29232
+// cv::borderInterpolate with BORDER_WRAP overflowed a 32-bit signed integer
+// when p is close to INT_MIN (e.g. p=-2147483583, len=269).
+TEST(Core_BorderInterpolate, wrap_no_overflow)
+{
+    // These values triggered signed integer overflow in the old code:
+    //   p - len + 1  ==  -2147483583 - 269 + 1  ==  -2147483851  (below INT_MIN)
+    const int len = 269;
+    const int p   = std::numeric_limits<int>::min() + 65;  // -2147483583
+
+    // Must not crash / invoke UB, and must return a value in [0, len-1].
+    int result = cv::borderInterpolate(p, len, cv::BORDER_WRAP);
+    EXPECT_GE(result, 0);
+    EXPECT_LT(result, len);
+
+    // Cross-check: the mathematical modulo result.
+    // Use long long to compute the reference safely.
+    long long ref = ((long long)p % len + len) % len;
+    EXPECT_EQ(result, (int)ref);
+}
+
+// Exhaustive smoke test: all border types should keep result in [0, len-1]
+// for a range of negative and positive out-of-bounds coordinates.
+TEST(Core_BorderInterpolate, wrap_range)
+{
+    const int len = 7;
+    const int types[] = { cv::BORDER_WRAP };
+    for (int btype : types)
+    {
+        for (int p = -3 * len; p < 3 * len; ++p)
+        {
+            int r = cv::borderInterpolate(p, len, btype);
+            EXPECT_GE(r, 0)   << "p=" << p;
+            EXPECT_LT(r, len) << "p=" << p;
+        }
+    }
+}
+
+}} // namespace opencv_test


### PR DESCRIPTION
## Summary

Fixes #29232 — signed integer overflow (undefined behaviour) in `cv::borderInterpolate` when `borderType == BORDER_WRAP` and `p` is close to `INT_MIN`.

### Root cause

```cpp
// Before – UB when p ≈ INT_MIN and len > 0
if( p < 0 )
    p -= ((p-len+1)/len)*len;
```

The sub-expression `p - len + 1` underflows a 32-bit signed integer when, for example, `p = -2147483583` and `len = 269`:

```
-2147483583 - 269 + 1 = -2147483851  <  INT_MIN  → UB
```

The API documentation explicitly permits any negative value of `p` with no upper bound on `len`, so this is reachable in normal use.

### Fix

Perform all intermediate arithmetic in `long long`; the final result always lies in `[0, len-1]` so the cast back to `int` is safe:

```cpp
// After
if( p < 0 )
    p = (int)((long long)p - (((long long)p - len + 1)/len)*len);
```

Note: casting only the *division* result back to `int` before multiplying (the pattern suggested in the issue) is still insufficient — the multiplication itself can overflow for extreme inputs such as `p = INT_MIN, len = 3`.

### Test plan

- [x] Added `modules/core/test/test_copy.cpp` with:
  - `Core_BorderInterpolate.wrap_no_overflow` — the exact values from the issue report; verifies result is in `[0, len-1]` and matches the `long long` reference.
  - `Core_BorderInterpolate.wrap_range` — exhaustive check over `[-3*len, 3*len)` for `BORDER_WRAP`.
- [x] Both tests pass with `opencv_test_core --gtest_filter="*BorderInterpolate*"`.
