### PR TITLE
fix: dnn build failure with PROTOBUF_UPDATE_FILES=ON due to missing generated caffe header

### DIFF
--- a/modules/dnn/CMakeLists.txt
+++ b/modules/dnn/CMakeLists.txt
@@ -112,8 +112,10 @@ set(libs "")
 
 if(HAVE_PROTOBUF)
   ocv_target_compile_definitions(${the_module} PRIVATE "HAVE_PROTOBUF=1")
+  set(fw_inc "${CMAKE_CURRENT_LIST_DIR}/misc/caffe" "${CMAKE_CURRENT_LIST_DIR}/misc/tensorflow" "${CMAKE_CURRENT_LIST_DIR}/misc/onnx")
 
   if(PROTOBUF_UPDATE_FILES)
+    list(INSERT fw_inc 0 "${CMAKE_CURRENT_BINARY_DIR}")
     file(GLOB proto_files "${CMAKE_CURRENT_LIST_DIR}/src/tensorflow/*.proto" "${CMAKE_CURRENT_LIST_DIR}/src/caffe/opencv-caffe.proto" "${CMAKE_CURRENT_LIST_DIR}/src/onnx/opencv-onnx.proto")
     if(CMAKE_VERSION VERSION_LESS "3.13.0")
       set(PROTOBUF_GENERATE_CPP_APPEND_PATH ON) # required for tensorflow
@@ -134,7 +136,6 @@ if(HAVE_PROTOBUF)
   else()
     file(GLOB fw_srcs "${CMAKE_CURRENT_LIST_DIR}/misc/tensorflow/*.cc" "${CMAKE_CURRENT_LIST_DIR}/misc/caffe/opencv-caffe.pb.cc" "${CMAKE_CURRENT_LIST_DIR}/misc/onnx/opencv-onnx.pb.cc")
     file(GLOB fw_hdrs "${CMAKE_CURRENT_LIST_DIR}/misc/tensorflow/*.h" "${CMAKE_CURRENT_LIST_DIR}/misc/caffe/opencv-caffe.pb.h" "${CMAKE_CURRENT_LIST_DIR}/misc/onnx/opencv-onnx.pb.h")
-    set(fw_inc "${CMAKE_CURRENT_LIST_DIR}/misc/caffe" "${CMAKE_CURRENT_LIST_DIR}/misc/tensorflow" "${CMAKE_CURRENT_LIST_DIR}/misc/onnx")
   endif()
 endif()
 


### PR DESCRIPTION
## Summary
With `PROTOBUF_UPDATE_FILES=ON`, the dnn module failed to build because the generated `opencv-caffe.pb.h` header (emitted into the CMake binary dir) was not on the include path, while the non-update branch added the `misc/` include dirs. This hoists the `fw_inc` include list so it applies in both branches and inserts the binary dir at the front when `PROTOBUF_UPDATE_FILES` is set, so freshly generated headers resolve.

Fixes #29291

AI was used for assistance.
