### PR TITLE
Skip DNN features test on 32-bit platforms as they time-to-time do not fit 2GB RAM

### DIFF
--- a/modules/features/test/test_aliked_lightglue.cpp
+++ b/modules/features/test/test_aliked_lightglue.cpp
@@ -22,7 +22,9 @@ static void skipIfClassicDnnEngine()
 
 TEST(Features2d_ALIKED, Regression)
 {
+    applyTestTag( CV_TEST_TAG_MEMORY_2GB);
     skipIfClassicDnnEngine();
+
     const std::string modelPath = cvtest::findDataFile("dnn/onnx/models/aliked-n16rot-top1k-640.onnx", false);
 
     Ptr<ALIKED> aliked = ALIKED::create(modelPath);
@@ -85,7 +87,9 @@ TEST(Features2d_ALIKED, Regression)
 
 TEST(Features2d_LightGlue, Regression)
 {
+    applyTestTag( CV_TEST_TAG_MEMORY_2GB);
     skipIfClassicDnnEngine();
+
     const std::string alikedPath = cvtest::findDataFile("dnn/onnx/models/aliked-n16rot-top1k-640.onnx", false);
     const std::string lgPath = cvtest::findDataFile("dnn/onnx/models/aliked_lightglue.onnx", false);
 


### PR DESCRIPTION
CI example:
```
 [ RUN      ] Features2d_ALIKED.Regression
  [ WARN:0@0.937] global net_impl_backend.cpp:350 cv::dnn::dnn5_v20260605::Net::Impl::setPreferableTarget Targets are not supported by the new graph engine for now
  unknown file: error: C++ exception with description "OpenCV(5.1.0-dev) C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 209715200 bytes in function 'cv::OutOfMemoryError'
  " thrown in the test body.
  [  FAILED  ] Features2d_ALIKED.Regression (1211 ms)
  [ RUN      ] Features2d_LightGlue.Regression
  [ WARN:0@2.144] global net_impl_backend.cpp:350 cv::dnn::dnn5_v20260605::Net::Impl::setPreferableTarget Targets are not supported by the new graph engine for now
  [ WARN:0@3.726] global net_impl_backend.cpp:350 cv::dnn::dnn5_v20260605::Net::Impl::setPreferableTarget Targets are not supported by the new graph engine for now
  unknown file: error: C++ exception with description "OpenCV(5.1.0-dev) C:\GHA-OCV-6\_work\opencv\opencv\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 209715200 bytes in function 'cv::OutOfMemoryError'
  " thrown in the test body.
  [  FAILED  ] Features2d_LightGlue.Regression (2792 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
