### PR TITLE
Fix: Correct perf test cosmetic issues

### DIFF
--- a/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
+++ b/modules/features2d/perf/opencl/perf_brute_force_matcher.cpp
@@ -145,6 +145,6 @@ OCL_PERF_TEST_P(BruteForceMatcherFixture, MatchCrossCheck, ::testing::Combine(OC
 }
 
 } // ocl
-} // cvtest
+} // opencv_test
 
 #endif // HAVE_OPENCL

--- a/modules/features2d/perf/opencl/perf_feature2d.cpp
+++ b/modules/features2d/perf/opencl/perf_feature2d.cpp
@@ -76,6 +76,6 @@ OCL_PERF_TEST_P(feature2d, detectAndExtract, testing::Combine(testing::Values(DE
 }
 
 } // ocl
-} // cvtest
+} // opencv_test
 
 #endif // HAVE_OPENCL


### PR DESCRIPTION
Fix wrong namespace closing comments in
OCL perf tests
Remove redundant AKAZE detectAndCompute
test with weak config
Preserve checkDeviceMaxMemoryAllocSize on
surviving test

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
