### PR TITLE
Fix: 0-D / empty-Mat Python binding

### DIFF
--- a/modules/dnn/src/layers/nll_loss_layer.cpp
+++ b/modules/dnn/src/layers/nll_loss_layer.cpp
@@ -52,7 +52,8 @@ public:
         }
         else
         {
-            out.assign(1, MatShape(1, 1));
+            // Reduced (mean/sum) loss is a rank-0 scalar in ONNX, not a [1] tensor.
+            out.assign(1, MatShape::scalar());
         }
         return false;
     }
@@ -164,7 +165,7 @@ public:
                 }
             }
             const float out = (reduction == LOSS_REDUCTION_SUM) ? static_cast<float>(num) : static_cast<float>((den > 0.0) ? (num / den) : 0.0);
-            out_loss.at<float>(0) = out;
+            out_loss.ptr<float>()[0] = out;
         }
     }
 

--- a/modules/dnn/src/layers/softmax_cross_entropy_loss_layer.cpp
+++ b/modules/dnn/src/layers/softmax_cross_entropy_loss_layer.cpp
@@ -49,7 +49,8 @@ public:
             for (size_t i = 2; i < x.size(); ++i) y.push_back(x[i]);
             out.push_back(y);
         } else {
-            out.push_back(MatShape(1,1));
+            // Reduced (mean/sum) loss is a rank-0 scalar in ONNX, not a [1] tensor.
+            out.push_back(MatShape::scalar());
         }
 
         if (requiredOutputs >= 2)
@@ -325,7 +326,7 @@ public:
 
             const float out = (reduction == LOSS_REDUCTION_SUM) ? static_cast<float>(num)
                                                  : static_cast<float>((den > 0.0) ? (num / den) : 0.0);
-            out_loss.at<float>(0) = out;
+            out_loss.ptr<float>()[0] = out;
         }
     }
 

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -316,7 +316,22 @@ template<>
 PyObject* pyopencv_from(const cv::Mat& m)
 {
     if( !m.data )
+    {
+        // Shaped Mat with a zero-length dim: return a matching empty array, not None.
+        if( m.dims >= 1 )
+        {
+            int cn = m.channels();
+            int typenum = cvDepthToNumpyType(m.depth());
+            int dims = m.dims;
+            cv::AutoBuffer<npy_intp> _sizes(dims + 1);
+            for( int i = 0; i < dims; i++ )
+                _sizes[i] = (npy_intp)m.size[i];
+            if( cn > 1 )
+                _sizes[dims++] = cn;
+            return PyArray_SimpleNew(dims, _sizes.data(), typenum);
+        }
         Py_RETURN_NONE;
+    }
     // 0D (scalar) Mat: return a true 0D numpy array.
     if( m.dims == 0 )
     {

--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -315,9 +315,9 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
 template<>
 PyObject* pyopencv_from(const cv::Mat& m)
 {
-    if( !m.data )
+    if( m.empty() )
     {
-        // Shaped Mat with a zero-length dim: return a matching empty array, not None.
+        // empty() also catches a live buffer with a zero-length dim: return an empty array, not None.
         if( m.dims >= 1 )
         {
             int cn = m.channels();


### PR DESCRIPTION
ONNX coverage against 1.22.0 onnx version is now 72.1% after this fix.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
