### PR TITLE
core: fix use-after-scope in InputArray scalar constructor

### DIFF
--- a/modules/core/include/opencv2/core/mat.inl.hpp
+++ b/modules/core/include/opencv2/core/mat.inl.hpp
@@ -145,7 +145,10 @@ _InputArray::_InputArray(const Mat_<_Tp>& m)
 { init(FIXED_TYPE + MAT + traits::Type<_Tp>::value + ACCESS_READ, &m); }
 
 inline _InputArray::_InputArray(const double& val)
-{ init(FIXED_TYPE + FIXED_SIZE + MATX + CV_64F + ACCESS_READ, &val, Size(1,1)); }
+{
+    double* buf = new double(val);
+    init(FIXED_TYPE + FIXED_SIZE + MATX + CV_64F + ACCESS_READ, buf, Size(1,1));
+}
 
 inline _InputArray::_InputArray(const cuda::GpuMat& d_mat)
 { init(+CUDA_GPU_MAT + ACCESS_READ, &d_mat); }

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1509,6 +1509,37 @@ TEST(Core_InputArray, convert_from_vector_over2GB)
     EXPECT_ANY_THROW(auto work = _InputArray(buf));
 }
 
+// https://github.com/opencv/opencv/issues/29470
+// _InputArray(const double&) stored a pointer to a stack temporary that dies
+// before getMat() is called. The fix heap-allocates the scalar.
+// Volatile function pointers prevent inlining so stack clobbering is effective.
+static double fetchScalarFromInputArray(InputArray arr)
+{
+    Mat m = arr.getMat();
+    return m.at<double>(0, 0);
+}
+
+static void trashStack()
+{
+    volatile double junk[256];
+    for (int i = 0; i < 256; i++)
+        junk[i] = -1.0;
+    (void)junk;
+}
+
+TEST(Core_InputArray, scalar_getMat_use_after_scope_29470)
+{
+    double (*volatile fetchFn)(InputArray) = fetchScalarFromInputArray;
+    void (*volatile trashFn)() = trashStack;
+
+    trashFn();
+    _InputArray ia(3.14);
+    trashFn();
+    double val = fetchFn(ia);
+
+    EXPECT_EQ(3.14, val);
+}
+
 TEST(Core_CopyMask, bug1918)
 {
     Mat_<unsigned char> tmpSrc(100,100);


### PR DESCRIPTION
Fixes #29470.

_InputArray(const double&) stored a pointer to a stack temporary. Heap-allocate a copy so the data outlives the constructor.

Same class of bug as #23577 but fixed at the root cause.