### PR TITLE
macOS: Fix CGBitmapInfo C++26 enum compilation error

### DIFF
--- a/modules/imgcodecs/src/apple_conversions.mm
+++ b/modules/imgcodecs/src/apple_conversions.mm
@@ -28,7 +28,7 @@ CGImageRef MatToCGImage(const cv::Mat& image) {
 
     // Preserve alpha transparency, if exists
     bool alpha = image.channels() == 4;
-    CGBitmapInfo bitmapInfo = (alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | kCGBitmapByteOrderDefault;
+    CGBitmapInfo bitmapInfo = (CGBitmapInfo)(alpha ? kCGImageAlphaLast : kCGImageAlphaNone) | (CGBitmapInfo)kCGBitmapByteOrderDefault;
 
     // Creating CGImage from cv::Mat
     CGImageRef imageRef = CGImageCreate(image.cols,
@@ -73,8 +73,8 @@ void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist) {
         colorSpace = CGColorSpaceCreateDeviceRGB();
         m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
         if (!alphaExist)
-            bitmapInfo = kCGImageAlphaNoneSkipLast |
-                                kCGBitmapByteOrderDefault;
+            bitmapInfo = (CGBitmapInfo)kCGImageAlphaNoneSkipLast |
+                                (CGBitmapInfo)kCGBitmapByteOrderDefault;
         else
             m = cv::Scalar(0);
         contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,
@@ -86,8 +86,8 @@ void CGImageToMat(const CGImageRef image, cv::Mat& m, bool alphaExist) {
     {
         m.create(rows, cols, CV_8UC4); // 8 bits per component, 4 channels
         if (!alphaExist)
-            bitmapInfo = kCGImageAlphaNoneSkipLast |
-                                kCGBitmapByteOrderDefault;
+            bitmapInfo = (CGBitmapInfo)kCGImageAlphaNoneSkipLast |
+                                (CGBitmapInfo)kCGBitmapByteOrderDefault;
         else
             m = cv::Scalar(0);
         contextRef = CGBitmapContextCreate(m.data, m.cols, m.rows, 8,


### PR DESCRIPTION
Fixes #29435

### Description
This PR resolves a compilation error under macOS 26 SDK / Apple Clang 21 with `-std=c++26` in `modules/imgcodecs/src/apple_conversions.mm`.

C++26 (P2864R2) removes deprecated implicit arithmetic conversions between different enumeration types. In newer macOS SDKs, `kCGBitmapByteOrderDefault` and `CGImageAlphaInfo` are distinct enum types, causing the bitwise OR `|` operation to become ill-formed and fail to compile. 

This fix applies explicit C-style casts to `CGBitmapInfo` before the bitwise OR operations are performed. Because Apple defines `CGBitmapInfo` using `CF_OPTIONS(uint32_t)`, this perfectly resolves the C++26 strict type requirements while maintaining the exact same underlying binary behavior.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
