### PR TITLE
core: fix signed integer overflow in cubeRoot

### DIFF
--- a/modules/core/src/mathfuncs.cpp
+++ b/modules/core/src/mathfuncs.cpp
@@ -138,7 +138,7 @@ CV_DISABLE_UBSAN float cubeRoot( float value )
     /* fr *= 2^ex * sign */
     m.f = value;
     v.f = fr;
-    v.i = (v.i + (ex << 23) + s) & (m.i*2 != 0 ? -1 : 0);
+    v.i = (v.i + (ex << 23) + s) & (m.u*2 != 0 ? -1 : 0);
     return v.f;
 }
 


### PR DESCRIPTION
Fixes #28926.

m.i * 2 overflows int32 for values >= 2.0f. Switch to unsigned and drop the UBSan suppression.