### PR TITLE
video: add RVV intrinsics path for pyramidal LK optical flow iteration loop

### DIFF
--- a/modules/video/src/lkpyramid.cpp
+++ b/modules/video/src/lkpyramid.cpp
@@ -469,6 +469,10 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
             const int16x4_t d28_2 = vdup_n_s16((int16_t)iw10);
             const int16x4_t d29_2 = vdup_n_s16((int16_t)iw11);
 
+#elif CV_RVV
+            const size_t rvv_lanes = __riscv_vsetvlmax_e16m1();
+            vfloat32m2_t rvvB1 = __riscv_vfmv_v_f_f32m2(0.f, rvv_lanes);
+            vfloat32m2_t rvvB2 = __riscv_vfmv_v_f_f32m2(0.f, rvv_lanes);
 #endif
 
             for( y = 0; y < winSize.height; y++ )
@@ -578,6 +582,61 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
                     vst1q_f32(nB1, nB1v);
                     vst1q_f32(nB2, nB2v);
                 }
+#elif CV_RVV
+                for( ; x < winSize.width*cn; )
+                {
+                    const size_t vl = __riscv_vsetvl_e16m1(winSize.width*cn - x);
+
+                    vuint16m1_t j00 = __riscv_vwcvtu_x_x_v_u16m1(
+                            __riscv_vle8_v_u8mf2(Jptr + x, vl), vl);
+                    vint32m2_t interp = __riscv_vwmul_vx_i32m2(
+                            __riscv_vreinterpret_i16m1(j00), (int16_t)iw00, vl);
+
+                    vuint16m1_t j01 = __riscv_vwcvtu_x_x_v_u16m1(
+                            __riscv_vle8_v_u8mf2(Jptr + x + cn, vl), vl);
+                    interp = __riscv_vwmacc_vx_i32m2(
+                            interp, (int16_t)iw01, __riscv_vreinterpret_i16m1(j01), vl);
+
+                    vuint16m1_t j10 = __riscv_vwcvtu_x_x_v_u16m1(
+                            __riscv_vle8_v_u8mf2(Jptr + x + stepJ, vl), vl);
+                    interp = __riscv_vwmacc_vx_i32m2(
+                            interp, (int16_t)iw10, __riscv_vreinterpret_i16m1(j10), vl);
+
+                    vuint16m1_t j11 = __riscv_vwcvtu_x_x_v_u16m1(
+                            __riscv_vle8_v_u8mf2(Jptr + x + stepJ + cn, vl), vl);
+                    interp = __riscv_vwmacc_vx_i32m2(
+                            interp, (int16_t)iw11, __riscv_vreinterpret_i16m1(j11), vl);
+
+                    interp = __riscv_vsra_vx_i32m2(
+                            __riscv_vadd_vx_i32m2(
+                                    interp, 1 << (W_BITS1 - 5 - 1), vl),
+                            W_BITS1 - 5, vl);
+                    vint32m2_t diff = __riscv_vsub_vv_i32m2(
+                            interp,
+                            __riscv_vwcvt_x_x_v_i32m2(
+                                    __riscv_vle16_v_i16m1(Iptr + x, vl), vl),
+                            vl);
+
+                    vint16m1x2_t gradient = __riscv_vlseg2e16_v_i16m1x2(dIptr, vl);
+                    vint32m2_t ix = __riscv_vwcvt_x_x_v_i32m2(
+                            __riscv_vget_v_i16m1x2_i16m1(gradient, 0), vl);
+                    vint32m2_t iy = __riscv_vwcvt_x_x_v_i32m2(
+                            __riscv_vget_v_i16m1x2_i16m1(gradient, 1), vl);
+
+                    rvvB1 = __riscv_vfadd_tu(
+                            rvvB1, rvvB1,
+                            __riscv_vfcvt_f_x_v_f32m2(
+                                    __riscv_vmul_vv_i32m2(diff, ix, vl), vl),
+                            vl);
+                    rvvB2 = __riscv_vfadd_tu(
+                            rvvB2, rvvB2,
+                            __riscv_vfcvt_f_x_v_f32m2(
+                                    __riscv_vmul_vv_i32m2(diff, iy, vl), vl),
+                            vl);
+
+                    x += (int)vl;
+                    dIptr += vl*2;
+                }
 #endif
 
                 for( ; x < winSize.width*cn; x++, dIptr += 2 )
@@ -601,6 +660,12 @@ void cv::detail::LKTrackerInvoker::operator()(const Range& range) const
 
             ib1 += (float)(nB1[0] + nB1[1] + nB1[2] + nB1[3]);
             ib2 += (float)(nB2[0] + nB2[1] + nB2[2] + nB2[3]);
+#elif CV_RVV
+            vfloat32m1_t rvvZero = __riscv_vfmv_v_f_f32m1(0.f, 1);
+            ib1 += __riscv_vfmv_f_s_f32m1_f32(
+                    __riscv_vfredusum_vs_f32m2_f32m1(rvvB1, rvvZero, rvv_lanes));
+            ib2 += __riscv_vfmv_f_s_f32m1_f32(
+                    __riscv_vfredusum_vs_f32m2_f32m1(rvvB2, rvvZero, rvv_lanes));
 #endif
 
             b1 = ib1*FLT_SCALE;


### PR DESCRIPTION

### Summary

On RISC-V platforms with scalable RVV enabled, `CV_SIMD128` is `0`, so the pyramidal Lucas-Kanade tracker (`cv::detail::LKTrackerInvoker`) can use neither the SIMD128 universal-intrinsics loop nor the AArch64 NEON loop. The per-iteration inner loop—bilinear interpolation of the second image patch plus the `(diff·Ix, diff·Iy)` mismatch-vector accumulation—is left to compiler auto-vectorization, which on GCC 14 emits an ordered float reduction (`vfredosum`) per image row.

This PR adds an RVV intrinsic implementation of this loop.

### Implementation
For RVV 1.0-compatible toolchains:
*   The loop is strip-mined with `vsetvl_e16m1`, handling row tails without assuming `VLEN=256` and eliminating the need for a scalar remainder loop.
*   Bilinear taps are loaded with `vle8` + `vwcvtu` widening, combined via `vwmul.vx` / `vwmacc.vx`, and descaled using add-round + `vsra` to match `CV_DESCALE` bit-exactly.
*   The interleaved gradient buffer (`Ix0 Iy0 Ix1 Iy1 …`) is de-interleaved with a single `vlseg2e16`.
*   Accumulators reside in `vfloat32m2_t` registers across the window. Partial strips use tail-undisturbed `vfadd` (`_tu`). A single unordered reduction (`vfredusum`) per point replaces per-row ordered reductions.
*   Only the dominant iteration loop is vectorized; other architectures remain unaffected.

### Performance
**Test Platform:** SpacemiT K1 (`rv64gcv`, `VLEN=256`), GCC 14.2.1, OpenCV 5.1.0-dev.

| Case (source, cn, points grid, winSize) | Baseline | Patched | Speedup |
| :--- | :--- | :--- | :--- |
| VGA, cn=4, 15x15, win=11 | 60.14 ms | 50.85 ms | **1.18x** |
| VGA, cn=1, 15x15, win=11 | 14.58 ms | 12.61 ms | **1.16x** |
| VGA, cn=3, 15x15, win=11 | 49.21 ms | 42.64 ms | **1.15x** |
| VGA, cn=4, 15x15, win=7 | 39.25 ms | 35.17 ms | **1.12x** |
| 720p, cn=1, 15x15, win=11 | 25.54 ms | 23.05 ms | **1.11x** |
| VGA, cn=4, 9x9, win=11 | 37.10 ms | 33.71 ms | **1.10x** |
| VGA, cn=3, 9x9, win=11 | 31.55 ms | 29.08 ms | **1.08x** |
| 720p, cn=1, 9x9, win=7 | 16.61 ms | 16.56 ms | 1.00x |

Geometric mean speedup: **1.06x**. No regressions observed across 48 test cases (range 1.00x–1.18x). Note: Baseline includes GCC 14 auto-vectorization; gains are on top of that.

### Tests
Existing optical flow tests pass on the target RVV platform:
$ ./opencv_test_video --gtest_filter='*OpticalFlowPyrLK*'

[ RUN      ] Video_OpticalFlowPyrLK.accuracy
[       OK ] Video_OpticalFlowPyrLK.accuracy (29 ms)
[ RUN      ] Video_OpticalFlowPyrLK.submat
[       OK ] Video_OpticalFlowPyrLK.submat (41 ms)
[  PASSED  ] 2 tests.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
