### PR TITLE
Replace "static inline" by "inline" in headers

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -3112,7 +3112,7 @@ public:
 
 };
 
-static inline
+inline
 String& operator << (String& out, Ptr<Formatted> fmtd)
 {
     fmtd->reset();
@@ -3121,7 +3121,7 @@ String& operator << (String& out, Ptr<Formatted> fmtd)
     return out;
 }
 
-static inline
+inline
 String& operator << (String& out, const Mat& mtx)
 {
     return out << Formatter::get()->format(mtx);

--- a/modules/core/include/opencv2/core/affine.hpp
+++ b/modules/core/include/opencv2/core/affine.hpp
@@ -615,7 +615,7 @@ V cv::operator*(const cv::Affine3<T>& affine, const V& v)
     return r;
 }
 
-static inline
+inline
 cv::Vec3f cv::operator*(const cv::Affine3f& affine, const cv::Vec3f& v)
 {
     const cv::Matx44f& m = affine.matrix;
@@ -626,7 +626,7 @@ cv::Vec3f cv::operator*(const cv::Affine3f& affine, const cv::Vec3f& v)
     return r;
 }
 
-static inline
+inline
 cv::Vec3d cv::operator*(const cv::Affine3d& affine, const cv::Vec3d& v)
 {
     const cv::Matx44d& m = affine.matrix;

--- a/modules/core/include/opencv2/core/base.hpp
+++ b/modules/core/include/opencv2/core/base.hpp
@@ -322,7 +322,7 @@ inline uint64 cv_absdiff(uint64 x, uint64 y) { return std::max(x, y) - std::min(
 inline float cv_absdiff(hfloat x, hfloat y) { return std::abs((float)x - (float)y); }
 inline float cv_absdiff(bfloat x, bfloat y) { return std::abs((float)x - (float)y); }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normL2Sqr(const _Tp* a, int n)
 {
     _AccTp s = 0;
@@ -334,7 +334,7 @@ _AccTp normL2Sqr(const _Tp* a, int n)
     return s;
 }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normL1(const _Tp* a, int n)
 {
     _AccTp s = 0;
@@ -343,7 +343,7 @@ _AccTp normL1(const _Tp* a, int n)
     return s;
 }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normInf(const _Tp* a, int n)
 {
     _AccTp s = 0;
@@ -352,7 +352,7 @@ _AccTp normInf(const _Tp* a, int n)
     return s;
 }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normL2Sqr(const _Tp* a, const _Tp* b, int n)
 {
     _AccTp s = 0;
@@ -364,7 +364,7 @@ _AccTp normL2Sqr(const _Tp* a, const _Tp* b, int n)
     return s;
 }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normL1(const _Tp* a, const _Tp* b, int n)
 {
     _AccTp s = 0;
@@ -373,7 +373,7 @@ _AccTp normL1(const _Tp* a, const _Tp* b, int n)
     return s;
 }
 
-template<typename _Tp, typename _AccTp> static inline
+template<typename _Tp, typename _AccTp> inline
 _AccTp normInf(const _Tp* a, const _Tp* b, int n)
 {
     _AccTp s = 0;
@@ -395,7 +395,7 @@ CV_EXPORTS_W float cubeRoot(float val);
 
 cubeRoot with argument of `double` type calls `std::cbrt(double)`
 */
-static inline
+inline
 double cubeRoot(double val)
 {
     return std::cbrt(val);
@@ -440,8 +440,8 @@ CV_EXPORTS_W String getIppVersion();
 CV_EXPORTS_W bool useIPP_NotExact();
 CV_EXPORTS_W void setUseIPP_NotExact(bool flag);
 #ifndef DISABLE_OPENCV_3_COMPATIBILITY
-static inline bool useIPP_NE() { return useIPP_NotExact(); }
-static inline void setUseIPP_NE(bool flag) { setUseIPP_NotExact(flag); }
+inline bool useIPP_NE() { return useIPP_NotExact(); }
+inline void setUseIPP_NE(bool flag) { setUseIPP_NotExact(flag); }
 #endif
 
 } // ipp

--- a/modules/core/include/opencv2/core/bindings_utils.hpp
+++ b/modules/core/include/opencv2/core/bindings_utils.hpp
@@ -23,19 +23,19 @@ CV_EXPORTS_W String dumpInputOutputArray(InputOutputArray argument);
 
 CV_EXPORTS_W String dumpInputOutputArrayOfArrays(InputOutputArrayOfArrays argument);
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpBool(bool argument)
 {
     return (argument) ? String("Bool: True") : String("Bool: False");
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpInt(int argument)
 {
     return cv::format("Int: %d", argument);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpInt64(int64 argument)
 {
     std::ostringstream oss("Int64: ", std::ios::ate);
@@ -43,7 +43,7 @@ String dumpInt64(int64 argument)
     return oss.str();
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpSizeT(size_t argument)
 {
     std::ostringstream oss("size_t: ", std::ios::ate);
@@ -51,45 +51,45 @@ String dumpSizeT(size_t argument)
     return oss.str();
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpFloat(float argument)
 {
     return cv::format("Float: %.2f", argument);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpDouble(double argument)
 {
     return cv::format("Double: %.2f", argument);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpCString(const char* argument)
 {
     return cv::format("String: %s", argument);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpString(const String& argument)
 {
     return cv::format("String: %s", argument.c_str());
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpRect(const Rect& argument)
 {
     return format("rect: (x=%d, y=%d, w=%d, h=%d)", argument.x, argument.y,
                   argument.width, argument.height);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpTermCriteria(const TermCriteria& argument)
 {
     return format("term_criteria: (type=%d, max_count=%d, epsilon=%lf",
                   argument.type, argument.maxCount, argument.epsilon);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpRotatedRect(const RotatedRect& argument)
 {
     return format("rotated_rect: (c_x=%f, c_y=%f, w=%f, h=%f, a=%f)",
@@ -97,7 +97,7 @@ String dumpRotatedRect(const RotatedRect& argument)
                   argument.size.height, argument.angle);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpRange(const Range& argument)
 {
     if (argument == Range::all())
@@ -119,27 +119,27 @@ CV_EXPORTS_W String dumpVectorOfRect(const std::vector<Rect>& vec);
 
 //! @cond IGNORED
 
-CV_WRAP static inline
+CV_WRAP inline
 String testOverloadResolution(int value, const Point& point = Point(42, 24))
 {
     return format("overload (int=%d, point=(x=%d, y=%d))", value, point.x,
                   point.y);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String testOverloadResolution(const Rect& rect)
 {
     return format("overload (rect=(x=%d, y=%d, w=%d, h=%d))", rect.x, rect.y,
                   rect.width, rect.height);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 RotatedRect testRotatedRect(float x, float y, float w, float h, float angle)
 {
     return RotatedRect(Point2f(x, y), Size2f(w, h), angle);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 std::vector<RotatedRect> testRotatedRectVector(float x, float y, float w, float h, float angle)
 {
     std::vector<RotatedRect> result;
@@ -148,19 +148,19 @@ std::vector<RotatedRect> testRotatedRectVector(float x, float y, float w, float 
     return result;
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 int testOverwriteNativeMethod(int argument)
 {
     return argument;
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String testReservedKeywordConversion(int positional_argument, int lambda = 2, int from = 3)
 {
     return format("arg=%d, lambda=%d, from=%d", positional_argument, lambda, from);
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 void generateVectorOfRect(size_t len, CV_OUT std::vector<Rect>& vec)
 {
     vec.resize(len);
@@ -173,7 +173,7 @@ void generateVectorOfRect(size_t len, CV_OUT std::vector<Rect>& vec)
     }
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 void generateVectorOfInt(size_t len, CV_OUT std::vector<int>& vec)
 {
     vec.resize(len);
@@ -186,7 +186,7 @@ void generateVectorOfInt(size_t len, CV_OUT std::vector<int>& vec)
     }
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 void generateVectorOfMat(size_t len, int rows, int cols, int dtype, CV_OUT std::vector<Mat>& vec)
 {
     vec.resize(len);
@@ -201,13 +201,13 @@ void generateVectorOfMat(size_t len, int rows, int cols, int dtype, CV_OUT std::
     }
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 void testRaiseGeneralException()
 {
     throw std::runtime_error("exception text");
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 AsyncArray testAsyncArray(InputArray argument)
 {
     AsyncPromise p;
@@ -215,7 +215,7 @@ AsyncArray testAsyncArray(InputArray argument)
     return p.getArrayResult();
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 AsyncArray testAsyncException()
 {
     AsyncPromise p;
@@ -230,7 +230,7 @@ AsyncArray testAsyncException()
     return p.getArrayResult();
 }
 
-CV_WRAP static inline
+CV_WRAP inline
 String dumpVec2i(const cv::Vec2i value = cv::Vec2i(42, 24)) {
     return format("Vec2i(%d, %d)", value[0], value[1]);
 }
@@ -264,7 +264,7 @@ struct CV_EXPORTS_W_PARAMS FunctionParams
     }
 };
 
-CV_WRAP static inline String
+CV_WRAP inline String
 copyMatAndDumpNamedArguments(InputArray src, OutputArray dst,
                              const FunctionParams& params = FunctionParams())
 {
@@ -274,7 +274,7 @@ copyMatAndDumpNamedArguments(InputArray src, OutputArray dst,
 }
 
 namespace nested {
-CV_WRAP static inline bool testEchoBooleanFunction(bool flag) {
+CV_WRAP inline bool testEchoBooleanFunction(bool flag) {
     return flag;
 }
 

--- a/modules/core/include/opencv2/core/cuda.inl.hpp
+++ b/modules/core/include/opencv2/core/cuda.inl.hpp
@@ -373,7 +373,7 @@ void* GpuMat::cudaPtr() const
     return data;
 }
 
-static inline
+inline
 GpuMat createContinuous(int rows, int cols, int type)
 {
     GpuMat m;
@@ -381,13 +381,13 @@ GpuMat createContinuous(int rows, int cols, int type)
     return m;
 }
 
-static inline
+inline
 void createContinuous(Size size, int type, OutputArray arr)
 {
     createContinuous(size.height, size.width, type, arr);
 }
 
-static inline
+inline
 GpuMat createContinuous(Size size, int type)
 {
     GpuMat m;
@@ -395,13 +395,13 @@ GpuMat createContinuous(Size size, int type)
     return m;
 }
 
-static inline
+inline
 void ensureSizeIsEnough(Size size, int type, OutputArray arr)
 {
     ensureSizeIsEnough(size.height, size.width, type, arr);
 }
 
-static inline
+inline
 void swap(GpuMat& a, GpuMat& b)
 {
     a.swap(b);
@@ -640,7 +640,7 @@ bool HostMem::empty() const
     return data == 0;
 }
 
-static inline
+inline
 void swap(HostMem& a, HostMem& b)
 {
     a.swap(b);

--- a/modules/core/include/opencv2/core/cuda/common.hpp
+++ b/modules/core/include/opencv2/core/cuda/common.hpp
@@ -63,7 +63,7 @@
 #endif
 
 namespace cv { namespace cuda {
-    static inline void checkCudaError(cudaError_t err, const char* file, const int line, const char* func)
+    inline void checkCudaError(cudaError_t err, const char* file, const int line, const char* func)
     {
         if (cudaSuccess != err) {
             cudaGetLastError(); // reset the last stored error to cudaSuccess
@@ -78,12 +78,12 @@ namespace cv { namespace cuda {
 
 namespace cv { namespace cuda
 {
-    template <typename T> static inline bool isAligned(const T* ptr, size_t size)
+    template <typename T> inline bool isAligned(const T* ptr, size_t size)
     {
         return reinterpret_cast<size_t>(ptr) % size == 0;
     }
 
-    static inline bool isAligned(size_t step, size_t size)
+    inline bool isAligned(size_t step, size_t size)
     {
         return step % size == 0;
     }

--- a/modules/core/include/opencv2/core/cuda/transform.hpp
+++ b/modules/core/include/opencv2/core/cuda/transform.hpp
@@ -56,14 +56,14 @@
 namespace cv { namespace cuda { namespace device
 {
     template <typename T, typename D, typename UnOp, typename Mask>
-    static inline void transform(PtrStepSz<T> src, PtrStepSz<D> dst, UnOp op, const Mask& mask, cudaStream_t stream)
+    inline void transform(PtrStepSz<T> src, PtrStepSz<D> dst, UnOp op, const Mask& mask, cudaStream_t stream)
     {
         typedef TransformFunctorTraits<UnOp> ft;
         transform_detail::TransformDispatcher<VecTraits<T>::cn == 1 && VecTraits<D>::cn == 1 && ft::smart_shift != 1>::call(src, dst, op, mask, stream);
     }
 
     template <typename T1, typename T2, typename D, typename BinOp, typename Mask>
-    static inline void transform(PtrStepSz<T1> src1, PtrStepSz<T2> src2, PtrStepSz<D> dst, BinOp op, const Mask& mask, cudaStream_t stream)
+    inline void transform(PtrStepSz<T1> src1, PtrStepSz<T2> src2, PtrStepSz<D> dst, BinOp op, const Mask& mask, cudaStream_t stream)
     {
         typedef TransformFunctorTraits<BinOp> ft;
         transform_detail::TransformDispatcher<VecTraits<T1>::cn == 1 && VecTraits<T2>::cn == 1 && VecTraits<D>::cn == 1 && ft::smart_shift != 1>::call(src1, src2, dst, op, mask, stream);

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -745,7 +745,7 @@ __CV_ENUM_FLAGS_BITWISE_XOR_EQ   (EnumType, EnumType)                           
 #  define CV_XADD(addr, delta) (int)_InterlockedExchangeAdd((long volatile*)addr, delta)
 #else
   #ifdef OPENCV_FORCE_UNSAFE_XADD
-    CV_INLINE int CV_XADD(int* addr, int delta) { int tmp = *addr; *addr += delta; return tmp; }
+    inline int CV_XADD(int* addr, int delta) { int tmp = *addr; *addr += delta; return tmp; }
   #else
     #error "OpenCV: can't define safe CV_XADD macro for current platform (unsupported). Define CV_XADD macro through custom port header (see OPENCV_INCLUDE_PORT_FILE)"
   #endif
@@ -985,7 +985,7 @@ protected:
 /** @brief Constructs the 'fourcc' code, used in video codecs and many other places.
     Simply call it with 4 chars like `CV_FOURCC('I', 'Y', 'U', 'V')`
 */
-CV_INLINE int CV_FOURCC(char c1, char c2, char c3, char c4)
+inline int CV_FOURCC(char c1, char c2, char c3, char c4)
 {
     return (c1 & 255) + ((c2 & 255) << 8) + ((c3 & 255) << 16) + ((c4 & 255) << 24);
 }

--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -594,68 +594,68 @@ __CV_ENUM_CLASS_EXPOSE_1(EnumType, MEMBER_CONST);                               
 __CV_EXPAND(__CV_ENUM_CLASS_EXPOSE_8(EnumType, __VA_ARGS__));                                         \
 
 #define __CV_ENUM_FLAGS_LOGICAL_NOT(EnumType)                                                         \
-static inline bool operator!(const EnumType& val)                                                     \
+inline bool operator!(const EnumType& val)                                                     \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return !static_cast<UnderlyingType>(val);                                                         \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_LOGICAL_NOT_EQ(Arg1Type, Arg2Type)                                            \
-static inline bool operator!=(const Arg1Type& a, const Arg2Type& b)                                   \
+inline bool operator!=(const Arg1Type& a, const Arg2Type& b)                                   \
 {                                                                                                     \
     return static_cast<int>(a) != static_cast<int>(b);                                                \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_LOGICAL_EQ(Arg1Type, Arg2Type)                                                \
-static inline bool operator==(const Arg1Type& a, const Arg2Type& b)                                   \
+inline bool operator==(const Arg1Type& a, const Arg2Type& b)                                   \
 {                                                                                                     \
     return static_cast<int>(a) == static_cast<int>(b);                                                \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_NOT(EnumType)                                                         \
-static inline EnumType operator~(const EnumType& val)                                                 \
+inline EnumType operator~(const EnumType& val)                                                 \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(~static_cast<UnderlyingType>(val));                                  \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_OR(EnumType, Arg1Type, Arg2Type)                                      \
-static inline EnumType operator|(const Arg1Type& a, const Arg2Type& b)                                \
+inline EnumType operator|(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) | static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_AND(EnumType, Arg1Type, Arg2Type)                                     \
-static inline EnumType operator&(const Arg1Type& a, const Arg2Type& b)                                \
+inline EnumType operator&(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) & static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_XOR(EnumType, Arg1Type, Arg2Type)                                     \
-static inline EnumType operator^(const Arg1Type& a, const Arg2Type& b)                                \
+inline EnumType operator^(const Arg1Type& a, const Arg2Type& b)                                \
 {                                                                                                     \
     typedef std::underlying_type<EnumType>::type UnderlyingType;                                      \
     return static_cast<EnumType>(static_cast<UnderlyingType>(a) ^ static_cast<UnderlyingType>(b));    \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_OR_EQ(EnumType, Arg1Type)                                             \
-static inline EnumType& operator|=(EnumType& _this, const Arg1Type& val)                              \
+inline EnumType& operator|=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) | static_cast<int>(val));                   \
     return _this;                                                                                     \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_AND_EQ(EnumType, Arg1Type)                                            \
-static inline EnumType& operator&=(EnumType& _this, const Arg1Type& val)                              \
+inline EnumType& operator&=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) & static_cast<int>(val));                   \
     return _this;                                                                                     \
 }                                                                                                     \
 
 #define __CV_ENUM_FLAGS_BITWISE_XOR_EQ(EnumType, Arg1Type)                                            \
-static inline EnumType& operator^=(EnumType& _this, const Arg1Type& val)                              \
+inline EnumType& operator^=(EnumType& _this, const Arg1Type& val)                              \
 {                                                                                                     \
     _this = static_cast<EnumType>(static_cast<int>(_this) ^ static_cast<int>(val));                   \
     return _this;                                                                                     \

--- a/modules/core/include/opencv2/core/cvstd.hpp
+++ b/modules/core/include/opencv2/core/cvstd.hpp
@@ -63,10 +63,10 @@
 
 namespace cv
 {
-    static inline uchar abs(uchar a) { return a; }
-    static inline ushort abs(ushort a) { return a; }
-    static inline unsigned abs(unsigned a) { return a; }
-    static inline uint64 abs(uint64 a) { return a; }
+    inline uchar abs(uchar a) { return a; }
+    inline ushort abs(ushort a) { return a; }
+    inline unsigned abs(unsigned a) { return a; }
+    inline uint64 abs(uint64 a) { return a; }
 
     using std::min;
     using std::max;
@@ -155,26 +155,26 @@ typedef std::string String;
 //! @cond IGNORED
 namespace details {
 // std::tolower is int->int
-static inline char char_tolower(char ch)
+inline char char_tolower(char ch)
 {
     return (char)std::tolower((int)ch);
 }
 // std::toupper is int->int
-static inline char char_toupper(char ch)
+inline char char_toupper(char ch)
 {
     return (char)std::toupper((int)ch);
 }
 } // namespace details
 //! @endcond
 
-static inline std::string toLowerCase(const std::string& str)
+inline std::string toLowerCase(const std::string& str)
 {
     std::string result(str);
     std::transform(result.begin(), result.end(), result.begin(), details::char_tolower);
     return result;
 }
 
-static inline std::string toUpperCase(const std::string& str)
+inline std::string toUpperCase(const std::string& str)
 {
     std::string result(str);
     std::transform(result.begin(), result.end(), result.begin(), details::char_toupper);

--- a/modules/core/include/opencv2/core/cvstd.inl.hpp
+++ b/modules/core/include/opencv2/core/cvstd.inl.hpp
@@ -74,7 +74,7 @@ public:
     typedef Vec<channel_type, channels> vec_type;
 };
 
-static inline
+inline
 std::ostream& operator << (std::ostream& out, Ptr<Formatted> fmtd)
 {
     fmtd->reset();
@@ -83,59 +83,59 @@ std::ostream& operator << (std::ostream& out, Ptr<Formatted> fmtd)
     return out;
 }
 
-static inline
+inline
 std::ostream& operator << (std::ostream& out, const Mat& mtx)
 {
     return out << Formatter::get()->format(mtx);
 }
 
-static inline
+inline
 std::ostream& operator << (std::ostream& out, const UMat& m)
 {
     return out << m.getMat(ACCESS_READ);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const Complex<_Tp>& c)
 {
     return out << "(" << c.re << "," << c.im << ")";
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const std::vector<Point_<_Tp> >& vec)
 {
     return out << Formatter::get()->format(Mat(vec));
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const std::vector<Point3_<_Tp> >& vec)
 {
     return out << Formatter::get()->format(Mat(vec));
 }
 
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 std::ostream& operator << (std::ostream& out, const Matx<_Tp, m, n>& matx)
 {
     return out << Formatter::get()->format(Mat(matx));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const Point_<_Tp>& p)
 {
     out << "[" << p.x << ", " << p.y << "]";
     return out;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const Point3_<_Tp>& p)
 {
     out << "[" << p.x << ", " << p.y << ", " << p.z << "]";
     return out;
 }
 
-template<typename _Tp, int n> static inline
+template<typename _Tp, int n> inline
 std::ostream& operator << (std::ostream& out, const Vec<_Tp, n>& vec)
 {
     out << "[";
@@ -157,19 +157,19 @@ std::ostream& operator << (std::ostream& out, const Vec<_Tp, n>& vec)
     return out;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const Size_<_Tp>& size)
 {
     return out << "[" << size.width << " x " << size.height << "]";
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 std::ostream& operator << (std::ostream& out, const Rect_<_Tp>& rect)
 {
     return out << "[" << rect.width << " x " << rect.height << " from (" << rect.x << ", " << rect.y << ")]";
 }
 
-static inline std::ostream& operator << (std::ostream& strm, const MatShape& shape)
+inline std::ostream& operator << (std::ostream& strm, const MatShape& shape)
 {
     strm << '[';
     if (shape.empty()) {
@@ -187,7 +187,7 @@ static inline std::ostream& operator << (std::ostream& strm, const MatShape& sha
     return strm;
 }
 
-static inline std::ostream &operator<< (std::ostream &s, cv::Range &r)
+inline std::ostream &operator<< (std::ostream &s, cv::Range &r)
 {
     return s << "[" << r.start << " : " << r.end << ")";
 }

--- a/modules/core/include/opencv2/core/cvstd_wrapper.hpp
+++ b/modules/core/include/opencv2/core/cvstd_wrapper.hpp
@@ -22,7 +22,7 @@ using std::nullptr_t;
 
 template <typename _Tp> using Ptr = std::shared_ptr<_Tp>;  // In ideal world it should look like this, but we need some compatibility workarounds below
 
-template<typename _Tp, typename ... A1> static inline
+template<typename _Tp, typename ... A1> inline
 Ptr<_Tp> makePtr(const A1&... a1) { return std::make_shared<_Tp>(a1...); }
 
 #else  // cv::Ptr with compatibility workarounds
@@ -134,7 +134,7 @@ struct Ptr : public std::shared_ptr<T>
     Ptr<Y> dynamicCast() const CV_NOEXCEPT { return std::dynamic_pointer_cast<Y>(*this); }
 };
 
-template<typename _Tp, typename ... A1> static inline
+template<typename _Tp, typename ... A1> inline
 Ptr<_Tp> makePtr(const A1&... a1)
 {
     static_assert( !has_custom_delete<_Tp>::value, "Can't use this makePtr with custom DefaultDeleter");

--- a/modules/core/include/opencv2/core/detail/dispatch_helper.impl.hpp
+++ b/modules/core/include/opencv2/core/detail/dispatch_helper.impl.hpp
@@ -11,7 +11,7 @@ namespace cv {
 namespace detail {
 
 template<template<typename> class Functor, typename... Args>
-static inline void depthDispatch(const int depth, Args&&... args)
+inline void depthDispatch(const int depth, Args&&... args)
 {
     switch (depth)
     {

--- a/modules/core/include/opencv2/core/eigen.hpp
+++ b/modules/core/include/opencv2/core/eigen.hpp
@@ -97,7 +97,7 @@ Mat a_mat;
 eigen2cv(a_tensor, a_mat);
 \endcode
 */
-template <typename _Tp, int _layout> static inline
+template <typename _Tp, int _layout> inline
 void eigen2cv( const Eigen::Tensor<_Tp, 3, _layout> &src, OutputArray dst )
 {
     if( !(_layout & Eigen::RowMajorBit) )
@@ -129,7 +129,7 @@ Eigen::Tensor<float, 3, Eigen::RowMajor> a_tensor(...);
 cv2eigen(a_mat, a_tensor);
 \endcode
 */
-template <typename _Tp, int _layout> static inline
+template <typename _Tp, int _layout> inline
 void cv2eigen( const Mat &src, Eigen::Tensor<_Tp, 3, _layout> &dst )
 {
     if( !(_layout & Eigen::RowMajorBit) )
@@ -173,7 +173,7 @@ Mat a_mat(2, 2, CV_32FC3, arr);
 Eigen::TensorMap<Eigen::Tensor<float, 3, Eigen::RowMajor>> a_tensormap = cv2eigen_tensormap<float>(a_mat);
 \endcode
 */
-template <typename _Tp> static inline
+template <typename _Tp> inline
 Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(InputArray src)
 {
     Mat mat = src.getMat();
@@ -182,7 +182,7 @@ Eigen::TensorMap<Eigen::Tensor<_Tp, 3, Eigen::RowMajor>> cv2eigen_tensormap(Inpu
 }
 #endif // OPENCV_EIGEN_TENSOR_SUPPORT
 
-template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
+template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> inline
 void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& src, OutputArray dst )
 {
     if( !(src.Flags & Eigen::RowMajorBit) )
@@ -200,7 +200,7 @@ void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCo
 }
 
 // Matx case
-template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
+template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> inline
 void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& src,
                Matx<_Tp, _rows, _cols>& dst )
 {
@@ -214,7 +214,7 @@ void eigen2cv( const Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCo
     }
 }
 
-template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
+template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& dst )
 {
@@ -242,7 +242,7 @@ void cv2eigen( const Mat& src,
 }
 
 // Matx case
-template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> static inline
+template<typename _Tp, int _rows, int _cols, int _options, int _maxRows, int _maxCols> inline
 void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
                Eigen::Matrix<_Tp, _rows, _cols, _options, _maxRows, _maxCols>& dst )
 {
@@ -260,7 +260,7 @@ void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
     }
 }
 
-template<typename _Tp>  static inline
+template<typename _Tp>  inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic>& dst )
 {
@@ -287,7 +287,7 @@ void cv2eigen( const Mat& src,
     }
 }
 
-template<typename _Tp>  static inline
+template<typename _Tp>  inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
 {
@@ -299,7 +299,7 @@ void cv2eigen( const Mat& src,
 }
 
 // Matx case
-template<typename _Tp, int _rows, int _cols> static inline
+template<typename _Tp, int _rows, int _cols> inline
 void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic>& dst )
 {
@@ -318,7 +318,7 @@ void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
     }
 }
 
-template<typename _Tp, int _rows, int _cols> static inline
+template<typename _Tp, int _rows, int _cols> inline
 void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>& dst )
 {
@@ -329,7 +329,7 @@ void cv2eigen( const Matx<_Tp, _rows, _cols>& src,
     Mat(src).copyTo(_dst);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, 1>& dst )
 {
@@ -354,7 +354,7 @@ void cv2eigen( const Mat& src,
 }
 
 // Matx case
-template<typename _Tp, int _rows> static inline
+template<typename _Tp, int _rows> inline
 void cv2eigen( const Matx<_Tp, _rows, 1>& src,
                Eigen::Matrix<_Tp, Eigen::Dynamic, 1>& dst )
 {
@@ -375,7 +375,7 @@ void cv2eigen( const Matx<_Tp, _rows, 1>& src,
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void cv2eigen( const Mat& src,
                Eigen::Matrix<_Tp, 1, Eigen::Dynamic>& dst )
 {
@@ -399,7 +399,7 @@ void cv2eigen( const Mat& src,
 }
 
 //Matx
-template<typename _Tp, int _cols> static inline
+template<typename _Tp, int _cols> inline
 void cv2eigen( const Matx<_Tp, 1, _cols>& src,
                Eigen::Matrix<_Tp, 1, Eigen::Dynamic>& dst )
 {

--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -196,7 +196,7 @@
  @param value floating-point number. If the value is outside of INT_MIN ... INT_MAX range, the
  result is not defined.
  */
-CV_INLINE int
+inline int
 cvRound( double value )
 {
 #if defined CV_INLINE_ROUND_DBL
@@ -232,7 +232,7 @@ cvRound( double value )
  @param value floating-point number. If the value is outside of INT_MIN ... INT_MAX range, the
  result is not defined.
  */
-CV_INLINE int cvFloor( double value )
+inline int cvFloor( double value )
 {
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
@@ -261,7 +261,7 @@ CV_INLINE int cvFloor( double value )
  @param value floating-point number. If the value is outside of INT_MIN ... INT_MAX range, the
  result is not defined.
  */
-CV_INLINE int cvCeil( double value )
+inline int cvCeil( double value )
 {
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
@@ -289,7 +289,7 @@ CV_INLINE int cvCeil( double value )
 
  The function returns 1 if the argument is Not A Number (as defined by IEEE754 standard), 0
  otherwise. */
-CV_INLINE int cvIsNaN( double value )
+inline int cvIsNaN( double value )
 {
 #if defined CV_INLINE_ISNAN_DBL
     CV_INLINE_ISNAN_DBL(value);
@@ -307,7 +307,7 @@ CV_INLINE int cvIsNaN( double value )
 
  The function returns 1 if the argument is a plus or minus infinity (as defined by IEEE754 standard)
  and 0 otherwise. */
-CV_INLINE int cvIsInf( double value )
+inline int cvIsInf( double value )
 {
 #if defined CV_INLINE_ISINF_DBL
     CV_INLINE_ISINF_DBL(value);
@@ -327,7 +327,7 @@ CV_INLINE int cvIsInf( double value )
 #ifdef __cplusplus
 
 /** @overload */
-CV_INLINE int cvRound(float value)
+inline int cvRound(float value)
 {
 #if defined CV_INLINE_ROUND_FLT
     CV_INLINE_ROUND_FLT(value);
@@ -355,14 +355,14 @@ CV_INLINE int cvRound(float value)
 }
 
 /** @overload */
-CV_INLINE int cvRound( int value )
+inline int cvRound( int value )
 {
     return value;
 }
 
 /** @overload */
 CV_DISABLE_UBSAN
-CV_INLINE int cvFloor( float value )
+inline int cvFloor( float value )
 {
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
@@ -385,13 +385,13 @@ CV_INLINE int cvFloor( float value )
 }
 
 /** @overload */
-CV_INLINE int cvFloor( int value )
+inline int cvFloor( int value )
 {
     return value;
 }
 
 /** @overload */
-CV_INLINE int cvCeil( float value )
+inline int cvCeil( float value )
 {
 #if defined CV__FASTMATH_ENABLE_GCC_MATH_BUILTINS || \
     defined CV__FASTMATH_ENABLE_CLANG_MATH_BUILTINS
@@ -414,13 +414,13 @@ CV_INLINE int cvCeil( float value )
 }
 
 /** @overload */
-CV_INLINE int cvCeil( int value )
+inline int cvCeil( int value )
 {
     return value;
 }
 
 /** @overload */
-CV_INLINE int cvIsNaN( float value )
+inline int cvIsNaN( float value )
 {
 #if defined CV_INLINE_ISNAN_FLT
     CV_INLINE_ISNAN_FLT(value);
@@ -432,7 +432,7 @@ CV_INLINE int cvIsNaN( float value )
 }
 
 /** @overload */
-CV_INLINE int cvIsInf( float value )
+inline int cvIsInf( float value )
 {
 #if defined CV_INLINE_ISINF_FLT
     CV_INLINE_ISINF_FLT(value);

--- a/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_cpp.hpp
@@ -589,43 +589,43 @@ enum {
 /** @brief Add values
 
 For all types. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_add(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_add(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Subtract values
 
 For all types. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_sub(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_sub(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Multiply values
 
 For 16- and 32-bit integer types and floating types. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_mul(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_mul(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Divide values
 
 For floating types only. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_div(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_div(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 
 /** @brief Bitwise AND
 
 Only for integer types. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_and(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_and(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Bitwise OR
 
 Only for integer types. */
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_or(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_or(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Bitwise XOR
 
 Only for integer types.*/
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_xor(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_xor(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b);
 
 /** @brief Bitwise NOT
 
 Only for integer types.*/
-template<typename _Tp, int n> CV_INLINE v_reg<_Tp, n> v_not(const v_reg<_Tp, n>& a);
+template<typename _Tp, int n> inline v_reg<_Tp, n> v_not(const v_reg<_Tp, n>& a);
 
 
 #ifndef CV_DOXYGEN
@@ -666,7 +666,7 @@ CV__HAL_INTRIN_IMPL_BIN_OP(*, v_mul)
 CV__HAL_INTRIN_EXPAND_WITH_FP_TYPES(CV__HAL_INTRIN_IMPL_BIN_OP_, /, v_div)
 
 #define CV__HAL_INTRIN_IMPL_BIT_OP_(_Tp, bit_op, func) \
-template<int n> CV_INLINE \
+template<int n> inline \
 v_reg<_Tp, n> func(const v_reg<_Tp, n>& a, const v_reg<_Tp, n>& b) \
 { \
     v_reg<_Tp, n> c; \
@@ -687,7 +687,7 @@ CV__HAL_INTRIN_IMPL_BIT_OP(|, v_or)
 CV__HAL_INTRIN_IMPL_BIT_OP(^, v_xor)
 
 #define CV__HAL_INTRIN_IMPL_BITWISE_NOT_(_Tp, dummy, dummy2) \
-template<int n> CV_INLINE \
+template<int n> inline \
 v_reg<_Tp, n> v_not(const v_reg<_Tp, n>& a) \
 { \
     v_reg<_Tp, n> c; \
@@ -2639,7 +2639,7 @@ template<int n> inline v_reg<float, n*2> v_cvt_f32(const v_reg<double, n>& a, co
 /** @brief Convert lower half to double
 
 Supported input type is cv::v_int32. */
-template<int n> CV_INLINE v_reg<double, n/2> v_cvt_f64(const v_reg<int, n>& a)
+template<int n> inline v_reg<double, n/2> v_cvt_f64(const v_reg<int, n>& a)
 {
     v_reg<double, (n/2)> c;
     for( int i = 0; i < (n/2); i++ )
@@ -2650,7 +2650,7 @@ template<int n> CV_INLINE v_reg<double, n/2> v_cvt_f64(const v_reg<int, n>& a)
 /** @brief Convert to double high part of vector
 
 Supported input type is cv::v_int32. */
-template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<int, n>& a)
+template<int n> inline v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<int, n>& a)
 {
     v_reg<double, (n/2)> c;
     for( int i = 0; i < (n/2); i++ )
@@ -2661,7 +2661,7 @@ template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<int, n
 /** @brief Convert lower half to double
 
 Supported input type is cv::v_float32. */
-template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64(const v_reg<float, n>& a)
+template<int n> inline v_reg<double, (n/2)> v_cvt_f64(const v_reg<float, n>& a)
 {
     v_reg<double, (n/2)> c;
     for( int i = 0; i < (n/2); i++ )
@@ -2672,7 +2672,7 @@ template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64(const v_reg<float, n>& 
 /** @brief Convert to double high part of vector
 
 Supported input type is cv::v_float32. */
-template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<float, n>& a)
+template<int n> inline v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<float, n>& a)
 {
     v_reg<double, (n/2)> c;
     for( int i = 0; i < (n/2); i++ )
@@ -2683,7 +2683,7 @@ template<int n> CV_INLINE v_reg<double, (n/2)> v_cvt_f64_high(const v_reg<float,
 /** @brief Convert to double
 
 Supported input type is cv::v_int64. */
-template<int n> CV_INLINE v_reg<double, n> v_cvt_f64(const v_reg<int64, n>& a)
+template<int n> inline v_reg<double, n> v_cvt_f64(const v_reg<int64, n>& a)
 {
     v_reg<double, n> c;
     for( int i = 0; i < n; i++ )

--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -575,11 +575,11 @@ public:
 };
 
 /** Helper to wrap custom types. @see InputArray */
-template<typename _Tp> static inline _InputArray rawIn(_Tp& v);
+template<typename _Tp> inline _InputArray rawIn(_Tp& v);
 /** Helper to wrap custom types. @see InputArray */
-template<typename _Tp> static inline _OutputArray rawOut(_Tp& v);
+template<typename _Tp> inline _OutputArray rawOut(_Tp& v);
 /** Helper to wrap custom types. @see InputArray */
-template<typename _Tp> static inline _InputOutputArray rawInOut(_Tp& v);
+template<typename _Tp> inline _InputOutputArray rawInOut(_Tp& v);
 
 CV__DEBUG_NS_END
 
@@ -3997,9 +3997,9 @@ CV_EXPORTS MatExpr operator + (const Mat& m, const MatExpr& e);
 CV_EXPORTS MatExpr operator + (const MatExpr& e, const Scalar& s);
 CV_EXPORTS MatExpr operator + (const Scalar& s, const MatExpr& e);
 CV_EXPORTS MatExpr operator + (const MatExpr& e1, const MatExpr& e2);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator + (const Mat& a, const Matx<_Tp, m, n>& b) { return a + Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator + (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) + b; }
 
 CV_EXPORTS MatExpr operator - (const Mat& a, const Mat& b);
@@ -4010,9 +4010,9 @@ CV_EXPORTS MatExpr operator - (const Mat& m, const MatExpr& e);
 CV_EXPORTS MatExpr operator - (const MatExpr& e, const Scalar& s);
 CV_EXPORTS MatExpr operator - (const Scalar& s, const MatExpr& e);
 CV_EXPORTS MatExpr operator - (const MatExpr& e1, const MatExpr& e2);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator - (const Mat& a, const Matx<_Tp, m, n>& b) { return a - Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator - (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) - b; }
 
 CV_EXPORTS MatExpr operator - (const Mat& m);
@@ -4026,9 +4026,9 @@ CV_EXPORTS MatExpr operator * (const Mat& m, const MatExpr& e);
 CV_EXPORTS MatExpr operator * (const MatExpr& e, double s);
 CV_EXPORTS MatExpr operator * (double s, const MatExpr& e);
 CV_EXPORTS MatExpr operator * (const MatExpr& e1, const MatExpr& e2);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator * (const Mat& a, const Matx<_Tp, m, n>& b) { return a * Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator * (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) * b; }
 
 CV_EXPORTS MatExpr operator / (const Mat& a, const Mat& b);
@@ -4039,81 +4039,81 @@ CV_EXPORTS MatExpr operator / (const Mat& m, const MatExpr& e);
 CV_EXPORTS MatExpr operator / (const MatExpr& e, double s);
 CV_EXPORTS MatExpr operator / (double s, const MatExpr& e);
 CV_EXPORTS MatExpr operator / (const MatExpr& e1, const MatExpr& e2);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator / (const Mat& a, const Matx<_Tp, m, n>& b) { return a / Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator / (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) / b; }
 
 CV_EXPORTS MatExpr operator < (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator < (const Mat& a, double s);
 CV_EXPORTS MatExpr operator < (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator < (const Mat& a, const Matx<_Tp, m, n>& b) { return a < Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator < (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) < b; }
 
 CV_EXPORTS MatExpr operator <= (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator <= (const Mat& a, double s);
 CV_EXPORTS MatExpr operator <= (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator <= (const Mat& a, const Matx<_Tp, m, n>& b) { return a <= Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator <= (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) <= b; }
 
 CV_EXPORTS MatExpr operator == (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator == (const Mat& a, double s);
 CV_EXPORTS MatExpr operator == (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator == (const Mat& a, const Matx<_Tp, m, n>& b) { return a == Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator == (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) == b; }
 
 CV_EXPORTS MatExpr operator != (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator != (const Mat& a, double s);
 CV_EXPORTS MatExpr operator != (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator != (const Mat& a, const Matx<_Tp, m, n>& b) { return a != Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator != (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) != b; }
 
 CV_EXPORTS MatExpr operator >= (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator >= (const Mat& a, double s);
 CV_EXPORTS MatExpr operator >= (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator >= (const Mat& a, const Matx<_Tp, m, n>& b) { return a >= Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator >= (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) >= b; }
 
 CV_EXPORTS MatExpr operator > (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator > (const Mat& a, double s);
 CV_EXPORTS MatExpr operator > (double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator > (const Mat& a, const Matx<_Tp, m, n>& b) { return a > Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator > (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) > b; }
 
 CV_EXPORTS MatExpr operator & (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator & (const Mat& a, const Scalar& s);
 CV_EXPORTS MatExpr operator & (const Scalar& s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator & (const Mat& a, const Matx<_Tp, m, n>& b) { return a & Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator & (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) & b; }
 
 CV_EXPORTS MatExpr operator | (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator | (const Mat& a, const Scalar& s);
 CV_EXPORTS MatExpr operator | (const Scalar& s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator | (const Mat& a, const Matx<_Tp, m, n>& b) { return a | Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator | (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) | b; }
 
 CV_EXPORTS MatExpr operator ^ (const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr operator ^ (const Mat& a, const Scalar& s);
 CV_EXPORTS MatExpr operator ^ (const Scalar& s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator ^ (const Mat& a, const Matx<_Tp, m, n>& b) { return a ^ Mat(b); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr operator ^ (const Matx<_Tp, m, n>& a, const Mat& b) { return Mat(a) ^ b; }
 
 CV_EXPORTS MatExpr operator ~(const Mat& m);
@@ -4121,17 +4121,17 @@ CV_EXPORTS MatExpr operator ~(const Mat& m);
 CV_EXPORTS MatExpr min(const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr min(const Mat& a, double s);
 CV_EXPORTS MatExpr min(double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr min (const Mat& a, const Matx<_Tp, m, n>& b) { return min(a, Mat(b)); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr min (const Matx<_Tp, m, n>& a, const Mat& b) { return min(Mat(a), b); }
 
 CV_EXPORTS MatExpr max(const Mat& a, const Mat& b);
 CV_EXPORTS MatExpr max(const Mat& a, double s);
 CV_EXPORTS MatExpr max(double s, const Mat& a);
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr max (const Mat& a, const Matx<_Tp, m, n>& b) { return max(a, Mat(b)); }
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 MatExpr max (const Matx<_Tp, m, n>& a, const Mat& b) { return max(Mat(a), b); }
 
 /** @brief Calculates an absolute value of each matrix element.

--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -75,7 +75,7 @@ namespace cv
 
 ////////////////////////// Custom (raw) type wrapper //////////////////////////
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 int rawType()
 {
     CV_StaticAssert(sizeof(_Tp) <= CV_CN_MAX, "sizeof(_Tp) is too large");
@@ -572,9 +572,9 @@ _InputOutputArray _InputOutputArray::rawInOut(std::array<_Tp, _Nm>& arr)
 }
 
 
-template<typename _Tp> static inline _InputArray rawIn(_Tp& v) { return _InputArray::rawIn(v); }
-template<typename _Tp> static inline _OutputArray rawOut(_Tp& v) { return _OutputArray::rawOut(v); }
-template<typename _Tp> static inline _InputOutputArray rawInOut(_Tp& v) { return _InputOutputArray::rawInOut(v); }
+template<typename _Tp> inline _InputArray rawIn(_Tp& v) { return _InputArray::rawIn(v); }
+template<typename _Tp> inline _OutputArray rawOut(_Tp& v) { return _OutputArray::rawOut(v); }
+template<typename _Tp> inline _InputOutputArray rawInOut(_Tp& v) { return _InputOutputArray::rawInOut(v); }
 
 CV__DEBUG_NS_END
 
@@ -2602,43 +2602,43 @@ inline MatConstIterator MatConstIterator::operator ++(int)
 }
 
 
-static inline
+inline
 bool operator == (const MatConstIterator& a, const MatConstIterator& b)
 {
     return a.m == b.m && a.ptr == b.ptr;
 }
 
-static inline
+inline
 bool operator != (const MatConstIterator& a, const MatConstIterator& b)
 {
     return !(a == b);
 }
 
-static inline
+inline
 bool operator < (const MatConstIterator& a, const MatConstIterator& b)
 {
     return a.ptr < b.ptr;
 }
 
-static inline
+inline
 bool operator > (const MatConstIterator& a, const MatConstIterator& b)
 {
     return a.ptr > b.ptr;
 }
 
-static inline
+inline
 bool operator <= (const MatConstIterator& a, const MatConstIterator& b)
 {
     return a.ptr <= b.ptr;
 }
 
-static inline
+inline
 bool operator >= (const MatConstIterator& a, const MatConstIterator& b)
 {
     return a.ptr >= b.ptr;
 }
 
-static inline
+inline
 ptrdiff_t operator - (const MatConstIterator& b, const MatConstIterator& a)
 {
     if( a.m != b.m )
@@ -2649,21 +2649,21 @@ ptrdiff_t operator - (const MatConstIterator& b, const MatConstIterator& a)
     return b.lpos() - a.lpos();
 }
 
-static inline
+inline
 MatConstIterator operator + (const MatConstIterator& a, ptrdiff_t ofs)
 {
     MatConstIterator b = a;
     return b += ofs;
 }
 
-static inline
+inline
 MatConstIterator operator + (ptrdiff_t ofs, const MatConstIterator& a)
 {
     MatConstIterator b = a;
     return b += ofs;
 }
 
-static inline
+inline
 MatConstIterator operator - (const MatConstIterator& a, ptrdiff_t ofs)
 {
     MatConstIterator b = a;
@@ -2785,33 +2785,33 @@ Point MatConstIterator_<_Tp>::pos() const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const MatConstIterator_<_Tp>& a, const MatConstIterator_<_Tp>& b)
 {
     return a.m == b.m && a.ptr == b.ptr;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const MatConstIterator_<_Tp>& a, const MatConstIterator_<_Tp>& b)
 {
     return a.m != b.m || a.ptr != b.ptr;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatConstIterator_<_Tp> operator + (const MatConstIterator_<_Tp>& a, ptrdiff_t ofs)
 {
     MatConstIterator t = (const MatConstIterator&)a + ofs;
     return (MatConstIterator_<_Tp>&)t;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatConstIterator_<_Tp> operator + (ptrdiff_t ofs, const MatConstIterator_<_Tp>& a)
 {
     MatConstIterator t = (const MatConstIterator&)a + ofs;
     return (MatConstIterator_<_Tp>&)t;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatConstIterator_<_Tp> operator - (const MatConstIterator_<_Tp>& a, ptrdiff_t ofs)
 {
     MatConstIterator t = (const MatConstIterator&)a - ofs;
@@ -2922,33 +2922,33 @@ _Tp& MatIterator_<_Tp>::operator [](ptrdiff_t i) const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const MatIterator_<_Tp>& a, const MatIterator_<_Tp>& b)
 {
     return a.m == b.m && a.ptr == b.ptr;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const MatIterator_<_Tp>& a, const MatIterator_<_Tp>& b)
 {
     return a.m != b.m || a.ptr != b.ptr;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatIterator_<_Tp> operator + (const MatIterator_<_Tp>& a, ptrdiff_t ofs)
 {
     MatConstIterator t = (const MatConstIterator&)a + ofs;
     return (MatIterator_<_Tp>&)t;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatIterator_<_Tp> operator + (ptrdiff_t ofs, const MatIterator_<_Tp>& a)
 {
     MatConstIterator t = (const MatConstIterator&)a + ofs;
     return (MatIterator_<_Tp>&)t;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatIterator_<_Tp> operator - (const MatIterator_<_Tp>& a, ptrdiff_t ofs)
 {
     MatConstIterator t = (const MatConstIterator&)a - ofs;
@@ -3011,13 +3011,13 @@ void SparseMatConstIterator::seekEnd()
 }
 
 
-static inline
+inline
 bool operator == (const SparseMatConstIterator& it1, const SparseMatConstIterator& it2)
 {
     return it1.m == it2.m && it1.ptr == it2.ptr;
 }
 
-static inline
+inline
 bool operator != (const SparseMatConstIterator& it1, const SparseMatConstIterator& it2)
 {
     return !(it1 == it2);
@@ -3308,155 +3308,155 @@ MatExpr::operator Mat_<_Tp>() const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr min(const Mat_<_Tp>& a, const Mat_<_Tp>& b)
 {
     return cv::min((const Mat&)a, (const Mat&)b);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr min(const Mat_<_Tp>& a, double s)
 {
     return cv::min((const Mat&)a, s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr min(double s, const Mat_<_Tp>& a)
 {
     return cv::min((const Mat&)a, s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr max(const Mat_<_Tp>& a, const Mat_<_Tp>& b)
 {
     return cv::max((const Mat&)a, (const Mat&)b);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr max(const Mat_<_Tp>& a, double s)
 {
     return cv::max((const Mat&)a, s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr max(double s, const Mat_<_Tp>& a)
 {
     return cv::max((const Mat&)a, s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 MatExpr abs(const Mat_<_Tp>& m)
 {
     return cv::abs((const Mat&)m);
 }
 
 
-static inline
+inline
 Mat& operator += (Mat& a, const MatExpr& b)
 {
     b.op->augAssignAdd(b, a);
     return a;
 }
 
-static inline
+inline
 const Mat& operator += (const Mat& a, const MatExpr& b)
 {
     b.op->augAssignAdd(b, (Mat&)a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Mat_<_Tp>& operator += (Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignAdd(b, a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 const Mat_<_Tp>& operator += (const Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignAdd(b, (Mat&)a);
     return a;
 }
 
-static inline
+inline
 Mat& operator -= (Mat& a, const MatExpr& b)
 {
     b.op->augAssignSubtract(b, a);
     return a;
 }
 
-static inline
+inline
 const Mat& operator -= (const Mat& a, const MatExpr& b)
 {
     b.op->augAssignSubtract(b, (Mat&)a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Mat_<_Tp>& operator -= (Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignSubtract(b, a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 const Mat_<_Tp>& operator -= (const Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignSubtract(b, (Mat&)a);
     return a;
 }
 
-static inline
+inline
 Mat& operator *= (Mat& a, const MatExpr& b)
 {
     b.op->augAssignMultiply(b, a);
     return a;
 }
 
-static inline
+inline
 const Mat& operator *= (const Mat& a, const MatExpr& b)
 {
     b.op->augAssignMultiply(b, (Mat&)a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Mat_<_Tp>& operator *= (Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignMultiply(b, a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 const Mat_<_Tp>& operator *= (const Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignMultiply(b, (Mat&)a);
     return a;
 }
 
-static inline
+inline
 Mat& operator /= (Mat& a, const MatExpr& b)
 {
     b.op->augAssignDivide(b, a);
     return a;
 }
 
-static inline
+inline
 const Mat& operator /= (const Mat& a, const MatExpr& b)
 {
     b.op->augAssignDivide(b, (Mat&)a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Mat_<_Tp>& operator /= (Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignDivide(b, a);
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 const Mat_<_Tp>& operator /= (const Mat_<_Tp>& a, const MatExpr& b)
 {
     b.op->augAssignDivide(b, (Mat&)a);
@@ -3607,7 +3607,7 @@ inline void UMatData::markDeviceCopyObsolete(bool flag)
 
 //! @endcond
 
-static inline
+inline
 void swap(MatExpr& a, MatExpr& b) { a.swap(b); }
 
 } //cv

--- a/modules/core/include/opencv2/core/matx.hpp
+++ b/modules/core/include/opencv2/core/matx.hpp
@@ -266,82 +266,82 @@ typedef Matx<double, 4, 4> Matx44d;
 typedef Matx<float, 6, 6> Matx66f;
 typedef Matx<double, 6, 6> Matx66d;
 
-template<typename _Tp, int m> static inline
+template<typename _Tp, int m> inline
 double determinant(const Matx<_Tp, m, m>& a);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double trace(const Matx<_Tp, m, n>& a);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double norm(const Matx<_Tp, m, n>& M);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double norm(const Matx<_Tp, m, n>& M, int normType);
 
-template<typename _Tp1, typename _Tp2, int m, int n> static inline
+template<typename _Tp1, typename _Tp2, int m, int n> inline
 Matx<_Tp1, m, n>& operator += (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b);
 
-template<typename _Tp1, typename _Tp2, int m, int n> static inline
+template<typename _Tp1, typename _Tp2, int m, int n> inline
 Matx<_Tp1, m, n>& operator -= (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator + (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator - (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, int alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, float alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, double alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, int alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, float alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, double alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (int alpha, const Matx<_Tp, m, n>& a);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (float alpha, const Matx<_Tp, m, n>& a);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (double alpha, const Matx<_Tp, m, n>& a);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, float alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, double alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, float alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, double alpha);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator - (const Matx<_Tp, m, n>& a);
 
-template<typename _Tp, int m, int n, int l> static inline
+template<typename _Tp, int m, int n, int l> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, l>& a, const Matx<_Tp, l, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Vec<_Tp, m> operator * (const Matx<_Tp, m, n>& a, const Vec<_Tp, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 bool operator == (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b);
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 bool operator != (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b);
 
 
@@ -485,64 +485,64 @@ typedef Vec<double, 6> Vec6d;
 template<typename _Tp, int cn> inline
 Vec<_Tp, cn> normalize(const Vec<_Tp, cn>& v);
 
-template<typename _Tp1, typename _Tp2, int cn> static inline
+template<typename _Tp1, typename _Tp2, int cn> inline
 Vec<_Tp1, cn>& operator += (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b);
 
-template<typename _Tp1, typename _Tp2, int cn> static inline
+template<typename _Tp1, typename _Tp2, int cn> inline
 Vec<_Tp1, cn>& operator -= (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator + (const Vec<_Tp, cn>& a, const Vec<_Tp, cn>& b);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator - (const Vec<_Tp, cn>& a, const Vec<_Tp, cn>& b);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, int alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, float alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, double alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, int alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, float alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, double alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, int alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (int alpha, const Vec<_Tp, cn>& a);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, float alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (float alpha, const Vec<_Tp, cn>& a);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, double alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (double alpha, const Vec<_Tp, cn>& a);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, int alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, float alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, double alpha);
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator - (const Vec<_Tp, cn>& a);
 
 template<typename _Tp> inline

--- a/modules/core/include/opencv2/core/matx.inl.hpp
+++ b/modules/core/include/opencv2/core/matx.inl.hpp
@@ -513,13 +513,13 @@ Vec<_Tp, n> Matx<_Tp, m, n>::solve(const Vec<_Tp, m>& rhs, int method) const
     return (Vec<_Tp, n>&)(x);
 }
 
-template<typename _Tp, int m> static inline
+template<typename _Tp, int m> inline
 double determinant(const Matx<_Tp, m, m>& a)
 {
     return cv::internal::Matx_DetOp<_Tp, m>()(a);
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double trace(const Matx<_Tp, m, n>& a)
 {
     _Tp s = 0;
@@ -528,13 +528,13 @@ double trace(const Matx<_Tp, m, n>& a)
     return s;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double norm(const Matx<_Tp, m, n>& M)
 {
     return std::sqrt(normL2Sqr<_Tp, double>(M.val, m*n));
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 double norm(const Matx<_Tp, m, n>& M, int normType)
 {
     switch(normType) {
@@ -550,7 +550,7 @@ double norm(const Matx<_Tp, m, n>& M, int normType)
     }
 }
 
-template<typename _Tp1, typename _Tp2, int m, int n> static inline
+template<typename _Tp1, typename _Tp2, int m, int n> inline
 Matx<_Tp1, m, n>& operator += (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b)
 {
     for( int i = 0; i < m*n; i++ )
@@ -558,7 +558,7 @@ Matx<_Tp1, m, n>& operator += (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b)
     return a;
 }
 
-template<typename _Tp1, typename _Tp2, int m, int n> static inline
+template<typename _Tp1, typename _Tp2, int m, int n> inline
 Matx<_Tp1, m, n>& operator -= (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b)
 {
     for( int i = 0; i < m*n; i++ )
@@ -566,19 +566,19 @@ Matx<_Tp1, m, n>& operator -= (Matx<_Tp1, m, n>& a, const Matx<_Tp2, m, n>& b)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator + (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b)
 {
     return Matx<_Tp, m, n>(a, b, Matx_AddOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator - (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b)
 {
     return Matx<_Tp, m, n>(a, b, Matx_SubOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, int alpha)
 {
     for( int i = 0; i < m*n; i++ )
@@ -586,7 +586,7 @@ Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, int alpha)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, float alpha)
 {
     for( int i = 0; i < m*n; i++ )
@@ -594,7 +594,7 @@ Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, float alpha)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, double alpha)
 {
     for( int i = 0; i < m*n; i++ )
@@ -602,43 +602,43 @@ Matx<_Tp, m, n>& operator *= (Matx<_Tp, m, n>& a, double alpha)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, int alpha)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, float alpha)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, n>& a, double alpha)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (int alpha, const Matx<_Tp, m, n>& a)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (float alpha, const Matx<_Tp, m, n>& a)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator * (double alpha, const Matx<_Tp, m, n>& a)
 {
     return Matx<_Tp, m, n>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, float alpha)
 {
     for( int i = 0; i < m*n; i++ )
@@ -646,7 +646,7 @@ Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, float alpha)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, double alpha)
 {
     for( int i = 0; i < m*n; i++ )
@@ -654,38 +654,38 @@ Matx<_Tp, m, n>& operator /= (Matx<_Tp, m, n>& a, double alpha)
     return a;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, float alpha)
 {
     return Matx<_Tp, m, n>(a, 1.f/alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator / (const Matx<_Tp, m, n>& a, double alpha)
 {
     return Matx<_Tp, m, n>(a, 1./alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Matx<_Tp, m, n> operator - (const Matx<_Tp, m, n>& a)
 {
     return Matx<_Tp, m, n>(a, -1, Matx_ScaleOp());
 }
 
-template<typename _Tp, int m, int n, int l> static inline
+template<typename _Tp, int m, int n, int l> inline
 Matx<_Tp, m, n> operator * (const Matx<_Tp, m, l>& a, const Matx<_Tp, l, n>& b)
 {
     return Matx<_Tp, m, n>(a, b, Matx_MatMulOp());
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 Vec<_Tp, m> operator * (const Matx<_Tp, m, n>& a, const Vec<_Tp, n>& b)
 {
     Matx<_Tp, m, 1> c(a, b, Matx_MatMulOp());
     return (const Vec<_Tp, m>&)(c);
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 bool operator == (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b)
 {
     for( int i = 0; i < m*n; i++ )
@@ -693,7 +693,7 @@ bool operator == (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b)
     return true;
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 bool operator != (const Matx<_Tp, m, n>& a, const Matx<_Tp, m, n>& b)
 {
     return !(a == b);
@@ -955,7 +955,7 @@ Vec<_Tp, cn> normalize(const Vec<_Tp, cn>& v)
     return v * (nv ? 1./nv : 0.);
 }
 
-template<typename _Tp1, typename _Tp2, int cn> static inline
+template<typename _Tp1, typename _Tp2, int cn> inline
 Vec<_Tp1, cn>& operator += (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b)
 {
     for( int i = 0; i < cn; i++ )
@@ -963,7 +963,7 @@ Vec<_Tp1, cn>& operator += (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b)
     return a;
 }
 
-template<typename _Tp1, typename _Tp2, int cn> static inline
+template<typename _Tp1, typename _Tp2, int cn> inline
 Vec<_Tp1, cn>& operator -= (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b)
 {
     for( int i = 0; i < cn; i++ )
@@ -971,19 +971,19 @@ Vec<_Tp1, cn>& operator -= (Vec<_Tp1, cn>& a, const Vec<_Tp2, cn>& b)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator + (const Vec<_Tp, cn>& a, const Vec<_Tp, cn>& b)
 {
     return Vec<_Tp, cn>(a, b, Matx_AddOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator - (const Vec<_Tp, cn>& a, const Vec<_Tp, cn>& b)
 {
     return Vec<_Tp, cn>(a, b, Matx_SubOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, int alpha)
 {
     for( int i = 0; i < cn; i++ )
@@ -991,7 +991,7 @@ Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, int alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, float alpha)
 {
     for( int i = 0; i < cn; i++ )
@@ -999,7 +999,7 @@ Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, float alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, double alpha)
 {
     for( int i = 0; i < cn; i++ )
@@ -1007,7 +1007,7 @@ Vec<_Tp, cn>& operator *= (Vec<_Tp, cn>& a, double alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, int alpha)
 {
     double ialpha = 1./alpha;
@@ -1016,7 +1016,7 @@ Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, int alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, float alpha)
 {
     float ialpha = 1.f/alpha;
@@ -1025,7 +1025,7 @@ Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, float alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, double alpha)
 {
     double ialpha = 1./alpha;
@@ -1034,61 +1034,61 @@ Vec<_Tp, cn>& operator /= (Vec<_Tp, cn>& a, double alpha)
     return a;
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, int alpha)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (int alpha, const Vec<_Tp, cn>& a)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, float alpha)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (float alpha, const Vec<_Tp, cn>& a)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (const Vec<_Tp, cn>& a, double alpha)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator * (double alpha, const Vec<_Tp, cn>& a)
 {
     return Vec<_Tp, cn>(a, alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, int alpha)
 {
     return Vec<_Tp, cn>(a, 1./alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, float alpha)
 {
     return Vec<_Tp, cn>(a, 1.f/alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator / (const Vec<_Tp, cn>& a, double alpha)
 {
     return Vec<_Tp, cn>(a, 1./alpha, Matx_ScaleOp());
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 Vec<_Tp, cn> operator - (const Vec<_Tp, cn>& a)
 {
     Vec<_Tp,cn> t;

--- a/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
+++ b/modules/core/include/opencv2/core/opencl/ocl_defs.hpp
@@ -16,7 +16,7 @@ namespace cv { namespace ocl {
 /// Call is similar to useOpenCL() but doesn't try to load OpenCL runtime or create OpenCL context
 CV_EXPORTS bool isOpenCLActivated();
 #else
-static inline bool isOpenCLActivated() { return false; }
+inline bool isOpenCLActivated() { return false; }
 #endif
 }} // namespace
 

--- a/modules/core/include/opencv2/core/operations.hpp
+++ b/modules/core/include/opencv2/core/operations.hpp
@@ -279,7 +279,7 @@ void Matx<_Tp, m, n>::convertTo(OutputArray dst, int type, double scale, double 
 ////////////////////////// Augmenting algebraic & logical operations //////////////////////////
 
 #define CV_MAT_AUG_OPERATOR1(op, cvop, A, B) \
-    static inline A& operator op (A& a, const B& b) { cvop; return a; }
+    inline A& operator op (A& a, const B& b) { cvop; return a; }
 
 #define CV_MAT_AUG_OPERATOR(op, cvop, A, B)   \
     CV_MAT_AUG_OPERATOR1(op, cvop, A, B)      \
@@ -290,8 +290,8 @@ void Matx<_Tp, m, n>::convertTo(OutputArray dst, int type, double scale, double 
     template<typename _Tp> CV_MAT_AUG_OPERATOR1(op, cvop, const A, B)
 
 #define CV_MAT_AUG_OPERATOR_TN(op, cvop, A)                                \
-    template<typename _Tp, int m, int n> static inline A& operator op (A& a, const Matx<_Tp,m,n>& b) { cvop; return a; } \
-    template<typename _Tp, int m, int n> static inline const A& operator op (const A& a, const Matx<_Tp,m,n>& b) { cvop; return a; }
+    template<typename _Tp, int m, int n> inline A& operator op (A& a, const Matx<_Tp,m,n>& b) { cvop; return a; } \
+    template<typename _Tp, int m, int n> inline const A& operator op (const A& a, const Matx<_Tp,m,n>& b) { cvop; return a; }
 
 CV_MAT_AUG_OPERATOR  (+=, cv::add(a, b, (const Mat&)a), Mat, Mat)
 CV_MAT_AUG_OPERATOR  (+=, cv::add(a, b, (const Mat&)a), Mat, Scalar)
@@ -430,7 +430,7 @@ inline unsigned RNG::next()
 }
 
 //! returns the next uniformly-distributed random number of the specified type
-template<typename _Tp> static inline _Tp randu()
+template<typename _Tp> inline _Tp randu()
 {
   return (_Tp)theRNG();
 }
@@ -438,13 +438,13 @@ template<typename _Tp> static inline _Tp randu()
 
 ///////////////////////////////// Formatted output of cv::Mat /////////////////////////////////
 
-static inline
+inline
 Ptr<Formatted> format(InputArray mtx, Formatter::FormatType fmt)
 {
     return Formatter::get(fmt)->format(mtx.getMat());
 }
 
-static inline
+inline
 int print(Ptr<Formatted> fmtd, FILE* stream = stdout)
 {
     int written = 0;
@@ -455,31 +455,31 @@ int print(Ptr<Formatted> fmtd, FILE* stream = stdout)
     return written;
 }
 
-static inline
+inline
 int print(const Mat& mtx, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(mtx), stream);
 }
 
-static inline
+inline
 int print(const UMat& mtx, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(mtx.getMat(ACCESS_READ)), stream);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 int print(const std::vector<Point_<_Tp> >& vec, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(Mat(vec)), stream);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 int print(const std::vector<Point3_<_Tp> >& vec, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(Mat(vec)), stream);
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 int print(const Matx<_Tp, m, n>& matx, FILE* stream = stdout)
 {
     return print(Formatter::get()->format(cv::Mat(matx)), stream);

--- a/modules/core/include/opencv2/core/persistence.hpp
+++ b/modules/core/include/opencv2/core/persistence.hpp
@@ -697,45 +697,45 @@ CV_EXPORTS void read(const FileNode& node, std::vector<DMatch>& matches);
 CV_EXPORTS void read(const FileNode& node, KeyPoint& value, const KeyPoint& default_value);
 CV_EXPORTS void read(const FileNode& node, DMatch& value, const DMatch& default_value);
 
-template<typename _Tp> static inline void read(const FileNode& node, Point_<_Tp>& value, const Point_<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Point_<_Tp>& value, const Point_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 2 ? default_value : Point_<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]));
 }
 
-template<typename _Tp> static inline void read(const FileNode& node, Point3_<_Tp>& value, const Point3_<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Point3_<_Tp>& value, const Point3_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 3 ? default_value : Point3_<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]),
                                                             saturate_cast<_Tp>(temp[2]));
 }
 
-template<typename _Tp> static inline void read(const FileNode& node, Size_<_Tp>& value, const Size_<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Size_<_Tp>& value, const Size_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 2 ? default_value : Size_<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]));
 }
 
-template<typename _Tp> static inline void read(const FileNode& node, Complex<_Tp>& value, const Complex<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Complex<_Tp>& value, const Complex<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 2 ? default_value : Complex<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]));
 }
 
-template<typename _Tp> static inline void read(const FileNode& node, Rect_<_Tp>& value, const Rect_<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Rect_<_Tp>& value, const Rect_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 4 ? default_value : Rect_<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]),
                                                           saturate_cast<_Tp>(temp[2]), saturate_cast<_Tp>(temp[3]));
 }
 
-template<typename _Tp, int cn> static inline void read(const FileNode& node, Vec<_Tp, cn>& value, const Vec<_Tp, cn>& default_value)
+template<typename _Tp, int cn> inline void read(const FileNode& node, Vec<_Tp, cn>& value, const Vec<_Tp, cn>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != cn ? default_value : Vec<_Tp, cn>(&temp[0]);
 }
 
-template<typename _Tp, int m, int n> static inline void read(const FileNode& node, Matx<_Tp, m, n>& value, const Matx<_Tp, m, n>& default_matx = Matx<_Tp, m, n>())
+template<typename _Tp, int m, int n> inline void read(const FileNode& node, Matx<_Tp, m, n>& value, const Matx<_Tp, m, n>& default_matx = Matx<_Tp, m, n>())
 {
     Mat temp;
     read(node, temp); // read as a Mat class
@@ -746,14 +746,14 @@ template<typename _Tp, int m, int n> static inline void read(const FileNode& nod
         value = Matx<_Tp, m, n>(temp);
 }
 
-template<typename _Tp> static inline void read(const FileNode& node, Scalar_<_Tp>& value, const Scalar_<_Tp>& default_value)
+template<typename _Tp> inline void read(const FileNode& node, Scalar_<_Tp>& value, const Scalar_<_Tp>& default_value)
 {
     std::vector<_Tp> temp; FileNodeIterator it = node.begin(); it >> temp;
     value = temp.size() != 4 ? default_value : Scalar_<_Tp>(saturate_cast<_Tp>(temp[0]), saturate_cast<_Tp>(temp[1]),
                                                             saturate_cast<_Tp>(temp[2]), saturate_cast<_Tp>(temp[3]));
 }
 
-static inline void read(const FileNode& node, Range& value, const Range& default_value)
+inline void read(const FileNode& node, Range& value, const Range& default_value)
 {
     Point2i temp(value.start, value.end); const Point2i default_temp = Point2i(default_value.start, default_value.end);
     read(node, temp, default_temp);
@@ -845,7 +845,7 @@ namespace internal
 
 //! @endcond
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const _Tp& value)
 {
     write(fs, String(), value);
@@ -875,14 +875,14 @@ void write( FileStorage& fs, const String& value )
     writeScalar(fs, value);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Point_<_Tp>& pt )
 {
     write(fs, pt.x);
     write(fs, pt.y);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Point3_<_Tp>& pt )
 {
     write(fs, pt.x);
@@ -890,21 +890,21 @@ void write(FileStorage& fs, const Point3_<_Tp>& pt )
     write(fs, pt.z);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Size_<_Tp>& sz )
 {
     write(fs, sz.width);
     write(fs, sz.height);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Complex<_Tp>& c )
 {
     write(fs, c.re);
     write(fs, c.im);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Rect_<_Tp>& r )
 {
     write(fs, r.x);
@@ -913,20 +913,20 @@ void write(FileStorage& fs, const Rect_<_Tp>& r )
     write(fs, r.height);
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 void write(FileStorage& fs, const Vec<_Tp, cn>& v )
 {
     for(int i = 0; i < cn; i++)
         write(fs, v.val[i]);
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 void write(FileStorage& fs, const Matx<_Tp, m, n>& x )
 {
     write(fs, Mat(x)); // write as a Mat class
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const Scalar_<_Tp>& s )
 {
     write(fs, s.val[0]);
@@ -935,83 +935,83 @@ void write(FileStorage& fs, const Scalar_<_Tp>& s )
     write(fs, s.val[3]);
 }
 
-static inline
+inline
 void write(FileStorage& fs, const Range& r )
 {
     write(fs, r.start);
     write(fs, r.end);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write( FileStorage& fs, const std::vector<_Tp>& vec )
 {
     cv::internal::VecWriterProxy<_Tp, traits::SafeFmt<_Tp>::fmt != 0> w(&fs);
     w(vec);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Point_<_Tp>& pt )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, pt);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Point3_<_Tp>& pt )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, pt);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Size_<_Tp>& sz )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, sz);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Complex<_Tp>& c )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, c);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Rect_<_Tp>& r )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, r);
 }
 
-template<typename _Tp, int cn> static inline
+template<typename _Tp, int cn> inline
 void write(FileStorage& fs, const String& name, const Vec<_Tp, cn>& v )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, v);
 }
 
-template<typename _Tp, int m, int n> static inline
+template<typename _Tp, int m, int n> inline
 void write(FileStorage& fs, const String& name, const Matx<_Tp, m, n>& x )
 {
     write(fs, name, Mat(x)); // write as a Mat class
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write(FileStorage& fs, const String& name, const Scalar_<_Tp>& s )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, s);
 }
 
-static inline
+inline
 void write(FileStorage& fs, const String& name, const Range& r )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
     write(fs, r);
 }
 
-static inline
+inline
 void write(FileStorage& fs, const String& name, const KeyPoint& kpt)
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
@@ -1024,7 +1024,7 @@ void write(FileStorage& fs, const String& name, const KeyPoint& kpt)
     write(fs, kpt.class_id);
 }
 
-static inline
+inline
 void write(FileStorage& fs, const String& name, const DMatch& m)
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+FileNode::FLOW);
@@ -1035,19 +1035,19 @@ void write(FileStorage& fs, const String& name, const DMatch& m)
 }
 
 template<typename _Tp, typename std::enable_if< std::is_enum<_Tp>::value >::type* = nullptr>
-static inline void write( FileStorage& fs, const String& name, const _Tp& val )
+inline void write( FileStorage& fs, const String& name, const _Tp& val )
 {
     write(fs, name, static_cast<int>(val));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write( FileStorage& fs, const String& name, const std::vector<_Tp>& vec )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ+(traits::SafeFmt<_Tp>::fmt != 0 ? FileNode::FLOW : 0));
     write(fs, vec);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void write( FileStorage& fs, const String& name, const std::vector< std::vector<_Tp> >& vec )
 {
     cv::internal::WriteStructContext ws(fs, name, FileNode::SEQ);
@@ -1061,14 +1061,14 @@ void write( FileStorage& fs, const String& name, const std::vector< std::vector<
 #ifdef CV__LEGACY_PERSISTENCE
 // This code is not needed anymore, but it is preserved here to keep source compatibility
 // Implementation is similar to templates instantiations
-static inline void write(FileStorage& fs, const KeyPoint& kpt) { write(fs, String(), kpt); }
-static inline void write(FileStorage& fs, const DMatch& m) { write(fs, String(), m); }
-static inline void write(FileStorage& fs, const std::vector<KeyPoint>& vec)
+inline void write(FileStorage& fs, const KeyPoint& kpt) { write(fs, String(), kpt); }
+inline void write(FileStorage& fs, const DMatch& m) { write(fs, String(), m); }
+inline void write(FileStorage& fs, const std::vector<KeyPoint>& vec)
 {
     cv::internal::VecWriterProxy<KeyPoint, 0> w(&fs);
     w(vec);
 }
-static inline void write(FileStorage& fs, const std::vector<DMatch>& vec)
+inline void write(FileStorage& fs, const std::vector<DMatch>& vec)
 {
     cv::internal::VecWriterProxy<DMatch, 0> w(&fs);
     w(vec);
@@ -1077,7 +1077,7 @@ static inline void write(FileStorage& fs, const std::vector<DMatch>& vec)
 #endif
 
 
-static inline
+inline
 void read(const FileNode& node, bool& value, bool default_value)
 {
     int temp;
@@ -1085,7 +1085,7 @@ void read(const FileNode& node, bool& value, bool default_value)
     value = temp != 0;
 }
 
-static inline
+inline
 void read(const FileNode& node, uchar& value, uchar default_value)
 {
     int temp;
@@ -1093,7 +1093,7 @@ void read(const FileNode& node, uchar& value, uchar default_value)
     value = saturate_cast<uchar>(temp);
 }
 
-static inline
+inline
 void read(const FileNode& node, schar& value, schar default_value)
 {
     int temp;
@@ -1101,7 +1101,7 @@ void read(const FileNode& node, schar& value, schar default_value)
     value = saturate_cast<schar>(temp);
 }
 
-static inline
+inline
 void read(const FileNode& node, ushort& value, ushort default_value)
 {
     int temp;
@@ -1109,7 +1109,7 @@ void read(const FileNode& node, ushort& value, ushort default_value)
     value = saturate_cast<ushort>(temp);
 }
 
-static inline
+inline
 void read(const FileNode& node, short& value, short default_value)
 {
     int temp;
@@ -1117,7 +1117,7 @@ void read(const FileNode& node, short& value, short default_value)
     value = saturate_cast<short>(temp);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void read( FileNodeIterator& it, std::vector<_Tp>& vec, size_t maxCount = (size_t)INT_MAX )
 {
     cv::internal::VecReaderProxy<_Tp, traits::SafeFmt<_Tp>::fmt != 0> r(&it);
@@ -1125,14 +1125,14 @@ void read( FileNodeIterator& it, std::vector<_Tp>& vec, size_t maxCount = (size_
 }
 
 template<typename _Tp, typename std::enable_if< std::is_enum<_Tp>::value >::type* = nullptr>
-static inline void read(const FileNode& node, _Tp& value, const _Tp& default_value = static_cast<_Tp>(0))
+inline void read(const FileNode& node, _Tp& value, const _Tp& default_value = static_cast<_Tp>(0))
 {
     int temp;
     read(node, temp, static_cast<int>(default_value));
     value = static_cast<_Tp>(temp);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void read( const FileNode& node, std::vector<_Tp>& vec, const std::vector<_Tp>& default_value = std::vector<_Tp>() )
 {
     if(node.empty())
@@ -1144,7 +1144,7 @@ void read( const FileNode& node, std::vector<_Tp>& vec, const std::vector<_Tp>& 
     }
 }
 
-static inline
+inline
 void read( const FileNode& node, std::vector<KeyPoint>& vec, const std::vector<KeyPoint>& default_value )
 {
     if(node.empty())
@@ -1153,7 +1153,7 @@ void read( const FileNode& node, std::vector<KeyPoint>& vec, const std::vector<K
         read(node, vec);
 }
 
-static inline
+inline
 void read( const FileNode& node, std::vector<DMatch>& vec, const std::vector<DMatch>& default_value )
 {
     if(node.empty())
@@ -1164,7 +1164,7 @@ void read( const FileNode& node, std::vector<DMatch>& vec, const std::vector<DMa
 
 /** @brief Writes data to a file storage.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 FileStorage& operator << (FileStorage& fs, const _Tp& value)
 {
     if( !fs.isOpened() )
@@ -1179,7 +1179,7 @@ FileStorage& operator << (FileStorage& fs, const _Tp& value)
 
 /** @brief Writes data to a file storage.
  */
-static inline
+inline
 FileStorage& operator << (FileStorage& fs, const char* str)
 {
     return (fs << String(str));
@@ -1187,7 +1187,7 @@ FileStorage& operator << (FileStorage& fs, const char* str)
 
 /** @brief Writes data to a file storage.
  */
-static inline
+inline
 FileStorage& operator << (FileStorage& fs, char* value)
 {
     return (fs << String(value));
@@ -1195,7 +1195,7 @@ FileStorage& operator << (FileStorage& fs, char* value)
 
 /** @brief Reads data from a file storage.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 FileNodeIterator& operator >> (FileNodeIterator& it, _Tp& value)
 {
     read( *it, value, _Tp());
@@ -1204,7 +1204,7 @@ FileNodeIterator& operator >> (FileNodeIterator& it, _Tp& value)
 
 /** @brief Reads data from a file storage.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 FileNodeIterator& operator >> (FileNodeIterator& it, std::vector<_Tp>& vec)
 {
     cv::internal::VecReaderProxy<_Tp, traits::SafeFmt<_Tp>::fmt != 0> r(&it);
@@ -1214,7 +1214,7 @@ FileNodeIterator& operator >> (FileNodeIterator& it, std::vector<_Tp>& vec)
 
 /** @brief Reads data from a file storage.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void operator >> (const FileNode& n, _Tp& value)
 {
     read( n, value, _Tp());
@@ -1222,7 +1222,7 @@ void operator >> (const FileNode& n, _Tp& value)
 
 /** @brief Reads data from a file storage.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 void operator >> (const FileNode& n, std::vector<_Tp>& vec)
 {
     FileNodeIterator it = n.begin();
@@ -1232,7 +1232,7 @@ void operator >> (const FileNode& n, std::vector<_Tp>& vec)
 /** @brief Reads KeyPoint from a file storage.
 */
 //It needs special handling because it contains two types of fields, int & float.
-static inline
+inline
 void operator >> (const FileNode& n, KeyPoint& kpt)
 {
     FileNodeIterator it = n.begin();
@@ -1240,12 +1240,12 @@ void operator >> (const FileNode& n, KeyPoint& kpt)
 }
 
 #ifdef CV__LEGACY_PERSISTENCE
-static inline
+inline
 void operator >> (const FileNode& n, std::vector<KeyPoint>& vec)
 {
     read(n, vec);
 }
-static inline
+inline
 void operator >> (const FileNode& n, std::vector<DMatch>& vec)
 {
     read(n, vec);
@@ -1255,7 +1255,7 @@ void operator >> (const FileNode& n, std::vector<DMatch>& vec)
 /** @brief Reads DMatch from a file storage.
 */
 //It needs special handling because it contains two types of fields, int & float.
-static inline
+inline
 void operator >> (const FileNode& n, DMatch& m)
 {
     FileNodeIterator it = n.begin();
@@ -1265,13 +1265,13 @@ void operator >> (const FileNode& n, DMatch& m)
 CV_EXPORTS bool operator == (const FileNodeIterator& it1, const FileNodeIterator& it2);
 CV_EXPORTS bool operator != (const FileNodeIterator& it1, const FileNodeIterator& it2);
 
-static inline
+inline
 ptrdiff_t operator - (const FileNodeIterator& it1, const FileNodeIterator& it2)
 {
     return it2.remaining() - it1.remaining();
 }
 
-static inline
+inline
 bool operator < (const FileNodeIterator& it1, const FileNodeIterator& it2)
 {
     return it1.remaining() > it2.remaining();

--- a/modules/core/include/opencv2/core/private.cuda.hpp
+++ b/modules/core/include/opencv2/core/private.cuda.hpp
@@ -94,7 +94,7 @@ namespace cv { namespace cuda {
     CV_EXPORTS GpuMat getInputMat(InputArray _src, Stream& stream);
 
     CV_EXPORTS GpuMat getOutputMat(OutputArray _dst, int rows, int cols, int type, Stream& stream);
-    static inline GpuMat getOutputMat(OutputArray _dst, Size size, int type, Stream& stream)
+    inline GpuMat getOutputMat(OutputArray _dst, Size size, int type, Stream& stream)
     {
         return getOutputMat(_dst, size.height, size.width, type, stream);
     }
@@ -108,13 +108,13 @@ namespace cv { namespace cuda {
 
 namespace cv { namespace cuda
 {
-    static inline void checkNppError(int code, const char* file, const int line, const char* func)
+    inline void checkNppError(int code, const char* file, const int line, const char* func)
     {
         if (code < 0)
             cv::error(cv::Error::GpuApiCallError, getNppErrorMessage(code), func, file, line);
     }
 
-    static inline void checkCudaDriverApiError(int code, const char* file, const int line, const char* func)
+    inline void checkCudaDriverApiError(int code, const char* file, const int line, const char* func)
     {
         if (code != CUDA_SUCCESS)
             cv::error(cv::Error::GpuApiCallError, getCudaDriverApiErrorMessage(code), func, file, line);

--- a/modules/core/include/opencv2/core/private.hpp
+++ b/modules/core/include/opencv2/core/private.hpp
@@ -91,7 +91,7 @@ namespace cv
         int _begin, _end, _grainsize;
     };
 
-    template<typename Body> static inline
+    template<typename Body> inline
     void parallel_for( const BlockedRange& range, const Body& body )
     {
         body(range);
@@ -100,7 +100,7 @@ namespace cv
 
     class Split {};
 
-    template<typename Body> static inline
+    template<typename Body> inline
     void parallel_reduce( const BlockedRange& range, Body& body )
     {
         body(range);
@@ -122,13 +122,13 @@ namespace cv
 #define  CV_TOGGLE_FLT(x) ((x)^((int)(x) < 0 ? 0x7fffffff : 0))
 #define  CV_TOGGLE_DBL(x) ((x)^((int64)(x) < 0 ? CV_BIG_INT(0x7fffffffffffffff) : 0))
 
-static inline void* cvAlignPtr( const void* ptr, int align = 32 )
+inline void* cvAlignPtr( const void* ptr, int align = 32 )
 {
     CV_DbgAssert ( (align & (align-1)) == 0 );
     return (void*)( ((size_t)ptr + align - 1) & ~(size_t)(align-1) );
 }
 
-static inline int cvAlign( int size, int align )
+inline int cvAlign( int size, int align )
 {
     CV_DbgAssert( (align & (align-1)) == 0 && size < INT_MAX );
     return (size + align - 1) & -align;
@@ -142,14 +142,14 @@ CV_EXPORTS void scalarToRawData(const cv::Scalar& s, void* buf, int type, int un
 CV_EXPORTS void* allocSingletonBuffer(size_t size);
 
 //! Allocate memory buffers which will not be freed, ease filtering memcheck issues. Uses fastMalloc() call
-template <typename T> static inline
+template <typename T> inline
 T* allocSingleton(size_t count = 1) { return static_cast<T*>(allocSingletonBuffer(sizeof(T) * count)); }
 
 //! Allocate memory buffers which will not be freed, ease filtering memcheck issues. Uses generic malloc() call.
 CV_EXPORTS void* allocSingletonNewBuffer(size_t size);
 
 //! Allocate memory buffers which will not be freed, ease filtering memcheck issues.  Uses generic malloc() call.
-template <typename T> static inline
+template <typename T> inline
 T* allocSingletonNew() { return new(allocSingletonNewBuffer(sizeof(T))) T(); }
 
 } // namespace
@@ -262,45 +262,45 @@ CV_EXPORTS   unsigned long long getIppTopFeatures(); // Returns top major enable
 }
 }
 
-static inline IppiSize ippiSize(size_t width, size_t height)
+inline IppiSize ippiSize(size_t width, size_t height)
 {
     IppiSize size = { (int)width, (int)height };
     return size;
 }
 
-static inline IppiSize ippiSize(const cv::Size & _size)
+inline IppiSize ippiSize(const cv::Size & _size)
 {
     IppiSize size = { _size.width, _size.height };
     return size;
 }
 
 #if IPP_VERSION_X100 >= 201700
-static inline IppiSizeL ippiSizeL(size_t width, size_t height)
+inline IppiSizeL ippiSizeL(size_t width, size_t height)
 {
     IppiSizeL size = { (IppSizeL)width, (IppSizeL)height };
     return size;
 }
 
-static inline IppiSizeL ippiSizeL(const cv::Size & _size)
+inline IppiSizeL ippiSizeL(const cv::Size & _size)
 {
     IppiSizeL size = { _size.width, _size.height };
     return size;
 }
 #endif
 
-static inline IppiPoint ippiPoint(const cv::Point & _point)
+inline IppiPoint ippiPoint(const cv::Point & _point)
 {
     IppiPoint point = { _point.x, _point.y };
     return point;
 }
 
-static inline IppiPoint ippiPoint(int x, int y)
+inline IppiPoint ippiPoint(int x, int y)
 {
     IppiPoint point = { x, y };
     return point;
 }
 
-static inline IppiBorderType ippiGetBorderType(int borderTypeNI)
+inline IppiBorderType ippiGetBorderType(int borderTypeNI)
 {
     return borderTypeNI == cv::BORDER_CONSTANT    ? ippBorderConst   :
            borderTypeNI == cv::BORDER_TRANSPARENT ? ippBorderTransp  :
@@ -309,7 +309,7 @@ static inline IppiBorderType ippiGetBorderType(int borderTypeNI)
            (IppiBorderType)-1;
 }
 
-static inline IppiMaskSize ippiGetMaskSize(int kx, int ky)
+inline IppiMaskSize ippiGetMaskSize(int kx, int ky)
 {
     return (kx == 1 && ky == 3) ? ippMskSize1x3 :
            (kx == 1 && ky == 5) ? ippMskSize1x5 :
@@ -320,7 +320,7 @@ static inline IppiMaskSize ippiGetMaskSize(int kx, int ky)
            (IppiMaskSize)-1;
 }
 
-static inline IppDataType ippiGetDataType(int depth)
+inline IppDataType ippiGetDataType(int depth)
 {
     depth = CV_MAT_DEPTH(depth);
     return depth == CV_8U ? ipp8u :
@@ -333,7 +333,7 @@ static inline IppDataType ippiGetDataType(int depth)
         (IppDataType)-1;
 }
 
-static inline int ippiSuggestThreadsNum(size_t width, size_t height, size_t elemSize, double multiplier)
+inline int ippiSuggestThreadsNum(size_t width, size_t height, size_t elemSize, double multiplier)
 {
     int threads = cv::getNumThreads();
     if(threads > 1 && height >= 64)
@@ -351,13 +351,13 @@ static inline int ippiSuggestThreadsNum(size_t width, size_t height, size_t elem
     return 1;
 }
 
-static inline int ippiSuggestThreadsNum(const cv::Mat &image, double multiplier)
+inline int ippiSuggestThreadsNum(const cv::Mat &image, double multiplier)
 {
     return ippiSuggestThreadsNum(image.cols, image.rows, image.elemSize(), multiplier);
 }
 
 #ifdef HAVE_IPP_IW
-static inline bool ippiCheckAnchor(int x, int y, int kernelWidth, int kernelHeight)
+inline bool ippiCheckAnchor(int x, int y, int kernelWidth, int kernelHeight)
 {
     if(x != ((kernelWidth-1)/2) || y != ((kernelHeight-1)/2))
         return 0;
@@ -365,12 +365,12 @@ static inline bool ippiCheckAnchor(int x, int y, int kernelWidth, int kernelHeig
         return 1;
 }
 
-static inline ::ipp::IwiSize ippiGetSize(const cv::Size & size)
+inline ::ipp::IwiSize ippiGetSize(const cv::Size & size)
 {
     return ::ipp::IwiSize((IwSize)size.width, (IwSize)size.height);
 }
 
-static inline IwiDerivativeType ippiGetDerivType(int dx, int dy, bool nvert)
+inline IwiDerivativeType ippiGetDerivType(int dx, int dy, bool nvert)
 {
     return (dx == 1 && dy == 0) ? ((nvert)?iwiDerivNVerFirst:iwiDerivVerFirst) :
            (dx == 0 && dy == 1) ? iwiDerivHorFirst :
@@ -379,7 +379,7 @@ static inline IwiDerivativeType ippiGetDerivType(int dx, int dy, bool nvert)
            (IwiDerivativeType)-1;
 }
 
-static inline void ippiGetImage(const cv::Mat &src, ::ipp::IwiImage &dst)
+inline void ippiGetImage(const cv::Mat &src, ::ipp::IwiImage &dst)
 {
     ::ipp::IwiBorderSize inMemBorder;
     if(src.isSubmatrix()) // already have physical border
@@ -397,14 +397,14 @@ static inline void ippiGetImage(const cv::Mat &src, ::ipp::IwiImage &dst)
     dst.Init(ippiSize(src.size()), ippiGetDataType(src.depth()), src.channels(), inMemBorder, (void*)src.ptr(), src.step);
 }
 
-static inline ::ipp::IwiImage ippiGetImage(const cv::Mat &src)
+inline ::ipp::IwiImage ippiGetImage(const cv::Mat &src)
 {
     ::ipp::IwiImage image;
     ippiGetImage(src, image);
     return image;
 }
 
-static inline IppiBorderType ippiGetBorder(::ipp::IwiImage &image, int ocvBorderType, ipp::IwiBorderSize &borderSize)
+inline IppiBorderType ippiGetBorder(::ipp::IwiImage &image, int ocvBorderType, ipp::IwiBorderSize &borderSize)
 {
     int            inMemFlags = 0;
     IppiBorderType border     = ippiGetBorderType(ocvBorderType & ~cv::BORDER_ISOLATED);
@@ -456,12 +456,12 @@ static inline IppiBorderType ippiGetBorder(::ipp::IwiImage &image, int ocvBorder
     return (IppiBorderType)(border|inMemFlags);
 }
 
-static inline ::ipp::IwValueFloat ippiGetValue(const cv::Scalar &scalar)
+inline ::ipp::IwValueFloat ippiGetValue(const cv::Scalar &scalar)
 {
     return ::ipp::IwValueFloat(scalar[0], scalar[1], scalar[2], scalar[3]);
 }
 
-static inline int ippiSuggestThreadsNum(const ::ipp::IwiImage &image, double multiplier)
+inline int ippiSuggestThreadsNum(const ::ipp::IwiImage &image, double multiplier)
 {
     return ippiSuggestThreadsNum(image.m_size.width, image.m_size.height, image.m_typeSize*image.m_channels, multiplier);
 }

--- a/modules/core/include/opencv2/core/private/cuda_stubs.hpp
+++ b/modules/core/include/opencv2/core/private/cuda_stubs.hpp
@@ -13,9 +13,9 @@
 #include "opencv2/core/base.hpp"
 
 #ifndef HAVE_CUDA
-static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::GpuNotSupported, "The library is compiled without CUDA support"); }
+inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::GpuNotSupported, "The library is compiled without CUDA support"); }
 #else
-static inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform"); }
+inline CV_NORETURN void throw_no_cuda() { CV_Error(cv::Error::StsNotImplemented, "The called functionality is disabled for current build or platform"); }
 #endif
 
 #endif // OPENCV_CORE_PRIVATE_CUDA_STUBS_HPP

--- a/modules/core/include/opencv2/core/saturate.hpp
+++ b/modules/core/include/opencv2/core/saturate.hpp
@@ -78,25 +78,25 @@ namespace cv
  @param v Function parameter.
  @sa add, subtract, multiply, divide, Mat::convertTo
  */
-template<typename _Tp> static inline _Tp saturate_cast(uchar v)    { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(uchar v)    { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(schar v)    { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(schar v)    { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(ushort v)   { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(ushort v)   { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(short v)    { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(short v)    { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(unsigned v) { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(unsigned v) { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(int v)      { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(int v)      { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(float v)    { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(float v)    { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(double v)   { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(double v)   { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(int64 v)    { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(int64 v)    { return _Tp(v); }
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(uint64 v)   { return _Tp(v); }
+template<typename _Tp> inline _Tp saturate_cast(uint64 v)   { return _Tp(v); }
 
 template<> inline uchar saturate_cast<uchar>(schar v)        { return (uchar)std::max((int)v, 0); }
 template<> inline uchar saturate_cast<uchar>(ushort v)       { return (uchar)std::min((unsigned)v, (unsigned)UCHAR_MAX); }
@@ -162,9 +162,9 @@ template<> inline uint64 saturate_cast<uint64>(double v)     { return (int64)rou
 
 
 /** @overload */
-template<typename _Tp> static inline _Tp saturate_cast(hfloat v) { return saturate_cast<_Tp>((float)v); }
-template<typename _Tp> static inline _Tp saturate_cast(bfloat v) { return saturate_cast<_Tp>((float)v); }
-template<typename _Tp> static inline _Tp saturate_cast(bool v) { return saturate_cast<_Tp>(v ? 1 : 0); }
+template<typename _Tp> inline _Tp saturate_cast(hfloat v) { return saturate_cast<_Tp>((float)v); }
+template<typename _Tp> inline _Tp saturate_cast(bfloat v) { return saturate_cast<_Tp>((float)v); }
+template<typename _Tp> inline _Tp saturate_cast(bool v) { return saturate_cast<_Tp>(v ? 1 : 0); }
 
 // in theory, we could use a LUT for 8u/8s->16f conversion,
 // but with hardware support for FP32->FP16 conversion the current approach is preferable

--- a/modules/core/include/opencv2/core/softfloat.hpp
+++ b/modules/core/include/opencv2/core/softfloat.hpp
@@ -403,8 +403,8 @@ CV_EXPORTS int  cvCeil(const cv::softdouble& a);
 namespace cv
 {
 /** @brief Saturate casts */
-template<typename _Tp> static inline _Tp saturate_cast(softfloat  a) { return _Tp(a); }
-template<typename _Tp> static inline _Tp saturate_cast(softdouble a) { return _Tp(a); }
+template<typename _Tp> inline _Tp saturate_cast(softfloat  a) { return _Tp(a); }
+template<typename _Tp> inline _Tp saturate_cast(softdouble a) { return _Tp(a); }
 
 template<> inline uchar saturate_cast<uchar>(softfloat  a) { return (uchar)std::max(std::min(cvRound(a), (int)UCHAR_MAX), 0); }
 template<> inline uchar saturate_cast<uchar>(softdouble a) { return (uchar)std::max(std::min(cvRound(a), (int)UCHAR_MAX), 0); }

--- a/modules/core/include/opencv2/core/types.hpp
+++ b/modules/core/include/opencv2/core/types.hpp
@@ -1049,115 +1049,115 @@ Complex<_Tp> Complex<_Tp>::conj() const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     return a.re == b.re && a.im == b.im;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     return a.re != b.re || a.im != b.im;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator + (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     return Complex<_Tp>( a.re + b.re, a.im + b.im );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator += (Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     a.re += b.re; a.im += b.im;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator - (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     return Complex<_Tp>( a.re - b.re, a.im - b.im );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator -= (Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     a.re -= b.re; a.im -= b.im;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator - (const Complex<_Tp>& a)
 {
     return Complex<_Tp>(-a.re, -a.im);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator * (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     return Complex<_Tp>( a.re*b.re - a.im*b.im, a.re*b.im + a.im*b.re );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator * (const Complex<_Tp>& a, _Tp b)
 {
     return Complex<_Tp>( a.re*b, a.im*b );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator * (_Tp b, const Complex<_Tp>& a)
 {
     return Complex<_Tp>( a.re*b, a.im*b );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator + (const Complex<_Tp>& a, _Tp b)
 {
     return Complex<_Tp>( a.re + b, a.im );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator - (const Complex<_Tp>& a, _Tp b)
 { return Complex<_Tp>( a.re - b, a.im ); }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator + (_Tp b, const Complex<_Tp>& a)
 {
     return Complex<_Tp>( a.re + b, a.im );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator - (_Tp b, const Complex<_Tp>& a)
 {
     return Complex<_Tp>( b - a.re, -a.im );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator += (Complex<_Tp>& a, _Tp b)
 {
     a.re += b; return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator -= (Complex<_Tp>& a, _Tp b)
 {
     a.re -= b; return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator *= (Complex<_Tp>& a, _Tp b)
 {
     a.re *= b; a.im *= b; return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 double abs(const Complex<_Tp>& a)
 {
     return std::sqrt( (double)a.re*a.re + (double)a.im*a.im);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator / (const Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     double t = 1./((double)b.re*b.re + (double)b.im*b.im);
@@ -1165,27 +1165,27 @@ Complex<_Tp> operator / (const Complex<_Tp>& a, const Complex<_Tp>& b)
                         (_Tp)((-a.re*b.im + a.im*b.re)*t) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp>& operator /= (Complex<_Tp>& a, const Complex<_Tp>& b)
 {
     a = a / b;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator / (const Complex<_Tp>& a, _Tp b)
 {
     _Tp t = (_Tp)1/b;
     return Complex<_Tp>( a.re*t, a.im*t );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator / (_Tp b, const Complex<_Tp>& a)
 {
     return Complex<_Tp>(b)/a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Complex<_Tp> operator /= (const Complex<_Tp>& a, _Tp b)
 {
     _Tp t = (_Tp)1/b;
@@ -1284,7 +1284,7 @@ Point_<_Tp>::inside( const Rect_<_Tp>& r ) const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator += (Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     a.x += b.x;
@@ -1292,7 +1292,7 @@ Point_<_Tp>& operator += (Point_<_Tp>& a, const Point_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator -= (Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     a.x -= b.x;
@@ -1300,7 +1300,7 @@ Point_<_Tp>& operator -= (Point_<_Tp>& a, const Point_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator *= (Point_<_Tp>& a, int b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1308,7 +1308,7 @@ Point_<_Tp>& operator *= (Point_<_Tp>& a, int b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator *= (Point_<_Tp>& a, float b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1316,7 +1316,7 @@ Point_<_Tp>& operator *= (Point_<_Tp>& a, float b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator *= (Point_<_Tp>& a, double b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1324,7 +1324,7 @@ Point_<_Tp>& operator *= (Point_<_Tp>& a, double b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator /= (Point_<_Tp>& a, int b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1332,7 +1332,7 @@ Point_<_Tp>& operator /= (Point_<_Tp>& a, int b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator /= (Point_<_Tp>& a, float b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1340,7 +1340,7 @@ Point_<_Tp>& operator /= (Point_<_Tp>& a, float b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp>& operator /= (Point_<_Tp>& a, double b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1348,93 +1348,93 @@ Point_<_Tp>& operator /= (Point_<_Tp>& a, double b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 double norm(const Point_<_Tp>& pt)
 {
     return std::sqrt((double)pt.x*pt.x + (double)pt.y*pt.y);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     return a.x == b.x && a.y == b.y;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     return a.x != b.x || a.y != b.y;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator + (const Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(a.x + b.x), saturate_cast<_Tp>(a.y + b.y) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator - (const Point_<_Tp>& a, const Point_<_Tp>& b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(a.x - b.x), saturate_cast<_Tp>(a.y - b.y) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator - (const Point_<_Tp>& a)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(-a.x), saturate_cast<_Tp>(-a.y) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (const Point_<_Tp>& a, int b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(a.x*b), saturate_cast<_Tp>(a.y*b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (int a, const Point_<_Tp>& b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(b.x*a), saturate_cast<_Tp>(b.y*a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (const Point_<_Tp>& a, float b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(a.x*b), saturate_cast<_Tp>(a.y*b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (float a, const Point_<_Tp>& b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(b.x*a), saturate_cast<_Tp>(b.y*a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (const Point_<_Tp>& a, double b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(a.x*b), saturate_cast<_Tp>(a.y*b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (double a, const Point_<_Tp>& b)
 {
     return Point_<_Tp>( saturate_cast<_Tp>(b.x*a), saturate_cast<_Tp>(b.y*a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator * (const Matx<_Tp, 2, 2>& a, const Point_<_Tp>& b)
 {
     Matx<_Tp, 2, 1> tmp = a * Vec<_Tp,2>(b.x, b.y);
     return Point_<_Tp>(tmp.val[0], tmp.val[1]);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (const Matx<_Tp, 3, 3>& a, const Point_<_Tp>& b)
 {
     Matx<_Tp, 3, 1> tmp = a * Vec<_Tp,3>(b.x, b.y, 1);
     return Point3_<_Tp>(tmp.val[0], tmp.val[1], tmp.val[2]);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator / (const Point_<_Tp>& a, int b)
 {
     Point_<_Tp> tmp(a);
@@ -1442,7 +1442,7 @@ Point_<_Tp> operator / (const Point_<_Tp>& a, int b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator / (const Point_<_Tp>& a, float b)
 {
     Point_<_Tp> tmp(a);
@@ -1450,7 +1450,7 @@ Point_<_Tp> operator / (const Point_<_Tp>& a, float b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point_<_Tp> operator / (const Point_<_Tp>& a, double b)
 {
     Point_<_Tp> tmp(a);
@@ -1459,10 +1459,10 @@ Point_<_Tp> operator / (const Point_<_Tp>& a, double b)
 }
 
 
-template<typename _AccTp> static inline _AccTp normL2Sqr(const Point_<int>& pt);
-template<typename _AccTp> static inline _AccTp normL2Sqr(const Point_<int64>& pt);
-template<typename _AccTp> static inline _AccTp normL2Sqr(const Point_<float>& pt);
-template<typename _AccTp> static inline _AccTp normL2Sqr(const Point_<double>& pt);
+template<typename _AccTp> inline _AccTp normL2Sqr(const Point_<int>& pt);
+template<typename _AccTp> inline _AccTp normL2Sqr(const Point_<int64>& pt);
+template<typename _AccTp> inline _AccTp normL2Sqr(const Point_<float>& pt);
+template<typename _AccTp> inline _AccTp normL2Sqr(const Point_<double>& pt);
 
 template<> inline int normL2Sqr<int>(const Point_<int>& pt) { return pt.dot(pt); }
 template<> inline int64 normL2Sqr<int64>(const Point_<int64>& pt) { return pt.dot(pt); }
@@ -1567,7 +1567,7 @@ Point3_<_Tp> Point3_<_Tp>::cross(const Point3_<_Tp>& pt) const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator += (Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     a.x += b.x;
@@ -1576,7 +1576,7 @@ Point3_<_Tp>& operator += (Point3_<_Tp>& a, const Point3_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator -= (Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     a.x -= b.x;
@@ -1585,7 +1585,7 @@ Point3_<_Tp>& operator -= (Point3_<_Tp>& a, const Point3_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator *= (Point3_<_Tp>& a, int b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1594,7 +1594,7 @@ Point3_<_Tp>& operator *= (Point3_<_Tp>& a, int b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator *= (Point3_<_Tp>& a, float b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1603,7 +1603,7 @@ Point3_<_Tp>& operator *= (Point3_<_Tp>& a, float b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator *= (Point3_<_Tp>& a, double b)
 {
     a.x = saturate_cast<_Tp>(a.x * b);
@@ -1612,7 +1612,7 @@ Point3_<_Tp>& operator *= (Point3_<_Tp>& a, double b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator /= (Point3_<_Tp>& a, int b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1621,7 +1621,7 @@ Point3_<_Tp>& operator /= (Point3_<_Tp>& a, int b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator /= (Point3_<_Tp>& a, float b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1630,7 +1630,7 @@ Point3_<_Tp>& operator /= (Point3_<_Tp>& a, float b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp>& operator /= (Point3_<_Tp>& a, double b)
 {
     a.x = saturate_cast<_Tp>(a.x / b);
@@ -1639,92 +1639,92 @@ Point3_<_Tp>& operator /= (Point3_<_Tp>& a, double b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 double norm(const Point3_<_Tp>& pt)
 {
     return std::sqrt((double)pt.x*pt.x + (double)pt.y*pt.y + (double)pt.z*pt.z);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     return a.x == b.x && a.y == b.y && a.z == b.z;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     return a.x != b.x || a.y != b.y || a.z != b.z;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator + (const Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(a.x + b.x), saturate_cast<_Tp>(a.y + b.y), saturate_cast<_Tp>(a.z + b.z));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator - (const Point3_<_Tp>& a, const Point3_<_Tp>& b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(a.x - b.x), saturate_cast<_Tp>(a.y - b.y), saturate_cast<_Tp>(a.z - b.z));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator - (const Point3_<_Tp>& a)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(-a.x), saturate_cast<_Tp>(-a.y), saturate_cast<_Tp>(-a.z) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (const Point3_<_Tp>& a, int b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(a.x*b), saturate_cast<_Tp>(a.y*b), saturate_cast<_Tp>(a.z*b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (int a, const Point3_<_Tp>& b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(b.x * a), saturate_cast<_Tp>(b.y * a), saturate_cast<_Tp>(b.z * a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (const Point3_<_Tp>& a, float b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(a.x * b), saturate_cast<_Tp>(a.y * b), saturate_cast<_Tp>(a.z * b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (float a, const Point3_<_Tp>& b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(b.x * a), saturate_cast<_Tp>(b.y * a), saturate_cast<_Tp>(b.z * a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (const Point3_<_Tp>& a, double b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(a.x * b), saturate_cast<_Tp>(a.y * b), saturate_cast<_Tp>(a.z * b) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (double a, const Point3_<_Tp>& b)
 {
     return Point3_<_Tp>( saturate_cast<_Tp>(b.x * a), saturate_cast<_Tp>(b.y * a), saturate_cast<_Tp>(b.z * a) );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator * (const Matx<_Tp, 3, 3>& a, const Point3_<_Tp>& b)
 {
     Matx<_Tp, 3, 1> tmp = a * Vec<_Tp,3>(b.x, b.y, b.z);
     return Point3_<_Tp>(tmp.val[0], tmp.val[1], tmp.val[2]);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Matx<_Tp, 4, 1> operator * (const Matx<_Tp, 4, 4>& a, const Point3_<_Tp>& b)
 {
     return a * Matx<_Tp, 4, 1>(b.x, b.y, b.z, 1);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator / (const Point3_<_Tp>& a, int b)
 {
     Point3_<_Tp> tmp(a);
@@ -1732,7 +1732,7 @@ Point3_<_Tp> operator / (const Point3_<_Tp>& a, int b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator / (const Point3_<_Tp>& a, float b)
 {
     Point3_<_Tp> tmp(a);
@@ -1740,7 +1740,7 @@ Point3_<_Tp> operator / (const Point3_<_Tp>& a, float b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Point3_<_Tp> operator / (const Point3_<_Tp>& a, double b)
 {
     Point3_<_Tp> tmp(a);
@@ -1792,7 +1792,7 @@ bool Size_<_Tp>::empty() const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp>& operator *= (Size_<_Tp>& a, _Tp b)
 {
     a.width *= b;
@@ -1800,7 +1800,7 @@ Size_<_Tp>& operator *= (Size_<_Tp>& a, _Tp b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp> operator * (const Size_<_Tp>& a, _Tp b)
 {
     Size_<_Tp> tmp(a);
@@ -1808,7 +1808,7 @@ Size_<_Tp> operator * (const Size_<_Tp>& a, _Tp b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp>& operator /= (Size_<_Tp>& a, _Tp b)
 {
     a.width /= b;
@@ -1816,7 +1816,7 @@ Size_<_Tp>& operator /= (Size_<_Tp>& a, _Tp b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp> operator / (const Size_<_Tp>& a, _Tp b)
 {
     Size_<_Tp> tmp(a);
@@ -1824,7 +1824,7 @@ Size_<_Tp> operator / (const Size_<_Tp>& a, _Tp b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp>& operator += (Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     a.width += b.width;
@@ -1832,7 +1832,7 @@ Size_<_Tp>& operator += (Size_<_Tp>& a, const Size_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp> operator + (const Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     Size_<_Tp> tmp(a);
@@ -1840,7 +1840,7 @@ Size_<_Tp> operator + (const Size_<_Tp>& a, const Size_<_Tp>& b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp>& operator -= (Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     a.width -= b.width;
@@ -1848,7 +1848,7 @@ Size_<_Tp>& operator -= (Size_<_Tp>& a, const Size_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Size_<_Tp> operator - (const Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     Size_<_Tp> tmp(a);
@@ -1856,13 +1856,13 @@ Size_<_Tp> operator - (const Size_<_Tp>& a, const Size_<_Tp>& b)
     return tmp;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     return a.width == b.width && a.height == b.height;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const Size_<_Tp>& a, const Size_<_Tp>& b)
 {
     return !(a == b);
@@ -1956,7 +1956,7 @@ bool Rect_<int>::contains(const Point_<float>& _pt) const
     return contains(Point_<double>(static_cast<double>(_pt.x), static_cast<double>(_pt.y)));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator += ( Rect_<_Tp>& a, const Point_<_Tp>& b )
 {
     a.x += b.x;
@@ -1964,7 +1964,7 @@ Rect_<_Tp>& operator += ( Rect_<_Tp>& a, const Point_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator -= ( Rect_<_Tp>& a, const Point_<_Tp>& b )
 {
     a.x -= b.x;
@@ -1972,7 +1972,7 @@ Rect_<_Tp>& operator -= ( Rect_<_Tp>& a, const Point_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator += ( Rect_<_Tp>& a, const Size_<_Tp>& b )
 {
     a.width += b.width;
@@ -1980,7 +1980,7 @@ Rect_<_Tp>& operator += ( Rect_<_Tp>& a, const Size_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator -= ( Rect_<_Tp>& a, const Size_<_Tp>& b )
 {
     const _Tp width = a.width - b.width;
@@ -1991,7 +1991,7 @@ Rect_<_Tp>& operator -= ( Rect_<_Tp>& a, const Size_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
 {
     if (a.empty() || b.empty()) {
@@ -2025,7 +2025,7 @@ Rect_<_Tp>& operator &= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp>& operator |= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
 {
     if (a.empty()) {
@@ -2042,37 +2042,37 @@ Rect_<_Tp>& operator |= ( Rect_<_Tp>& a, const Rect_<_Tp>& b )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == (const Rect_<_Tp>& a, const Rect_<_Tp>& b)
 {
     return a.x == b.x && a.y == b.y && a.width == b.width && a.height == b.height;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != (const Rect_<_Tp>& a, const Rect_<_Tp>& b)
 {
     return a.x != b.x || a.y != b.y || a.width != b.width || a.height != b.height;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator + (const Rect_<_Tp>& a, const Point_<_Tp>& b)
 {
     return Rect_<_Tp>( a.x + b.x, a.y + b.y, a.width, a.height );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator - (const Rect_<_Tp>& a, const Point_<_Tp>& b)
 {
     return Rect_<_Tp>( a.x - b.x, a.y - b.y, a.width, a.height );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator + (const Rect_<_Tp>& a, const Size_<_Tp>& b)
 {
     return Rect_<_Tp>( a.x, a.y, a.width + b.width, a.height + b.height );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator - (const Rect_<_Tp>& a, const Size_<_Tp>& b)
 {
     const _Tp width = a.width - b.width;
@@ -2081,14 +2081,14 @@ Rect_<_Tp> operator - (const Rect_<_Tp>& a, const Size_<_Tp>& b)
     return Rect_<_Tp>( a.x, a.y, width, height );
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator & (const Rect_<_Tp>& a, const Rect_<_Tp>& b)
 {
     Rect_<_Tp> c = a;
     return c &= b;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Rect_<_Tp> operator | (const Rect_<_Tp>& a, const Rect_<_Tp>& b)
 {
     Rect_<_Tp> c = a;
@@ -2101,7 +2101,7 @@ Rect_<_Tp> operator | (const Rect_<_Tp>& a, const Rect_<_Tp>& b)
  * computes the complement of the Jaccard Index as described in <https://en.wikipedia.org/wiki/Jaccard_index>.
  * For rectangles this reduces to computing the intersection over the union.
  */
-template<typename _Tp> static inline
+template<typename _Tp> inline
 double jaccardDistance(const Rect_<_Tp>& a, const Rect_<_Tp>& b) {
     _Tp Aa = a.area();
     _Tp Ab = b.area();
@@ -2164,25 +2164,25 @@ Range Range::all()
 }
 
 
-static inline
+inline
 bool operator == (const Range& r1, const Range& r2)
 {
     return r1.start == r2.start && r1.end == r2.end;
 }
 
-static inline
+inline
 bool operator != (const Range& r1, const Range& r2)
 {
     return !(r1 == r2);
 }
 
-static inline
+inline
 bool operator !(const Range& r)
 {
     return r.start == r.end;
 }
 
-static inline
+inline
 Range operator & (const Range& r1, const Range& r2)
 {
     Range r(std::max(r1.start, r2.start), std::min(r1.end, r2.end));
@@ -2190,26 +2190,26 @@ Range operator & (const Range& r1, const Range& r2)
     return r;
 }
 
-static inline
+inline
 Range& operator &= (Range& r1, const Range& r2)
 {
     r1 = r1 & r2;
     return r1;
 }
 
-static inline
+inline
 Range operator + (const Range& r1, int delta)
 {
     return Range(r1.start + delta, r1.end + delta);
 }
 
-static inline
+inline
 Range operator + (int delta, const Range& r1)
 {
     return Range(r1.start + delta, r1.end + delta);
 }
 
-static inline
+inline
 Range operator - (const Range& r1, int delta)
 {
     return r1 + (-delta);
@@ -2323,7 +2323,7 @@ Scalar_<_Tp>::operator Scalar_<T2>() const
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator += (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     a.val[0] += b.val[0];
@@ -2333,7 +2333,7 @@ Scalar_<_Tp>& operator += (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator -= (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     a.val[0] -= b.val[0];
@@ -2343,7 +2343,7 @@ Scalar_<_Tp>& operator -= (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator *= ( Scalar_<_Tp>& a, _Tp v )
 {
     a.val[0] *= v;
@@ -2353,21 +2353,21 @@ Scalar_<_Tp>& operator *= ( Scalar_<_Tp>& a, _Tp v )
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator == ( const Scalar_<_Tp>& a, const Scalar_<_Tp>& b )
 {
     return a.val[0] == b.val[0] && a.val[1] == b.val[1] &&
            a.val[2] == b.val[2] && a.val[3] == b.val[3];
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 bool operator != ( const Scalar_<_Tp>& a, const Scalar_<_Tp>& b )
 {
     return a.val[0] != b.val[0] || a.val[1] != b.val[1] ||
            a.val[2] != b.val[2] || a.val[3] != b.val[3];
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator + (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     return Scalar_<_Tp>(a.val[0] + b.val[0],
@@ -2376,7 +2376,7 @@ Scalar_<_Tp> operator + (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
                         a.val[3] + b.val[3]);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator - (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     return Scalar_<_Tp>(saturate_cast<_Tp>(a.val[0] - b.val[0]),
@@ -2385,7 +2385,7 @@ Scalar_<_Tp> operator - (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
                         saturate_cast<_Tp>(a.val[3] - b.val[3]));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator * (const Scalar_<_Tp>& a, _Tp alpha)
 {
     return Scalar_<_Tp>(a.val[0] * alpha,
@@ -2394,13 +2394,13 @@ Scalar_<_Tp> operator * (const Scalar_<_Tp>& a, _Tp alpha)
                         a.val[3] * alpha);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator * (_Tp alpha, const Scalar_<_Tp>& a)
 {
     return a*alpha;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator - (const Scalar_<_Tp>& a)
 {
     return Scalar_<_Tp>(saturate_cast<_Tp>(-a.val[0]),
@@ -2410,7 +2410,7 @@ Scalar_<_Tp> operator - (const Scalar_<_Tp>& a)
 }
 
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator * (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     return Scalar_<_Tp>(saturate_cast<_Tp>(a[0]*b[0] - a[1]*b[1] - a[2]*b[2] - a[3]*b[3]),
@@ -2419,14 +2419,14 @@ Scalar_<_Tp> operator * (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
                         saturate_cast<_Tp>(a[0]*b[3] + a[1]*b[2] - a[2]*b[1] + a[3]*b[0]));
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator *= (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     a = a * b;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator / (const Scalar_<_Tp>& a, _Tp alpha)
 {
     return Scalar_<_Tp>(a.val[0] / alpha,
@@ -2435,48 +2435,48 @@ Scalar_<_Tp> operator / (const Scalar_<_Tp>& a, _Tp alpha)
                         a.val[3] / alpha);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<float> operator / (const Scalar_<float>& a, float alpha)
 {
     float s = 1 / alpha;
     return Scalar_<float>(a.val[0] * s, a.val[1] * s, a.val[2] * s, a.val[3] * s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<double> operator / (const Scalar_<double>& a, double alpha)
 {
     double s = 1 / alpha;
     return Scalar_<double>(a.val[0] * s, a.val[1] * s, a.val[2] * s, a.val[3] * s);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator /= (Scalar_<_Tp>& a, _Tp alpha)
 {
     a = a / alpha;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator / (_Tp a, const Scalar_<_Tp>& b)
 {
     _Tp s = a / (b[0]*b[0] + b[1]*b[1] + b[2]*b[2] + b[3]*b[3]);
     return b.conj() * s;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp> operator / (const Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     return a * ((_Tp)1 / b);
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar_<_Tp>& operator /= (Scalar_<_Tp>& a, const Scalar_<_Tp>& b)
 {
     a = a / b;
     return a;
 }
 
-template<typename _Tp> static inline
+template<typename _Tp> inline
 Scalar operator * (const Matx<_Tp, 4, 4>& a, const Scalar& b)
 {
     Matx<double, 4, 1> c((Matx<double, 4, 4>)a, b, Matx_MatMulOp());

--- a/modules/core/include/opencv2/core/utility.hpp
+++ b/modules/core/include/opencv2/core/utility.hpp
@@ -477,7 +477,7 @@ std::cout << tm;
 @endcode
 */
 
-static inline
+inline
 std::ostream& operator << (std::ostream& out, const TickMeter& tm)
 {
     return out << tm.getTimeSec() << "sec";
@@ -537,7 +537,7 @@ The function returns the aligned pointer of the same type as the input pointer:
 @param ptr Aligned pointer.
 @param n Alignment size that must be a power of two.
  */
-template<typename _Tp> static inline _Tp* alignPtr(_Tp* ptr, int n=(int)sizeof(_Tp))
+template<typename _Tp> inline _Tp* alignPtr(_Tp* ptr, int n=(int)sizeof(_Tp))
 {
     CV_DbgAssert((n & (n - 1)) == 0); // n is a power of 2
     return (_Tp*)(((size_t)ptr + n-1) & -n);
@@ -550,7 +550,7 @@ The function returns the minimum number that is greater than or equal to sz and 
 @param sz Buffer size to align.
 @param n Alignment size that must be a power of two.
  */
-static inline size_t alignSize(size_t sz, int n)
+inline size_t alignSize(size_t sz, int n)
 {
     CV_DbgAssert((n & (n - 1)) == 0); // n is a power of 2
     return (sz + n-1) & -n;
@@ -562,13 +562,13 @@ Use this function instead of `ceil((float)a / b)` expressions.
 
 @sa alignSize
 */
-static inline int divUp(int a, unsigned int b)
+inline int divUp(int a, unsigned int b)
 {
     CV_DbgAssert(a >= 0);
     return (a + b - 1) / b;
 }
 /** @overload */
-static inline size_t divUp(size_t a, unsigned int b)
+inline size_t divUp(size_t a, unsigned int b)
 {
     return (a + b - 1) / b;
 }
@@ -579,13 +579,13 @@ Use this function instead of `ceil((float)a / b) * b` expressions.
 
 @sa divUp
 */
-static inline int roundUp(int a, unsigned int b)
+inline int roundUp(int a, unsigned int b)
 {
     CV_DbgAssert(a >= 0);
     return a + b - 1 - (a + b -1) % b;
 }
 /** @overload */
-static inline size_t roundUp(size_t a, unsigned int b)
+inline size_t roundUp(size_t a, unsigned int b)
 {
     return a + b - 1 - (a + b - 1) % b;
 }
@@ -596,32 +596,32 @@ Usage: `isAligned<sizeof(int)>(...)`
 
 @note Alignment(N) must be a power of 2 (2**k, 2^k)
 */
-template<int N, typename T> static inline
+template<int N, typename T> inline
 bool isAligned(const T& data)
 {
     CV_StaticAssert((N & (N - 1)) == 0, "");  // power of 2
     return (((size_t)data) & (N - 1)) == 0;
 }
 /** @overload */
-template<int N> static inline
+template<int N> inline
 bool isAligned(const void* p1)
 {
     return isAligned<N>((size_t)p1);
 }
 /** @overload */
-template<int N> static inline
+template<int N> inline
 bool isAligned(const void* p1, const void* p2)
 {
     return isAligned<N>(((size_t)p1)|((size_t)p2));
 }
 /** @overload */
-template<int N> static inline
+template<int N> inline
 bool isAligned(const void* p1, const void* p2, const void* p3)
 {
     return isAligned<N>(((size_t)p1)|((size_t)p2)|((size_t)p3));
 }
 /** @overload */
-template<int N> static inline
+template<int N> inline
 bool isAligned(const void* p1, const void* p2, const void* p3, const void* p4)
 {
     return isAligned<N>(((size_t)p1)|((size_t)p2)|((size_t)p3)|((size_t)p4));
@@ -660,7 +660,7 @@ The function returns true if the optimized code is enabled. Otherwise, it return
  */
 CV_EXPORTS_W bool useOptimized();
 
-static inline size_t getElemSize(int type) { return (size_t)CV_ELEM_SIZE(type); }
+inline size_t getElemSize(int type) { return (size_t)CV_ELEM_SIZE(type); }
 
 /////////////////////////////// Parallel Primitives //////////////////////////////////
 
@@ -701,7 +701,7 @@ public:
 };
 
 //! @ingroup core_parallel
-static inline
+inline
 void parallel_for_(const Range& range, std::function<void(const Range&)> functor, double nstripes=-1.)
 {
     parallel_for_(range, ParallelLoopBodyLambdaWrapper(functor), nstripes);

--- a/modules/core/include/opencv2/core/utils/instrumentation.hpp
+++ b/modules/core/include/opencv2/core/utils/instrumentation.hpp
@@ -113,7 +113,7 @@ enum FLAGS
 };
 
 CV_EXPORTS void       setFlags(FLAGS modeFlags);
-static inline void    setFlags(int modeFlags) { setFlags((FLAGS)modeFlags); }
+inline void    setFlags(int modeFlags) { setFlags((FLAGS)modeFlags); }
 CV_EXPORTS FLAGS      getFlags();
 
 } // namespace instr

--- a/modules/core/include/opencv2/core/utils/plugin_loader.private.hpp
+++ b/modules/core/include/opencv2/core/utils/plugin_loader.private.hpp
@@ -24,7 +24,7 @@ typedef wchar_t FileSystemChar_t;
 typedef std::wstring FileSystemPath_t;
 
 // TODO wchar_t <=> UTF-8
-static inline
+inline
 FileSystemPath_t toFileSystemPath(const std::string& p)
 {
     FileSystemPath_t result;
@@ -35,7 +35,7 @@ FileSystemPath_t toFileSystemPath(const std::string& p)
 }
 
 // TODO wchar_t <=> UTF-8
-static inline
+inline
 std::string toPrintablePath(const FileSystemPath_t& p)
 {
     std::string result;
@@ -55,12 +55,12 @@ typedef void* LibHandle_t;
 typedef char FileSystemChar_t;
 typedef std::string FileSystemPath_t;
 
-static inline FileSystemPath_t toFileSystemPath(const std::string& p) { return p; }
-static inline std::string toPrintablePath(const FileSystemPath_t& p) { return p; }
+inline FileSystemPath_t toFileSystemPath(const std::string& p) { return p; }
+inline std::string toPrintablePath(const FileSystemPath_t& p) { return p; }
 #endif
 
 
-static inline
+inline
 void* getSymbol_(LibHandle_t h, const char* symbolName)
 {
 #if defined(_WIN32)
@@ -70,7 +70,7 @@ void* getSymbol_(LibHandle_t h, const char* symbolName)
 #endif
 }
 
-static inline
+inline
 LibHandle_t libraryLoad_(const FileSystemPath_t& filename)
 {
 #if defined(_WIN32)
@@ -86,7 +86,7 @@ LibHandle_t libraryLoad_(const FileSystemPath_t& filename)
 #endif
 }
 
-static inline
+inline
 void libraryRelease_(LibHandle_t h)
 {
 #if defined(_WIN32)
@@ -96,7 +96,7 @@ void libraryRelease_(LibHandle_t h)
 #endif
 }
 
-static inline
+inline
 std::string libraryPrefix()
 {
 #if defined(_WIN32)
@@ -105,7 +105,7 @@ std::string libraryPrefix()
     return "lib";
 #endif
 }
-static inline
+inline
 std::string librarySuffix()
 {
 #if defined(_WIN32)

--- a/modules/core/include/opencv2/core/utils/trace.private.hpp
+++ b/modules/core/include/opencv2/core/utils/trace.private.hpp
@@ -127,7 +127,7 @@ struct RegionStatistics
     }
 };
 
-static inline
+inline
 std::ostream& operator<<(std::ostream& out, const RegionStatistics& stat)
 {
     out << "skip=" << stat.currentSkippedRegions
@@ -182,7 +182,7 @@ struct RegionStatisticsStatus
     void checkResetSkipMode(int leaveDepth);
 };
 
-static inline
+inline
 std::ostream& operator<<(std::ostream& out, const RegionStatisticsStatus& s)
 {
     out << "ignore={";

--- a/modules/core/include/opencv2/core/vsx_utils.hpp
+++ b/modules/core/include/opencv2/core/vsx_utils.hpp
@@ -264,14 +264,14 @@ VSX_IMPL_1VRG(vec_udword2, vec_dword2,  vpopcntd, vec_popcntu)
     VSX_REDIRECT_1RG(vec_double2, vec_float4,  vec_cvfo, vec_doubleo)
 #else
 //  Fallback: implement vec_cvfo using scalar operations (to ensure successful linking)
-    static inline vec_float4 vec_cvfo(const vec_double2& a)
+    inline vec_float4 vec_cvfo(const vec_double2& a)
     {
         float r0 = static_cast<float>(reinterpret_cast<const double*>(&a)[0]);
         float r1 = static_cast<float>(reinterpret_cast<const double*>(&a)[1]);
         return (vec_float4){r0, 0.f, r1, 0.f};
     }
 
-    static inline vec_double2 vec_cvfo(const vec_float4& a)
+    inline vec_double2 vec_cvfo(const vec_float4& a)
     {
         double r0 = static_cast<double>(reinterpret_cast<const float*>(&a)[0]);
         double r1 = static_cast<double>(reinterpret_cast<const float*>(&a)[2]);

--- a/modules/dnn/include/opencv2/dnn/shape_utils.hpp
+++ b/modules/dnn/include/opencv2/dnn/shape_utils.hpp
@@ -60,7 +60,7 @@ struct _Range : public cv::Range
     _Range(int start_, int size_ = 1) : cv::Range(start_, start_ + size_) {}
 };
 
-static inline Mat slice(const Mat &m, const _Range &r0)
+inline Mat slice(const Mat &m, const _Range &r0)
 {
     Range ranges[CV_MAX_DIM];
     for (int i = 1; i < m.dims; i++)
@@ -69,7 +69,7 @@ static inline Mat slice(const Mat &m, const _Range &r0)
     return m(&ranges[0]);
 }
 
-static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1)
+inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1)
 {
     CV_Assert(m.dims >= 2);
     Range ranges[CV_MAX_DIM];
@@ -80,7 +80,7 @@ static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1)
     return m(&ranges[0]);
 }
 
-static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const _Range &r2)
+inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const _Range &r2)
 {
     CV_Assert(m.dims >= 3);
     Range ranges[CV_MAX_DIM];
@@ -92,7 +92,7 @@ static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const 
     return m(&ranges[0]);
 }
 
-static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const _Range &r2, const _Range &r3)
+inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const _Range &r2, const _Range &r3)
 {
     CV_Assert(m.dims >= 4);
     Range ranges[CV_MAX_DIM];
@@ -105,7 +105,7 @@ static inline Mat slice(const Mat &m, const _Range &r0, const _Range &r1, const 
     return m(&ranges[0]);
 }
 
-static inline Mat getPlane(const Mat &m, int n, int cn)
+inline Mat getPlane(const Mat &m, int n, int cn)
 {
     CV_Assert(m.dims > 2);
     int sz[CV_MAX_DIM];
@@ -116,25 +116,25 @@ static inline Mat getPlane(const Mat &m, int n, int cn)
     return Mat(m.dims - 2, sz, m.type(), (void*)m.ptr<float>(n, cn));
 }
 
-static inline MatShape shape(const int* dims, const int n)
+inline MatShape shape(const int* dims, const int n)
 {
     MatShape shape;
     shape.assign(dims, dims + n);
     return shape;
 }
 
-static inline MatShape shape(const Mat& mat)
+inline MatShape shape(const Mat& mat)
 {
     return mat.shape();
 }
 
-static inline MatShape shape(const UMat& mat)
+inline MatShape shape(const UMat& mat)
 {
     return mat.shape();
 }
 
 #if 0  // issues with MatExpr wrapped into InputArray
-static inline
+inline
 MatShape shape(InputArray input)
 {
     int sz[CV_MAX_DIM];
@@ -145,14 +145,14 @@ MatShape shape(InputArray input)
 
 namespace {inline bool is_neg(int i) { return i < 0; }}
 
-static inline MatShape shape(int a0, int a1=-1, int a2=-1, int a3=-1)
+inline MatShape shape(int a0, int a1=-1, int a2=-1, int a3=-1)
 {
     int shape_[] = {a0, a1, a2, a3};
     int dims = 1 + (a1 >= 0) + (a1 >= 0 && a2 >= 0) + (a1 >= 0 && a2 >= 0 && a3 >= 0);
     return shape(shape_, dims);
 }
 
-static inline size_t total(const MatShape& shape, int start = -1, int end = -1)
+inline size_t total(const MatShape& shape, int start = -1, int end = -1)
 {
     //if (shape.empty())
     //    return 0;
@@ -175,7 +175,7 @@ static inline size_t total(const MatShape& shape, int start = -1, int end = -1)
 }
 
 // TODO: rename to countDimsElements()
-static inline size_t total(const Mat& mat, int start = -1, int end = -1)
+inline size_t total(const Mat& mat, int start = -1, int end = -1)
 {
     if (mat.empty())
         return 0;
@@ -197,7 +197,7 @@ static inline size_t total(const Mat& mat, int start = -1, int end = -1)
     return elems;
 }
 
-static inline MatShape concat(const MatShape& a, const MatShape& b)
+inline MatShape concat(const MatShape& a, const MatShape& b)
 {
     MatShape c = a;
     size_t a_size = a.size(), b_size = b.size(), c_size = a_size + b_size;
@@ -208,7 +208,7 @@ static inline MatShape concat(const MatShape& a, const MatShape& b)
     return c;
 }
 
-static inline std::string toString(const MatShape& shape, const String& name = "")
+inline std::string toString(const MatShape& shape, const String& name = "")
 {
     std::ostringstream ss;
     if (!name.empty())
@@ -218,7 +218,7 @@ static inline std::string toString(const MatShape& shape, const String& name = "
 }
 
 template<typename _Tp>
-static inline std::string toString(const std::vector<_Tp>& shape, const String& name = "")
+inline std::string toString(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::ostringstream ss;
     if (!name.empty())
@@ -231,19 +231,19 @@ static inline std::string toString(const std::vector<_Tp>& shape, const String& 
 }
 
 template<typename _Tp>
-static inline void print(const std::vector<_Tp>& shape, const String& name = "")
+inline void print(const std::vector<_Tp>& shape, const String& name = "")
 {
     std::cout << toString(shape, name) << std::endl;
 }
 template<typename _Tp>
-static inline std::ostream& operator<<(std::ostream &out, const std::vector<_Tp>& shape)
+inline std::ostream& operator<<(std::ostream &out, const std::vector<_Tp>& shape)
 {
     out << toString(shape);
     return out;
 }
 
 /// @brief Converts axis from `[-dims; dims)` (similar to Python's slice notation) to `[0; dims)` range.
-static inline
+inline
 int normalize_axis(int axis, int dims)
 {
     CV_Assert(dims >= 0);
@@ -252,13 +252,13 @@ int normalize_axis(int axis, int dims)
     return axis;
 }
 
-static inline
+inline
 int normalize_axis(int axis, const MatShape& shape)
 {
     return normalize_axis(axis, (int)shape.size());
 }
 
-static inline
+inline
 Range normalize_axis_range(const Range& r, int axisSize)
 {
     if (r == Range::all() || r == Range(0, INT_MAX))
@@ -272,7 +272,7 @@ Range normalize_axis_range(const Range& r, int axisSize)
     return clamped;
 }
 
-static inline
+inline
 bool isAllOnes(const MatShape &inputShape, int startPos, int endPos)
 {
     CV_CheckGE(startPos, 0, "");

--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -591,7 +591,7 @@ CV_EXPORTS_W bool imwriteWithMetadata( const String& filename, InputArray img,
                                        const std::vector<int>& params = std::vector<int>());
 
 //! @brief multi-image overload for bindings
-CV_WRAP static inline
+CV_WRAP inline
 bool imwritemulti(const String& filename, InputArrayOfArrays img,
                   const std::vector<int>& params = std::vector<int>())
 {

--- a/modules/imgcodecs/src/utils.hpp
+++ b/modules/imgcodecs/src/utils.hpp
@@ -145,7 +145,7 @@ struct RowPitchParams {
 RowPitchParams calculateRowPitch(int width, int bpp, int alignment, const char* format_name);
 int calculateRowSize(int width, int nch, const char* format_name);
 
-CV_INLINE bool  isBigEndian( void )
+inline bool  isBigEndian( void )
 {
 #ifdef WORDS_BIGENDIAN
     return true;

--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1213,7 +1213,7 @@ CV_EXPORTS_W Mat getGaborKernel( Size ksize, double sigma, double theta, double 
                                  double gamma, double psi = CV_PI*0.5, int ktype = CV_64F );
 
 //! returns "magic" border value for erosion and dilation. It is automatically transformed to Scalar::all(-DBL_MAX) for dilation.
-static inline Scalar morphologyDefaultBorderValue() { return Scalar::all(DBL_MAX); }
+inline Scalar morphologyDefaultBorderValue() { return Scalar::all(DBL_MAX); }
 
 /** @brief Returns a structuring element of the specified size and shape for morphological operations.
 
@@ -2430,7 +2430,7 @@ float initWideAngleProjMap(InputArray cameraMatrix, InputArray distCoeffs,
                            Size imageSize, int destImageWidth,
                            int m1type, OutputArray map1, OutputArray map2,
                            enum UndistortTypes projType = PROJ_SPHERICAL_EQRECT, double alpha = 0);
-static inline
+inline
 float initWideAngleProjMap(InputArray cameraMatrix, InputArray distCoeffs,
                            Size imageSize, int destImageWidth,
                            int m1type, OutputArray map1, OutputArray map2,

--- a/modules/imgproc/include/opencv2/imgproc/bindings.hpp
+++ b/modules/imgproc/include/opencv2/imgproc/bindings.hpp
@@ -16,7 +16,7 @@ namespace cv {
  *
  * @sa HoughLines
  */
-CV_WRAP static inline
+CV_WRAP inline
 void HoughLinesWithAccumulator(
         InputArray image, OutputArray lines,
         double rho, double theta, int threshold,
@@ -36,7 +36,7 @@ void HoughLinesWithAccumulator(
  *
  * @sa HoughCircles
  */
-CV_WRAP static inline
+CV_WRAP inline
 void HoughCirclesWithAccumulator(
         InputArray image, OutputArray circles,
         int method, double dp, double minDist,

--- a/modules/stitching/include/opencv2/stitching/detail/util_inl.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/util_inl.hpp
@@ -98,30 +98,30 @@ B Graph::walkBreadthFirst(int from, B body) const
 //////////////////////////////////////////////////////////////////////////////
 // Some auxiliary math functions
 
-static inline
+inline
 float normL2(const Point3f& a)
 {
     return a.x * a.x + a.y * a.y + a.z * a.z;
 }
 
 
-static inline
+inline
 float normL2(const Point3f& a, const Point3f& b)
 {
     return normL2(a - b);
 }
 
 
-static inline
+inline
 double normL2sq(const Mat &r)
 {
     return r.dot(r);
 }
 
 
-static inline int sqr(int x) { return x * x; }
-static inline float sqr(float x) { return x * x; }
-static inline double sqr(double x) { return x * x; }
+inline int sqr(int x) { return x * x; }
+inline float sqr(float x) { return x * x; }
+inline double sqr(double x) { return x * x; }
 
 } // namespace detail
 } // namespace cv

--- a/modules/ts/include/opencv2/ts.hpp
+++ b/modules/ts/include/opencv2/ts.hpp
@@ -219,38 +219,38 @@ void checkTestTags();
 
 void applyTestTag_(const std::string& tag);
 
-static inline void applyTestTag(const std::string& tag1, const std::string& tag2)
+inline void applyTestTag(const std::string& tag1, const std::string& tag2)
 { applyTestTag_(tag1); applyTestTag_(tag2); checkTestTags(); }
-static inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3)
+inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3)
 { applyTestTag_(tag1); applyTestTag_(tag2); applyTestTag_(tag3); checkTestTags(); }
-static inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4)
+inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4)
 { applyTestTag_(tag1); applyTestTag_(tag2); applyTestTag_(tag3); applyTestTag_(tag4); checkTestTags(); }
-static inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4, const std::string& tag5)
+inline void applyTestTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4, const std::string& tag5)
 { applyTestTag_(tag1); applyTestTag_(tag2); applyTestTag_(tag3); applyTestTag_(tag4); applyTestTag_(tag5); checkTestTags(); }
 
 
 /** Append global skip test tags
 */
 void registerGlobalSkipTag(const std::string& skipTag);
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2)
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2)
 { registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); }
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3)
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3)
 { registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); registerGlobalSkipTag(tag3); }
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4)
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4)
 { registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); registerGlobalSkipTag(tag3); registerGlobalSkipTag(tag4); }
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
     const std::string& tag5)
 {
     registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); registerGlobalSkipTag(tag3); registerGlobalSkipTag(tag4);
     registerGlobalSkipTag(tag5);
 }
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
     const std::string& tag5, const std::string& tag6)
 {
     registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); registerGlobalSkipTag(tag3); registerGlobalSkipTag(tag4);
     registerGlobalSkipTag(tag5); registerGlobalSkipTag(tag6);
 }
-static inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
+inline void registerGlobalSkipTag(const std::string& tag1, const std::string& tag2, const std::string& tag3, const std::string& tag4,
     const std::string& tag5, const std::string& tag6, const std::string& tag7)
 {
     registerGlobalSkipTag(tag1); registerGlobalSkipTag(tag2); registerGlobalSkipTag(tag3); registerGlobalSkipTag(tag4);

--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -344,7 +344,7 @@ protected:
 #endif
 };
 
-CV_INLINE void
+static inline void
         _cvUpdatePixelBackgroundNP(int x_idx, const uchar* data, int nchannels, int m_nN,
         uchar* m_aModel,
         uchar* m_nNextLongUpdate,
@@ -395,7 +395,7 @@ CV_INLINE void
     };
 }
 
-CV_INLINE int
+static inline int
         _cvCheckPixelBackgroundNP(const uchar* data, int nchannels,
         int m_nN,
         uchar* m_aModel,

--- a/modules/video/src/bgfg_gaussmix2.cpp
+++ b/modules/video/src/bgfg_gaussmix2.cpp
@@ -477,7 +477,7 @@ struct GMM
 // shadow detection performed per pixel
 // should work for rgb data, could be useful for gray scale and depth data as well
 // See: Prati,Mikic,Trivedi,Cucchiara,"Detecting Moving Shadows...",IEEE PAMI,2003.
-CV_INLINE bool
+static inline bool
 detectShadowGMM(const float* data, int nchannels, int nmodes,
                 const GMM* gmm, const float* mean,
                 float Tb, float TB, float tau)


### PR DESCRIPTION
This fixes #29436

I also replaced CV_INLINE which can be removed in a later PR.

I can make a similar PR for 4.x if you want.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
