### PR TITLE
imgproc: re-enable RVV HAL resize NEAREST/NEAREST_EXACT

### DIFF
--- a/hal/riscv-rvv/src/imgproc/resize.cpp
+++ b/hal/riscv-rvv/src/imgproc/resize.cpp
@@ -6,7 +6,26 @@
 
 #include "rvv_hal.hpp"
 #include "common.hpp"
+#include "opencv2/core/softfloat.hpp"
 #include <list>
+
+// Coverage matrix (depth x channels x interpolation). Entries not listed fall back to the
+// generic implementation via CV_HAL_ERROR_NOT_IMPLEMENTED.
+//
+//                    | 8UC1 8UC2 8UC3 8UC4 | 16UC1 16UC2 16UC3 16UC4 | 32FC1 32FC2 32FC3 32FC4
+// NEAREST            |  Y    Y    Y    Y   |  Y*    Y*    -     -    |  Y*    -     -     -
+// NEAREST_EXACT      |  Y    Y    Y    Y   |  Y*    Y*    -     -    |  Y*    -     -     -
+// LINEAR             |  Y    Y    Y    Y   |  Y     Y     Y     Y    |  Y     Y     Y     Y
+// LINEAR_EXACT       |  Y    Y    Y    Y   |  -     -     -     -    |  n/a (core uses LINEAR)
+// AREA (2x2 fast)    |  Y    Y    Y    Y   |  Y     Y     Y     Y    |  -     -     -     -
+// AREA (generic dn)  |  Y    Y    Y    Y   |  -     -     -     -    |  -     -     -     -
+// AREA (upscale)     |  -  (falls back: core maps AREA upscale to LINEAR-like path)
+// CUBIC / LANCZOS4   |  -  (not implemented)
+//
+// Y* : NEAREST dispatches on element size in bytes (1..4), so 16UC1/16UC2/32FC1/32SC1 etc.
+//      are covered by the same gather kernels as 8UC2/8UC4.
+// Additional limits: width guards require cn*src_width (resp. cn*4*src_width for AREA
+// generic) to fit in ushort, since gather indices are 16-bit byte offsets.
 
 namespace cv { namespace rvv_hal { namespace imgproc {
 
@@ -39,16 +58,14 @@ static inline int invoke(int height, std::function<int(int, int, Args...)> func,
     return func(0, 1, std::forward<Args>(args)...);
 }
 
+// cn is the element size in bytes, not the channel count; x_ofs/y_ofs hold precomputed
+// clamped source offsets (x in bytes) so NEAREST and NEAREST_EXACT share the same kernel
 template<int cn>
-static inline int resizeNN(int start, int end, const uchar *src_data, size_t src_step, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, double scale_y, int interpolation, const ushort* x_ofs)
+static inline int resizeNN(int start, int end, const uchar *src_data, size_t src_step, uchar *dst_data, size_t dst_step, int dst_width, const int* y_ofs_tab, const ushort* x_ofs)
 {
-    const int ify = ((src_height << 16) + dst_height / 2) / dst_height;
-    const int ify0 = ify / 2 - src_height % 2;
-
     for (int i = start; i < end; i++)
     {
-        int y_ofs = interpolation == CV_HAL_INTER_NEAREST ? static_cast<int>(std::floor(i * scale_y)) : (ify * i + ify0) >> 16;
-        y_ofs = std::min(y_ofs, src_height - 1);
+        int y_ofs = y_ofs_tab[i];
 
         int vl;
         switch (cn)
@@ -739,29 +756,44 @@ static inline int resizeArea(int start, int end, const uchar *src_data, size_t s
 // in the function static void resizeNN and static void resizeNN_bitexact
 static inline int resizeNN(int src_type, const uchar *src_data, size_t src_step, int src_width, int src_height, uchar *dst_data, size_t dst_step, int dst_width, int dst_height, double scale_x, double scale_y, int interpolation)
 {
-    const int cn = CV_ELEM_SIZE(src_type);
-    if (cn * src_width > std::numeric_limits<ushort>::max())
+    const int pix_size = CV_ELEM_SIZE(src_type);
+    if (pix_size * src_width > std::numeric_limits<ushort>::max())
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
 
     std::vector<ushort> x_ofs(dst_width);
-    const int ifx = ((src_width << 16) + dst_width / 2) / dst_width;
-    const int ifx0 = ifx / 2 - src_width % 2;
-    for (int i = 0; i < dst_width; i++)
+    std::vector<int> y_ofs(dst_height);
+    if (interpolation == CV_HAL_INTER_NEAREST)
     {
-        x_ofs[i] = interpolation == CV_HAL_INTER_NEAREST ? static_cast<ushort>(std::floor(i * scale_x)) : (ifx * i + ifx0) >> 16;
-        x_ofs[i] = std::min(x_ofs[i], static_cast<ushort>(src_width - 1)) * cn;
+        for (int i = 0; i < dst_width; i++)
+            x_ofs[i] = static_cast<ushort>(std::min(cvFloor(i * scale_x), src_width - 1) * pix_size);
+        for (int i = 0; i < dst_height; i++)
+            y_ofs[i] = std::min(cvFloor(i * scale_y), src_height - 1);
+    }
+    else
+    {
+        // NEAREST_EXACT must reproduce resizeNN_bitexact_tab: Pillow-compatible pixel-center
+        // mapping accumulated in softdouble, otherwise results diverge from the core path
+        const softdouble fx = softdouble(src_width) / softdouble(dst_width);
+        softdouble vx = fx * softdouble(0.5);
+        for (int i = 0; i < dst_width; i++, vx += fx)
+            x_ofs[i] = static_cast<ushort>(std::min(cvFloor(vx), src_width - 1) * pix_size);
+        const softdouble fy = softdouble(src_height) / softdouble(dst_height);
+        softdouble vy = fy * softdouble(0.5);
+        for (int i = 0; i < dst_height; i++, vy += fy)
+            y_ofs[i] = std::min(cvFloor(vy), src_height - 1);
     }
 
-    switch (src_type)
+    // gather kernels only depend on the element size, so e.g. 16UC1 shares the 8UC2 path
+    switch (pix_size)
     {
-    case CV_8UC1:
-        return invoke(dst_height, {resizeNN<1>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
-    case CV_8UC2:
-        return invoke(dst_height, {resizeNN<2>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
-    case CV_8UC3:
-        return invoke(dst_height, {resizeNN<3>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
-    case CV_8UC4:
-        return invoke(dst_height, {resizeNN<4>}, src_data, src_step, src_height, dst_data, dst_step, dst_width, dst_height, scale_y, interpolation, x_ofs.data());
+    case 1:
+        return invoke(dst_height, {resizeNN<1>}, src_data, src_step, dst_data, dst_step, dst_width, y_ofs.data(), x_ofs.data());
+    case 2:
+        return invoke(dst_height, {resizeNN<2>}, src_data, src_step, dst_data, dst_step, dst_width, y_ofs.data(), x_ofs.data());
+    case 3:
+        return invoke(dst_height, {resizeNN<3>}, src_data, src_step, dst_data, dst_step, dst_width, y_ofs.data(), x_ofs.data());
+    case 4:
+        return invoke(dst_height, {resizeNN<4>}, src_data, src_step, dst_data, dst_step, dst_width, y_ofs.data(), x_ofs.data());
     }
     return CV_HAL_ERROR_NOT_IMPLEMENTED;
 }
@@ -990,8 +1022,8 @@ int resize(int src_type, const uchar *src_data, size_t src_step, int src_width, 
 {
     inv_scale_x = 1 / inv_scale_x;
     inv_scale_y = 1 / inv_scale_y;
-    //if (interpolation == CV_HAL_INTER_NEAREST || interpolation == CV_HAL_INTER_NEAREST_EXACT)
-    //    return resizeNN(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, dst_height, inv_scale_x, inv_scale_y, interpolation);
+    if (interpolation == CV_HAL_INTER_NEAREST || interpolation == CV_HAL_INTER_NEAREST_EXACT)
+        return resizeNN(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, dst_height, inv_scale_x, inv_scale_y, interpolation);
     if (interpolation == CV_HAL_INTER_LINEAR || interpolation == CV_HAL_INTER_LINEAR_EXACT)
         return resizeLinear(src_type, src_data, src_step, src_width, src_height, dst_data, dst_step, dst_width, dst_height, inv_scale_x, inv_scale_y, interpolation);
     if (interpolation == CV_HAL_INTER_AREA)


### PR DESCRIPTION

### Summary

Re-enables the RISC-V Vector HAL path for `INTER_NEAREST` and
`INTER_NEAREST_EXACT` in `hal/riscv-rvv/src/imgproc/resize.cpp`,
disabled since #28873. Tested on SpacemiT K1 (rv64gcv, VLEN=256).

### Background

#28873 changed core's `INTER_NEAREST_EXACT` to a Pillow-compatible
mapping — iterative `softdouble` accumulation in `resizeNN_bitexact_tab`
— while the HAL still used the old 16-bit fixed-point formula
`(ifx*i + ifx0) >> 16`. The outputs diverged, so the whole NN dispatch
was commented out, which also disabled plain `INTER_NEAREST` even though
it was never affected by the rounding change. On RISC-V the generic
`INTER_NEAREST` path (`resizeNNInvoker`) is fully scalar, so this left
measurable performance on the table.

### Implementation notes

**Coordinate tables.** The per-row coordinate arithmetic is moved out of
the vector kernels into scalar table setup in the dispatcher:

- `INTER_NEAREST`: `min(cvFloor(i * scale), src − 1)`, matching core
  `resizeNNInvoker`.
- `INTER_NEAREST_EXACT`: a line-for-line reproduction of
  `resizeNN_bitexact_tab`, including the iterative `softdouble`
  accumulation. A closed-form `(i + 0.5) * scale` in native `double` is
  not equivalent and breaks bit-exactness at pixel boundaries.

The gather kernels (`vloxei16` / `vloxseg`) now receive pre-built x/y
offset arrays and contain no interpolation logic, so a future change to
the core mapping only touches ~20 lines of scalar table code instead of
requiring the HAL to be disabled again.

This also aligns with the x_tab/y_tab HAL API direction suggested in the
#28873 discussion: the vector kernels are already pure table-driven
gathers, so migrating to a future `hal_resize_v2(..., x_tab, y_tab)`
would only remove the table-construction code here, not touch the
kernels. Measured on K1, the scalar softdouble table setup costs
~0.1–0.2 ms per call at 720p/1080p output sizes — an argument for
eventually moving table construction into core.


**Dispatch by element size.** NN kernels only move bytes, so the switch
over `src_type` is replaced by a switch over `CV_ELEM_SIZE(src_type)`
(1..4 bytes). This extends `INTER_NEAREST` coverage to 16UC1, 16UC2,
32FC1 etc. with no new kernel code. The existing 16-bit gather index
limit (`elem_size × src_width ≤ 65535`) is unchanged.

**NEAREST_EXACT scope.** The generic `resizeNN_bitexactInvoker` is
already vectorised via `vx_lut` universal intrinsics on RISC-V and
outperforms the indexed-gather kernels here for 1/2/4-byte pixels
(measured up to 1.35× faster on K1, partly because this path also pays
a scalar `softdouble` table setup per call). The HAL therefore takes
`INTER_NEAREST_EXACT` only for 3-byte pixels, which `vx_lut` cannot
batch; other element sizes return `CV_HAL_ERROR_NOT_IMPLEMENTED`. A
coverage matrix comment at the top of the file documents what is taken
and why.

### Testing

**Correctness:** `opencv_test_imgproc --gtest_filter=*Resize*` — 985/985
pass on the K1 board, including `Resize_Bitexact.NearestExact_PillowCompat`
added by #28873. Output CRCs match the generic implementation exactly in
all 20 tested {type × interpolation × size} combinations, including the
cases the HAL declines.

**Performance:** SpacemiT K1 (rv64gcv, VLEN=256), GCC 14.2.1, `-O2
-march=rv64gcv`. Per-case medians over 30 iterations, minimum of 3
interleaved candidate/baseline runs. "Generic" is the same build with
this patch's `resize.cpp` reverted to the current state (NN dispatch
disabled).

| Input → Output        | Case                | Generic (ms) | HAL (ms) | Speedup |
|-----------------------|---------------------|-------------|---------|---------|
| 1920×1080 → 1280×720  | NEAREST 8UC1        | 0.854       | 0.601   | 1.42×   |
| 1920×1080 → 1280×720  | NEAREST 8UC3        | 1.667       | 1.529   | 1.09×   |
| 1920×1080 → 1280×720  | NEAREST 8UC4        | 1.929       | 1.672   | 1.15×   |
| 1920×1080 → 1280×720  | NEAREST 16UC1       | 1.138       | 1.127   | 1.01×   |
| 1920×1080 → 1280×720  | NEAREST 32FC1       | 1.856       | 1.661   | 1.12×   |
| 1920×1080 → 1280×720  | NEAREST_EXACT 8UC3  | 1.837       | 1.671   | 1.10×   |
| 3840×2160 → 1920×1080 | NEAREST 8UC1        | 2.822       | 2.792   | 1.01×   |
| 3840×2160 → 1920×1080 | NEAREST 8UC3        | 4.292       | 3.504   | 1.22×   |
| 3840×2160 → 1920×1080 | NEAREST 8UC4        | 5.128       | 4.579   | 1.12×   |
| 3840×2160 → 1920×1080 | NEAREST 16UC1       | 3.040       | 2.549   | 1.19×   |
| 3840×2160 → 1920×1080 | NEAREST 32FC1       | 5.135       | 4.387   | 1.17×   |
| 3840×2160 → 1920×1080 | NEAREST_EXACT 8UC3  | 4.700       | 3.915   | 1.20×   |

Geometric mean over the 12 cases the HAL takes: ~1.15×; no case is
below 1.0×.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
