### PR TITLE
dnn: add RVV LMUL=1 kernel for convBlock_F32 (ConvolutionLayer, rv64gcv)

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/convolution.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/convolution.cpp
@@ -2206,6 +2206,70 @@ void convBlock_F32(int np, const float* a, const float* b, float* c, int ldc, bo
         return;
     }
     convBlockNoSIMD(np, a, b, c, ldc, init_c, outLen, convMR, convNR);
+#elif CV_RVV
+{
+    // LMUL=1 kernel: vlanes = VLEN/32 (8 at VLEN=256).
+    // OpenCV's v_float32 is vfloat32m2_t (LMUL=2, vlanes=2*VLEN/32=16 at VLEN=256);
+    // 24 % 16 != 0, so the 24-wide tile requires LMUL=1 and native intrinsics.
+    // vfmacc.vf (scalar-into-vector FMA) avoids a broadcast register.
+    // Only the exact full-tile case (outLen==convNR) is handled; tails fall to scalar.
+    const size_t vl = __riscv_vsetvlmax_e32m1();
+    if (convMR == 4 && (size_t)convNR == 3 * vl && outLen == convNR)
+    {
+        vfloat32m1_t c00 = __riscv_vfmv_v_f_f32m1(0.f, vl);
+        vfloat32m1_t c01 = c00, c02 = c00;
+        vfloat32m1_t c10 = c00, c11 = c00, c12 = c00;
+        vfloat32m1_t c20 = c00, c21 = c00, c22 = c00;
+        vfloat32m1_t c30 = c00, c31 = c00, c32 = c00;
+        for (int p = 0; p < np; p++, a += convMR, b += convNR)
+        {
+            vfloat32m1_t b0 = __riscv_vle32_v_f32m1(b,          vl);
+            vfloat32m1_t b1 = __riscv_vle32_v_f32m1(b + vl,     vl);
+            vfloat32m1_t b2 = __riscv_vle32_v_f32m1(b + 2 * vl, vl);
+            c00 = __riscv_vfmacc_vf_f32m1(c00, a[0], b0, vl);
+            c01 = __riscv_vfmacc_vf_f32m1(c01, a[0], b1, vl);
+            c02 = __riscv_vfmacc_vf_f32m1(c02, a[0], b2, vl);
+            c10 = __riscv_vfmacc_vf_f32m1(c10, a[1], b0, vl);
+            c11 = __riscv_vfmacc_vf_f32m1(c11, a[1], b1, vl);
+            c12 = __riscv_vfmacc_vf_f32m1(c12, a[1], b2, vl);
+            c20 = __riscv_vfmacc_vf_f32m1(c20, a[2], b0, vl);
+            c21 = __riscv_vfmacc_vf_f32m1(c21, a[2], b1, vl);
+            c22 = __riscv_vfmacc_vf_f32m1(c22, a[2], b2, vl);
+            c30 = __riscv_vfmacc_vf_f32m1(c30, a[3], b0, vl);
+            c31 = __riscv_vfmacc_vf_f32m1(c31, a[3], b1, vl);
+            c32 = __riscv_vfmacc_vf_f32m1(c32, a[3], b2, vl);
+        }
+        if (!init_c)
+        {
+            c00 = __riscv_vfadd_vv_f32m1(c00, __riscv_vle32_v_f32m1(c,                   vl), vl);
+            c01 = __riscv_vfadd_vv_f32m1(c01, __riscv_vle32_v_f32m1(c + vl,              vl), vl);
+            c02 = __riscv_vfadd_vv_f32m1(c02, __riscv_vle32_v_f32m1(c + 2 * vl,          vl), vl);
+            c10 = __riscv_vfadd_vv_f32m1(c10, __riscv_vle32_v_f32m1(c + ldc,             vl), vl);
+            c11 = __riscv_vfadd_vv_f32m1(c11, __riscv_vle32_v_f32m1(c + ldc + vl,        vl), vl);
+            c12 = __riscv_vfadd_vv_f32m1(c12, __riscv_vle32_v_f32m1(c + ldc + 2 * vl,    vl), vl);
+            c20 = __riscv_vfadd_vv_f32m1(c20, __riscv_vle32_v_f32m1(c + 2 * ldc,         vl), vl);
+            c21 = __riscv_vfadd_vv_f32m1(c21, __riscv_vle32_v_f32m1(c + 2 * ldc + vl,    vl), vl);
+            c22 = __riscv_vfadd_vv_f32m1(c22, __riscv_vle32_v_f32m1(c + 2 * ldc + 2 * vl, vl), vl);
+            c30 = __riscv_vfadd_vv_f32m1(c30, __riscv_vle32_v_f32m1(c + 3 * ldc,         vl), vl);
+            c31 = __riscv_vfadd_vv_f32m1(c31, __riscv_vle32_v_f32m1(c + 3 * ldc + vl,    vl), vl);
+            c32 = __riscv_vfadd_vv_f32m1(c32, __riscv_vle32_v_f32m1(c + 3 * ldc + 2 * vl, vl), vl);
+        }
+        __riscv_vse32_v_f32m1(c,                    c00, vl);
+        __riscv_vse32_v_f32m1(c + vl,               c01, vl);
+        __riscv_vse32_v_f32m1(c + 2 * vl,           c02, vl);
+        __riscv_vse32_v_f32m1(c + ldc,              c10, vl);
+        __riscv_vse32_v_f32m1(c + ldc + vl,         c11, vl);
+        __riscv_vse32_v_f32m1(c + ldc + 2 * vl,     c12, vl);
+        __riscv_vse32_v_f32m1(c + 2 * ldc,          c20, vl);
+        __riscv_vse32_v_f32m1(c + 2 * ldc + vl,     c21, vl);
+        __riscv_vse32_v_f32m1(c + 2 * ldc + 2 * vl, c22, vl);
+        __riscv_vse32_v_f32m1(c + 3 * ldc,          c30, vl);
+        __riscv_vse32_v_f32m1(c + 3 * ldc + vl,     c31, vl);
+        __riscv_vse32_v_f32m1(c + 3 * ldc + 2 * vl, c32, vl);
+        return;
+    }
+    convBlockNoSIMD(np, a, b, c, ldc, init_c, outLen, convMR, convNR);
+}
 #else
     convBlockNoSIMD(np, a, b, c, ldc, init_c, outLen, convMR, convNR);
     return;


### PR DESCRIPTION
Complementary to #29403 (5.x). Ports the same fix to the 4.x branch,
where the identical condition applies.

### Problem
On rv64gcv hardware (e.g. SpacemiT K1, VLEN=256), `convBlock_F32` in
`ConvolutionLayer` falls through to `convBlockNoSIMD` — a scalar triple
loop that heap-allocates a temporary buffer on every call. The RVV
vector unit is entirely unused.

### Solution

Add a `#elif CV_RVV` branch before the `#else` fallback in
`convBlock_F32`.

`vfloat32m1_t` (LMUL=1) gives `vlanes=8` at VLEN=256, and
`3×8=24=CONV_NR_FP32`.  The kernel keeps 12 accumulator registers
(`c00`…`c32`, 4 rows × 3 vectors) and uses `vfmacc.vf` for scalar
broadcast FMA without an explicit vector broadcast instruction.  Partial
tiles (`outLen < convNR`) fall through to `convBlockNoSIMD` unchanged.

The change is a direct port of the 5.x patch from #29403; tile geometry
and dispatch structure are identical in both branches.

### Performance

SpacemiT K1 (rv64gcv, VLEN=256, 8-core 1.6 GHz),
`opencv_perf_dnn --gtest_filter="Conv*" --perf_force_samples=20`.

Baseline: `convBlockNoSIMD` (scalar). Candidate: this patch.

| Test suite | Cases | Geomean | All faster? | Max |
|---|---|---|---|---|
| Conv | 109 | **3.16×** | 109 / 109 | **6.82×** |
| Conv\_1x1 | 383 | **2.96×** | 383 / 383 | 6.13× |
| Conv\_3x3S1D1 | 294 | **2.94×** | 294 / 294 | 5.51× |
| Conv3D | 16 | 1.61× | 16 / 16 | 3.50× |

Representative case — `Conv.conv/40`
(`K=7×7, IN=1×3×224×224→64ch, S=2`): **35.5 ms → 5.2 ms (6.82×)**.

`Conv_Depthwise` uses a separate code path and is unaffected (geomean
1.03×, within measurement noise).

### Accuracy

`opencv_test_dnn --gtest_filter="Test_ONNX_layers.*"` on the same board:

| | Baseline | Candidate |
|---|---|---|
| Passed | 224 | 224 |
| Failed | 1 | 1 |
| Disabled | 6 | 6 |
| **New failures** | — | **0** |

The one failure (`Test_ONNX_layers.Tile/0`) is pre-existing and
unrelated to this change.

### Related

- #29403 — identical patch for 5.x
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
