### PR TITLE
bound categorical split indices in dtrees readSplit

### DIFF
--- a/modules/ml/src/tree.cpp
+++ b/modules/ml/src/tree.cpp
@@ -1839,12 +1839,14 @@ int DTreesImpl::readSplit( const FileNode& fn )
     Split split;
 
     int vi = (int)fn["var"];
-    CV_Assert( 0 <= vi && vi <= (int)varType.size() );
+    CV_Assert( 0 <= vi && vi < (int)varMapping.size() );
     vi = varMapping[vi]; // convert to varIdx if needed
+    CV_Assert( 0 <= vi && vi < (int)varType.size() );
     split.varIdx = vi;
 
     if( varType[vi] == VAR_CATEGORICAL ) // split on categorical var
     {
+        CV_Assert( vi < (int)catOfs.size() );
         int i, val, ssize = getSubsetSize(vi);
         split.subsetOfs = (int)subsets.size();
         for( i = 0; i < ssize; i++ )
@@ -1860,6 +1862,7 @@ int DTreesImpl::readSplit( const FileNode& fn )
         if( fns.isInt() )
         {
             val = (int)fns;
+            CV_Assert( 0 <= val && (val >> 5) < ssize );
             subset[val >> 5] |= 1 << (val & 31);
         }
         else
@@ -1869,6 +1872,7 @@ int DTreesImpl::readSplit( const FileNode& fn )
             for( i = 0; i < n; i++, ++it )
             {
                 val = (int)*it;
+                CV_Assert( 0 <= val && (val >> 5) < ssize );
                 subset[val >> 5] |= 1 << (val & 31);
             }
         }

--- a/modules/ml/test/test_save_load.cpp
+++ b/modules/ml/test/test_save_load.cpp
@@ -96,6 +96,61 @@ ML_Legacy_Param param_list[] = {
 
 INSTANTIATE_TEST_CASE_P(/**/, ML_Legacy_Params, testing::ValuesIn(param_list));
 
+TEST(ML_DTrees, load_bad_categorical_split)
+{
+    // Train a tree with a categorical input so the model carries a
+    // categorical split serialized as an "in"/"not_in" value list.
+    const int n = 40;
+    Mat samples(n, 1, CV_32F);
+    Mat responses(n, 1, CV_32S);
+    for (int i = 0; i < n; i++)
+    {
+        int cat = i % 4;
+        samples.at<float>(i, 0) = (float)cat;
+        responses.at<int>(i, 0) = (cat == 1 || cat == 2) ? 1 : 0;
+    }
+    Mat varType(2, 1, CV_8U);
+    varType.at<uchar>(0) = ml::VAR_CATEGORICAL;
+    varType.at<uchar>(1) = ml::VAR_CATEGORICAL;
+
+    Ptr<ml::TrainData> td = ml::TrainData::create(samples, ml::ROW_SAMPLE, responses,
+                                                  noArray(), noArray(), noArray(), varType);
+    Ptr<ml::DTrees> dt = ml::DTrees::create();
+    dt->setMaxDepth(4);
+    dt->setCVFolds(0);
+    dt->setMaxCategories(4);
+    dt->setMinSampleCount(1);
+    dt->train(td);
+
+    const string filename = cv::tempfile(".yml");
+    dt->save(filename);
+
+    string model;
+    {
+        std::ifstream in(filename.c_str());
+        std::stringstream ss;
+        ss << in.rdbuf();
+        model = ss.str();
+    }
+
+    // Category values in the split list index a per-split subset bitmask.
+    // Injecting a value larger than the number of categories used to write
+    // past that bitmask; loading such a model must be rejected, not crash.
+    size_t pos = model.find("in:");
+    ASSERT_NE(pos, string::npos);
+    size_t br = model.find('[', pos);
+    ASSERT_NE(br, string::npos);
+    model.insert(br + 1, "1000000,");
+    {
+        std::ofstream out(filename.c_str());
+        out << model;
+    }
+
+    Ptr<ml::DTrees> bad;
+    EXPECT_THROW(bad = ml::DTrees::load(filename), Exception);
+    remove(filename.c_str());
+}
+
 /*TEST(ML_SVM, throw_exception_when_save_untrained_model)
 {
     Ptr<cv::ml::SVM> svm;


### PR DESCRIPTION
`DTreesImpl::readSplit` takes the split's variable index and its category values straight from the loaded model and uses them as array indices without a range check. A model whose split node carries an out-of-range `var`, or an `in`/`not_in` category value past the split's subset bitmask, indexes `varMapping`/`varType` out of bounds or writes past the `subsets` buffer while `DTrees`/`RTrees`/`Boost::load` parses the tree. The `var` bound was also off by one (`vi <= varType.size()`), letting `varMapping[vi]` read one past the end.

Before: a crafted category value corrupts heap memory during load (ASan reports a heap-buffer-overflow in `readSplit`). After: the mapped variable index is checked against `varType`/`catOfs` and each category value is bounded by the subset size before the bit is set, so a malformed model throws `cv::Exception` like the other bad-model paths. The bound mirrors the one training already uses when it fills the same bitmask, and keeping it in `readSplit` covers `DTrees`, `RTrees`, and `Boost` since they all funnel through it. Valid models round-trip unchanged; the cost is a couple of comparisons per split at load time.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake
