### PR TITLE
doc: update TRUCO publication status

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -1350,7 +1350,7 @@
 @article{TRUCO2026,
   title={TRUCO: A Scalable Lock-Free Algorithm for Parallel Contour Extraction},
   author={Mu\~noz-Salinas, Rafael and Romero-Ramírez, Francisco J. and Marín-Jiménez, Manuel J.},
-  journal={Pattern Recognition under review},
+  journal={To be published},
   year={2026}
 }
 


### PR DESCRIPTION
Updates TRUCO publication status in doc/opencv.bib.