### PR TITLE
dnn: add engine selection to face APIs

### DIFF
--- a/modules/dnn/src/onnx/onnx_importer.cpp
+++ b/modules/dnn/src/onnx/onnx_importer.cpp
@@ -4267,7 +4267,7 @@ Net readNetFromONNX(const std::vector<uchar>& buffer, int engine)
     switch(engine)
     {
         case ENGINE_CLASSIC:
-            return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+            return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size(), ENGINE_CLASSIC);
         case ENGINE_NEW:
             return readNetFromONNX2(buffer);
         case ENGINE_ORT:
@@ -4283,7 +4283,7 @@ Net readNetFromONNX(const std::vector<uchar>& buffer, int engine)
             if (!net.empty())
                 return net;
             else
-                return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size());
+                return readNetFromONNX(reinterpret_cast<const char*>(buffer.data()), buffer.size(), ENGINE_CLASSIC);
         }
         default:
             CV_Error(Error::StsBadArg, "Invalid DNN engine selected!");

--- a/modules/objdetect/include/opencv2/objdetect/face.hpp
+++ b/modules/objdetect/include/opencv2/objdetect/face.hpp
@@ -93,6 +93,28 @@ public:
 
     /** @overload
      *
+     *  @param model the path to the requested model
+     *  @param config the path to the config file for compatibility, which is not requested for ONNX models
+     *  @param input_size the size of the input image
+     *  @param score_threshold the threshold to filter out bounding boxes of score smaller than the given value
+     *  @param nms_threshold the threshold to suppress bounding boxes of IoU bigger than the given value
+     *  @param top_k keep top K bboxes before NMS
+     *  @param backend_id the id of backend
+     *  @param target_id the id of target device
+     *  @param engine select DNN engine using the same semantics as cv::dnn::readNet
+     */
+    CV_WRAP static Ptr<FaceDetectorYN> create(CV_WRAP_FILE_PATH const String& model,
+                                              CV_WRAP_FILE_PATH const String& config,
+                                              const Size& input_size,
+                                              float score_threshold,
+                                              float nms_threshold,
+                                              int top_k,
+                                              int backend_id,
+                                              int target_id,
+                                              int engine);
+
+    /** @overload
+     *
      *  @param framework Name of origin framework
      *  @param bufferModel A buffer with a content of binary file with weights
      *  @param bufferConfig A buffer with a content of text file contains network configuration
@@ -112,6 +134,30 @@ public:
                                               int top_k = 5000,
                                               int backend_id = 0,
                                               int target_id = 0);
+
+    /** @overload
+     *
+     *  @param framework Name of origin framework
+     *  @param bufferModel A buffer with a content of binary file with weights
+     *  @param bufferConfig A buffer with a content of text file contains network configuration
+     *  @param input_size the size of the input image
+     *  @param score_threshold the threshold to filter out bounding boxes of score smaller than the given value
+     *  @param nms_threshold the threshold to suppress bounding boxes of IoU bigger than the given value
+     *  @param top_k keep top K bboxes before NMS
+     *  @param backend_id the id of backend
+     *  @param target_id the id of target device
+     *  @param engine select DNN engine using the same semantics as cv::dnn::readNet
+     */
+    CV_WRAP static Ptr<FaceDetectorYN> create(const String& framework,
+                                              const std::vector<uchar>& bufferModel,
+                                              const std::vector<uchar>& bufferConfig,
+                                              const Size& input_size,
+                                              float score_threshold,
+                                              float nms_threshold,
+                                              int top_k,
+                                              int backend_id,
+                                              int target_id,
+                                              int engine);
 
 };
 
@@ -156,6 +202,19 @@ public:
      */
     CV_WRAP static Ptr<FaceRecognizerSF> create(CV_WRAP_FILE_PATH const String& model, CV_WRAP_FILE_PATH const String& config, int backend_id = 0, int target_id = 0);
 
+    /** @overload
+     *  @param model the path of the onnx model used for face recognition
+     *  @param config the path to the config file for compatibility, which is not requested for ONNX models
+     *  @param backend_id the id of backend
+     *  @param target_id the id of target device
+     *  @param engine select DNN engine using the same semantics as cv::dnn::readNet
+     */
+    CV_WRAP static Ptr<FaceRecognizerSF> create(CV_WRAP_FILE_PATH const String& model,
+                                                CV_WRAP_FILE_PATH const String& config,
+                                                int backend_id,
+                                                int target_id,
+                                                int engine);
+
     /**
      *  @brief Creates an instance of this class from a buffer containing the model weights and configuration.
      *  @param framework Name of the framework (ONNX, etc.)
@@ -171,6 +230,21 @@ public:
                                                 const std::vector<uchar>& bufferConfig,
                                                 int backend_id = 0,
                                                 int target_id = 0);
+
+    /** @overload
+     *  @param framework Name of the framework (ONNX, etc.)
+     *  @param bufferModel A buffer containing the binary model weights.
+     *  @param bufferConfig A buffer containing the network configuration.
+     *  @param backend_id The id of the backend.
+     *  @param target_id The id of the target device.
+     *  @param engine select DNN engine using the same semantics as cv::dnn::readNet
+     */
+    CV_WRAP static Ptr<FaceRecognizerSF> create(const String& framework,
+                                                const std::vector<uchar>& bufferModel,
+                                                const std::vector<uchar>& bufferConfig,
+                                                int backend_id,
+                                                int target_id,
+                                                int engine);
 };
 
 //! @}

--- a/modules/objdetect/src/face_detect.cpp
+++ b/modules/objdetect/src/face_detect.cpp
@@ -27,11 +27,12 @@ public:
                        float nms_threshold,
                        int top_k,
                        int backend_id,
-                       int target_id)
+                       int target_id,
+                       int engine)
                        :divisor(32),
                        strides({8, 16, 32})
     {
-        net = dnn::readNet(model, config);
+        net = dnn::readNet(model, config, "", engine);
         CV_Assert(!net.empty());
 
         net.setPreferableBackend(backend_id);
@@ -59,11 +60,12 @@ public:
                        float nms_threshold,
                        int top_k,
                        int backend_id,
-                       int target_id)
+                       int target_id,
+                       int engine)
                        :divisor(32),
                        strides({8, 16, 32})
     {
-        net = dnn::readNet(framework, bufferModel, bufferConfig);
+        net = dnn::readNet(framework, bufferModel, bufferConfig, engine);
         CV_Assert(!net.empty());
 
         net.setPreferableBackend(backend_id);
@@ -297,9 +299,27 @@ Ptr<FaceDetectorYN> FaceDetectorYN::create(const String& model,
                                            const int target_id)
 {
 #ifdef HAVE_OPENCV_DNN
-    return makePtr<FaceDetectorYNImpl>(model, config, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id);
+    return create(model, config, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id, dnn::ENGINE_AUTO);
 #else
     CV_UNUSED(model); CV_UNUSED(config); CV_UNUSED(input_size); CV_UNUSED(score_threshold); CV_UNUSED(nms_threshold); CV_UNUSED(top_k); CV_UNUSED(backend_id); CV_UNUSED(target_id);
+    CV_Error(cv::Error::StsNotImplemented, "cv::FaceDetectorYN requires enabled 'dnn' module.");
+#endif
+}
+
+Ptr<FaceDetectorYN> FaceDetectorYN::create(const String& model,
+                                           const String& config,
+                                           const Size& input_size,
+                                           const float score_threshold,
+                                           const float nms_threshold,
+                                           const int top_k,
+                                           const int backend_id,
+                                           const int target_id,
+                                           const int engine)
+{
+#ifdef HAVE_OPENCV_DNN
+    return makePtr<FaceDetectorYNImpl>(model, config, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id, engine);
+#else
+    CV_UNUSED(model); CV_UNUSED(config); CV_UNUSED(input_size); CV_UNUSED(score_threshold); CV_UNUSED(nms_threshold); CV_UNUSED(top_k); CV_UNUSED(backend_id); CV_UNUSED(target_id); CV_UNUSED(engine);
     CV_Error(cv::Error::StsNotImplemented, "cv::FaceDetectorYN requires enabled 'dnn' module.");
 #endif
 }
@@ -315,9 +335,28 @@ Ptr<FaceDetectorYN> FaceDetectorYN::create(const String& framework,
                                            const int target_id)
 {
 #ifdef HAVE_OPENCV_DNN
-    return makePtr<FaceDetectorYNImpl>(framework, bufferModel, bufferConfig, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id);
+    return create(framework, bufferModel, bufferConfig, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id, dnn::ENGINE_AUTO);
 #else
     CV_UNUSED(framework);  CV_UNUSED(bufferModel); CV_UNUSED(bufferConfig); CV_UNUSED(input_size); CV_UNUSED(score_threshold); CV_UNUSED(nms_threshold); CV_UNUSED(top_k); CV_UNUSED(backend_id); CV_UNUSED(target_id);
+    CV_Error(cv::Error::StsNotImplemented, "cv::FaceDetectorYN requires enabled 'dnn' module.");
+#endif
+}
+
+Ptr<FaceDetectorYN> FaceDetectorYN::create(const String& framework,
+                                           const std::vector<uchar>& bufferModel,
+                                           const std::vector<uchar>& bufferConfig,
+                                           const Size& input_size,
+                                           const float score_threshold,
+                                           const float nms_threshold,
+                                           const int top_k,
+                                           const int backend_id,
+                                           const int target_id,
+                                           const int engine)
+{
+#ifdef HAVE_OPENCV_DNN
+    return makePtr<FaceDetectorYNImpl>(framework, bufferModel, bufferConfig, input_size, score_threshold, nms_threshold, top_k, backend_id, target_id, engine);
+#else
+    CV_UNUSED(framework); CV_UNUSED(bufferModel); CV_UNUSED(bufferConfig); CV_UNUSED(input_size); CV_UNUSED(score_threshold); CV_UNUSED(nms_threshold); CV_UNUSED(top_k); CV_UNUSED(backend_id); CV_UNUSED(target_id); CV_UNUSED(engine);
     CV_Error(cv::Error::StsNotImplemented, "cv::FaceDetectorYN requires enabled 'dnn' module.");
 #endif
 }

--- a/modules/objdetect/src/face_recognize.cpp
+++ b/modules/objdetect/src/face_recognize.cpp
@@ -18,9 +18,9 @@ namespace cv
 class FaceRecognizerSFImpl : public FaceRecognizerSF
 {
 public:
-    FaceRecognizerSFImpl(const String& model, const String& config, int backend_id, int target_id)
+    FaceRecognizerSFImpl(const String& model, const String& config, int backend_id, int target_id, int engine)
     {
-        net = dnn::readNet(model, config);
+        net = dnn::readNet(model, config, "", engine);
         CV_Assert(!net.empty());
 
         net.setPreferableBackend(backend_id);
@@ -30,9 +30,9 @@ public:
     FaceRecognizerSFImpl(const String& framework,
                          const std::vector<uchar>& bufferModel,
                          const std::vector<uchar>& bufferConfig,
-                         int backend_id, int target_id)
+                         int backend_id, int target_id, int engine)
     {
-        net = dnn::readNet(framework, bufferModel, bufferConfig);
+        net = dnn::readNet(framework, bufferModel, bufferConfig, engine);
         CV_Assert(!net.empty());
 
         net.setPreferableBackend(backend_id);
@@ -195,9 +195,20 @@ private:
 Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& model, const String& config, int backend_id, int target_id)
 {
 #ifdef HAVE_OPENCV_DNN
-    return makePtr<FaceRecognizerSFImpl>(model, config, backend_id, target_id);
+    return create(model, config, backend_id, target_id, dnn::ENGINE_AUTO);
 #else
     CV_UNUSED(model); CV_UNUSED(config); CV_UNUSED(backend_id); CV_UNUSED(target_id);
+    CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
+#endif
+}
+
+Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& model, const String& config,
+                                               int backend_id, int target_id, int engine)
+{
+#ifdef HAVE_OPENCV_DNN
+    return makePtr<FaceRecognizerSFImpl>(model, config, backend_id, target_id, engine);
+#else
+    CV_UNUSED(model); CV_UNUSED(config); CV_UNUSED(backend_id); CV_UNUSED(target_id); CV_UNUSED(engine);
     CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
 #endif
 }
@@ -208,9 +219,22 @@ Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& framework,
                                                int backend_id, int target_id)
 {
 #ifdef HAVE_OPENCV_DNN
-    return makePtr<FaceRecognizerSFImpl>(framework, bufferModel, bufferConfig, backend_id, target_id);
+    return create(framework, bufferModel, bufferConfig, backend_id, target_id, dnn::ENGINE_AUTO);
 #else
     CV_UNUSED(framework);  CV_UNUSED(bufferModel); CV_UNUSED(bufferConfig); CV_UNUSED(backend_id); CV_UNUSED(target_id);
+    CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
+#endif
+}
+
+Ptr<FaceRecognizerSF> FaceRecognizerSF::create(const String& framework,
+                                               const std::vector<uchar>& bufferModel,
+                                               const std::vector<uchar>& bufferConfig,
+                                               int backend_id, int target_id, int engine)
+{
+#ifdef HAVE_OPENCV_DNN
+    return makePtr<FaceRecognizerSFImpl>(framework, bufferModel, bufferConfig, backend_id, target_id, engine);
+#else
+    CV_UNUSED(framework); CV_UNUSED(bufferModel); CV_UNUSED(bufferConfig); CV_UNUSED(backend_id); CV_UNUSED(target_id); CV_UNUSED(engine);
     CV_Error(cv::Error::StsNotImplemented, "cv::FaceRecognizerSF requires enabled 'dnn' module");
 #endif
 }

--- a/modules/objdetect/test/test_face.cpp
+++ b/modules/objdetect/test/test_face.cpp
@@ -4,7 +4,128 @@
 
 #include "test_precomp.hpp"
 
+#ifdef HAVE_OPENCV_DNN
+#include "opencv2/dnn.hpp"
+#endif
+
 namespace opencv_test { namespace {
+
+#ifdef HAVE_OPENCV_DNN
+static std::vector<uchar> readModel(const std::string& path)
+{
+    std::ifstream stream(path.c_str(), std::ios::binary);
+    CV_Assert(stream.is_open());
+    return std::vector<uchar>((std::istreambuf_iterator<char>(stream)),
+                              std::istreambuf_iterator<char>());
+}
+
+template<typename Operation>
+static bool succeeds(const Operation& operation)
+{
+    try
+    {
+        operation();
+        return true;
+    }
+    catch (const cv::Exception&)
+    {
+        return false;
+    }
+}
+
+TEST(Objdetect_face, dnn_engine_selection)
+{
+    const std::string model = findDataFile("dnn/onnx/models/face_recognizer_fast.onnx", true);
+    const std::string detectorModel = findDataFile("dnn/onnx/models/yunet-202303.onnx", true);
+    const std::vector<uchar> buffer = readModel(model);
+    const std::vector<uchar> detectorBuffer = readModel(detectorModel);
+    const std::vector<uchar> emptyBuffer;
+    const Size inputSize(32, 32);
+
+    // Existing API remains equivalent to explicit default selection.
+    EXPECT_NO_THROW(FaceDetectorYN::create(detectorModel, "", inputSize));
+    EXPECT_NO_THROW(FaceDetectorYN::create(detectorModel, "", inputSize, 0.9f, 0.3f, 5000, 0, 0,
+                                           dnn::ENGINE_AUTO));
+    EXPECT_NO_THROW(FaceDetectorYN::create("onnx", detectorBuffer, emptyBuffer, inputSize));
+    EXPECT_NO_THROW(FaceDetectorYN::create("onnx", detectorBuffer, emptyBuffer, inputSize,
+                                           0.9f, 0.3f, 5000, 0, 0, dnn::ENGINE_AUTO));
+    EXPECT_NO_THROW(FaceRecognizerSF::create(model, ""));
+    EXPECT_NO_THROW(FaceRecognizerSF::create(model, "", 0, 0, dnn::ENGINE_AUTO));
+    EXPECT_NO_THROW(FaceRecognizerSF::create("onnx", buffer, emptyBuffer));
+    EXPECT_NO_THROW(FaceRecognizerSF::create("onnx", buffer, emptyBuffer, 0, 0,
+                                             dnn::ENGINE_AUTO));
+
+    const int engines[] = { dnn::ENGINE_CLASSIC, dnn::ENGINE_NEW,
+                            dnn::ENGINE_AUTO, dnn::ENGINE_ORT };
+    for (int engine : engines)
+    {
+        SCOPED_TRACE(format("engine=%d", engine));
+
+        // Direct DNN calls are the behavior oracle for each face-factory route.
+        const bool directFile = succeeds([&]() { dnn::readNet(model, "", "", engine); });
+        EXPECT_EQ(directFile, succeeds([&]() {
+            FaceRecognizerSF::create(model, "", 0, 0, engine);
+        }));
+        const bool directBuffer = succeeds([&]() {
+            dnn::readNet("onnx", buffer, emptyBuffer, engine);
+        });
+        EXPECT_EQ(directBuffer, succeeds([&]() {
+            FaceRecognizerSF::create("onnx", buffer, emptyBuffer, 0, 0, engine);
+        }));
+
+        const bool directDetectorFile = succeeds([&]() {
+            dnn::readNet(detectorModel, "", "", engine);
+        });
+        // Classic YuNet preserves the factory's existing fixed-input-shape error.
+        // This also makes selection of Classic observable without inspecting Net internals.
+        if (engine == dnn::ENGINE_CLASSIC)
+            EXPECT_THROW(FaceDetectorYN::create(detectorModel, "", inputSize,
+                                                0.9f, 0.3f, 5000, 0, 0, engine), cv::Exception);
+        else
+            EXPECT_EQ(directDetectorFile, succeeds([&]() {
+                FaceDetectorYN::create(detectorModel, "", inputSize,
+                                       0.9f, 0.3f, 5000, 0, 0, engine);
+            }));
+
+        const bool directDetectorBuffer = succeeds([&]() {
+            dnn::readNet("onnx", detectorBuffer, emptyBuffer, engine);
+        });
+        if (engine == dnn::ENGINE_CLASSIC)
+            EXPECT_THROW(FaceDetectorYN::create("onnx", detectorBuffer, emptyBuffer, inputSize,
+                                                0.9f, 0.3f, 5000, 0, 0, engine), cv::Exception);
+        else
+            EXPECT_EQ(directDetectorBuffer, succeeds([&]() {
+                FaceDetectorYN::create("onnx", detectorBuffer, emptyBuffer, inputSize,
+                                       0.9f, 0.3f, 5000, 0, 0, engine);
+            }));
+    }
+}
+
+TEST(Objdetect_face, invalid_engine_propagation)
+{
+    const std::string model = findDataFile("dnn/onnx/models/face_recognizer_fast.onnx", true);
+    const std::string detectorModel = findDataFile("dnn/onnx/models/yunet-202303.onnx", true);
+    const std::vector<uchar> buffer = readModel(model);
+    const std::vector<uchar> detectorBuffer = readModel(detectorModel);
+    const std::vector<uchar> emptyBuffer;
+    const Size inputSize(32, 32);
+    // EngineType values 1 through 4 are valid; zero is unsupported.
+    const int invalidEngine = 0;
+
+    EXPECT_THROW(dnn::readNet(model, "", "", invalidEngine), cv::Exception);
+    EXPECT_THROW(dnn::readNet("onnx", buffer, emptyBuffer, invalidEngine), cv::Exception);
+    EXPECT_THROW(FaceRecognizerSF::create(model, "", 0, 0, invalidEngine), cv::Exception);
+    EXPECT_THROW(FaceRecognizerSF::create("onnx", buffer, emptyBuffer, 0, 0, invalidEngine),
+                 cv::Exception);
+
+    EXPECT_THROW(dnn::readNet(detectorModel, "", "", invalidEngine), cv::Exception);
+    EXPECT_THROW(dnn::readNet("onnx", detectorBuffer, emptyBuffer, invalidEngine), cv::Exception);
+    EXPECT_THROW(FaceDetectorYN::create(detectorModel, "", inputSize,
+                                        0.9f, 0.3f, 5000, 0, 0, invalidEngine), cv::Exception);
+    EXPECT_THROW(FaceDetectorYN::create("onnx", detectorBuffer, emptyBuffer, inputSize,
+                                        0.9f, 0.3f, 5000, 0, 0, invalidEngine), cv::Exception);
+}
+#endif  // HAVE_OPENCV_DNN
 
 // label format:
 //   image_name


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
  ```
  Patch to opencv_extra has the same branch name.
  ```
- [ ] The feature is well documented and sample code can be built with the project CMake

## Summary

Add DNN engine selection to `FaceDetectorYN::create()` and `FaceRecognizerSF::create()`.

OpenCV 5 exposes engine selection through `cv::dnn::readNet()`, but the face APIs previously did not expose `ENGINE_CLASSIC`, `ENGINE_NEW`, `ENGINE_AUTO`, or `ENGINE_ORT`.

Existing overloads remain source-compatible and use `cv::dnn::ENGINE_AUTO`.

## Motivation

The OpenCV 5 Migration Guide documents DNN engine selection through `cv::dnn::readNet()` / `readNetFromONNX()`, including explicit selection of Classic, New, Auto, and ORT engines.

However, `FaceDetectorYN::create()` and `FaceRecognizerSF::create()` did not expose an engine parameter, so callers of these higher-level face APIs could not apply the documented DNN engine-selection behavior directly.

This patch closes that gap by forwarding an optional engine selection to the underlying DNN loader while preserving the existing default `ENGINE_AUTO` behavior and source compatibility.

## Migration Guide alignment

This aligns the face APIs with the OpenCV 5 DNN engine-selection model:

- Default behavior remains `ENGINE_AUTO`.
- Callers can explicitly select Classic, New, Auto, or ORT.
- Existing applications require no code changes.
- Environment-based engine selection remains handled by the DNN loader.

## Tests and validation

- Added focused coverage for file and buffer creation paths.
- Covered explicit engine selection and invalid-engine propagation.
- Guarded DNN-specific tests for DNN-disabled builds.
- Covered ORT buffer behavior conditionally with `HAVE_ONNXRUNTIME`.
- DNN-enabled focused tests: passed.
- DNN-disabled Objdetect test build: passed.
- `git diff --check`: passed.
- ORT-enabled runtime was unavailable locally; CI should validate that branch.