### PR TITLE
hal_rvv core: Cover more data types for split with native RVV intrinsics

### DIFF
--- a/hal/riscv-rvv/include/core.hpp
+++ b/hal/riscv-rvv/include/core.hpp
@@ -99,9 +99,18 @@ int fast_atan_64(const double* y, const double* x, double* dst, size_t n, bool a
 /* ############ split ############ */
 
 int split8u(const uchar* src, uchar** dst, int len, int cn);
+int split16u(const ushort* src, ushort** dst, int len, int cn);
+int split32s(const int* src, int** dst, int len, int cn);
+int split64s(const int64* src, int64** dst, int len, int cn);
 
 #undef cv_hal_split8u
 #define cv_hal_split8u cv::rvv_hal::core::split8u
+#undef cv_hal_split16u
+#define cv_hal_split16u cv::rvv_hal::core::split16u
+#undef cv_hal_split32s
+#define cv_hal_split32s cv::rvv_hal::core::split32s
+#undef cv_hal_split64s
+#define cv_hal_split64s cv::rvv_hal::core::split64s
 
 /* ############ sqrt ############ */
 

--- a/hal/riscv-rvv/src/core/split.cpp
+++ b/hal/riscv-rvv/src/core/split.cpp
@@ -86,6 +86,241 @@ int split8u(const uchar* src, uchar** dst, int len, int cn)
     return CV_HAL_ERROR_OK;
 }
 
+
+int split16u(const ushort* src, ushort** dst, int len, int cn)
+{
+    int vl = 0;
+    if (cn == 1)
+    {
+        ushort* dst0 = dst[0];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e16m8(len - i);
+            __riscv_vse16_v_u16m8(dst0 + i, __riscv_vle16_v_u16m8(src + i, vl), vl);
+        }
+    }
+    else if (cn == 2)
+    {
+        ushort *dst0 = dst[0], *dst1 = dst[1];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e16m4(len - i);
+            vuint16m4x2_t seg = __riscv_vlseg2e16_v_u16m4x2(src + i * cn, vl);
+            __riscv_vse16_v_u16m4(dst0 + i, __riscv_vget_v_u16m4x2_u16m4(seg, 0), vl);
+            __riscv_vse16_v_u16m4(dst1 + i, __riscv_vget_v_u16m4x2_u16m4(seg, 1), vl);
+        }
+    }
+    else if (cn == 3)
+    {
+        ushort *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e16m2(len - i);
+            vuint16m2x3_t seg = __riscv_vlseg3e16_v_u16m2x3(src + i * cn, vl);
+            __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 0), vl);
+            __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 1), vl);
+            __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 2), vl);
+        }
+    }
+    else if (cn == 4)
+    {
+        ushort *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e16m2(len - i);
+            vuint16m2x4_t seg = __riscv_vlseg4e16_v_u16m2x4(src + i * cn, vl);
+            __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 0), vl);
+            __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 1), vl);
+            __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 2), vl);
+            __riscv_vse16_v_u16m2(dst3 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 3), vl);
+        }
+    }
+    else
+    {
+        int k = 0;
+        for (; k <= cn - 4; k += 4)
+        {
+            ushort *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e16m2(len - i);
+                vuint16m2x4_t seg = __riscv_vlsseg4e16_v_u16m2x4(src + k + i * cn, cn * sizeof(ushort), vl);
+                __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 0), vl);
+                __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 1), vl);
+                __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 2), vl);
+                __riscv_vse16_v_u16m2(dst3 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 3), vl);
+            }
+        }
+        for (; k < cn; ++k)
+        {
+            ushort* dstK = dst[k];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e16m2(len - i);
+                vuint16m2_t seg = __riscv_vlse16_v_u16m2(src + k + i * cn, cn * sizeof(ushort), vl);
+                __riscv_vse16_v_u16m2(dstK + i, seg, vl);
+            }
+        }
+    }
+    return CV_HAL_ERROR_OK;
+}
+
+int split32s(const int* src, int** dst, int len, int cn)
+{
+    int vl = 0;
+    if (cn == 1)
+    {
+        int* dst0 = dst[0];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e32m8(len - i);
+            __riscv_vse32_v_i32m8(dst0 + i, __riscv_vle32_v_i32m8(src + i, vl), vl);
+        }
+    }
+    else if (cn == 2)
+    {
+        int *dst0 = dst[0], *dst1 = dst[1];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e32m4(len - i);
+            vint32m4x2_t seg = __riscv_vlseg2e32_v_i32m4x2(src + i * cn, vl);
+            __riscv_vse32_v_i32m4(dst0 + i, __riscv_vget_v_i32m4x2_i32m4(seg, 0), vl);
+            __riscv_vse32_v_i32m4(dst1 + i, __riscv_vget_v_i32m4x2_i32m4(seg, 1), vl);
+        }
+    }
+    else if (cn == 3)
+    {
+        int *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e32m2(len - i);
+            vint32m2x3_t seg = __riscv_vlseg3e32_v_i32m2x3(src + i * cn, vl);
+            __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 0), vl);
+            __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 1), vl);
+            __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 2), vl);
+        }
+    }
+    else if (cn == 4)
+    {
+        int *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e32m2(len - i);
+            vint32m2x4_t seg = __riscv_vlseg4e32_v_i32m2x4(src + i * cn, vl);
+            __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 0), vl);
+            __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 1), vl);
+            __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 2), vl);
+            __riscv_vse32_v_i32m2(dst3 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 3), vl);
+        }
+    }
+    else
+    {
+        int k = 0;
+        for (; k <= cn - 4; k += 4)
+        {
+            int *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e32m2(len - i);
+                vint32m2x4_t seg = __riscv_vlsseg4e32_v_i32m2x4(src + k + i * cn, cn * sizeof(int), vl);
+                __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 0), vl);
+                __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 1), vl);
+                __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 2), vl);
+                __riscv_vse32_v_i32m2(dst3 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 3), vl);
+            }
+        }
+        for (; k < cn; ++k)
+        {
+            int* dstK = dst[k];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e32m2(len - i);
+                vint32m2_t seg = __riscv_vlse32_v_i32m2(src + k + i * cn, cn * sizeof(int), vl);
+                __riscv_vse32_v_i32m2(dstK + i, seg, vl);
+            }
+        }
+    }
+    return CV_HAL_ERROR_OK;
+}
+
+int split64s(const int64* src, int64** dst, int len, int cn)
+{
+    int vl = 0;
+    if (cn == 1)
+    {
+        int64* dst0 = dst[0];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e64m8(len - i);
+            __riscv_vse64_v_i64m8(dst0 + i, __riscv_vle64_v_i64m8(src + i, vl), vl);
+        }
+    }
+    else if (cn == 2)
+    {
+        int64 *dst0 = dst[0], *dst1 = dst[1];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e64m4(len - i);
+            vint64m4x2_t seg = __riscv_vlseg2e64_v_i64m4x2(src + i * cn, vl);
+            __riscv_vse64_v_i64m4(dst0 + i, __riscv_vget_v_i64m4x2_i64m4(seg, 0), vl);
+            __riscv_vse64_v_i64m4(dst1 + i, __riscv_vget_v_i64m4x2_i64m4(seg, 1), vl);
+        }
+    }
+    else if (cn == 3)
+    {
+        int64 *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e64m2(len - i);
+            vint64m2x3_t seg = __riscv_vlseg3e64_v_i64m2x3(src + i * cn, vl);
+            __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 0), vl);
+            __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 1), vl);
+            __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 2), vl);
+        }
+    }
+    else if (cn == 4)
+    {
+        int64 *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
+        for (int i = 0; i < len; i += vl)
+        {
+            vl = __riscv_vsetvl_e64m2(len - i);
+            vint64m2x4_t seg = __riscv_vlseg4e64_v_i64m2x4(src + i * cn, vl);
+            __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 0), vl);
+            __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 1), vl);
+            __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 2), vl);
+            __riscv_vse64_v_i64m2(dst3 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 3), vl);
+        }
+    }
+    else
+    {
+        int k = 0;
+        for (; k <= cn - 4; k += 4)
+        {
+            int64 *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e64m2(len - i);
+                vint64m2x4_t seg = __riscv_vlsseg4e64_v_i64m2x4(src + k + i * cn, cn * sizeof(int64), vl);
+                __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 0), vl);
+                __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 1), vl);
+                __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 2), vl);
+                __riscv_vse64_v_i64m2(dst3 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 3), vl);
+            }
+        }
+        for (; k < cn; ++k)
+        {
+            int64* dstK = dst[k];
+            for (int i = 0; i < len; i += vl)
+            {
+                vl = __riscv_vsetvl_e64m2(len - i);
+                vint64m2_t seg = __riscv_vlse64_v_i64m2(src + k + i * cn, cn * sizeof(int64), vl);
+                __riscv_vse64_v_i64m2(dstK + i, seg, vl);
+            }
+        }
+    }
+    return CV_HAL_ERROR_OK;
+}
+
 #endif // CV_HAL_RVV_1P0_ENABLED
 
 }}} // cv::rvv_hal::core

--- a/hal/riscv-rvv/src/core/split.cpp
+++ b/hal/riscv-rvv/src/core/split.cpp
@@ -8,318 +8,91 @@ namespace cv { namespace rvv_hal { namespace core {
 
 #if CV_HAL_RVV_1P0_ENABLED
 
-int split8u(const uchar* src, uchar** dst, int len, int cn)
-{
-    int vl = 0;
-    if (cn == 1)
-    {
-        uchar* dst0 = dst[0];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e8m8(len - i);
-            __riscv_vse8_v_u8m8(dst0 + i, __riscv_vle8_v_u8m8(src + i, vl), vl);
-        }
-    }
-    else if (cn == 2)
-    {
-        uchar *dst0 = dst[0], *dst1 = dst[1];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e8m4(len - i);
-            vuint8m4x2_t seg = __riscv_vlseg2e8_v_u8m4x2(src + i * cn, vl);
-            __riscv_vse8_v_u8m4(dst0 + i, __riscv_vget_v_u8m4x2_u8m4(seg, 0), vl);
-            __riscv_vse8_v_u8m4(dst1 + i, __riscv_vget_v_u8m4x2_u8m4(seg, 1), vl);
-        }
-    }
-    else if (cn == 3)
-    {
-        uchar *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e8m2(len - i);
-            vuint8m2x3_t seg = __riscv_vlseg3e8_v_u8m2x3(src + i * cn, vl);
-            __riscv_vse8_v_u8m2(dst0 + i, __riscv_vget_v_u8m2x3_u8m2(seg, 0), vl);
-            __riscv_vse8_v_u8m2(dst1 + i, __riscv_vget_v_u8m2x3_u8m2(seg, 1), vl);
-            __riscv_vse8_v_u8m2(dst2 + i, __riscv_vget_v_u8m2x3_u8m2(seg, 2), vl);
-        }
-    }
-    else if (cn == 4)
-    {
-        uchar *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e8m2(len - i);
-            vuint8m2x4_t seg = __riscv_vlseg4e8_v_u8m2x4(src + i * cn, vl);
-            __riscv_vse8_v_u8m2(dst0 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 0), vl);
-            __riscv_vse8_v_u8m2(dst1 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 1), vl);
-            __riscv_vse8_v_u8m2(dst2 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 2), vl);
-            __riscv_vse8_v_u8m2(dst3 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 3), vl);
-        }
-    }
-    else
-    {
-        int k = 0;
-        for (; k <= cn - 4; k += 4)
-        {
-            uchar *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e8m2(len - i);
-                vuint8m2x4_t seg = __riscv_vlsseg4e8_v_u8m2x4(src + k + i * cn, cn, vl);
-                __riscv_vse8_v_u8m2(dst0 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 0), vl);
-                __riscv_vse8_v_u8m2(dst1 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 1), vl);
-                __riscv_vse8_v_u8m2(dst2 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 2), vl);
-                __riscv_vse8_v_u8m2(dst3 + i, __riscv_vget_v_u8m2x4_u8m2(seg, 3), vl);
-            }
-        }
-        for (; k < cn; ++k)
-        {
-            uchar* dstK = dst[k];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e8m2(len - i);
-                vuint8m2_t seg = __riscv_vlse8_v_u8m2(src + k + i * cn, cn, vl);
-                __riscv_vse8_v_u8m2(dstK + i, seg, vl);
-            }
-        }
-    }
-    return CV_HAL_ERROR_OK;
+#define OPENCV_HAL_IMPL_RVV_SPLIT(func, T, vtype, suffix, width) \
+int func(const T* src, T** dst, int len, int cn) \
+{ \
+    int vl = 0; \
+    if (cn == 1) \
+    { \
+        T* dst0 = dst[0]; \
+        for (int i = 0; i < len; i += vl) \
+        { \
+            vl = __riscv_vsetvl_e##width##m8(len - i); \
+            __riscv_vse##width##_v_##suffix##m8(dst0 + i, __riscv_vle##width##_v_##suffix##m8(src + i, vl), vl); \
+        } \
+    } \
+    else if (cn == 2) \
+    { \
+        T *dst0 = dst[0], *dst1 = dst[1]; \
+        for (int i = 0; i < len; i += vl) \
+        { \
+            vl = __riscv_vsetvl_e##width##m4(len - i); \
+            v##vtype##m4x2_t seg = __riscv_vlseg2e##width##_v_##suffix##m4x2(src + i * cn, vl); \
+            __riscv_vse##width##_v_##suffix##m4(dst0 + i, __riscv_vget_v_##suffix##m4x2_##suffix##m4(seg, 0), vl); \
+            __riscv_vse##width##_v_##suffix##m4(dst1 + i, __riscv_vget_v_##suffix##m4x2_##suffix##m4(seg, 1), vl); \
+        } \
+    } \
+    else if (cn == 3) \
+    { \
+        T *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2]; \
+        for (int i = 0; i < len; i += vl) \
+        { \
+            vl = __riscv_vsetvl_e##width##m2(len - i); \
+            v##vtype##m2x3_t seg = __riscv_vlseg3e##width##_v_##suffix##m2x3(src + i * cn, vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst0 + i, __riscv_vget_v_##suffix##m2x3_##suffix##m2(seg, 0), vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst1 + i, __riscv_vget_v_##suffix##m2x3_##suffix##m2(seg, 1), vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst2 + i, __riscv_vget_v_##suffix##m2x3_##suffix##m2(seg, 2), vl); \
+        } \
+    } \
+    else if (cn == 4) \
+    { \
+        T *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3]; \
+        for (int i = 0; i < len; i += vl) \
+        { \
+            vl = __riscv_vsetvl_e##width##m2(len - i); \
+            v##vtype##m2x4_t seg = __riscv_vlseg4e##width##_v_##suffix##m2x4(src + i * cn, vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst0 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 0), vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst1 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 1), vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst2 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 2), vl); \
+            __riscv_vse##width##_v_##suffix##m2(dst3 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 3), vl); \
+        } \
+    } \
+    else \
+    { \
+        int k = 0; \
+        for (; k <= cn - 4; k += 4) \
+        { \
+            T *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3]; \
+            for (int i = 0; i < len; i += vl) \
+            { \
+                vl = __riscv_vsetvl_e##width##m2(len - i); \
+                v##vtype##m2x4_t seg = __riscv_vlsseg4e##width##_v_##suffix##m2x4(src + k + i * cn, cn * sizeof(T), vl); \
+                __riscv_vse##width##_v_##suffix##m2(dst0 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 0), vl); \
+                __riscv_vse##width##_v_##suffix##m2(dst1 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 1), vl); \
+                __riscv_vse##width##_v_##suffix##m2(dst2 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 2), vl); \
+                __riscv_vse##width##_v_##suffix##m2(dst3 + i, __riscv_vget_v_##suffix##m2x4_##suffix##m2(seg, 3), vl); \
+            } \
+        } \
+        for (; k < cn; ++k) \
+        { \
+            T* dstK = dst[k]; \
+            for (int i = 0; i < len; i += vl) \
+            { \
+                vl = __riscv_vsetvl_e##width##m2(len - i); \
+                v##vtype##m2_t seg = __riscv_vlse##width##_v_##suffix##m2(src + k + i * cn, cn * sizeof(T), vl); \
+                __riscv_vse##width##_v_##suffix##m2(dstK + i, seg, vl); \
+            } \
+        } \
+    } \
+    return CV_HAL_ERROR_OK; \
 }
 
+OPENCV_HAL_IMPL_RVV_SPLIT(split8u, uchar, uint8, u8, 8)
+OPENCV_HAL_IMPL_RVV_SPLIT(split16u, ushort, uint16, u16, 16)
+OPENCV_HAL_IMPL_RVV_SPLIT(split32s, int, int32, i32, 32)
+OPENCV_HAL_IMPL_RVV_SPLIT(split64s, int64, int64, i64, 64)
 
-int split16u(const ushort* src, ushort** dst, int len, int cn)
-{
-    int vl = 0;
-    if (cn == 1)
-    {
-        ushort* dst0 = dst[0];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e16m8(len - i);
-            __riscv_vse16_v_u16m8(dst0 + i, __riscv_vle16_v_u16m8(src + i, vl), vl);
-        }
-    }
-    else if (cn == 2)
-    {
-        ushort *dst0 = dst[0], *dst1 = dst[1];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e16m4(len - i);
-            vuint16m4x2_t seg = __riscv_vlseg2e16_v_u16m4x2(src + i * cn, vl);
-            __riscv_vse16_v_u16m4(dst0 + i, __riscv_vget_v_u16m4x2_u16m4(seg, 0), vl);
-            __riscv_vse16_v_u16m4(dst1 + i, __riscv_vget_v_u16m4x2_u16m4(seg, 1), vl);
-        }
-    }
-    else if (cn == 3)
-    {
-        ushort *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e16m2(len - i);
-            vuint16m2x3_t seg = __riscv_vlseg3e16_v_u16m2x3(src + i * cn, vl);
-            __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 0), vl);
-            __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 1), vl);
-            __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x3_u16m2(seg, 2), vl);
-        }
-    }
-    else if (cn == 4)
-    {
-        ushort *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e16m2(len - i);
-            vuint16m2x4_t seg = __riscv_vlseg4e16_v_u16m2x4(src + i * cn, vl);
-            __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 0), vl);
-            __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 1), vl);
-            __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 2), vl);
-            __riscv_vse16_v_u16m2(dst3 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 3), vl);
-        }
-    }
-    else
-    {
-        int k = 0;
-        for (; k <= cn - 4; k += 4)
-        {
-            ushort *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e16m2(len - i);
-                vuint16m2x4_t seg = __riscv_vlsseg4e16_v_u16m2x4(src + k + i * cn, cn * sizeof(ushort), vl);
-                __riscv_vse16_v_u16m2(dst0 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 0), vl);
-                __riscv_vse16_v_u16m2(dst1 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 1), vl);
-                __riscv_vse16_v_u16m2(dst2 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 2), vl);
-                __riscv_vse16_v_u16m2(dst3 + i, __riscv_vget_v_u16m2x4_u16m2(seg, 3), vl);
-            }
-        }
-        for (; k < cn; ++k)
-        {
-            ushort* dstK = dst[k];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e16m2(len - i);
-                vuint16m2_t seg = __riscv_vlse16_v_u16m2(src + k + i * cn, cn * sizeof(ushort), vl);
-                __riscv_vse16_v_u16m2(dstK + i, seg, vl);
-            }
-        }
-    }
-    return CV_HAL_ERROR_OK;
-}
-
-int split32s(const int* src, int** dst, int len, int cn)
-{
-    int vl = 0;
-    if (cn == 1)
-    {
-        int* dst0 = dst[0];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e32m8(len - i);
-            __riscv_vse32_v_i32m8(dst0 + i, __riscv_vle32_v_i32m8(src + i, vl), vl);
-        }
-    }
-    else if (cn == 2)
-    {
-        int *dst0 = dst[0], *dst1 = dst[1];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e32m4(len - i);
-            vint32m4x2_t seg = __riscv_vlseg2e32_v_i32m4x2(src + i * cn, vl);
-            __riscv_vse32_v_i32m4(dst0 + i, __riscv_vget_v_i32m4x2_i32m4(seg, 0), vl);
-            __riscv_vse32_v_i32m4(dst1 + i, __riscv_vget_v_i32m4x2_i32m4(seg, 1), vl);
-        }
-    }
-    else if (cn == 3)
-    {
-        int *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e32m2(len - i);
-            vint32m2x3_t seg = __riscv_vlseg3e32_v_i32m2x3(src + i * cn, vl);
-            __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 0), vl);
-            __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 1), vl);
-            __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x3_i32m2(seg, 2), vl);
-        }
-    }
-    else if (cn == 4)
-    {
-        int *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e32m2(len - i);
-            vint32m2x4_t seg = __riscv_vlseg4e32_v_i32m2x4(src + i * cn, vl);
-            __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 0), vl);
-            __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 1), vl);
-            __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 2), vl);
-            __riscv_vse32_v_i32m2(dst3 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 3), vl);
-        }
-    }
-    else
-    {
-        int k = 0;
-        for (; k <= cn - 4; k += 4)
-        {
-            int *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e32m2(len - i);
-                vint32m2x4_t seg = __riscv_vlsseg4e32_v_i32m2x4(src + k + i * cn, cn * sizeof(int), vl);
-                __riscv_vse32_v_i32m2(dst0 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 0), vl);
-                __riscv_vse32_v_i32m2(dst1 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 1), vl);
-                __riscv_vse32_v_i32m2(dst2 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 2), vl);
-                __riscv_vse32_v_i32m2(dst3 + i, __riscv_vget_v_i32m2x4_i32m2(seg, 3), vl);
-            }
-        }
-        for (; k < cn; ++k)
-        {
-            int* dstK = dst[k];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e32m2(len - i);
-                vint32m2_t seg = __riscv_vlse32_v_i32m2(src + k + i * cn, cn * sizeof(int), vl);
-                __riscv_vse32_v_i32m2(dstK + i, seg, vl);
-            }
-        }
-    }
-    return CV_HAL_ERROR_OK;
-}
-
-int split64s(const int64* src, int64** dst, int len, int cn)
-{
-    int vl = 0;
-    if (cn == 1)
-    {
-        int64* dst0 = dst[0];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e64m8(len - i);
-            __riscv_vse64_v_i64m8(dst0 + i, __riscv_vle64_v_i64m8(src + i, vl), vl);
-        }
-    }
-    else if (cn == 2)
-    {
-        int64 *dst0 = dst[0], *dst1 = dst[1];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e64m4(len - i);
-            vint64m4x2_t seg = __riscv_vlseg2e64_v_i64m4x2(src + i * cn, vl);
-            __riscv_vse64_v_i64m4(dst0 + i, __riscv_vget_v_i64m4x2_i64m4(seg, 0), vl);
-            __riscv_vse64_v_i64m4(dst1 + i, __riscv_vget_v_i64m4x2_i64m4(seg, 1), vl);
-        }
-    }
-    else if (cn == 3)
-    {
-        int64 *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e64m2(len - i);
-            vint64m2x3_t seg = __riscv_vlseg3e64_v_i64m2x3(src + i * cn, vl);
-            __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 0), vl);
-            __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 1), vl);
-            __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x3_i64m2(seg, 2), vl);
-        }
-    }
-    else if (cn == 4)
-    {
-        int64 *dst0 = dst[0], *dst1 = dst[1], *dst2 = dst[2], *dst3 = dst[3];
-        for (int i = 0; i < len; i += vl)
-        {
-            vl = __riscv_vsetvl_e64m2(len - i);
-            vint64m2x4_t seg = __riscv_vlseg4e64_v_i64m2x4(src + i * cn, vl);
-            __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 0), vl);
-            __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 1), vl);
-            __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 2), vl);
-            __riscv_vse64_v_i64m2(dst3 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 3), vl);
-        }
-    }
-    else
-    {
-        int k = 0;
-        for (; k <= cn - 4; k += 4)
-        {
-            int64 *dst0 = dst[k], *dst1 = dst[k + 1], *dst2 = dst[k + 2], *dst3 = dst[k + 3];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e64m2(len - i);
-                vint64m2x4_t seg = __riscv_vlsseg4e64_v_i64m2x4(src + k + i * cn, cn * sizeof(int64), vl);
-                __riscv_vse64_v_i64m2(dst0 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 0), vl);
-                __riscv_vse64_v_i64m2(dst1 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 1), vl);
-                __riscv_vse64_v_i64m2(dst2 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 2), vl);
-                __riscv_vse64_v_i64m2(dst3 + i, __riscv_vget_v_i64m2x4_i64m2(seg, 3), vl);
-            }
-        }
-        for (; k < cn; ++k)
-        {
-            int64* dstK = dst[k];
-            for (int i = 0; i < len; i += vl)
-            {
-                vl = __riscv_vsetvl_e64m2(len - i);
-                vint64m2_t seg = __riscv_vlse64_v_i64m2(src + k + i * cn, cn * sizeof(int64), vl);
-                __riscv_vse64_v_i64m2(dstK + i, seg, vl);
-            }
-        }
-    }
-    return CV_HAL_ERROR_OK;
-}
+#undef OPENCV_HAL_IMPL_RVV_SPLIT
 
 #endif // CV_HAL_RVV_1P0_ENABLED
 


### PR DESCRIPTION
Covering 16-bit, 32-bit and 64-bit split.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
