### PR TITLE
Remove useless logger include from the public API

### DIFF
--- a/modules/calib/src/precomp.hpp
+++ b/modules/calib/src/precomp.hpp
@@ -45,7 +45,7 @@
 #include "opencv2/core/utility.hpp"
 
 #include "opencv2/core/private.hpp"
-
+#include "opencv2/core/utils/logger.hpp"
 #include "opencv2/calib.hpp"
 #include "opencv2/geometry.hpp"
 #include "opencv2/imgproc.hpp"

--- a/modules/geometry/include/opencv2/geometry/2d.hpp
+++ b/modules/geometry/include/opencv2/geometry/2d.hpp
@@ -6,7 +6,6 @@
 #define OPENCV_2D_HPP
 
 #include "opencv2/core.hpp"
-#include "opencv2/core/utils/logger.hpp"
 
 namespace cv {
 

--- a/modules/geometry/include/opencv2/geometry/3d.hpp
+++ b/modules/geometry/include/opencv2/geometry/3d.hpp
@@ -7,7 +7,6 @@
 
 #include "opencv2/core.hpp"
 #include "opencv2/core/affine.hpp"
-#include "opencv2/core/utils/logger.hpp"
 #include "opencv2/geometry/segment.hpp"
 
 /**

--- a/modules/imgproc/src/precomp.hpp
+++ b/modules/imgproc/src/precomp.hpp
@@ -52,6 +52,7 @@
 #include "opencv2/core/hal/hal.hpp"
 #include "opencv2/core/check.hpp"
 #include "opencv2/core/utils/buffer_area.private.hpp"
+#include "opencv2/core/utils/logger.hpp"
 #include "opencv2/imgproc/hal/hal.hpp"
 #include "hal_replacement.hpp"
 


### PR DESCRIPTION
This creates a conflict with some internal Google lib defining the same symbols.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
