### PR TITLE
FFmpeg wrapper update for 4.14.0 release.

### DIFF
--- a/3rdparty/ffmpeg/ffmpeg.cmake
+++ b/3rdparty/ffmpeg/ffmpeg.cmake
@@ -1,9 +1,9 @@
-# Binaries branch name: ffmpeg/4.x_20251226
-# Binaries were created for OpenCV: cff7581175d2abfc6aef2e4f04f482e258b5c864
-ocv_update(FFMPEG_BINARIES_COMMIT "d82ad9a54a7b42a1648a9cae8fed5c2f20ea396c")
-ocv_update(FFMPEG_FILE_HASH_BIN32 "47730de2286110b0d1250ff9cf50ce56")
-ocv_update(FFMPEG_FILE_HASH_BIN64 "3248b4663ffef770cdb54ec8b9d16a28")
-ocv_update(FFMPEG_FILE_HASH_CMAKE "8862c87496e2e8c375965e1277dee1c7")
+# Binaries branch name: ffmpeg/4.x_20260715
+# Binaries were created for OpenCV: 6b640b424c516d27217700392a7ed6a362e040a5
+ocv_update(FFMPEG_BINARIES_COMMIT "bd9418020a5c342be979c56d6e6434261959d3af")
+ocv_update(FFMPEG_FILE_HASH_BIN32 "31968b434799d3dd56969b15aac3efa8")
+ocv_update(FFMPEG_FILE_HASH_BIN64 "84757ed0f16ddedce99227529d3165e9")
+ocv_update(FFMPEG_FILE_HASH_CMAKE "e09efc33312d1173be8a9446f3b088fe")
 
 function(download_win_ffmpeg script_var)
   set(${script_var} "" PARENT_SCOPE)

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -845,8 +845,6 @@ TEST(videoio_ffmpeg, create_with_property_badarg)
     EXPECT_FALSE(cap.isOpened());
 }
 
-// requires FFmpeg wrapper rebuild on Windows
-#ifndef _WIN32
 TEST(videoio_ffmpeg, open_with_format_cv8uc3)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -862,7 +860,6 @@ TEST(videoio_ffmpeg, open_with_format_cv8uc3)
     ASSERT_TRUE(cap.read(frame));
     EXPECT_EQ(frame.channels(), 3);
 }
-#endif
 
 // related issue: https://github.com/opencv/opencv/issues/16821
 TEST(videoio_ffmpeg, DISABLED_open_from_web)
@@ -1049,12 +1046,9 @@ inline static std::string videoio_ffmpeg_mismatch_name_printer(const testing::Te
 
 INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_channel_mismatch, testing::ValuesIn(mismatch_cases), videoio_ffmpeg_mismatch_name_printer);
 
-#ifndef _WIN32
-
 typedef tuple<string, string> AlphaChannelParams;
 typedef testing::TestWithParam< AlphaChannelParams > videoio_ffmpeg_alpha_channel;
 
-// New feature in https://github.com/opencv/opencv/pull/28751 requires FFmpeg wrapper rebuild on Windows
 TEST_P(videoio_ffmpeg_alpha_channel, write_read)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -1116,7 +1110,6 @@ AlphaChannelParams alpha_params[] =
 };
 
 INSTANTIATE_TEST_CASE_P(/**/, videoio_ffmpeg_alpha_channel, testing::ValuesIn(alpha_params));
-#endif
 
 // related issue: https://github.com/opencv/opencv/issues/23088
 TEST(ffmpeg_cap_properties, set_pos_get_msec)


### PR DESCRIPTION
3rdparty: https://github.com/opencv/opencv_3rdparty/pull/110

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
