### PR TITLE
cmake: warn when external image-codec library is requested but not found 🤖🤖🤖

### DIFF
--- a/cmake/OpenCVFindLibsGrfmt.cmake
+++ b/cmake/OpenCVFindLibsGrfmt.cmake
@@ -45,6 +45,11 @@ else()
   endif()
 
   if(NOT ZLIB_FOUND)
+    if(NOT BUILD_ZLIB)
+      message(WARNING "ZLIB library has not been found, falling back to built-in version. "
+              "Set ZLIB_ROOT or ZLIB_DIR variable so that find_package(ZLIB) would be able to find it. "
+              "See find_package and FindZLIB cmake documentation for details.")
+    endif()
     ocv_clear_vars(ZLIB_LIBRARY ZLIB_LIBRARIES ZLIB_INCLUDE_DIR)
 
     set(ZLIB_LIBRARY zlib CACHE INTERNAL "")
@@ -83,6 +88,12 @@ if(WITH_JPEG)
   endif()
 
   if(NOT JPEG_FOUND)
+    if(NOT BUILD_JPEG)
+      message(WARNING "JPEG library has not been found, falling back to built-in version. "
+              "Add the external installation prefix to CMAKE_PREFIX_PATH, or set JPEG_INCLUDE_DIR "
+              "and JPEG_LIBRARY, so that FindJPEG can locate it. "
+              "See FindJPEG cmake documentation for details.")
+    endif()
     ocv_clear_vars(JPEG_LIBRARY JPEG_INCLUDE_DIR)
 
     if(NOT BUILD_JPEG_TURBO_DISABLE)
@@ -153,6 +164,12 @@ if(WITH_TIFF)
   endif()
 
   if(NOT TIFF_FOUND)
+    if(NOT BUILD_TIFF)
+      message(WARNING "TIFF library has not been found, falling back to built-in version. "
+              "Add the external installation prefix to CMAKE_PREFIX_PATH, or set TIFF_INCLUDE_DIR "
+              "and TIFF_LIBRARY, so that FindTIFF can locate it. "
+              "See FindTIFF cmake documentation for details.")
+    endif()
     ocv_clear_vars(TIFF_LIBRARY TIFF_LIBRARIES TIFF_INCLUDE_DIR)
 
     set(TIFF_LIBRARY libtiff CACHE INTERNAL "")
@@ -201,6 +218,11 @@ endif()
 if(WITH_WEBP AND NOT WEBP_FOUND
     AND (NOT ANDROID OR HAVE_CPUFEATURES)
 )
+  if(NOT BUILD_WEBP)
+    message(WARNING "WebP library has not been found, falling back to built-in version. "
+            "Set WEBP_INCLUDE_DIR and WEBP_LIBRARY, or add the external installation prefix to "
+            "CMAKE_PREFIX_PATH, so that the external WebP can be located.")
+  endif()
   ocv_clear_vars(WEBP_LIBRARY WEBP_INCLUDE_DIR)
   set(WEBP_LIBRARY libwebp CACHE INTERNAL "")
   set(WEBP_LIBRARIES ${WEBP_LIBRARY})
@@ -353,6 +375,11 @@ if(NOT HAVE_SPNG AND WITH_PNG)
   endif()
 
   if(NOT PNG_FOUND)
+    if(NOT BUILD_PNG)
+      message(WARNING "PNG library has not been found, falling back to built-in version. "
+              "Set PNG_ROOT or PNG_DIR variable so that find_package(PNG) would be able to find it. "
+              "See find_package and FindPNG cmake documentation for details.")
+    endif()
     ocv_clear_vars(PNG_LIBRARY PNG_LIBRARIES PNG_INCLUDE_DIR PNG_DEFINITIONS)
 
     set(PNG_LIBRARY libpng CACHE INTERNAL "")


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Closes #26746

## Motivation

When a user disables a bundled image-codec dependency (for example `-DBUILD_ZLIB=OFF`) in order to supply an external build, `cmake/OpenCVFindLibsGrfmt.cmake` runs `find_package(ZLIB)` (or the equivalent module for the other codecs). If that search fails, the configure step **silently** falls back to compiling the bundled `3rdparty/zlib` static library.

As reported in #26746, this is misleading:

- The editable `ZLIB_LIBRARY_DEBUG` / `ZLIB_LIBRARY_RELEASE` cache entries that appear after the fallback have no effect on the resulting build.
- Nothing points the user at the variable that actually controls the search, so it is very hard to guess.

Two maintainers confirmed the behavior in the thread, and @mshabunin proposed adding a detailed warning (including suggested wording for zlib). This PR implements the low-risk half of that plan: **helpful diagnostics only**. The existing built-in fallback behavior is intentionally left unchanged, so configurations that currently rely on the fallback keep building.

## Changes

In `cmake/OpenCVFindLibsGrfmt.cmake`, each bundled-fallback branch now emits a `message(WARNING ...)` guarded by `NOT BUILD_<lib>`, so the fallback is no longer silent **only** when the user explicitly opted out of the bundled build. Applied consistently to the `zlib`, `libjpeg`, `libtiff`, `libpng` and `libwebp` fallback branches.

Each warning names the search inputs that the corresponding lookup actually honors:

- **zlib** and **png** are located with `find_package(ZLIB)` / `find_package(PNG)`, so their warnings point at `ZLIB_ROOT`/`ZLIB_DIR` and `PNG_ROOT`/`PNG_DIR` (the module- and config-mode knobs, matching @mshabunin's suggested wording).
- **jpeg** and **tiff** are pulled in via `include(FindJPEG)` / `include(FindTIFF)` (not `find_package`), where `<pkg>_ROOT` is not applied to the module's `find_path`/`find_library` calls. Their warnings therefore point at `CMAKE_PREFIX_PATH` and the `*_INCLUDE_DIR`/`*_LIBRARY` cache variables that these modules actually consume.
- **webp** is detected by OpenCV's own `cmake/OpenCVFindWebP.cmake`, so its warning points at `CMAKE_PREFIX_PATH` and `WEBP_INCLUDE_DIR`/`WEBP_LIBRARY`.

The more invasive alternative floated in the thread (hard-fail instead of falling back) is deliberately left out to keep the change mergeable and avoid regressing configurations that rely on the current fallback.

## Testing

OpenCV has no unit-test harness for build-system messages, so there is no accompanying `opencv_extra` patch (hence that checklist item is left unchecked).

Verification performed locally:

- The edited `cmake/OpenCVFindLibsGrfmt.cmake` parses cleanly (`if`/`endif` balance and command syntax validated by driving it through `cmake -P` with the OpenCV helper macros stubbed).
- The new warnings are guarded by `NOT BUILD_<lib>`, so a **default** configure (`BUILD_<lib>=ON`, the CI configuration) prints no new output and the fallback path is unchanged. A warning is emitted only when the user sets `BUILD_<lib>=OFF` and no external library is found.

AI was used for assistance.
