### PR TITLE
Fix Python typing module shadowing in subprocesses (#28766)

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -4,7 +4,7 @@ OpenCV Python binary extension loader
 import os
 import importlib
 import sys
-
+import typing
 __all__ = []
 
 try:

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -991,22 +991,18 @@ class AlgorithmImplHit(NewOpenCVTests):
     def test_callable(self):
         res = cv.getDefaultAlgorithmHint()
         self.assertTrue(res is not None)
-        
 class Test_Issue28766(NewOpenCVTests):
     def test_typing_module_shadowing(self):
         # Regression test for Issue #28766: cv2/__init__.py shadowing stdlib typing
         import subprocess
         import sys
-        
         # We run this in a completely fresh subprocess to ensure sys.modules is clean.
         # If the bug is present, importing typing or numpy after cv2 will crash.
         script = "import cv2; import typing; import numpy"
-        
         try:
             # Execute the script in an isolated Python environment
             subprocess.check_call([sys.executable, "-c", script])
         except subprocess.CalledProcessError as e:
             self.fail(f"Namespace shadowing bug reproduced: Subprocess crashed with {e}")
-
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()

--- a/modules/python/test/test_misc.py
+++ b/modules/python/test/test_misc.py
@@ -991,6 +991,22 @@ class AlgorithmImplHit(NewOpenCVTests):
     def test_callable(self):
         res = cv.getDefaultAlgorithmHint()
         self.assertTrue(res is not None)
+        
+class Test_Issue28766(NewOpenCVTests):
+    def test_typing_module_shadowing(self):
+        # Regression test for Issue #28766: cv2/__init__.py shadowing stdlib typing
+        import subprocess
+        import sys
+        
+        # We run this in a completely fresh subprocess to ensure sys.modules is clean.
+        # If the bug is present, importing typing or numpy after cv2 will crash.
+        script = "import cv2; import typing; import numpy"
+        
+        try:
+            # Execute the script in an isolated Python environment
+            subprocess.check_call([sys.executable, "-c", script])
+        except subprocess.CalledProcessError as e:
+            self.fail(f"Namespace shadowing bug reproduced: Subprocess crashed with {e}")
 
 if __name__ == '__main__':
     NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Fix Python typing module shadowing in subprocesses (#28766)


### Description
Resolves #28766 

When loading OpenCV in an isolated subprocess (like `multiprocessing` `spawn`), the bootstrap loader in `cv2/__init__.py` aggressively modifies `sys.path` by inserting the `cv2/` folder at index 0. This causes downstream dependencies (like `numpy.linalg`) to falsely resolve `cv2/typing/` when attempting to `import typing` which leads to a fatal namespace collision and circular import crash.

### Changes Made
1. **Preemptive Caching:** Added `import typing` at the absolute entry point of the python loader (`modules/python/package/cv2/__init__.py`). This forces Python to resolve and lock the standard library `typing` module into the global `sys.modules` cache *before* any dynamic `sys.path` mutations occur.
2. **Regression Test:** Added a sandboxed unit test inside `modules/python/test/test_misc.py` that spawns a clean Python subprocess and imports `cv2` followed by `typing` and `numpy` to explicitly verify the path collision is neutralized. 

### Testing
- [x] Verified fix locally by attempting to reproduce the subprocess crash.
- [x] Unit test `test_typing_module_shadowing` passes successfully.