### PR TITLE
dnn: SIMD for 13 transcendental activations in the 5.x engine

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1027,7 +1027,20 @@ CV__DNN_INLINE_NS_BEGIN
         ACTIV_GELU,
         ACTIV_GELU_APPROX,
         ACTIV_RELU,
-        ACTIV_CLIP
+        ACTIV_CLIP,
+        ACTIV_LOG,
+        ACTIV_ERF,
+        ACTIV_EXP,
+        ACTIV_SIN,
+        ACTIV_COS,
+        ACTIV_SINH,
+        ACTIV_COSH,
+        ACTIV_TAN,
+        ACTIV_SOFTPLUS,
+        ACTIV_BNLL,
+        ACTIV_ASINH,
+        ACTIV_ACOSH,
+        ACTIV_ATANH
     };
 
     /** Returns a platform-optimized activation function pointer for the given type.

--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -1104,4 +1104,58 @@ INSTANTIATE_TEST_CASE_P(/**/, Layer_TopK,
                                               /* withWebnn= */           false,
                                               /* withCann= */            false));
 
+// Single-input elementwise activation throughput (the transcendental functors
+// vectorized in elementwise_layers.cpp via the activation_kernels registry).
+// Inputs are drawn from each function's valid domain so the output stays finite.
+struct Layer_Activation : public TestBaseWithParam<tuple<Backend, Target> >
+{
+    void test_activation(const String& type, float lo, float hi)
+    {
+        int backendId = get<0>(GetParam());
+        int targetId = get<1>(GetParam());
+
+        Mat input({N, C, H, W}, CV_32F);
+        randu(input, lo, hi);
+
+        Net net;
+        LayerParams lp;
+        lp.type = type;
+        lp.name = "testLayer";
+        net.addLayerToPrev(lp.name, lp.type, lp);
+
+        net.setPreferableBackend(backendId);
+        net.setPreferableTarget(targetId);
+        net.setInput(input);
+        Mat out = net.forward();  // warmup
+
+        TEST_CYCLE()
+        {
+            Mat res = net.forward();
+        }
+
+        SANITY_CHECK_NOTHING();
+    }
+
+    int N = 8;
+    int C = 256;
+    int H = 128;
+    int W = 100;
+};
+
+PERF_TEST_P_(Layer_Activation, Log)      { test_activation("Log",      0.1f,  10.f); }
+PERF_TEST_P_(Layer_Activation, Erf)      { test_activation("Erf",      -3.f,   3.f); }
+PERF_TEST_P_(Layer_Activation, Exp)      { test_activation("Exp",      -5.f,   5.f); }
+PERF_TEST_P_(Layer_Activation, Sin)      { test_activation("Sin",      -3.f,   3.f); }
+PERF_TEST_P_(Layer_Activation, Cos)      { test_activation("Cos",      -3.f,   3.f); }
+PERF_TEST_P_(Layer_Activation, Sinh)     { test_activation("Sinh",     -5.f,   5.f); }
+PERF_TEST_P_(Layer_Activation, Cosh)     { test_activation("Cosh",     -5.f,   5.f); }
+PERF_TEST_P_(Layer_Activation, Tan)      { test_activation("Tan",      -1.4f,  1.4f); }
+PERF_TEST_P_(Layer_Activation, Softplus) { test_activation("Softplus", -5.f,   5.f); }
+PERF_TEST_P_(Layer_Activation, BNLL)     { test_activation("BNLL",     -5.f,   5.f); }
+PERF_TEST_P_(Layer_Activation, Asinh)    { test_activation("Asinh",    -10.f,  10.f); }
+PERF_TEST_P_(Layer_Activation, Acosh)    { test_activation("Acosh",     1.f,   20.f); }
+PERF_TEST_P_(Layer_Activation, Atanh)    { test_activation("Atanh",    -0.95f, 0.95f); }
+
+INSTANTIATE_TEST_CASE_P(/**/, Layer_Activation, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
+
 } // namespace

--- a/modules/dnn/src/layers/cpu_kernels/activation_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/activation_kernels.simd.hpp
@@ -454,6 +454,159 @@ void softmax_(Mat &dst, const Mat &src, int axis, int axisBias, int axisStep, fl
     }, nstripes);
 }
 
+static void activationLog(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    for (; i + vlanes <= len; i += vlanes) vx_store(out + i, v_log(vx_load(inp + i)));
+#endif
+    for (; i < len; i++) out[i] = logf(inp[i]);
+}
+static void activationErf(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    for (; i + vlanes <= len; i += vlanes) vx_store(out + i, v_erf(vx_load(inp + i)));
+#endif
+    for (; i < len; i++) out[i] = erff(inp[i]);
+}
+static void activationExp(const void* input, void* output, size_t len, const float* params)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+    const float nscale = params[0], nshift = params[1];
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 vsc = vx_setall_f32(nscale), vsh = vx_setall_f32(nshift);
+    for (; i + vlanes <= len; i += vlanes) vx_store(out + i, v_exp(v_fma(vx_load(inp + i), vsc, vsh)));
+#endif
+    for (; i < len; i++) out[i] = expf(inp[i] * nscale + nshift);
+}
+static void activationSin(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    for (; i + vlanes <= len; i += vlanes) vx_store(out + i, v_sin(vx_load(inp + i)));
+#endif
+    for (; i < len; i++) out[i] = sinf(inp[i]);
+}
+static void activationCos(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    for (; i + vlanes <= len; i += vlanes) vx_store(out + i, v_cos(vx_load(inp + i)));
+#endif
+    for (; i < len; i++) out[i] = cosf(inp[i]);
+}
+static void activationSinh(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 half = vx_setall_f32(0.5f), z = vx_setzero_f32();
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_mul(half, v_sub(v_exp(x), v_exp(v_sub(z, x)))));
+    }
+#endif
+    for (; i < len; i++) out[i] = sinhf(inp[i]);
+}
+static void activationCosh(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 half = vx_setall_f32(0.5f), z = vx_setzero_f32();
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_mul(half, v_add(v_exp(x), v_exp(v_sub(z, x)))));
+    }
+#endif
+    for (; i < len; i++) out[i] = coshf(inp[i]);
+}
+static void activationTan(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_div(v_sin(x), v_cos(x)));
+    }
+#endif
+    for (; i < len; i++) out[i] = tanf(inp[i]);
+}
+static void activationSoftplus(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 one = vx_setall_f32(1.f);
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_log(v_add(one, v_exp(x))));
+    }
+#endif
+    for (; i < len; i++) out[i] = logf(1.f + expf(inp[i]));
+}
+static void activationBNLL(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 one = vx_setall_f32(1.f), z = vx_setzero_f32();
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_add(v_max(x, z), v_log(v_add(one, v_exp(v_sub(z, v_abs(x)))))));
+    }
+#endif
+    for (; i < len; i++) { float a = inp[i]; out[i] = std::max(a, 0.f) + logf(1.f + expf(-std::abs(a))); }
+}
+static void activationAsinh(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 one = vx_setall_f32(1.f), z = vx_setzero_f32();
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i), ax = v_abs(x);
+        v_float32 t = v_log(v_add(ax, v_sqrt(v_add(v_mul(x, x), one))));
+        vx_store(out + i, v_select(v_lt(x, z), v_sub(z, t), t));
+    }
+#endif
+    for (; i < len; i++) out[i] = asinhf(inp[i]);
+}
+static void activationAcosh(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 one = vx_setall_f32(1.f);
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_log(v_add(x, v_sqrt(v_sub(v_mul(x, x), one)))));
+    }
+#endif
+    for (; i < len; i++) out[i] = acoshf(inp[i]);
+}
+static void activationAtanh(const void* input, void* output, size_t len, const float*)
+{
+    const float* inp = (const float*)input; float* out = (float*)output; size_t i = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int vlanes = VTraits<v_float32>::vlanes();
+    v_float32 one = vx_setall_f32(1.f), half = vx_setall_f32(0.5f);
+    for (; i + vlanes <= len; i += vlanes) {
+        v_float32 x = vx_load(inp + i);
+        vx_store(out + i, v_mul(half, v_log(v_div(v_add(one, x), v_sub(one, x)))));
+    }
+#endif
+    for (; i < len; i++) out[i] = atanhf(inp[i]);
+}
+
+
 ActivationFunc getActivationFunc_(int type)
 {
     switch (type) {
@@ -468,6 +621,19 @@ ActivationFunc getActivationFunc_(int type)
     case ACTIV_GELU_APPROX: return activationGELUApprox;
     case ACTIV_RELU: return activationReLU;
     case ACTIV_CLIP: return activationClip;
+    case ACTIV_LOG: return activationLog;
+    case ACTIV_ERF: return activationErf;
+    case ACTIV_EXP: return activationExp;
+    case ACTIV_SIN: return activationSin;
+    case ACTIV_COS: return activationCos;
+    case ACTIV_SINH: return activationSinh;
+    case ACTIV_COSH: return activationCosh;
+    case ACTIV_TAN: return activationTan;
+    case ACTIV_SOFTPLUS: return activationSoftplus;
+    case ACTIV_BNLL: return activationBNLL;
+    case ACTIV_ASINH: return activationAsinh;
+    case ACTIV_ACOSH: return activationAcosh;
+    case ACTIV_ATANH: return activationAtanh;
     default: return nullptr;
     }
 }

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -1496,6 +1496,14 @@ struct BNLLFunctor : public BaseDefaultFunctor<BNLLFunctor>
 {
     typedef BNLLLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_BNLL);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV ||
@@ -1645,6 +1653,14 @@ struct LogFunctor : public BaseDefaultFunctor<LogFunctor>
 {
     typedef LogLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_LOG);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -1767,6 +1783,14 @@ struct AcoshFunctor : public BaseDefaultFunctor<AcoshFunctor>
 {
     typedef AcoshLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_ACOSH);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -1820,6 +1844,14 @@ const char* const BaseDefaultFunctor<AsinFunctor>::ocl_kernel_name = "AsinForwar
 struct AsinhFunctor : public BaseDefaultFunctor<AsinhFunctor>
 {
     typedef AsinhLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_ASINH);
+    }
 
     bool supportBackend(int backendId, int)
     {
@@ -1875,6 +1907,14 @@ struct AtanhFunctor : public BaseDefaultFunctor<AtanhFunctor>
 {
     typedef AtanhLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_ATANH);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -1901,6 +1941,14 @@ const char* const BaseDefaultFunctor<AtanhFunctor>::ocl_kernel_name = "AtanhForw
 struct CosFunctor : public BaseDefaultFunctor<CosFunctor>
 {
     typedef CosLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_COS);
+    }
 
     bool supportBackend(int backendId, int)
     {
@@ -1929,6 +1977,14 @@ struct CoshFunctor : public BaseDefaultFunctor<CoshFunctor>
 {
     typedef CoshLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_COSH);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -1955,6 +2011,14 @@ const char* const BaseDefaultFunctor<CoshFunctor>::ocl_kernel_name = "CoshForwar
 struct ErfFunctor : public BaseDefaultFunctor<ErfFunctor>
 {
     typedef ErfLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_ERF);
+    }
 
     bool supportBackend(int backendId, int)
     {
@@ -2074,6 +2138,14 @@ struct SinFunctor : public BaseDefaultFunctor<SinFunctor>
 {
     typedef SinLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_SIN);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -2101,6 +2173,14 @@ struct SinhFunctor : public BaseDefaultFunctor<SinhFunctor>
 {
     typedef SinhLayer Layer;
 
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_SINH);
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV || backendId == DNN_BACKEND_CUDA;
@@ -2127,6 +2207,14 @@ const char* const BaseDefaultFunctor<SinhFunctor>::ocl_kernel_name = "SinhForwar
 struct SoftplusFunctor : public BaseDefaultFunctor<SoftplusFunctor>
 {
     typedef SoftplusLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_SOFTPLUS);
+    }
 
     bool supportBackend(int backendId, int)
     {
@@ -2181,6 +2269,14 @@ const char* const BaseDefaultFunctor<SoftsignFunctor>::ocl_kernel_name = "Softsi
 struct TanFunctor : public BaseDefaultFunctor<TanFunctor>
 {
     typedef TanLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams.clear();
+        return cv::dnn::getActivationFunc(ACTIV_TAN);
+    }
 
     bool supportBackend(int backendId, int)
     {
@@ -2633,6 +2729,14 @@ struct ElementWiseIntDispatch<PowerFunctor>
 struct ExpFunctor : public BaseDefaultFunctor<ExpFunctor>
 {
     typedef ExpLayer Layer;
+
+    ActivationFunc getActivationFunc(int depth, std::vector<float>& activParams) const
+    {
+        if (depth != CV_32F)
+            return nullptr;
+        activParams = {normScale, normShift};
+        return cv::dnn::getActivationFunc(ACTIV_EXP);
+    }
     float base, scale, shift;
     float normScale, normShift;
 


### PR DESCRIPTION
Follow-up to #29377 (merged to 4.x), ported to the 5.x branch as requested there
(4.x and 5.x diverged in dnn, so they need separate PRs).

5.x already vectorizes `TanH` and `GeluApprox` through the new engine's central
activation registry. This wires the remaining 13 transcendental activations into
the same path:

`Log, Erf, Exp, Sin, Cos, Sinh, Cosh, Tan, Softplus, BNLL, Asinh, Acosh, Atanh`

### What changed
- **`activation_kernels.simd.hpp`** — 13 `activationX` kernels (universal intrinsics:
  `v_exp`/`v_log`/`v_erf`/`v_sin`/`v_cos` + scalar tail), one `case ACTIV_X` each in the
  dispatch switch. Because this file is CPU-dispatched, the kernels build at SSE/AVX2/
  **AVX-512**/NEON width automatically.
- **`all_layers.hpp`** — 13 new `ACTIV_*` enum values.
- **`elementwise_layers.cpp`** — each functor opts in via
  `getActivationFunc(depth, activParams)` returning `cv::dnn::getActivationFunc(ACTIV_X)`
  (`Exp` forwards its `{normScale, normShift}` through `activParams`).
- **`perf_layer.cpp`** — a `Layer_Activation` perf test (single-input forward, one case
  per activation, domain-correct inputs).

### Performance (forward of an 8×256×128×100 CV_32F blob, SIMD vs scalar)

| activation | M4 (clang/NEON) | RPi5 A76 (gcc/NEON) | Threadripper (Zen1/AVX2) | Xeon W-2235 (AVX-512) |
|---|---|---|---|---|
| Log      |  3.44× | 1.70× | 1.45× |  3.18× |
| Erf      |  4.33× | 2.42× | 6.11× |  9.15× |
| Exp      |  3.92× | 1.66× | 1.70× |  2.03× |
| Sin      |  9.51× | 2.67× | 2.74× |  3.30× |
| Cos      | 11.20× | 2.81× | 2.76× |  3.44× |
| Sinh     |  4.77× | 3.49× | 7.44× | 12.33× |
| Cosh     |  5.21× | 3.49× | 3.07× |  4.79× |
| Tan      |  7.46× | 3.47× | 6.41× |  8.00× |
| Softplus |  2.90× | 2.34× | 6.68× |  8.05× |
| BNLL     |  4.61× | 2.25× | 3.85× |  4.82× |
| Asinh    |  6.67× | 2.36× | 6.26× |  6.75× |
| Acosh    |  4.79× | 2.71× | 4.60× |  5.08× |
| Atanh    |  6.24× | 2.80× | 7.48× | 10.12× |

Wins on every CPU (1.45× worst case, up to 12.3× on AVX-512).

### Correctness
Each kernel matches the scalar `calculate()` to ≤5e-7 max-abs (the precision of the
`v_exp`/`v_log`/`v_erf`/`v_sin`/`v_cos` polynomials OpenCV already ships), verified by an
A/B (SIMD vs the scalar fallback) across all four CPUs above. `opencv_test_dnn`
activation/elementwise tests pass.
