### PR TITLE
videoio: fix build with FFmpeg 9 after AVCodec::pix_fmts removal

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_hw.hpp
+++ b/modules/videoio/src/cap_ffmpeg_hw.hpp
@@ -757,7 +757,7 @@ AVCodec *hw_find_codec(AVCodecID id, AVHWDeviceType hw_type, int (*check_categor
 #endif
             if (hw_type == AV_HWDEVICE_TYPE_CUDA) // CUDA encoders don't support avcodec_get_hw_config()
                 hw_native_fmt = AV_PIX_FMT_CUDA;
-#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+#if LIBAVCODEC_BUILD >= AV_VERSION_INT(61, 13, 100)
             if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE) {
                 const AVPixelFormat *pix_fmts = NULL;
                 int num_pix_fmts = 0;
@@ -770,15 +770,15 @@ AVCodec *hw_find_codec(AVCodecID id, AVHWDeviceType hw_type, int (*check_categor
                     (const void **)&pix_fmts,
                     &num_pix_fmts);
 
-            if (ret >= 0 && pix_fmts && num_pix_fmts > 0) {
-                    for (int i = 0; i < num_pix_fmts; i++) {
-                        if (pix_fmts[i] == hw_native_fmt) {
-                            *hw_pix_fmt = hw_native_fmt;
-                            if (hw_check_codec(c, hw_type, disabled_codecs))
-                                return c;
+                if (ret >= 0 && pix_fmts && num_pix_fmts > 0) {
+                        for (int i = 0; i < num_pix_fmts; i++) {
+                            if (pix_fmts[i] == hw_native_fmt) {
+                                *hw_pix_fmt = hw_native_fmt;
+                                if (hw_check_codec(c, hw_type, disabled_codecs))
+                                    return c;
+                            }
                         }
                     }
-                }
             }
 #else
             if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE && c->pix_fmts) {

--- a/modules/videoio/src/cap_ffmpeg_hw.hpp
+++ b/modules/videoio/src/cap_ffmpeg_hw.hpp
@@ -757,6 +757,30 @@ AVCodec *hw_find_codec(AVCodecID id, AVHWDeviceType hw_type, int (*check_categor
 #endif
             if (hw_type == AV_HWDEVICE_TYPE_CUDA) // CUDA encoders don't support avcodec_get_hw_config()
                 hw_native_fmt = AV_PIX_FMT_CUDA;
+#if LIBAVCODEC_VERSION_INT >= AV_VERSION_INT(61, 13, 100)
+            if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE) {
+                const AVPixelFormat *pix_fmts = NULL;
+                int num_pix_fmts = 0;
+
+                int ret = avcodec_get_supported_config(
+                    NULL,
+                    c,
+                    AV_CODEC_CONFIG_PIX_FORMAT,
+                    0,
+                    (const void **)&pix_fmts,
+                    &num_pix_fmts);
+
+            if (ret >= 0 && pix_fmts && num_pix_fmts > 0) {
+                    for (int i = 0; i < num_pix_fmts; i++) {
+                        if (pix_fmts[i] == hw_native_fmt) {
+                            *hw_pix_fmt = hw_native_fmt;
+                            if (hw_check_codec(c, hw_type, disabled_codecs))
+                                return c;
+                        }
+                    }
+                }
+            }
+#else
             if (av_codec_is_encoder(c) && hw_native_fmt != AV_PIX_FMT_NONE && c->pix_fmts) {
                 for (int i = 0; c->pix_fmts[i] != AV_PIX_FMT_NONE; i++) {
                     if (c->pix_fmts[i] == hw_native_fmt) {
@@ -766,6 +790,7 @@ AVCodec *hw_find_codec(AVCodecID id, AVHWDeviceType hw_type, int (*check_categor
                     }
                 }
             }
+#endif
             for (int i = 0;; i++) {
                 const AVCodecHWConfig *hw_config = avcodec_get_hw_config(c, i);
                 if (!hw_config)

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2627,37 +2627,36 @@ static AVCodecContext * icv_configure_video_stream_FFMPEG(AVFormatContext *oc,
     c->time_base.den = frame_rate;
     c->time_base.num = frame_rate_base;
     /* adjust time base for supported framerates */
-    // AVCodec::supported_framerates was deprecated in FFmpeg 7.1 and removed in
-    // FFmpeg 9. avcodec_get_supported_config() returns the same list together
-    // with its entry count, so use it when available.
 #if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(61, 13, 100)
-    const AVRational *supported_framerates = NULL;
-    int num_supported_framerates = 0;
-    if (codec)
-        avcodec_get_supported_config(NULL, codec, AV_CODEC_CONFIG_FRAME_RATE, 0,
-                                     (const void **)&supported_framerates, &num_supported_framerates);
-    if (supported_framerates && num_supported_framerates > 0){
-        AVRational req = {frame_rate, frame_rate_base};
-        const AVRational *best=NULL;
-        AVRational best_error= {INT_MAX, 1};
-        for(int i = 0; i < num_supported_framerates; i++){
-            const AVRational *p = &supported_framerates[i];
-            AVRational error= av_sub_q(req, *p);
-            if(error.num <0) error.num *= -1;
-            if(av_cmp_q(error, best_error) < 0){
-                best_error= error;
-                best= p;
+    if (codec){
+        const AVRational *supported_framerates = NULL;
+        int num_supported_framerates = 0;
+        int ret = avcodec_get_supported_config(NULL, codec, AV_CODEC_CONFIG_FRAME_RATE, 0,
+                                               (const void **)&supported_framerates, &num_supported_framerates);
+
+        if (ret >= 0 && supported_framerates && num_supported_framerates > 0){
+            AVRational req = {frame_rate, frame_rate_base};
+            const AVRational *best=NULL;
+            AVRational best_error= {INT_MAX, 1};
+            for(int i = 0; i < num_supported_framerates; i++){
+                const AVRational *p = &supported_framerates[i];
+                AVRational error = av_sub_q(req, *p);
+                if(error.num <0) error.num *= -1;
+                if(av_cmp_q(error, best_error) < 0){
+                    best_error = error;
+                    best = p;
+                }
             }
-        }
-        if (best == NULL)
-        {
+            if (best == NULL)
+            {
 #ifdef CV_FFMPEG_CODECPAR
-            avcodec_free_context(&c);
+                avcodec_free_context(&c);
 #endif
-            return NULL;
+                return NULL;
+            }
+            c->time_base.den = best->num;
+            c->time_base.num = best->den;
         }
-        c->time_base.den= best->num;
-        c->time_base.num= best->den;
     }
 #else
     if(codec && codec->supported_framerates){

--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2627,6 +2627,39 @@ static AVCodecContext * icv_configure_video_stream_FFMPEG(AVFormatContext *oc,
     c->time_base.den = frame_rate;
     c->time_base.num = frame_rate_base;
     /* adjust time base for supported framerates */
+    // AVCodec::supported_framerates was deprecated in FFmpeg 7.1 and removed in
+    // FFmpeg 9. avcodec_get_supported_config() returns the same list together
+    // with its entry count, so use it when available.
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(61, 13, 100)
+    const AVRational *supported_framerates = NULL;
+    int num_supported_framerates = 0;
+    if (codec)
+        avcodec_get_supported_config(NULL, codec, AV_CODEC_CONFIG_FRAME_RATE, 0,
+                                     (const void **)&supported_framerates, &num_supported_framerates);
+    if (supported_framerates && num_supported_framerates > 0){
+        AVRational req = {frame_rate, frame_rate_base};
+        const AVRational *best=NULL;
+        AVRational best_error= {INT_MAX, 1};
+        for(int i = 0; i < num_supported_framerates; i++){
+            const AVRational *p = &supported_framerates[i];
+            AVRational error= av_sub_q(req, *p);
+            if(error.num <0) error.num *= -1;
+            if(av_cmp_q(error, best_error) < 0){
+                best_error= error;
+                best= p;
+            }
+        }
+        if (best == NULL)
+        {
+#ifdef CV_FFMPEG_CODECPAR
+            avcodec_free_context(&c);
+#endif
+            return NULL;
+        }
+        c->time_base.den= best->num;
+        c->time_base.num= best->den;
+    }
+#else
     if(codec && codec->supported_framerates){
         const AVRational *p= codec->supported_framerates;
         AVRational req = {frame_rate, frame_rate_base};
@@ -2650,6 +2683,7 @@ static AVCodecContext * icv_configure_video_stream_FFMPEG(AVFormatContext *oc,
         c->time_base.den= best->num;
         c->time_base.num= best->den;
     }
+#endif
 
     c->gop_size = 12; /* emit one intra frame every twelve frames at most */
     c->pix_fmt = pixel_format;


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/29655
Fixes https://github.com/opencv/opencv/issues/29504

### Summary

`AVCodec::pix_fmts` was removed from `AVCodec` in newer FFmpeg releases, causing the FFmpeg backend to fail to compile. This change replaces direct access to `AVCodec::pix_fmts` with `avcodec_get_supported_config()` for newer FFmpeg versions while preserving the existing implementation for older releases through version-based compatibility checks.

### Implementation

- use `avcodec_get_supported_config()` to retrieve supported pixel formats for newer FFmpeg versions where `AVCodec::pix_fmts` is no longer available.
- Preserve the existing `AVCodec::pix_fmts` implementation for older FFmpeg versions through version-based compatibility checks.
- Keep the existing hardware codec selection logic unchanged, updating only the pixel format lookup mechanism.

### Testing

I verified the change with both the default FFmpeg configuration and FFmpeg 9.

for FFmpeg 9, I built FFmpeg from source (`libavcodec 63.1.100`), configured OpenCV to use that installation with `find_package`, and confirmed that the `pix_fmts` compatibility change compiles successfully.


### Additional observation

While validating this change against FFmpeg 9, I encountered another build failure caused by the removal of `AVCodec::supported_framerates` in `cap_ffmpeg_impl.hpp`. This appears to be a separate compatibility issue and is outside the scope of this PR.

Fixes #29504


### Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch.
- [x] There is a reference to the original bug report and related work.
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable.
- [ ] Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake.
