### PR TITLE
hal_rvv core: Optimize RVV HAL masked copy

### DIFF
--- a/hal/riscv-rvv/src/core/copy_mask.cpp
+++ b/hal/riscv-rvv/src/core/copy_mask.cpp
@@ -30,8 +30,27 @@ static int copyToMasked_e##X##c1(const uchar *src_data, size_t src_step, const u
     return CV_HAL_ERROR_OK; \
 }
 
-CV_HAL_RVV_COPY_MASK_eXc1(8,  8)
-CV_HAL_RVV_COPY_MASK_eXc1(16, 4)
+#define CV_HAL_RVV_COPY_MASK_MERGE_eXc1(X, data_lmul, mask_lmul) \
+static int copyToMasked_e##X##c1(const uchar *src_data, size_t src_step, const uchar *mask_data, size_t mask_step, \
+                                 uchar *dst_data, size_t dst_step, int width, int height) { \
+    for (; height--; mask_data += mask_step, src_data += src_step, dst_data += dst_step) { \
+        const uint##X##_t *src = (const uint##X##_t*)src_data; \
+        uint##X##_t *dst = (uint##X##_t*)dst_data; \
+        int vl; \
+        for (int i = 0; i < width; i += vl) { \
+            vl = __riscv_vsetvl_e##X##m##data_lmul(width - i); \
+            auto m = __riscv_vmsne(__riscv_vle8_v_u8m##mask_lmul(mask_data + i, vl), 0, vl); \
+            auto src_v = __riscv_vle##X##_v_u##X##m##data_lmul(src + i, vl); \
+            auto dst_v = __riscv_vle##X##_v_u##X##m##data_lmul(dst + i, vl); \
+            __riscv_vse##X##_v_u##X##m##data_lmul(dst + i, __riscv_vmerge(dst_v, src_v, m, vl), vl); \
+        } \
+    } \
+    return CV_HAL_ERROR_OK; \
+}
+
+CV_HAL_RVV_COPY_MASK_MERGE_eXc1(8,  8, 8)
+CV_HAL_RVV_COPY_MASK_MERGE_eXc1(16, 8, 4)
+
 CV_HAL_RVV_COPY_MASK_eXc1(32, 2)
 CV_HAL_RVV_COPY_MASK_eXc1(64, 1)
 


### PR DESCRIPTION
Merge is better in average mask density than selected-store for 8-bit and 16-bit. However,  from 0%-20% selected is much better than merge for 32-bit and 64-bit, making it less worthy to apply the same change.

Tested with 1920x1080 C1 mat.
| Mask density | 8-bit selected | 8-bit merge | 16-bit selected | 16-bit merge | 32-bit selected | 32-bit merge | 64-bit selected | 64-bit merge |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 0% | 0.49 | 1.59 | 0.74 | 2.95 | 1.35 | 5.70 | 2.22 | 11.91 |
| 10% | 3.43 | 1.69 | 4.82 | 2.84 | 2.27 | 6.31 | 2.99 | 12.00 |
| 20% | 1.63 | 1.57 | 6.34 | 3.12 | 8.77 | 6.10 | 4.83 | 12.04 |
| 30% | 1.68 | 1.59 | 4.74 | 2.97 | 13.47 | 5.67 | 14.90 | 11.79 |
| 40% | 1.57 | 1.56 | 6.57 | 2.79 | 11.85 | 5.66 | 14.32 | 11.84 |
| 50% | 1.56 | 1.56 | 6.54 | 2.80 | 12.45 | 5.75 | 10.87 | 11.88 |
| 60% | 1.59 | 1.61 | 4.87 | 2.80 | 7.17 | 6.19 | 11.46 | 11.36 |
| 70% | 1.88 | 1.58 | 4.72 | 2.80 | 7.86 | 5.62 | 10.85 | 11.76 |
| 80% | 2.08 | 1.56 | 4.69 | 2.80 | 7.34 | 6.13 | 13.17 | 11.60 |
| 90% | 3.48 | 1.61 | 5.68 | 2.97 | 6.24 | 5.96 | 12.85 | 11.46 |
| 100% | 1.32 | 1.68 | 2.41 | 3.08 | 3.73 | 5.93 | 7.64 | 11.74 |

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
