### PR TITLE
dnn: map FP16 input types to FP32 in getFLOPS for the new graph engine

### DIFF
--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -2466,6 +2466,21 @@ std::vector<String> Net::Impl::getUnconnectedOutLayersNames() /*const*/
 }
 
 
+// The new graph engine has no FP16 execution path yet: it runs FP32 on CPU regardless
+// of the requested (e.g. OpenCL FP16) target. Map FP16 input types to FP32 so that
+// shape/FLOPS inference through Layer::getTypes() does not reject them.
+static std::vector<MatType> filterFP16InputTypes(const std::vector<MatType>& types)
+{
+    std::vector<MatType> result = types;
+    for (MatType& t : result)
+    {
+        if (t == CV_16F)
+            t = CV_32F;
+    }
+    return result;
+}
+
+
 int64 Net::Impl::getFLOPSGraph(const Ptr<Graph>& graph,
                                const std::vector<MatShape>& shapeCache,
                                const std::vector<MatType>& typeCache) const
@@ -2524,10 +2539,14 @@ int64 Net::Impl::getFLOPS(const std::vector<MatShape>& netInputShapes,
                           const std::vector<MatType>& netInputTypes) /*const*/
 {
     if (mainGraph) {
+        // The new graph engine executes in FP32 on CPU regardless of the requested
+        // target, so FP16 input types (e.g. coming from an OpenCL FP16 target) would be
+        // rejected by Layer::getTypes(). Normalize them to FP32 for shape/FLOPS inference.
+        std::vector<MatType> inputTypes = filterFP16InputTypes(netInputTypes);
         LayerShapes shapes;
         std::vector<MatShape> shapeCache;
         std::vector<MatType> typeCache;
-        tryInferShapes(netInputShapes, netInputTypes, shapes, shapeCache, typeCache);
+        tryInferShapes(netInputShapes, inputTypes, shapes, shapeCache, typeCache);
         return getFLOPSGraph(mainGraph, shapeCache, typeCache);
     }
 
@@ -2553,10 +2572,11 @@ int64 Net::Impl::getFLOPS(
         const std::vector<MatType>& netInputTypes) /*const*/
 {
     if (mainGraph) {
+        std::vector<MatType> inputTypes = filterFP16InputTypes(netInputTypes);
         LayerShapes shapes;
         std::vector<MatShape> shapeCache;
         std::vector<MatType> typeCache;
-        tryInferShapes(netInputShapes, netInputTypes, shapes, shapeCache, typeCache);
+        tryInferShapes(netInputShapes, inputTypes, shapes, shapeCache, typeCache);
 
         CV_Assert(0 <= layerId && layerId < (int)totalLayers);
         int localIdx = layerId;


### PR DESCRIPTION
OpenCV DNN engine offers API to compute flops spent by inference of the model. For obvious reasons this path goes through complete shape inference and type inference.

For some reason our type inference is fragile and fails if one of the inputs is FP16, but the platform does not support FP16. That is, we are not trying to run inference (which runs just fine, BTW, it automatically falls back to FP32), we just computing FLOPs, but it does not like FP16. This is fixed now by simple replacement of FP16 with FP32 when we compute FLOPs. In general, we need to revise the whole procedure, but maybe the fix is good enough.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
