### PR TITLE
core: Fix mul32f and addWeighted32f to use native f32 SIMD paths

### DIFF
--- a/modules/core/perf/perf_addWeighted.cpp
+++ b/modules/core/perf/perf_addWeighted.cpp
@@ -4,7 +4,7 @@ namespace opencv_test
 {
 using namespace perf;
 
-#define TYPICAL_MAT_TYPES_ADWEIGHTED  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1
+#define TYPICAL_MAT_TYPES_ADWEIGHTED  CV_8UC1, CV_8UC4, CV_8SC1, CV_16UC1, CV_16SC1, CV_32SC1, CV_32FC1
 #define TYPICAL_MATS_ADWEIGHTED       testing::Combine(testing::Values(szVGA, sz720p, sz1080p), testing::Values(TYPICAL_MAT_TYPES_ADWEIGHTED))
 
 PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)
@@ -31,7 +31,10 @@ PERF_TEST_P(Size_MatType, addWeighted, TYPICAL_MATS_ADWEIGHTED)
 
     TEST_CYCLE() cv::addWeighted( src1, alpha, src2, beta, gamma, dst, dst.type() );
 
-    SANITY_CHECK(dst, depth == CV_32S ? 4 : 1);
+    if (depth == CV_32F)
+        SANITY_CHECK(dst, 1e-4, ERROR_RELATIVE);
+    else
+        SANITY_CHECK(dst, depth == CV_32S ? 4 : 1);
 }
 
 } // namespace

--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -1566,7 +1566,7 @@ void mul_loop_d<double, v_float64>(const double* src1, size_t step1, const doubl
     DEFINE_SIMD_FUN(fun, _T1, v_float64, _OP)
 
 DEFINE_SIMD_SAT(mul, mul_loop)
-DEFINE_SIMD_F32(mul, mul_loop_d)
+DEFINE_SIMD_F32(mul, mul_loop)
 DEFINE_SIMD_S32(mul, mul_loop_d)
 DEFINE_SIMD_F64(mul, mul_loop_d)
 
@@ -1834,7 +1834,7 @@ void add_weighted_loop_d<double, v_float64>(const double* src1, size_t step1, co
 
 DEFINE_SIMD_SAT(addWeighted, add_weighted_loop)
 DEFINE_SIMD_S32(addWeighted, add_weighted_loop_d)
-DEFINE_SIMD_F32(addWeighted, add_weighted_loop_d)
+DEFINE_SIMD_F32(addWeighted, add_weighted_loop)
 DEFINE_SIMD_F64(addWeighted, add_weighted_loop_d)
 
 //=======================================

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -185,6 +185,10 @@ struct AddWeightedOp : public BaseAddOp
         int dtype = (flags & MIXED_TYPE) ? dst.type() : -1;
         cv::addWeighted(src[0], alpha, src[1], beta, gamma[0], dst, dtype);
     }
+    double getMaxErr(int depth)
+    {
+        return depth < CV_32F ? 1 : depth == CV_32F ? 1e-4 : 1e-12;
+    }
 };
 
 struct MulOp : public BaseElemWiseOp


### PR DESCRIPTION
OpenCV Extra: https://github.com/opencv/opencv_extra/pull/1388

- add 32FC1 coverage to addWeighted benchmark
- avoid intermediate double for f32 variants of scaled multiply and addWeighted.
- Relax AddWeighted 32F test tolerance to match f32 FMA semantics.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake