### PR TITLE
core: add RVV cvRound fast path, 4.x

### DIFF
--- a/modules/core/include/opencv2/core/fast_math.hpp
+++ b/modules/core/include/opencv2/core/fast_math.hpp
@@ -81,6 +81,13 @@
     #undef pixel
   #endif
 
+  #if CV_RVV
+    #define CV__FASTMATH_ENABLE_RVV
+    #if !defined(OPENCV_SKIP_INCLUDE_RISCV_VECTOR_H)
+      #include <riscv_vector.h>
+    #endif
+  #endif
+
   #if defined(CV_INLINE_ROUND_FLT)
     // user-specified version
     // CV_INLINE_ROUND_DBL should be defined too
@@ -201,6 +208,11 @@ cvRound( double value )
 {
 #if defined CV_INLINE_ROUND_DBL
     CV_INLINE_ROUND_DBL(value);
+#elif defined CV__FASTMATH_ENABLE_RVV
+    const size_t vl = __riscv_vsetvl_e64m2(1);
+    vfloat64m2_t v = __riscv_vfmv_v_f_f64m2(value, vl);
+    vint32m1_t r = __riscv_vfncvt_x_f_w_i32m1(v, vl);
+    return (int)__riscv_vmv_x_s_i32m1_i32(r);
 #elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
     float64x1_t v = vdup_n_f64(value);
     int64x1_t r = vcvtn_s64_f64(v);
@@ -331,6 +343,11 @@ CV_INLINE int cvRound(float value)
 {
 #if defined CV_INLINE_ROUND_FLT
     CV_INLINE_ROUND_FLT(value);
+#elif defined CV__FASTMATH_ENABLE_RVV
+    const size_t vl = __riscv_vsetvl_e32m1(1);
+    vfloat32m1_t v = __riscv_vfmv_v_f_f32m1(value, vl);
+    vint32m1_t r = __riscv_vfcvt_x_f_v_i32m1(v, vl);
+    return (int)__riscv_vmv_x_s_i32m1_i32(r);
 #elif defined(_MSC_VER) && (defined(_M_ARM64) || defined(_M_ARM64EC))
     float32x2_t v = vdup_n_f32(value);
     int32x2_t r = vcvtn_s32_f32(v);


### PR DESCRIPTION

Complementary PR of #29494 

The implementations are largely the same, and CvRound reports 37%~64% on the same setup.

## Perfomance



Name of Test | core-SpacemiT-K1-cvround-4.x | core-SpacemiT-K1-cvround-4.x-patch | core-SpacemiT-K1-cvround-4.x-patchvscore-SpacemiT-K1-cvround-4.x(x-factor)
-- | -- | -- | --
CvRound_Float::Size_MatType::(127x61, 32FC1) | 0.134 | 0.083 | 1.62
CvRound_Float::Size_MatType::(127x61, 64FC1) | 0.137 | 0.092 | 1.48
CvRound_Float::Size_MatType::(640x480, 32FC1) | 5.498 | 3.344 | 1.64
CvRound_Float::Size_MatType::(640x480, 64FC1) | 5.363 | 3.785 | 1.42
CvRound_Float::Size_MatType::(1280x720, 32FC1) | 16.360 | 10.090 | 1.62
CvRound_Float::Size_MatType::(1280x720, 64FC1) | 16.030 | 11.486 | 1.40
CvRound_Float::Size_MatType::(1920x1080, 32FC1) | 37.330 | 22.849 | 1.63
CvRound_Float::Size_MatType::(1920x1080, 64FC1) | 36.089 | 26.349 | 1.37

## Tests

using ` ./build/bin/opencv_test_core  --gtest_filter="*CvRound*" `     

```
[==========] Running 2 tests from 2 test cases.
[----------] Global test environment set-up.
[----------] 1 test from Core_round
[ RUN      ] Core_round.CvRound
[       OK ] Core_round.CvRound (0 ms)
[----------] 1 test from Core_round (0 ms total)

[----------] 1 test from Core_SoftFloat
[ RUN      ] Core_SoftFloat.CvRound
[       OK ] Core_SoftFloat.CvRound (0 ms)
[----------] 1 test from Core_SoftFloat (0 ms total)

[----------] Global test environment tear-down
[==========] 2 tests from 2 test cases ran. (1 ms total)
[  PASSED  ] 2 tests.
```


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
