### PR TITLE
bound marker string length in aruco readDictionary

### DIFF
--- a/modules/objdetect/src/aruco/aruco_dictionary.cpp
+++ b/modules/objdetect/src/aruco/aruco_dictionary.cpp
@@ -109,12 +109,16 @@ bool Dictionary::readDictionary(const cv::FileNode& fn) {
     int nMarkers = 0, _markerSize = 0;
     if (fn.empty() || !readParameter("nmarkers", nMarkers, fn) || !readParameter("markersize", _markerSize, fn))
         return false;
+    if (_markerSize <= 0)
+        return false;
     Mat bytes(0, 0, CV_8UC1), marker(_markerSize, _markerSize, CV_8UC1);
     std::string markerString;
     for (int i = 0; i < nMarkers; i++) {
         std::ostringstream ostr;
         ostr << i;
         if (!readParameter("marker_" + ostr.str(), markerString, fn))
+            return false;
+        if (markerString.size() != (size_t)_markerSize * _markerSize)
             return false;
         for (int j = 0; j < (int) markerString.size(); j++)
             marker.at<unsigned char>(j) = (markerString[j] == '0') ? 0 : 1;

--- a/modules/objdetect/test/test_arucodetection.cpp
+++ b/modules/objdetect/test/test_arucodetection.cpp
@@ -1409,6 +1409,46 @@ TEST(CV_ArucoMultiDict, serialization)
 }
 
 
+TEST(CV_ArucoDictionary, readDictionary_oversized_marker)
+{
+    // A marker string longer than markersize*markersize must be rejected instead of
+    // being written past the markersize x markersize buffer in readDictionary.
+    std::string serialized;
+    {
+        FileStorage fs_out(".json", FileStorage::WRITE + FileStorage::MEMORY);
+        ASSERT_TRUE(fs_out.isOpened());
+        fs_out << "nmarkers" << 1;
+        fs_out << "markersize" << 5;
+        fs_out << "marker_0" << std::string(2000, '1');
+        serialized = fs_out.releaseAndGetString();
+    }
+    FileStorage fs_in(serialized, FileStorage::READ + FileStorage::MEMORY);
+    ASSERT_TRUE(fs_in.isOpened());
+    aruco::Dictionary dict;
+    bool ok = true;
+    ASSERT_NO_THROW(ok = dict.readDictionary(fs_in.root()));
+    EXPECT_FALSE(ok);
+}
+
+
+TEST(CV_ArucoDictionary, readDictionary_roundtrip)
+{
+    aruco::Dictionary dict = aruco::getPredefinedDictionary(aruco::DICT_5X5_50);
+    std::string serialized;
+    {
+        FileStorage fs_out(".json", FileStorage::WRITE + FileStorage::MEMORY);
+        ASSERT_TRUE(fs_out.isOpened());
+        dict.writeDictionary(fs_out);
+        serialized = fs_out.releaseAndGetString();
+    }
+    FileStorage fs_in(serialized, FileStorage::READ + FileStorage::MEMORY);
+    ASSERT_TRUE(fs_in.isOpened());
+    aruco::Dictionary loaded;
+    ASSERT_TRUE(loaded.readDictionary(fs_in.root()));
+    EXPECT_EQ(dict, loaded);
+}
+
+
 struct ArucoThreading: public testing::TestWithParam<aruco::CornerRefineMethod>
 {
     struct NumThreadsSetter {


### PR DESCRIPTION
Dictionary::readDictionary sizes the marker Mat as markersize x markersize, then writes one byte per character of each marker_i string through marker.at<unsigned char>(j). The string length comes straight from the file node and is never compared against the buffer, so a dictionary whose marker_0 is longer than markersize*markersize walks past the Mat. In a release build the CV_DbgAssert bound inside Mat::at is compiled out, so the extra characters land on the heap as an out-of-bounds write. markersize is also used to allocate that Mat before it is validated, so a nonpositive value reaches the constructor first.

Reject markersize <= 0 before the Mat is built, and require each marker string to hold exactly markersize*markersize characters before the write loop. Before, a malformed or oversized node corrupted the heap (or threw from the Mat constructor on a negative size); after, it returns false the same way a missing parameter already does. A dictionary produced by writeDictionary always writes markersize*markersize characters per marker, so valid files round-trip unchanged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake
