### PR TITLE
core: add CV_8F (E4M3FN) depth and Mat conversion support

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -978,7 +978,89 @@ public:
 protected:
     ushort w;
 };
+CV_INLINE uchar cv_cvt_f32_to_fp8e4m3fn(float x)
+{
+    Cv32suf in;
+    in.f = x;
+    unsigned sign = (in.u >> 31) & 0x1;
+    unsigned exp32 = (in.u >> 23) & 0xFF;
+    unsigned mant32 = in.u & 0x7FFFFF;
 
+    if (exp32 == 0xFF)
+        return (uchar)((sign << 7) | 0x7F);
+
+    int exp8 = (int)exp32 - 127 + 7;
+
+    if (exp8 >= 16)
+    {
+        return (uchar)((sign << 7) | 0x7E);
+    }
+
+    if (exp8 <= 0)
+    {
+        int shift = 1 - exp8;
+        if (shift > 9)
+            return (uchar)(sign << 7);
+        unsigned mant_full = mant32 | 0x800000;
+        unsigned mant8 = mant_full >> (20 + shift);
+        return (uchar)((sign << 7) | (mant8 & 0x7));
+    }
+
+    unsigned mant8 = (mant32 >> 20) & 0x7;
+    if (exp8 == 15 && mant8 == 7)
+    {
+        return (uchar)((sign << 7) | 0x7E);
+    }
+    return (uchar)((sign << 7) | ((unsigned)exp8 << 3) | mant8);
+}
+CV_INLINE float cv_fp8e4m3fn_lut_gen(uchar w)
+{
+    unsigned sign = (w >> 7) & 0x1;
+    unsigned exp8 = (w >> 3) & 0xF;
+    unsigned mant8 = w & 0x7;
+
+    Cv32suf out;
+    if (exp8 == 0 && mant8 == 0)
+    {
+        out.u = sign << 31;
+        return out.f;
+    }
+    if (exp8 == 0xF && mant8 == 0x7)
+    {
+        out.u = 0x7FC00000u | (sign << 31);
+        return out.f;
+    }
+    if (exp8 == 0)
+    {
+        float val = (float)mant8 * 0.001953125f;
+        return sign ? -val : val;
+    }
+    int exp32 = (int)exp8 - 7 + 127;
+    out.u = (sign << 31) | ((unsigned)exp32 << 23) | (mant8 << 20);
+    return out.f;
+}
+
+CV_INLINE const float* fp8e4m3fn_lut()
+{
+    static float table[256];
+    static bool inited = false;
+    if (!inited)
+    {
+        for (int i = 0; i < 256; i++)
+            table[i] = cv_fp8e4m3fn_lut_gen((uchar)i);
+        inited = true;
+    }
+    return table;
+}
+class fp8_e4m3_t
+{
+public:
+    fp8_e4m3_t() : w(0) {}
+    explicit fp8_e4m3_t(float x) { w = cv_cvt_f32_to_fp8e4m3fn(x); }
+    operator float() const { return fp8e4m3fn_lut()[w]; }
+protected:
+    uchar w;
+};
 }
 #endif
 

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -521,7 +521,7 @@ Cv64suf;
     CV_16U - 2 bytes
     ...
 */
-#define CV_ELEM_SIZE1(type) ((int)((0x4881228442211ULL >> (CV_MAT_DEPTH(type) * 4)) & 15))
+#define CV_ELEM_SIZE1(type) ((int)((0x14881228442211ULL >> (CV_MAT_DEPTH(type) * 4)) & 15))
 
 #define CV_ELEM_SIZE(type) (CV_MAT_CN(type)*CV_ELEM_SIZE1(type))
 

--- a/modules/core/include/opencv2/core/hal/interface.h
+++ b/modules/core/include/opencv2/core/hal/interface.h
@@ -64,7 +64,8 @@ typedef int16_t cv_hal_bf16;
 #define CV_64U  10
 #define CV_64S  11
 #define CV_32U  12
-#define CV_DEPTH_CURR_MAX 13
+#define CV_8F   13
+#define CV_DEPTH_CURR_MAX 14
 
 #define CV_MAT_DEPTH_MASK       (CV_DEPTH_MAX - 1)
 #define CV_MAT_DEPTH(flags)     ((flags) & CV_MAT_DEPTH_MASK)
@@ -151,6 +152,12 @@ typedef int16_t cv_hal_bf16;
 #define CV_16BFC3 CV_MAKETYPE(CV_16BF,3)
 #define CV_16BFC4 CV_MAKETYPE(CV_16BF,4)
 #define CV_16BFC(n) CV_MAKETYPE(CV_16BF,(n))
+
+#define CV_8FC1 CV_MAKETYPE(CV_8F,1)
+#define CV_8FC2 CV_MAKETYPE(CV_8F,2)
+#define CV_8FC3 CV_MAKETYPE(CV_8F,3)
+#define CV_8FC4 CV_MAKETYPE(CV_8F,4)
+#define CV_8FC(n) CV_MAKETYPE(CV_8F,(n))
 
 //! @name Comparison operation
 //! @sa cv::CmpTypes

--- a/modules/core/include/opencv2/core/traits.hpp
+++ b/modules/core/include/opencv2/core/traits.hpp
@@ -336,6 +336,21 @@ public:
          };
 };
 
+template<> class DataType<fp8_e4m3_t>
+{
+public:
+    typedef fp8_e4m3_t  value_type;
+    typedef float       work_type;
+    typedef value_type  channel_type;
+    typedef value_type  vec_type;
+    enum { generic_type = 0,
+           depth        = CV_8F,
+           channels     = 1,
+           fmt          = (int)'B',
+           type         = CV_MAKETYPE(depth, channels)
+         };
+};
+
 /** @brief A helper class for cv::DataType
 
 The class is specialized for each fundamental numerical data type supported by OpenCV. It provides
@@ -432,6 +447,12 @@ template<> class TypeDepth<CV_16BF>
 {
     enum { depth = CV_16BF };
     typedef bfloat value_type;
+};
+
+template<> class TypeDepth<CV_8F>
+{
+    enum { depth = CV_8F };
+    typedef fp8_e4m3_t value_type;
 };
 
 template<> class TypeDepth<CV_Bool>

--- a/modules/core/src/convert.hpp
+++ b/modules/core/src/convert.hpp
@@ -49,6 +49,15 @@ static inline void vx_load_as(const hfloat* ptr, v_float32& a)
 static inline void vx_load_as(const bfloat* ptr, v_float32& a)
 { a = vx_load_expand(ptr); }
 
+static inline void vx_load_as(const fp8_e4m3_t* ptr, v_float32& a)
+{
+    float buf[VTraits<v_float32>::max_nlanes];
+    const int n = VTraits<v_float32>::vlanes();
+    for (int i = 0; i < n; i++)
+        buf[i] = (float)ptr[i];
+    a = vx_load(buf);
+}
+
 static inline void v_store_as(ushort* ptr, const v_float32& a)
 { v_pack_u_store(ptr, v_round(a)); }
 
@@ -80,6 +89,27 @@ static inline void v_store_as(fp8_e4m3_t* ptr, const v_float32& a)
     const int n = VTraits<v_float32>::vlanes();
     for (int i = 0; i < n; i++)
         ptr[i] = fp8_e4m3_t(buf[i]);
+}
+
+static inline void vx_load_pair_as(const fp8_e4m3_t* ptr, v_float32& a, v_float32& b)
+{
+    const int n = VTraits<v_float32>::vlanes();
+    float bufA[VTraits<v_float32>::max_nlanes];
+    float bufB[VTraits<v_float32>::max_nlanes];
+    for (int i = 0; i < n; i++) bufA[i] = (float)ptr[i];
+    for (int i = 0; i < n; i++) bufB[i] = (float)ptr[n + i];
+    a = vx_load(bufA);
+    b = vx_load(bufB);
+}
+static inline void vx_load_pair_as(const fp8_e4m3_t* ptr, v_float64& a, v_float64& b)
+{
+    const int n = VTraits<v_float64>::vlanes();
+    double bufA[VTraits<v_float64>::max_nlanes];
+    double bufB[VTraits<v_float64>::max_nlanes];
+    for (int i = 0; i < n; i++) bufA[i] = (double)(float)ptr[i];
+    for (int i = 0; i < n; i++) bufB[i] = (double)(float)ptr[n + i];
+    a = vx_load(bufA);
+    b = vx_load(bufB);
 }
 
 static inline void v_store_as(int64_t* ptr, const v_float32& a)

--- a/modules/core/src/convert.hpp
+++ b/modules/core/src/convert.hpp
@@ -73,6 +73,15 @@ static inline void v_store_as(hfloat* ptr, const v_float32& a)
 static inline void v_store_as(bfloat* ptr, const v_float32& a)
 { v_pack_store(ptr, a); }
 
+static inline void v_store_as(fp8_e4m3_t* ptr, const v_float32& a)
+{
+    float buf[VTraits<v_float32>::max_nlanes];
+    v_store(buf, a);
+    const int n = VTraits<v_float32>::vlanes();
+    for (int i = 0; i < n; i++)
+        ptr[i] = fp8_e4m3_t(buf[i]);
+}
+
 static inline void v_store_as(int64_t* ptr, const v_float32& a)
 {
     v_int32 ia = v_round(a);

--- a/modules/core/src/convert.simd.hpp
+++ b/modules/core/src/convert.simd.hpp
@@ -355,6 +355,7 @@ DEF_CVTBOOL2_FUNC(8b64f, double, 1)
 DEF_CVTBOOL2_FUNC(8b64s, int64_t, 1)
 DEF_CVTBOOL2_FUNC(8b16f, uint16_t, 0x3c00) // hfloat(1.0f)
 DEF_CVTBOOL2_FUNC(8b16bf, uint16_t, 0x3f80) // bfloat(1.0f)
+DEF_CVTBOOL2_FUNC(8b8f, uint8_t, 0x38) // fp8_e4m3(1.0f)
 
 ////////////////////// 16u -> ... ////////////////////////
 
@@ -492,6 +493,17 @@ DEF_CVT_FUNC(8f64u, cvt1_, fp8_e4m3_t, uint64_t, v_float32)
 DEF_CVT_FUNC(8f64s, cvt1_, fp8_e4m3_t, int64_t, v_float32)
 DEF_CVT_FUNC(8f16f, cvt1_, fp8_e4m3_t, hfloat, v_float32)
 DEF_CVT_FUNC(8f16bf, cvt1_, fp8_e4m3_t, bfloat, v_float32)
+static void cvt8f8b(const uchar* src_, size_t sstep, const uchar*, size_t,
+                     uchar* dst, size_t dstep, Size size, void*)
+{
+    CV_INSTRUMENT_REGION();
+    const fp8_e4m3_t* src = (const fp8_e4m3_t*)src_;
+    sstep /= sizeof(src[0]);
+    for (int i = 0; i < size.height; i++, src += sstep, dst += dstep) {
+        for (int j = 0; j < size.width; j++)
+            dst[j] = ((float)src[j] != 0.0f);
+    }
+}
 
 ////////////////////// 64s -> ... ////////////////////////
 
@@ -714,6 +726,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f8f :
             sdepth == CV_16F ? cvt16f8f :
             sdepth == CV_16BF ? cvt16bf8f :
+            sdepth == CV_Bool ? cvt8b8f :
             sdepth == CV_64U ? cvt64u8f :
             sdepth == CV_64S ? cvt64s8f :
             0) :
@@ -728,6 +741,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f8b :
             sdepth == CV_16F ? cvt16f8b :
             sdepth == CV_16BF ? cvt16f8b : // same as cvt16f8b
+            sdepth == CV_8F ? cvt8f8b :
             sdepth == CV_Bool ? cvt8u :
             sdepth == CV_64U ? cvt64s8b :
             sdepth == CV_64S ? cvt64s8b :

--- a/modules/core/src/convert.simd.hpp
+++ b/modules/core/src/convert.simd.hpp
@@ -382,6 +382,7 @@ DEF_CVT_FUNC(16s64u, cvt_, short, uint64_t, v_uint32)
 DEF_CVT_FUNC(16s64s, cvt_, short, int64_t, v_int32)
 DEF_CVT_FUNC(16s16f, cvt1_,short, hfloat, v_float32)
 DEF_CVT_FUNC(16s16bf, cvt1_, short, bfloat, v_float32)
+DEF_CVT_FUNC(16s8f, cvt1_, short, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(16s8b, short, 0)
 
 ////////////////////// 32u -> ... ////////////////////////
@@ -396,6 +397,7 @@ DEF_CVT_FUNC(32u64f, cvt_, unsigned, double, v_float32)
 DEF_CVT_SCALAR_FUNC(32u64s, unsigned, int64_t)
 DEF_CVT_FUNC(32u16f, cvt1_, unsigned, hfloat, v_float32)
 DEF_CVT_FUNC(32u16bf, cvt1_, int, bfloat, v_float32)
+DEF_CVT_FUNC(32u8f, cvt1_, unsigned, fp8_e4m3_t, v_float32)
 
 ////////////////////// 32s -> ... ////////////////////////
 
@@ -410,6 +412,7 @@ DEF_CVT_FUNC(32s64u, cvt_, int, uint64_t, v_uint32)
 DEF_CVT_FUNC(32s64s, cvt_, int, int64_t, v_int32)
 DEF_CVT_FUNC(32s16f, cvt1_,int, hfloat, v_float32)
 DEF_CVT_FUNC(32s16bf, cvt1_, int, bfloat, v_float32)
+DEF_CVT_FUNC(32s8f, cvt1_, int, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(32s8b, int, 0)
 
 ////////////////////// 32f -> ... ////////////////////////
@@ -441,6 +444,7 @@ DEF_CVT_FUNC(64f64u, cvt_64f, double, uint64_t, v_float64)
 DEF_CVT_FUNC(64f64s, cvt_64f, double, int64_t, v_float32)
 DEF_CVT_FUNC(64f16f, cvt1_,double, hfloat, v_float32)
 DEF_CVT_FUNC(64f16bf, cvt1_,double, bfloat, v_float32)
+DEF_CVT_FUNC(64f8f, cvt1_, double, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(64f8b, int64_t, 1)
 
 ////////////////////// 16f -> ... ////////////////////////
@@ -456,6 +460,7 @@ DEF_CVT_FUNC(16f64f, cvt1_, hfloat, double, v_float32)
 DEF_CVT_FUNC(16f64u, cvt1_, hfloat, uint64_t, v_float32)
 DEF_CVT_FUNC(16f64s, cvt1_, hfloat, int64_t, v_float32)
 DEF_CVT_FUNC(16f16bf, cvt1_, hfloat, bfloat, v_float32)
+DEF_CVT_FUNC(16f8f, cvt1_, hfloat, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(16f8b, short, 1)
 
 ////////////////////// 16bf -> ... ////////////////////////
@@ -471,13 +476,22 @@ DEF_CVT_FUNC(16bf64f, cvt1_, bfloat, double, v_float32)
 DEF_CVT_FUNC(16bf64u, cvt1_, bfloat, uint64_t, v_float32)
 DEF_CVT_FUNC(16bf64s, cvt1_, bfloat, int64_t, v_float32)
 DEF_CVT_FUNC(16bf16f, cvt1_, bfloat, hfloat, v_float32)
+DEF_CVT_FUNC(16bf8f, cvt1_, bfloat, fp8_e4m3_t, v_float32)
 
 ////////////////////// 8f -> ... ////////////////////////
 
 DEF_CVT_FUNC(8f8u,  cvt_, fp8_e4m3_t, uchar,  v_float32)
 DEF_CVT_FUNC(8f8s,  cvt_, fp8_e4m3_t, schar,  v_float32)
 DEF_CVT_FUNC(8f16u, cvt1_, fp8_e4m3_t, ushort, v_float32)
+DEF_CVT_FUNC(8f16s, cvt1_, fp8_e4m3_t, short,  v_float32)
+DEF_CVT_FUNC(8f32u, cvt1_, fp8_e4m3_t, unsigned, v_float32)
+DEF_CVT_FUNC(8f32s, cvt1_, fp8_e4m3_t, int,    v_float32)
 DEF_CVT_FUNC(8f32f, cvt1_, fp8_e4m3_t, float,  v_float32)
+DEF_CVT_FUNC(8f64f, cvt1_, fp8_e4m3_t, double, v_float32)
+DEF_CVT_FUNC(8f64u, cvt1_, fp8_e4m3_t, uint64_t, v_float32)
+DEF_CVT_FUNC(8f64s, cvt1_, fp8_e4m3_t, int64_t, v_float32)
+DEF_CVT_FUNC(8f16f, cvt1_, fp8_e4m3_t, hfloat, v_float32)
+DEF_CVT_FUNC(8f16bf, cvt1_, fp8_e4m3_t, bfloat, v_float32)
 
 ////////////////////// 64s -> ... ////////////////////////
 
@@ -492,6 +506,7 @@ DEF_CVT_FUNC(64s64f, cvt_64f, int64_t, double,  v_float64)
 DEF_CVT_FUNC(64s64u, cvt_, int64_t, uint64_t, v_uint64)
 DEF_CVT_FUNC(64s16f, cvt1_,int64_t, hfloat, v_float32)
 DEF_CVT_FUNC(64s16bf, cvt1_, int64_t, bfloat, v_float32)
+DEF_CVT_FUNC(64s8f, cvt1_, int64_t, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(64s8b, int64_t, 0)
 
 ////////////////////// 64u -> ... ////////////////////////
@@ -506,6 +521,7 @@ DEF_CVT_FUNC(64u32f, cvt_64f, uint64_t, float,  v_float64)
 DEF_CVT_FUNC(64u64f, cvt_64f, uint64_t, double,  v_float64)
 DEF_CVT_FUNC(64u16f, cvt1_,uint64_t, hfloat, v_float32)
 DEF_CVT_FUNC(64u16bf, cvt1_, uint64_t, bfloat, v_float32)
+DEF_CVT_FUNC(64u8f, cvt1_, uint64_t, fp8_e4m3_t, v_float32)
 
 ///////////// "conversion" w/o conversion ///////////////
 
@@ -585,6 +601,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f16s :
             sdepth == CV_16F ? cvt16f16s :
             sdepth == CV_16BF ? cvt16bf16s :
+            sdepth == CV_8F ? cvt8f16s :
             sdepth == CV_Bool ? cvt8b16s :
             sdepth == CV_64U ? cvt64u16s :
             sdepth == CV_64S ? cvt64s16s :
@@ -600,6 +617,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f32u :
             sdepth == CV_16F ? cvt16f32u :
             sdepth == CV_16BF ? cvt16bf32u :
+            sdepth == CV_8F ? cvt8f32u :
             sdepth == CV_Bool ? cvt8b32s :
             sdepth == CV_64U ? cvt64u32u :
             sdepth == CV_64S ? cvt64s32u :
@@ -616,6 +634,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f32s :
             sdepth == CV_16F ? cvt16f32s :
             sdepth == CV_16BF ? cvt16bf32s :
+            sdepth == CV_8F ? cvt8f32s :
             sdepth == CV_Bool ? cvt8b32s :
             sdepth == CV_64U ? cvt64u32s :
             sdepth == CV_64S ? cvt64s32s :
@@ -647,6 +666,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64s :
             sdepth == CV_16F ? cvt16f64f :
             sdepth == CV_16BF ? cvt16bf64f :
+            sdepth == CV_8F ? cvt8f64f :
             sdepth == CV_Bool ? cvt8b64f :
             sdepth == CV_64U ? cvt64u64f :
             sdepth == CV_64S ? cvt64s64f :
@@ -662,6 +682,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f16f :
             sdepth == CV_16F ? cvt16u :
             sdepth == CV_16BF ? cvt16bf16f :
+            sdepth == CV_8F ? cvt8f16f :
             sdepth == CV_Bool ? cvt8b16f :
             sdepth == CV_64U ? cvt64u16f :
             sdepth == CV_64S ? cvt64s16f :
@@ -680,12 +701,21 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_Bool ? cvt8b16bf :
             sdepth == CV_64U ? cvt64u16bf :
             sdepth == CV_64S ? cvt64s16bf :
+            sdepth == CV_8F ? cvt8f16bf :
             0) :
         ddepth == CV_8F ? (
             sdepth == CV_8U ? cvt8u8f :
             sdepth == CV_8S ? cvt8s8f :
             sdepth == CV_16U ? cvt16u8f :
+            sdepth == CV_16S ? cvt16s8f :
+            sdepth == CV_32U ? cvt32u8f :
+            sdepth == CV_32S ? cvt32s8f :
             sdepth == CV_32F ? cvt32f8f :
+            sdepth == CV_64F ? cvt64f8f :
+            sdepth == CV_16F ? cvt16f8f :
+            sdepth == CV_16BF ? cvt16bf8f :
+            sdepth == CV_64U ? cvt64u8f :
+            sdepth == CV_64S ? cvt64s8f :
             0) :
         ddepth == CV_Bool ? (
             sdepth == CV_8U ? cvt8u8b :
@@ -713,6 +743,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f64u :
             sdepth == CV_16F ? cvt16f64u :
             sdepth == CV_16BF ? cvt16bf64u :
+            sdepth == CV_8F ? cvt8f64u :
             sdepth == CV_Bool ? cvt8b64s :
             sdepth == CV_64U ? cvt64s :
             sdepth == CV_64S ? cvt64s64u :
@@ -728,6 +759,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f64s :
             sdepth == CV_16F ? cvt16f64s :
             sdepth == CV_16BF ? cvt16bf64s :
+            sdepth == CV_8F ? cvt8f64s :
             sdepth == CV_Bool ? cvt8b64s :
             sdepth == CV_64U ? cvt64s :
             sdepth == CV_64S ? cvt64s :

--- a/modules/core/src/convert.simd.hpp
+++ b/modules/core/src/convert.simd.hpp
@@ -343,6 +343,7 @@ DEF_CVT_FUNC(8s64u, cvt_,  schar, uint64_t, v_uint32)
 DEF_CVT_FUNC(8s64s, cvt_,  schar, int64_t,  v_int32)
 DEF_CVT_FUNC(8s16f, cvt1_, schar, hfloat, v_float32)
 DEF_CVT_FUNC(8s16bf, cvt1_, schar, bfloat, v_float32)
+DEF_CVT_FUNC(8s8f, cvt1_, schar, fp8_e4m3_t, v_float32)
 
 ////////////////////// 8b -> ... ////////////////////////
 
@@ -366,6 +367,7 @@ DEF_CVT_FUNC(16u64f, cvt_, ushort, double, v_int32)
 DEF_CVT_SCALAR_FUNC(16u64s, ushort, int64_t)
 DEF_CVT_FUNC(16u16f, cvt1_,ushort, hfloat, v_float32)
 DEF_CVT_FUNC(16u16bf, cvt1_, ushort, bfloat, v_float32)
+DEF_CVT_FUNC(16u8f, cvt1_, ushort, fp8_e4m3_t, v_float32)
 
 ////////////////////// 16s -> ... ////////////////////////
 
@@ -423,6 +425,7 @@ DEF_CVT_FUNC(32f64u, cvt_64f, float, uint64_t, v_float64)
 DEF_CVT_FUNC(32f64s, cvt_64f, float, int64_t, v_float64)
 DEF_CVT_FUNC(32f16f, cvt1_,float, hfloat, v_float32)
 DEF_CVT_FUNC(32f16bf, cvt1_,float, bfloat, v_float32)
+DEF_CVT_FUNC(32f8f, cvt1_, float, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(32f8b, int, 1)
 
 ////////////////////// 64f -> ... ////////////////////////
@@ -666,6 +669,12 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_Bool ? cvt8b16bf :
             sdepth == CV_64U ? cvt64u16bf :
             sdepth == CV_64S ? cvt64s16bf :
+            0) :
+        ddepth == CV_8F ? (
+            sdepth == CV_8U ? cvt8u8f :
+            sdepth == CV_8S ? cvt8s8f :
+            sdepth == CV_16U ? cvt16u8f :
+            sdepth == CV_32F ? cvt32f8f :
             0) :
         ddepth == CV_Bool ? (
             sdepth == CV_8U ? cvt8u8b :

--- a/modules/core/src/convert.simd.hpp
+++ b/modules/core/src/convert.simd.hpp
@@ -472,6 +472,13 @@ DEF_CVT_FUNC(16bf64u, cvt1_, bfloat, uint64_t, v_float32)
 DEF_CVT_FUNC(16bf64s, cvt1_, bfloat, int64_t, v_float32)
 DEF_CVT_FUNC(16bf16f, cvt1_, bfloat, hfloat, v_float32)
 
+////////////////////// 8f -> ... ////////////////////////
+
+DEF_CVT_FUNC(8f8u,  cvt_, fp8_e4m3_t, uchar,  v_float32)
+DEF_CVT_FUNC(8f8s,  cvt_, fp8_e4m3_t, schar,  v_float32)
+DEF_CVT_FUNC(8f16u, cvt1_, fp8_e4m3_t, ushort, v_float32)
+DEF_CVT_FUNC(8f32f, cvt1_, fp8_e4m3_t, float,  v_float32)
+
 ////////////////////// 64s -> ... ////////////////////////
 
 DEF_CVT_FUNC(64s8u,  cvt_, int64_t, uchar,  v_int32)
@@ -530,6 +537,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f8u :
             sdepth == CV_16F ? cvt16f8u :
             sdepth == CV_16BF ? cvt16bf8u :
+            sdepth == CV_8F ? cvt8f8u :
             sdepth == CV_Bool ? cvt8b8u :
             sdepth == CV_64U ? cvt64u8u :
             sdepth == CV_64S ? cvt64s8u :
@@ -545,6 +553,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f8s :
             sdepth == CV_16F ? cvt16f8s :
             sdepth == CV_16BF ? cvt16bf8s :
+            sdepth == CV_8F ? cvt8f8s :
             sdepth == CV_Bool ? cvt8b8u :
             sdepth == CV_64U ? cvt64u8s :
             sdepth == CV_64S ? cvt64s8s :
@@ -560,6 +569,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f16u :
             sdepth == CV_16F ? cvt16f16u :
             sdepth == CV_16BF ? cvt16bf16u :
+            sdepth == CV_8F ? cvt8f16u :
             sdepth == CV_Bool ? cvt8b16s :
             sdepth == CV_64U ? cvt64u16u :
             sdepth == CV_64S ? cvt64s16u :
@@ -621,6 +631,7 @@ BinaryFunc getConvertFunc(int sdepth_, int ddepth_)
             sdepth == CV_64F ? cvt64f32f :
             sdepth == CV_16F ? cvt16f32f :
             sdepth == CV_16BF ? cvt16bf32f :
+            sdepth == CV_8F ? cvt8f32f :
             sdepth == CV_Bool ? cvt8b32f :
             sdepth == CV_64U ? cvt64u32f :
             sdepth == CV_64S ? cvt64s32f :

--- a/modules/core/src/convert.simd.hpp
+++ b/modules/core/src/convert.simd.hpp
@@ -21,6 +21,7 @@ void cvt32f16bf(const float* src, bfloat* dst, int len);
 void addRNGBias32f(float* arr, const float* scaleBiasPairs, int len, int cn);
 void addRNGBias64f(double* arr, const double* scaleBiasPairs, int len, int cn);
 
+
 CV_CPU_OPTIMIZATION_NAMESPACE_END
 } // namespace cv::hal
 
@@ -315,6 +316,7 @@ static void cvt##suffix(const uchar* src_, size_t sstep, const uchar*, size_t, \
     } \
 }
 
+
 ////////////////////// 8u -> ... ////////////////////////
 
 DEF_CVT_FUNC(8u8s,  cvt_,  uchar, schar,    v_int16)
@@ -325,6 +327,7 @@ DEF_CVT_FUNC(8u64f, cvt_,  uchar, double,   v_int32)
 DEF_CVT_SCALAR_FUNC(8u64s, uchar, int64_t)
 DEF_CVT_FUNC(8u16f, cvt1_, uchar, hfloat, v_float32)
 DEF_CVT_FUNC(8u16bf, cvt1_, uchar, bfloat, v_float32)
+DEF_CVT_FUNC(8u8f, cvt1_, uchar, fp8_e4m3_t, v_float32)
 DEF_CVT2BOOL_FUNC(8u8b, uchar, 0)
 
 ////////////////////// 8s -> ... ////////////////////////

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -3069,6 +3069,64 @@ TEST(Core_ConvertTo, regression_12121)
     }
 }
 
+TEST(Core_ConvertTo, fp8_e4m3_basic_roundtrip)
+{
+    Mat src(1, 4, CV_32FC1);
+    src.at<float>(0,0) = 1.0f;
+    src.at<float>(0,1) = 0.0f;
+    src.at<float>(0,2) = 448.0f;
+    src.at<float>(0,3) = -2.0f;
+
+    Mat fp8;
+    src.convertTo(fp8, CV_8F);
+    EXPECT_EQ(CV_8F, fp8.depth());
+    EXPECT_EQ((size_t)1, fp8.elemSize());
+
+    Mat back;
+    fp8.convertTo(back, CV_32F);
+    EXPECT_FLOAT_EQ(1.0f, back.at<float>(0,0));
+    EXPECT_FLOAT_EQ(0.0f, back.at<float>(0,1));
+    EXPECT_FLOAT_EQ(448.0f, back.at<float>(0,2));
+    EXPECT_FLOAT_EQ(-2.0f, back.at<float>(0,3));
+}
+
+TEST(Core_ConvertTo, fp8_e4m3_overflow_clamps_not_nan)
+{
+    // Values that round to the byte pattern reserved for NaN (0x7F) must
+    // clamp to the max finite value (448.0) instead of colliding with it.
+    Mat src(1, 3, CV_32FC1);
+    src.at<float>(0,0) = 500.0f;
+    src.at<float>(0,1) = 420.0f; // inside the collision zone before rounding
+    src.at<float>(0,2) = -500.0f;
+
+    Mat fp8, back;
+    src.convertTo(fp8, CV_8F);
+    fp8.convertTo(back, CV_32F);
+
+    EXPECT_FLOAT_EQ(448.0f, back.at<float>(0,0));
+    EXPECT_FALSE(cvIsNaN(back.at<float>(0,1)));
+    EXPECT_FLOAT_EQ(-448.0f, back.at<float>(0,2));
+}
+
+TEST(Core_ConvertTo, fp8_e4m3_uchar_and_ushort_paths)
+{
+    Mat src8u(1, 3, CV_8UC1);
+    src8u.at<uchar>(0,0) = 0;
+    src8u.at<uchar>(0,1) = 1;
+    src8u.at<uchar>(0,2) = 255;
+
+    Mat fp8;
+    src8u.convertTo(fp8, CV_8F);
+    Mat back8u;
+    fp8.convertTo(back8u, CV_8U);
+    EXPECT_EQ(0, back8u.at<uchar>(0,0));
+    EXPECT_EQ(1, back8u.at<uchar>(0,1));
+    // 255 exceeds fp8's max finite (448 is fine, so 255 is representable
+    // in the lower-precision fp8 grid but may round; just check it's finite
+    // and within a reasonable tolerance of the original)
+    EXPECT_NEAR(255.0, (double)back8u.at<uchar>(0,2), 16.0);
+}
+
 TEST(Core_MeanStdDev, regression_multichannel)
 {
     {


### PR DESCRIPTION
Part of #29313.

Adds `CV_8F`, an 8-bit floating point depth using the E4M3FN encoding, following the `CV_16BF`/bfloat precedent from #23865.

**What's done:**
- `fp8_e4m3_t` struct (`cvdef.h`) with LUT-based upcast and bit-level downcast, including a fix for a NaN-pattern collision at the top of the representable range
- `CV_8F` enum registration (`hal/interface.h`) and `DataType`/`TypeDepth` specializations (`traits.hpp`)
- Full `Mat::convertTo` support to/from every existing depth (`CV_8U/8S/16U/16S/32U/32S/32F/64F/16F/16BF/64U/64S/Bool`)
- Fixed a latent bug in `CV_ELEM_SIZE1`'s packed depth-size lookup table that only covered depths 0–12, silently returning `elemSize()==0` for any depth ≥13
- GTest coverage for the core conversion paths and the NaN-collision regression

**Not included :**
- `FileStorage` (YAML/XML) serialization for `CV_8F`
- SIMD/HAL intrinsics (`v_float8x16`) for hardware dispatch
- DNN/ONNX importer integration
- Python `ml_dtypes` bindings

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
