### PR TITLE
imgproc: add UMat/OpenCL regression test for findContours hierarchy (#23574)

### DIFF
--- a/modules/imgproc/test/test_contours_new.cpp
+++ b/modules/imgproc/test/test_contours_new.cpp
@@ -5,6 +5,7 @@
 #include "test_precomp.hpp"
 #include "opencv2/ts/ocl_test.hpp"
 #include "opencv2/imgproc/detail/legacy.hpp"
+#include "opencv2/core/ocl.hpp"
 
 #define CHECK_OLD 1
 
@@ -604,5 +605,62 @@ TEST(Imgproc_FindContours, link_runs)
     EXPECT_MAT_NEAR(Mat(hierarchy_o), Mat(hierarchy), 0);
 #endif
 }
+
+// See https://github.com/opencv/opencv/issues/23574:
+// with OpenCL enabled, findContours() used to return an all-zero hierarchy
+// when the destination was a UMat, while the contours themselves were correct
+// and the same call on a Mat destination was fine. Verify across all
+// retrieval modes/methods that the hierarchy downloaded from a UMat
+// destination matches the Mat-based reference.
+typedef testing::TestWithParam<tuple<int, int>> Imgproc_FindContours_OCL_UMat;
+
+TEST_P(Imgproc_FindContours_OCL_UMat, hierarchy_matches_cpu)
+{
+    if (!cv::ocl::haveOpenCL())
+        throw SkipTestException("OpenCL is not available");
+
+    const int mode = get<0>(GetParam());
+    const int method = get<1>(GetParam());
+
+    const bool useOCL_prev = cv::ocl::useOpenCL();
+    cv::ocl::setUseOpenCL(true);
+
+    Mat img = Mat::zeros(200, 200, CV_8UC1);
+    rectangle(img, Rect(20, 20, 100, 100), Scalar::all(255), FILLED);
+    rectangle(img, Rect(40, 40, 20, 20), Scalar::all(0), FILLED);
+    rectangle(img, Rect(150, 150, 30, 30), Scalar::all(255), FILLED);
+
+    vector<vector<Point>> contours_ref;
+    vector<Vec4i> hierarchy_ref;
+    findContours(img, contours_ref, hierarchy_ref, mode, method);
+
+    UMat uimg = img.getUMat(ACCESS_READ);
+    vector<UMat> contours_umat;
+    UMat hierarchy_umat;
+    findContours(uimg, contours_umat, hierarchy_umat, mode, method);
+
+    ASSERT_EQ(contours_ref.size(), contours_umat.size());
+    if (!hierarchy_ref.empty())
+    {
+        Mat hierarchy_downloaded = hierarchy_umat.getMat(ACCESS_READ);
+        ASSERT_EQ((size_t)hierarchy_downloaded.total(), hierarchy_ref.size());
+        // findContours() on a std::vector<Vec4i> yields an Nx1 matrix; on a
+        // UMat destination it yields 1xN. Reshape so the comparison is
+        // shape-agnostic.
+        EXPECT_MAT_NEAR(Mat(hierarchy_ref), hierarchy_downloaded.reshape(0, (int)hierarchy_ref.size()), 0);
+    }
+
+    cv::ocl::setUseOpenCL(useOCL_prev);
+}
+
+// no RETR_FLOODFILL - it requires CV_32S input and isn't part of this UMat regression
+INSTANTIATE_TEST_CASE_P(
+    ,
+    Imgproc_FindContours_OCL_UMat,
+    testing::Combine(testing::Values(RETR_EXTERNAL, RETR_LIST, RETR_CCOMP, RETR_TREE),
+                     testing::Values(CHAIN_APPROX_NONE,
+                                     CHAIN_APPROX_SIMPLE,
+                                     CHAIN_APPROX_TC89_L1,
+                                     CHAIN_APPROX_TC89_KCOS)));
 
 }}  // namespace opencv_test


### PR DESCRIPTION
### Issue
Closes #23574.

### What this PR does

#23574 reported that `findContours()` returns an all-zero **hierarchy** array when OpenCL is enabled and the destination is a `UMat`, while the **contours** themselves come back correct. It was originally reproduced by @mshabunin in C++ against `findContours_legacy()`.

While investigating, I found the bug is **already fixed** on `4.x` — as a side effect of #25146 (the C++ rewrite of `findContours`, first released in **4.10.0**). `contourTreeToResults()` in `modules/imgproc/src/contours_common.cpp` (which replaced the old C-API-based hierarchy writing) handles the `UMat` destination correctly. Nobody traced the fix back to this issue, so it stayed open.

I confirmed this concretely on real hardware (NVIDIA GeForce RTX 3050 Laptop GPU, OpenCL 3.0 CUDA, driver 566.07 — the same GPU model as the original report):
- `findContours_legacy()` with a `UMat` hierarchy destination **still reproduces** the all-zero bug.
- Current `findContours()` with the same input returns the **correct** hierarchy, matching the `Mat`-based reference exactly.

### Change

Adds a parameterized regression test, `Imgproc_FindContours_OCL_UMat.hierarchy_matches_cpu`, covering all retrieval modes (`RETR_EXTERNAL/LIST/CCOMP/TREE`) × chain-approximation methods (`CHAIN_APPROX_NONE/SIMPLE/TC89_L1/TC89_KCOS`) — 16 cases. Each case forces OpenCL on, runs `findContours()` with `UMat` inputs/outputs, downloads the hierarchy, and compares it against the `Mat`-based reference. This guards against the coherency bug resurfacing in a future refactor.

`RETR_FLOODFILL` is excluded since it requires `CV_32S` input and isn't part of the UMat destination scenario reported in the issue.

### Testing

- `opencv_test_imgproc --gtest_filter=*Imgproc_FindContours_OCL_UMat*`: 16/16 pass on real OpenCL hardware (NVIDIA RTX 3050).
- Full contour test file (`test_contours.cpp` + `test_contours_new.cpp`): 159/159 pass, no regressions.
- Full `opencv_test_imgproc` suite: pre-existing failures only, all due to missing `opencv_extra` test data on this local build environment (`shared/lena.png`, `shared/fruits.png`, etc. not found) — unrelated to this change, no contour-related failures.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (4.x).
- [x] There is a reference to the original bug report - #23574.
- [x] There is no code duplication, code is clean and commented if needed.
- [x] The feature/fix is covered by tests.

🤖 Investigated and prepared with [Claude Code](https://claude.com/claude-code).