### PR TITLE
Relaxed G-API tests for GStreamer to support Ubuntu 26.04.

### DIFF
--- a/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp
+++ b/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp
@@ -77,7 +77,7 @@ TEST_P(GStreamerSourceTest, AccuracyTest)
 
     EXPECT_FALSE(ccomp.running());
 
-    EXPECT_EQ(streamLength, framesCount);
+    EXPECT_NEAR(streamLength, framesCount, 1);
 }
 
 TEST_P(GStreamerSourceTest, TimestampsTest)
@@ -124,12 +124,12 @@ TEST_P(GStreamerSourceTest, TimestampsTest)
     EXPECT_FALSE(ccomp.running());
 
     EXPECT_EQ(0L, allSeqIds.front());
-    EXPECT_EQ(int64_t(streamLength) - 1, allSeqIds.back());
-    EXPECT_EQ(streamLength, allSeqIds.size());
+    EXPECT_NEAR(int64_t(streamLength) - 1, allSeqIds.back(), 1);
+    EXPECT_NEAR(streamLength, allSeqIds.size(), 1);
     EXPECT_TRUE(std::is_sorted(allSeqIds.begin(), allSeqIds.end()));
     EXPECT_EQ(allSeqIds.size(), std::set<int64_t>(allSeqIds.begin(), allSeqIds.end()).size());
 
-    EXPECT_EQ(streamLength, allTimestamps.size());
+    EXPECT_NEAR(streamLength, allTimestamps.size(), 1);
     EXPECT_TRUE(std::is_sorted(allTimestamps.begin(), allTimestamps.end()));
 }
 
@@ -270,7 +270,7 @@ TEST_P(GStreamerSourceTest, GFrameTest)
 
     EXPECT_FALSE(ccomp.running());
 
-    EXPECT_EQ(streamLength, framesCount);
+    EXPECT_NEAR(streamLength, framesCount, 1);
 }
 
 


### PR DESCRIPTION
Ubuntu 26.04 version of GStreamer reports 1 more frame for stream. Test failures reported by CI:
```
 [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:80: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4028 ms)
  [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:80: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4032 ms)
  [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:127: Failure
  Expected equality of these values:
    int64_t(streamLength) - 1
      Which is: 9
    allSeqIds.back()
      Which is: 10
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:128: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allSeqIds.size()
      Which is: 11
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:132: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allTimestamps.size()
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4032 ms)
  [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:127: Failure
  Expected equality of these values:
    int64_t(streamLength) - 1
      Which is: 9
    allSeqIds.back()
      Which is: 10
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:128: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allSeqIds.size()
      Which is: 11
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:132: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allTimestamps.size()
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4031 ms)
  [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:273: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4034 ms)
  [ RUN      ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:273: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10) (4031 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:80: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3356 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:80: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3354 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:127: Failure
  Expected equality of these values:
    int64_t(streamLength) - 1
      Which is: 9
    allSeqIds.back()
      Which is: 10
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:128: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allSeqIds.size()
      Which is: 11
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:132: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allTimestamps.size()
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3357 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:127: Failure
  Expected equality of these values:
    int64_t(streamLength) - 1
      Which is: 9
    allSeqIds.back()
      Which is: 10
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:128: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allSeqIds.size()
      Which is: 11
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:132: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    allTimestamps.size()
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3350 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:273: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3351 ms)
  [ RUN      ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  /home/ubuntu/opencv/modules/gapi/test/streaming/gapi_gstreamersource_tests.cpp:273: Failure
  Expected equality of these values:
    streamLength
      Which is: 10
    framesCount
      Which is: 11
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10) (3345 ms)
  [----------] Global test environment tear-down
  [ SKIPSTAT ] 2 tests skipped
  [ SKIPSTAT ] TAG='verylong' skip 2 tests
  [==========] 15507 tests from 512 test cases ran. (191242 ms total)
  [  PASSED  ] 15495 tests.
  [  FAILED  ] 12 tests, listed below:
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] CameraEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc is-live=true pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=1920,height=1080,framerate=3/1 ! appsink", 1920x1080, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.AccuracyTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.TimestampsTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/0, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=NV12,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
  [  FAILED  ] FileEmulatingPipeline/GStreamerSourceTest.GFrameTest/1, where GetParam() = ("videotestsrc pattern=colors num-buffers=10 ! videorate ! videoscale ! video/x-raw,format=GRAY8,width=640,height=420,framerate=3/1 ! appsink", 640x420, 10)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
