### PR TITLE
Skip some BERT tests on 32-bit platforms as they do not fit into 2gb ram

### DIFF
--- a/modules/dnn/test/test_model.cpp
+++ b/modules/dnn/test/test_model.cpp
@@ -829,8 +829,9 @@ INSTANTIATE_TEST_CASE_P(/**/, Reproducibility_ViT_ONNX,
 typedef testing::TestWithParam<Target> Reproducibility_BERT_ONNX;
 TEST_P(Reproducibility_BERT_ONNX, Accuracy)
 {
+    applyTestTag(CV_TEST_TAG_MEMORY_2GB);
+
     Target targetId = GetParam();
-    applyTestTag(targetId == DNN_TARGET_CPU ? CV_TEST_TAG_MEMORY_1GB : CV_TEST_TAG_MEMORY_2GB);
     ASSERT_TRUE(ocl::useOpenCL() || targetId == DNN_TARGET_CPU || targetId == DNN_TARGET_CPU_FP16);
     auto engine_forced = static_cast<EngineType>(
     cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", ENGINE_AUTO));


### PR DESCRIPTION
CI example:
```
  [ RUN      ] Reproducibility_BERT_ONNX.Accuracy/2, where GetParam() = CPU
  [ WARN:0@115.876] global net_impl_backend.cpp:350 cv::dnn::dnn5_v20260605::Net::Impl::setPreferableTarget Targets are not supported by the new graph engine for now
  unknown file: error: C++ exception with description "bad allocation" thrown in the test body.
  [  FAILED  ] Reproducibility_BERT_ONNX.Accuracy/2, where GetParam() = CPU (2677 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
