### PR TITLE
bound einsum subscript index before reading input shape

### DIFF
--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -953,6 +953,8 @@ void LayerEinsumImpl::processEquation(const std::vector<MatShape>& inputs)
                 CV_CheckNE(letterIdx, -1,
                     "The only permissible subscript labels are lowercase letters (a-z) and uppercase letters (A-Z).");
 
+                CV_CheckLT(dim_count, rank,
+                    "The Einsum subscripts string has an excessive number of subscript labels compared to the rank of the input.");
                 int dimValue = shape[dim_count];
 
                 // The subscript label was not found in the global subscript label array
@@ -980,8 +982,7 @@ void LayerEinsumImpl::processEquation(const std::vector<MatShape>& inputs)
                 ++letter2count[letterIdx];
                 currTokenIndices.push_back(letter2index[letterIdx]);
 
-                CV_CheckLE(++dim_count, rank,
-                    "The Einsum subscripts string has an excessive number of subscript labels compared to the rank of the input.");
+                ++dim_count;
             }
         }
 


### PR DESCRIPTION
processEquation reads shape[dim_count] to pick up each subscript's axis size, but the bound that keeps dim_count inside the input rank runs one step later, after the read. An Einsum equation that gives an input more subscript labels than that input's declared rank (say "abc" against a rank-2 tensor) reads one element past the end of the shape vector before the check fires. The equation and the per-input shapes both come from the model, so a crafted graph hits this during layer construction on load.

Move the range check ahead of the index so an over-long token is rejected before shape[dim_count] is read. Valid equations behave the same and the too-many-labels case raises the same error, only earlier. The bound belongs in this loop because dim_count and the shape vector meet only here, not at any caller.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake