### PR TITLE
core: optimize 8UC2 channel extraction

### DIFF
--- a/modules/core/perf/perf_split.cpp
+++ b/modules/core/perf/perf_split.cpp
@@ -30,4 +30,28 @@ PERF_TEST_P( Size_Depth_Channels, split,
     SANITY_CHECK(mv, 2e-5);
 }
 
+typedef tuple<Size, int> Size_Channel_t;
+typedef perf::TestBaseWithParam<Size_Channel_t> Size_Channel;
+
+PERF_TEST_P( Size_Channel, extractChannel,
+             testing::Combine
+             (
+                 testing::Values(TYPICAL_MAT_SIZES),
+                 testing::Values(0, 1)
+             )
+           )
+{
+    Size sz = get<0>(GetParam());
+    int channel = get<1>(GetParam());
+
+    Mat src(sz, CV_8UC2);
+    Mat dst(sz, CV_8UC1);
+    randu(src, 0, 255);
+
+    int runs = (sz.width <= 640) ? 8 : 1;
+    TEST_CYCLE_MULTIRUN(runs) extractChannel(src, dst, channel);
+
+    SANITY_CHECK(dst);
+}
+
 } // namespace

--- a/modules/core/src/channels.cpp
+++ b/modules/core/src/channels.cpp
@@ -418,6 +418,35 @@ static bool ipp_insertChannel(const Mat &src, Mat &dst, int channel)
 }
 #endif
 
+namespace cv
+{
+template<int channel> static void extractChannel8uC2_(const Mat& src, Mat& dst)
+{
+    for (int row = 0; row < src.rows; ++row)
+    {
+        const uchar* source = src.ptr<uchar>(row);
+        uchar* destination = dst.ptr<uchar>(row);
+        int column = 0;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        const int lanes = VTraits<v_uint8>::vlanes();
+        for (; column <= src.cols - lanes; column += lanes)
+        {
+            v_uint8 channel0, channel1;
+            v_load_deinterleave(source + column * 2, channel0, channel1);
+            v_store(destination + column, channel == 0 ? channel0 : channel1);
+        }
+#endif
+        for (; column < src.cols; ++column)
+            destination[column] = source[column * 2 + channel];
+    }
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    vx_cleanup();
+#endif
+}
+}
+
 void cv::extractChannel(InputArray _src, OutputArray _dst, int coi)
 {
     CV_INSTRUMENT_REGION();
@@ -442,6 +471,15 @@ void cv::extractChannel(InputArray _src, OutputArray _dst, int coi)
     Mat dst = _dst.getMat();
 
     CV_IPP_RUN_FAST(ipp_extractChannel(src, dst, coi))
+
+    if (src.dims <= 2 && src.type() == CV_8UC2)
+    {
+        if (coi == 0)
+            extractChannel8uC2_<0>(src, dst);
+        else
+            extractChannel8uC2_<1>(src, dst);
+        return;
+    }
 
     mixChannels(&src, 1, &dst, 1, ch, 1);
 }

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1602,6 +1602,33 @@ TEST(Core_Arithm, scalar_handling_19599)  // https://github.com/opencv/opencv/is
     EXPECT_EQ(1, c.rows);
 }
 
+TEST(Core_ExtractChannel, twoChannel8uSubmatrix)
+{
+    Mat sourceStorage(5, 37, CV_8UC2);
+    randu(sourceStorage, 0, 256);
+    Mat source = sourceStorage(Rect(3, 1, 31, 3));
+    ASSERT_FALSE(source.isContinuous());
+
+    for (int channel = 0; channel < 2; ++channel)
+    {
+        Mat destinationStorage(5, 37, CV_8UC1, Scalar::all(0));
+        Mat destination = destinationStorage(Rect(3, 1, source.cols, source.rows));
+        Mat expected(source.size(), CV_8UC1);
+        ASSERT_FALSE(destination.isContinuous());
+
+        for (int row = 0; row < source.rows; ++row)
+        {
+            const uchar* sourceRow = source.ptr<uchar>(row);
+            uchar* expectedRow = expected.ptr<uchar>(row);
+            for (int column = 0; column < source.cols; ++column)
+                expectedRow[column] = sourceRow[column * 2 + channel];
+        }
+
+        extractChannel(source, destination, channel);
+        EXPECT_EQ(0, cvtest::norm(expected, destination, NORM_INF));
+    }
+}
+
 // https://github.com/opencv/opencv/issues/24163
 typedef tuple<perf::MatDepth,int,int,int> Arith_Regression24163Param;
 typedef testing::TestWithParam<Arith_Regression24163Param> Core_Arith_Regression24163;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

### Motivation

`cv::extractChannel()` currently falls back to the generic `mixChannels()`
implementation for two-channel 8-bit matrices.

This path is also used by:

- `COLOR_YUV2GRAY_UYVY`
- `COLOR_YUV2GRAY_YUY2`
- `COLOR_YUV2GRAY_YUYV`

These conversions are commonly used to extract the luma plane from packed
YUV422 camera frames. On AArch64, the generic implementation was significantly
slower than a direct NEON deinterleaving load.

### Changes

- Add a specialized universal-intrinsics path for `CV_8UC2` to `CV_8UC1`
  channel extraction.
- Use `v_load_deinterleave()` and `v_store()` for the vectorized loop.
- Preserve the existing IPP path and generic `mixChannels()` fallback.
- Support both channels, non-contiguous matrices, ROIs, row strides, and
  scalar tails.
- Add a regression test covering both channels with a non-contiguous,
  non-vector-aligned submatrix.

No new public API or external dependency is introduced.

### Performance

Measured on a Qualcomm SA8295 Android `arm64-v8a` target:

- OpenCV 4.13-based Android build
- Release/O3
- IPP disabled
- Single thread
- Process pinned to one CPU
- Median of 15 trials

The values below are execution-time ratios relative to a direct
`vld2q_u8` NEON implementation. Lower is better.

| Resolution | Existing implementation | Optimized implementation |
|------------|------------------------:|-------------------------:|
| 640x480    | 6.68x                   | 1.02x                    |
| 1280x720   | 4.28x                   | 1.02x                    |
| 1920x1080  | 3.67x                   | 0.98x                    |
| 3840x2160  | 2.42x                   | 1.03x                    |

YUYV measurements showed similar results. The generated AArch64 code uses
`ld2` followed by a vector store for both channel indices.

Related opencv_extra PR: https://github.com/opencv/opencv_extra/pull/1397

