### PR TITLE
dnn: fix TF importer crash on models without computational layers

### DIFF
--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -102,6 +102,14 @@ bool Net::Impl::empty() const
 }
 
 
+void Net::Impl::checkModelOutputs() const
+{
+    const bool haveOutputs = mainGraph ? !mainGraph->outputs().empty() : !empty();
+    if (!haveOutputs)
+        CV_Error(Error::StsError, "DNN: the model does not contain any outputs");
+}
+
+
 void Net::Impl::clear()
 {
     CV_TRACE_FUNCTION();

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -162,6 +162,9 @@ struct Net::Impl : public detail::NetImplBase
     int dump_indent;
 
     virtual bool empty() const;
+    // Throws if the model has no outputs. Implemented by the engine so that
+    // all model importers report such models in the same way.
+    void checkModelOutputs() const;
     virtual void setPreferableBackend(Net& net, int backendId);
     virtual void setPreferableTarget(int targetId);
 

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -562,6 +562,8 @@ void Net::Impl::prepareForInference()
     }
 #endif
 
+    checkModelOutputs();
+
     if (!prepared) {
         fuseQDQ();
         constFold();

--- a/modules/dnn/src/tensorflow/tf_importer.cpp
+++ b/modules/dnn/src/tensorflow/tf_importer.cpp
@@ -3081,8 +3081,11 @@ void TFImporter::populateNet()
     if (newEngine)
     {
         Net::Impl* netimpl = dstNet.getImpl();
-        for (const std::string& outputName : layersOutputs.back())
-            netimpl->newArg(outputName, DNN_ARG_OUTPUT);
+        if (!layersOutputs.empty())
+        {
+            for (const std::string& outputName : layersOutputs.back())
+                netimpl->newArg(outputName, DNN_ARG_OUTPUT);
+        }
         for (size_t layerId = 0; layerId < layersOutputs.size(); layerId++)
         {
             for (const std::string& outputName : layersOutputs[layerId])
@@ -3296,7 +3299,8 @@ Net readNetFromTensorflow(const char* bufferModel, size_t lenModel,
 Net readNetFromTensorflow(const std::vector<uchar>& bufferModel, const std::vector<uchar>&                                    bufferConfig, int engine,
                           const std::vector<String>& extraOutputs)
 {
-    const char* bufferModelPtr = reinterpret_cast<const char*>(&bufferModel[0]);
+    const char* bufferModelPtr = bufferModel.empty() ? NULL :
+                                 reinterpret_cast<const char*>(&bufferModel[0]);
     const char* bufferConfigPtr = bufferConfig.empty() ? NULL :
                                   reinterpret_cast<const char*>(&bufferConfig[0]);
     return readNetFromTensorflow(bufferModelPtr, bufferModel.size(),

--- a/modules/dnn/test/test_tf_importer.cpp
+++ b/modules/dnn/test/test_tf_importer.cpp
@@ -1911,6 +1911,23 @@ TEST(Test_TensorFlow_Importer, tf_graph_simplifier_buffer_overflow_21947)
     EXPECT_ANY_THROW(readNetFromTensorflow(reinterpret_cast<const char*>(payload), sizeof(payload) / sizeof(payload[0])));
 }
 
+TEST(Test_TensorFlow_Importer, no_layers_graph)
+{
+    // A valid GraphDef without model outputs used to crash the importer.
+    // The engine has to report it as a regular exception instead.
+    std::string config =
+        "node {\n"
+        "  name: \"x\"\n"
+        "  op: \"Placeholder\"\n"
+        "  attr { key: \"dtype\" value { type: DT_FLOAT } }\n"
+        "}\n";
+    EXPECT_THROW(readNetFromTensorflow(NULL, 0, config.c_str(), config.size()), cv::Exception);
+
+    // an empty model buffer must not be dereferenced
+    std::vector<uchar> bufferConfig(config.begin(), config.end());
+    EXPECT_THROW(readNetFromTensorflow(std::vector<uchar>(), bufferConfig), cv::Exception);
+}
+
 TEST(Test_TF_Model, Inception_GetLayer)
 {
     const std::string model = findDataFile("dnn/tensorflow_inception_graph.pb", false);


### PR DESCRIPTION
### Summary

`readNetFromTensorflow()` crashes on a valid `GraphDef` that produces no outputs, for example a graph containing only `Placeholder` or `Const` nodes. `TFImporter::populateNet()` dereferences `layersOutputs.back()` without checking that the vector is not empty.

Still reproducible on current 5.x: without this patch the new regression test aborts with SIGILL (exit 132) under AppleClang.

```cpp
// g.pbtxt: node { name: "x" op: "Placeholder" attr { key: "dtype" value { type: DT_FLOAT } } }
cv::dnn::Net net = cv::dnn::readNetFromTensorflow("", "g.pbtxt");
```

### Changes

- Report the problem from the engine instead of the parser, as requested in review. `Net::Impl::checkModelOutputs()` raises `DNN: the model does not contain any outputs` and runs from `Net::Impl::prepareForInference()`, which every importer goes through, so TensorFlow, ONNX and TFLite all fail the same way.
- `TFImporter::populateNet()` no longer dereferences an empty `layersOutputs`; it does not report the condition itself any more.
- The `std::vector<uchar>` overload of `readNetFromTensorflow()` no longer dereferences element `[0]` of an empty `bufferModel`, matching the check that already existed for `bufferConfig`.
- Data-free regression test `Test_TensorFlow_Importer.no_layers_graph`.

### Note on the rebase

The branch was rebased onto current 5.x and squashed into a single commit. The previous revision predated the removal of the classic engine, so it referenced `ENGINE_CLASSIC` and no longer compiled; the engine-specific branches and the engine-parameterised test are gone with it.

### Testing

- Release build of `opencv_test_dnn` (`BUILD_LIST=dnn,ts`, AppleClang, arm64), no new compiler warnings.
- Reverting only the source changes and keeping the test reproduces the crash on 5.x tip; with the patch `Test_TensorFlow_Importer.*` passes.
- The test also passes with `OPENCV_FORCE_DNN_ENGINE` unset and set to `0`, `1` and `2`.
- Full `opencv_test_dnn` run: every failure is a pre-existing missing-test-data failure (no local opencv_extra), none mentions the new error.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.
- [x] The PR is proposed to the proper branch.
- [ ] There is a reference to the original bug report and related work.
- [x] Accuracy/performance test data in opencv_extra is not applicable; the regression test is data-free.
- [ ] The feature is well documented and sample code can be built with the project CMake.
