### PR TITLE
Fix remap with BORDER_TRANSPARENT for INTER_LINEAR float maps (#29412)

### DIFF
--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1507,7 +1507,7 @@ void cv::remap( InputArray _src, OutputArray _dst,
         }
     }
 
-    if (interpolation == INTER_LINEAR) {
+    if (interpolation == INTER_LINEAR && borderType != BORDER_TRANSPARENT) {
         if (map1.depth() == CV_32F) {
             const auto *src_data = src.ptr<const uint8_t>();
             auto *dst_data = dst.ptr<uint8_t>();

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1067,6 +1067,21 @@ TEST(Imgproc_Remap, issue_23562)
     }
 }
 
+TEST(Imgproc_Remap, issue_29412)
+{
+    Mat src(3, 4, CV_8UC1, Scalar(10));
+    Mat_<float> mapx(7, 8), mapy(7, 8);
+    for (int r = 0; r < 7; ++r)
+        for (int c = 0; c < 8; ++c) { mapx(r, c) = -1.5f + c; mapy(r, c) = -1.5f + r; }
+
+    Mat ref = Mat::zeros(7, 8, CV_8UC1);
+    ref(Rect(2, 2, 4, 3)).setTo(10);
+
+    Mat dst = Mat::zeros(7, 8, CV_8UC1);
+    remap(src, dst, mapx, mapy, INTER_LINEAR, BORDER_TRANSPARENT);
+    ASSERT_EQ(0.0, cvtest::norm(ref, dst, NORM_INF));
+}
+
 TEST(Imgproc_Resize, issue_26497)
 {
     std::vector<float> vec = {0.f, 1.f, 2.f, 3.f};


### PR DESCRIPTION
Fixes #29412.

remap() with BORDER_TRANSPARENT is supposed to leave the destination
pixels untouched when a source coordinate falls outside the image. In 5.0,
float32 maps with INTER_LINEAR stopped doing this: instead of leaving those
pixels alone, they get filled in, so the result looks like BORDER_CONSTANT
(a black border) rather than transparent. INTER_LANCZOS4 still works, which
points to the cause: the 5.0 remap rewrite added a new code path for linear,
and that path doesn't handle the transparent border correctly.

The older code path handles it correctly and already has test coverage
(from #23754). This change makes transparent linear remap use that path
instead of the new one.

INTER_CUBIC shows the same bug, but its old code path was removed in 5.0, so
it can't be fixed the same way and needs separate work — not included here.

Added a regression test (Imgproc_Remap.issue_29412) using the reporter's
exact example. Full imgproc test suite passes.

Assisted-by: Claude