### PR TITLE
dnn: fix out-of-bounds access in RVV Winograd kernels when VLEN > 256

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/conv_winograd_f63.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv_winograd_f63.simd.hpp
@@ -909,7 +909,10 @@ void impl_accum_F32(const uchar* inwptr_, const uchar* wptr_, uchar* outbuf_, in
     const float* wptr   = (const float*)wptr_;
     float*       outbuf = (float*)outbuf_;
     CV_Assert(winoIblock == 6 && winoKblock == 4 && winoAtomF32 == 8);
-    const size_t vl = __riscv_vsetvlmax_e32m1(); // 8 on VLEN=256
+    // One atom is winoAtomF32 == 8 floats, so vl must be 8 regardless of VLEN;
+    // vsetvlmax would return VLEN/32 (16 at VLEN=512, 32 at VLEN=1024) and make the
+    // atom loads below overlap their neighbours and the stores run past outbuf.
+    const size_t vl = __riscv_vsetvl_e32m1(8);
 
     if (iblock > 3) {
         for (int atom_id = 0; atom_id < winoNatomF32; atom_id++,
@@ -1039,7 +1042,7 @@ void impl_BtXB_8x8_F32(const float* inptr, int inpstep, uchar* outptr_, int Cg,
                         const int winoIblock, const int winoAtomF32)
 {
     float* outptr = (float*)outptr_;
-    const size_t vl = __riscv_vsetvlmax_e32m1();
+    const size_t vl = __riscv_vsetvl_e32m1(8); // 8x8 tile: exactly 8 lanes, any VLEN
     float tmp[8][8], tmp2[8][8];
 
     wino_bt8x8_rvv(inptr,           inptr+inpstep,   inptr+inpstep*2, inptr+inpstep*3,
@@ -1094,7 +1097,7 @@ void impl_AtXA_8x8_F32(const uchar* inptr_, int inpstep,
                         float bias, float minval, float maxval, bool ifMinMaxAct)
 {
     const float* inptr = (const float*)inptr_;
-    const size_t vl  = __riscv_vsetvlmax_e32m1();
+    const size_t vl  = __riscv_vsetvl_e32m1(8); // 8-wide winograd rows, any VLEN
     const size_t vl6 = __riscv_vsetvl_e32m1(6);
     float tmp[8][8], tmp2[8][8];
 


### PR DESCRIPTION
### Problem

The RVV Winograd F(6x3) kernels derive their vector length from the hardware instead of from the data:

    const size_t vl = __riscv_vsetvlmax_e32m1(); // 8 on VLEN=256

`__riscv_vsetvlmax_e32m1()` returns `VLEN/32`. But `vl` here must describe the data being walked, which is fixed-width:

* `impl_accum_F32` processes one atom = `winoAtomF32` = 8 floats (the function asserts this); its loads are hardcoded at `pw`, `pw+8`, `pw+16`, `pw+24`.
* `impl_BtXB_8x8_F32` / `impl_AtXA_8x8_F32` process 8-wide rows of the 8x8 Winograd tile (`CONV_WINO_SIZE = 6 + 3 - 1 = 8`).

Neither 8 has anything to do with `VLEN/32`. They coincide only at VLEN=256.

The only gate is in `getWinofunc_F32()`: `if ((int)__riscv_vsetvlmax_e32m1() >= 8)`

which admits every VLEN >= 256, not just 256. So on any core with VLEN >= 512:

* `vle32(pw, vl)` for `w0` reads into `w1`'s atom (they are 8 floats apart), so accumulator lanes above 7 hold cross-atom garbage;
* the final `vse32` runs past the end of `outbuf`.

| VLEN | vl | last index | outcome |
|------|----|------------|---------|
| 128  | 4  | -          | Winograd disabled by the `>= 8` gate - safe |
| 256  | 8  | 1535       | exactly the last valid element - correct |
| 512  | 16 | 1543       | **8 floats past the end** |
| 1024 | 32 | 1559       | **24 floats past the end** |

`vl == 8` landing exactly on the buffer end is why VLEN=256 has always worked and this went unnoticed.

This is an out-of-bounds **write**, not merely wrong numbers, and it is reached by any 3x3 stride-1 fp32 convolution. 

### Reproduction

VLEN=1024 core (SpacemiT K3, A100 cluster), pristine 5.x:

    [ RUN      ] ConvolutionWinograd.Accuracy
    *** stack smashing detected ***: terminated
    Aborted (rc=134)

Every 3x3s1 convolution test in the suite aborts, not just this one.

### Fix

Pin `vl` to the width of the data, using the explicit-AVL idiom the file already uses one line below for the 6-wide output rows
(`__riscv_vsetvl_e32m1(6)`): `const size_t vl = __riscv_vsetvl_e32m1(8);`

`__riscv_vsetvl_e32m1(8)` returns `min(8, VLMAX)`, so `vl` no longer depends on VLEN. The `vlmax >= 8` gate in `getWinofunc_F32()` is still required (it guarantees 8 lanes exist at LMUL=1) and is unchanged.

At VLEN=256 the emitted `vl` is 8 before and after, so **behaviour on existing hardware is bit-identical**. Wider cores now use 8 of their available lanes rather than corrupting memory; recovering that width would require changing the Winograd data layout.

### Testing

SpacemiT K3, GCC 15.2.0, `CPU_BASELINE=RVV`, Release, `opencv_test_dnn --gtest_filter=*Conv*:*conv*` with `OPENCV_TEST_DATA_PATH` set:

| Core | Before | After |
|------|--------|-------|
| X100, VLEN=256  | 934 ran, 931 passed | 934 ran, 931 passed |
| A100, VLEN=1024 | **SIGABRT** (stack smashing) | 934 ran, 931 passed |

`ConvolutionWinograd.Accuracy` passes at VLEN=1024 after the fix.
