### PR TITLE
dnn: silence false-positive CPU target warning for New graph engine

### DIFF
--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -348,7 +348,9 @@ void Net::Impl::setPreferableTarget(int targetId)
     if (mainGraph)
     {
         if (targetId != DNN_TARGET_CPU)
+        {
             CV_LOG_WARNING(NULL, "Targets are not supported by the new graph engine for now");
+        }
         return;
     }
     if (netWasQuantized && targetId != DNN_TARGET_CPU &&

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -347,7 +347,8 @@ void Net::Impl::setPreferableTarget(int targetId)
 
     if (mainGraph)
     {
-        CV_LOG_WARNING(NULL, "Targets are not supported by the new graph engine for now");
+        if (targetId != DNN_TARGET_CPU)
+            CV_LOG_WARNING(NULL, "Targets are not supported by the new graph engine for now");
         return;
     }
     if (netWasQuantized && targetId != DNN_TARGET_CPU &&


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
* [x] The PR is proposed to the proper branch (`5.x`)
* [ ] There is a reference to the original bug report and related work
  No existing OpenCV issue or pull request directly covers this warning. This PR is the original report and fix.
* [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
  Not applicable. This patch changes only diagnostic behavior for an existing CPU no-op path.
* [ ] The feature is well documented and sample code can be built with the project CMake
  Not applicable. This patch adds no feature or public API.

## Summary

Suppress a misleading warning emitted when OpenCV 5 New DNN graph engine receives its default CPU target request.

`FaceDetectorYN` and `FaceRecognizerSF` call:

```cpp
net.setPreferableTarget(DNN_TARGET_CPU);
```

after loading their networks.

When New graph engine is active, target switching is not supported. OpenCV therefore currently prints:

```text
Targets are not supported by the new graph engine for now
```

However, New graph engine already executes on CPU. The CPU request does not require a target change, is ignored, and inference continues through New graph engine.

The warning therefore suggests a failed configuration or fallback to Classic DNN even though neither occurs.

## Change

Treat `DNN_TARGET_CPU` as a silent no-op when generic New graph engine is active.

```text
New graph engine + CPU target
→ no target change needed
→ return unchanged
→ no warning

New graph engine + non-CPU target
→ target remains unsupported
→ preserve existing warning
→ return unchanged
```

## Behavior before

```text
New graph engine active
→ caller requests CPU
→ request is ignored
→ warning emitted
→ inference continues on New graph engine
```

## Behavior after

```text
New graph engine active
→ caller requests CPU
→ request is ignored
→ no warning
→ inference continues on New graph engine
```

## Unchanged behavior

* New graph engine selection is unchanged.
* Inference execution is unchanged.
* CPU remains the effective target for generic New graph engine.
* Classic DNN behavior is unchanged.
* ONNX Runtime handling is unchanged.
* Non-CPU targets continue to emit the existing warning.

## Motivation

The current diagnostic is a false positive for the default CPU request. It reports unsupported target selection even though CPU is already the active execution target and inference succeeds through New graph engine.

## Testing

* Built OpenCV locally.
* Ran relevant DNN tests.
* Verified New graph engine still loads and executes affected models.
* Verified CPU target requests no longer emit the misleading warning.
* Verified non-CPU target requests retain the existing unsupported-target warning.
