### PR TITLE
dnn: keep fastGemmThin accumulators in registers on scalable-vector targets (RVV)

### DIFF
--- a/modules/dnn/perf/perf_gemm.cpp
+++ b/modules/dnn/perf/perf_gemm.cpp
@@ -83,6 +83,13 @@ static const GemmParam_t test_matmul_configs[] = {
     { {16, 197, 64 }, {16, 64, 197} },
     { {16, 50, 64}, {16, 64, 50} },
     { {16, 50, 50}, {16, 50, 64} },
+
+    // transformer token generation cases (thin-M GEMV, fastGemmThin path)
+    { {1, 1, 768}, {1, 768, 768} },
+    { {1, 1, 768}, {1, 768, 3072} },
+    { {1, 1, 3072}, {1, 3072, 768} },
+    { {1, 2, 768}, {1, 768, 768} },
+    { {1, 4, 768}, {1, 768, 768} },
 };
 
 struct GemmParamId

--- a/modules/dnn/src/layers/cpu_kernels/fast_gemm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_gemm.cpp
@@ -276,6 +276,45 @@ static inline int fast_gemm_thin_lanes() {
 #endif
 }
 
+#if CV_SIMD_SCALABLE
+// Apply the alpha/beta epilogue to one accumulator row.
+static inline void fast_gemm_thin_store_row(float* c, v_float32 acc,
+                                            v_float32 v_alpha, float beta) {
+    if (beta == 0.f)
+        vx_store(c, v_mul(acc, v_alpha));
+    else if (beta == 1.f)
+        vx_store(c, v_fma(acc, v_alpha, vx_load(c)));
+    else
+        vx_store(c, v_fma(acc, v_alpha, v_mul(vx_load(c), vx_setall_f32(beta))));
+}
+
+// Multiply MR (1..4) rows of A by one packed-B strip. Sizeless vector types
+// cannot form the acc[] array the CV_SIMD path uses, so the accumulators are
+// named variables selected by the compile-time MR (the `if (MR > n)` branches
+// fold away) and stay in registers for the whole K loop. Accumulation remains
+// in increasing-k order, bit-exact with the previous scratch-buffer code.
+template<int MR>
+static inline void fast_gemm_thin_block(int K, const float* A, int lda0, int lda1,
+                                        const float* b_strip, int NR,
+                                        v_float32 v_alpha, float beta,
+                                        float* c_strip, int ldc) {
+    v_float32 c0 = vx_setzero_f32(), c1 = vx_setzero_f32();
+    v_float32 c2 = vx_setzero_f32(), c3 = vx_setzero_f32();
+    for (int k = 0; k < K; k++) {
+        v_float32 bv = vx_load(b_strip + k * NR);
+        const float* a = A + k * lda1;
+                     c0 = v_fma(bv, vx_setall_f32(a[0]),         c0);
+        if (MR > 1) c1 = v_fma(bv, vx_setall_f32(a[lda0]),       c1);
+        if (MR > 2) c2 = v_fma(bv, vx_setall_f32(a[2 * lda0]),   c2);
+        if (MR > 3) c3 = v_fma(bv, vx_setall_f32(a[3 * lda0]),   c3);
+    }
+                 fast_gemm_thin_store_row(c_strip,             c0, v_alpha, beta);
+    if (MR > 1)  fast_gemm_thin_store_row(c_strip + ldc,       c1, v_alpha, beta);
+    if (MR > 2)  fast_gemm_thin_store_row(c_strip + 2 * ldc,   c2, v_alpha, beta);
+    if (MR > 3)  fast_gemm_thin_store_row(c_strip + 3 * ldc,   c3, v_alpha, beta);
+}
+#endif // CV_SIMD_SCALABLE
+
 static inline void fast_gemm_thin_strip(int M, int K, float alpha,
                                         const float* A, int lda0, int lda1,
                                         const float* b_strip,
@@ -311,37 +350,17 @@ static inline void fast_gemm_thin_strip(int M, int K, float alpha,
         }
     }
 #elif CV_SIMD_SCALABLE
-    // Scalable vector types (e.g. RVV) are sizeless and cannot form arrays;
-    // back the per-row accumulators with a scalar scratch buffer.
+    // Process the strip in register-resident row blocks; the common thin case
+    // M <= 4 (transformer token generation) is a single pass.
     const int NR = VTraits<v_float32>::vlanes();
-    float acc_buf[FAST_GEMM_THIN_MAX_M * VTraits<v_float32>::max_nlanes];
-    for (int m = 0; m < M; m++) vx_store(acc_buf + m * NR, vx_setzero_f32());
-
-    for (int k = 0; k < K; k++) {
-        v_float32 bv = vx_load(b_strip + k * NR);
-        for (int m = 0; m < M; m++) {
-            v_float32 am = vx_setall_f32(A[m * lda0 + k * lda1]);
-            v_float32 acc_m = vx_load(acc_buf + m * NR);
-            vx_store(acc_buf + m * NR, v_fma(bv, am, acc_m));
-        }
-    }
-
     const v_float32 v_alpha = vx_setall_f32(alpha);
-    if (beta == 0.f) {
-        for (int m = 0; m < M; m++)
-            vx_store(c_strip + m * ldc, v_mul(vx_load(acc_buf + m * NR), v_alpha));
-    } else if (beta == 1.f) {
-        for (int m = 0; m < M; m++) {
-            v_float32 cv = vx_load(c_strip + m * ldc);
-            vx_store(c_strip + m * ldc, v_fma(vx_load(acc_buf + m * NR), v_alpha, cv));
-        }
-    } else {
-        const v_float32 v_beta = vx_setall_f32(beta);
-        for (int m = 0; m < M; m++) {
-            v_float32 cv = vx_load(c_strip + m * ldc);
-            cv = v_mul(cv, v_beta);
-            vx_store(c_strip + m * ldc, v_fma(vx_load(acc_buf + m * NR), v_alpha, cv));
-        }
+    int m = 0;
+    for (; m + 4 <= M; m += 4)
+        fast_gemm_thin_block<4>(K, A + m * lda0, lda0, lda1, b_strip, NR, v_alpha, beta, c_strip + m * ldc, ldc);
+    switch (M - m) {
+        case 1: fast_gemm_thin_block<1>(K, A + m * lda0, lda0, lda1, b_strip, NR, v_alpha, beta, c_strip + m * ldc, ldc); break;
+        case 2: fast_gemm_thin_block<2>(K, A + m * lda0, lda0, lda1, b_strip, NR, v_alpha, beta, c_strip + m * ldc, ldc); break;
+        case 3: fast_gemm_thin_block<3>(K, A + m * lda0, lda0, lda1, b_strip, NR, v_alpha, beta, c_strip + m * ldc, ldc); break;
     }
 #else
     const int NR = FAST_GEMM_THIN_SCALAR_NR;

--- a/modules/dnn/test/test_fast_gemm.cpp
+++ b/modules/dnn/test/test_fast_gemm.cpp
@@ -1,0 +1,85 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+static Mat referenceMatMul(const Mat& A, const Mat& B, bool trans_a, float alpha)
+{
+    const int M = trans_a ? A.cols : A.rows;
+    const int K = trans_a ? A.rows : A.cols;
+    const int N = B.cols;
+    Mat expected(M, N, CV_32F);
+
+    for (int m = 0; m < M; m++)
+    {
+        float* dst = expected.ptr<float>(m);
+        for (int n = 0; n < N; n++)
+        {
+            float acc = 0.f;
+            for (int k = 0; k < K; k++)
+            {
+                const float a = trans_a ? A.ptr<float>(k)[m] : A.ptr<float>(m)[k];
+                acc += a * B.ptr<float>(k)[n];
+            }
+            dst[n] = alpha * acc;
+        }
+    }
+    return expected;
+}
+
+// Exercises the fastGemmThin path (constant-B MatMul): M covers every register
+// block width and the multi-block remainder, N covers full strips and partial
+// column tails for any VLEN <= 512.
+TEST(DNN_FastGemmThin, MatMulAccuracy)
+{
+    static const int m_values[] = { 1, 2, 3, 4, 5 };
+    static const int k_values[] = { 1, 3, 4, 7, 16, 64 };
+    static const int n_values[] = { 16, 19, 64, 67, 80, 83 };
+    static const float alpha_values[] = { 1.f, -0.5f };
+
+    RNG rng(0x5EED);
+    for (int M : m_values)
+    {
+        for (int N : n_values)
+        {
+            for (int K : k_values)
+            {
+                Mat B(K, N, CV_32F);
+                rng.fill(B, RNG::UNIFORM, -1.f, 1.f);
+
+                for (int trans_a = 0; trans_a <= 1; trans_a++)
+                {
+                    Mat A(trans_a ? K : M, trans_a ? M : K, CV_32F);
+                    rng.fill(A, RNG::UNIFORM, -1.f, 1.f);
+
+                    for (float alpha : alpha_values)
+                    {
+                        LayerParams lp;
+                        lp.type = "MatMul";
+                        lp.name = "thin_matmul";
+                        lp.set("transA", trans_a != 0);
+                        lp.set("transB", false);
+                        lp.set("alpha", alpha);
+                        lp.blobs.push_back(B);
+
+                        Net net;
+                        net.addLayerToPrev(lp.name, lp.type, lp);
+                        net.setInputsNames(std::vector<String>{ "A" });
+                        net.setInput(A, "A");
+                        Mat actual = net.forward();
+                        Mat expected = referenceMatMul(A, B, trans_a != 0, alpha);
+
+                        EXPECT_LE(cv::norm(expected, actual, NORM_INF), 2e-5f * std::max(K, 1))
+                            << "M=" << M << ", N=" << N << ", K=" << K
+                            << ", trans_a=" << trans_a << ", alpha=" << alpha;
+                    }
+                }
+            }
+        }
+    }
+}
+
+}} // namespace

--- a/modules/dnn/test/test_fast_gemm.cpp
+++ b/modules/dnn/test/test_fast_gemm.cpp
@@ -30,56 +30,48 @@ static Mat referenceMatMul(const Mat& A, const Mat& B, bool trans_a, float alpha
     return expected;
 }
 
-// Exercises the fastGemmThin path (constant-B MatMul): M covers every register
+// Exercises the fastGemmThin path (constant-B MatMul). M covers every register
 // block width and the multi-block remainder, N covers full strips and partial
 // column tails for any VLEN <= 512.
-TEST(DNN_FastGemmThin, MatMulAccuracy)
+typedef testing::TestWithParam<tuple<int, int, int, int, float>> DNN_FastGemmThin;
+
+TEST_P(DNN_FastGemmThin, MatMulAccuracy)
 {
-    static const int m_values[] = { 1, 2, 3, 4, 5 };
-    static const int k_values[] = { 1, 3, 4, 7, 16, 64 };
-    static const int n_values[] = { 16, 19, 64, 67, 80, 83 };
-    static const float alpha_values[] = { 1.f, -0.5f };
+    int M = get<0>(GetParam()), N = get<1>(GetParam()), K = get<2>(GetParam());
+    int trans_a = get<3>(GetParam());
+    float alpha = get<4>(GetParam());
 
     RNG rng(0x5EED);
-    for (int M : m_values)
-    {
-        for (int N : n_values)
-        {
-            for (int K : k_values)
-            {
-                Mat B(K, N, CV_32F);
-                rng.fill(B, RNG::UNIFORM, -1.f, 1.f);
+    Mat B(K, N, CV_32F);            rng.fill(B, RNG::UNIFORM, -1.f, 1.f);
+    Mat A(trans_a ? K : M, trans_a ? M : K, CV_32F);
+    rng.fill(A, RNG::UNIFORM, -1.f, 1.f);
 
-                for (int trans_a = 0; trans_a <= 1; trans_a++)
-                {
-                    Mat A(trans_a ? K : M, trans_a ? M : K, CV_32F);
-                    rng.fill(A, RNG::UNIFORM, -1.f, 1.f);
+    LayerParams lp;
+    lp.type = "MatMul";
+    lp.name = "thin_matmul";
+    lp.set("transA", trans_a != 0);
+    lp.set("transB", false);
+    lp.set("alpha", alpha);
+    lp.blobs.push_back(B);
 
-                    for (float alpha : alpha_values)
-                    {
-                        LayerParams lp;
-                        lp.type = "MatMul";
-                        lp.name = "thin_matmul";
-                        lp.set("transA", trans_a != 0);
-                        lp.set("transB", false);
-                        lp.set("alpha", alpha);
-                        lp.blobs.push_back(B);
+    Net net;
+    net.addLayerToPrev(lp.name, lp.type, lp);
+    net.setInputsNames(std::vector<String>{ "A" });
+    net.setInput(A, "A");
+    Mat actual = net.forward();
+    Mat expected = referenceMatMul(A, B, trans_a != 0, alpha);
 
-                        Net net;
-                        net.addLayerToPrev(lp.name, lp.type, lp);
-                        net.setInputsNames(std::vector<String>{ "A" });
-                        net.setInput(A, "A");
-                        Mat actual = net.forward();
-                        Mat expected = referenceMatMul(A, B, trans_a != 0, alpha);
-
-                        EXPECT_LE(cv::norm(expected, actual, NORM_INF), 2e-5f * std::max(K, 1))
-                            << "M=" << M << ", N=" << N << ", K=" << K
-                            << ", trans_a=" << trans_a << ", alpha=" << alpha;
-                    }
-                }
-            }
-        }
-    }
+    EXPECT_LE(cv::norm(expected, actual, NORM_INF), 2e-5f * std::max(K, 1))
+        << "M=" << M << ", N=" << N << ", K=" << K
+        << ", trans_a=" << trans_a << ", alpha=" << alpha;
 }
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/, DNN_FastGemmThin, Combine(
+    Values(1, 2, 3, 4, 5),
+    Values(16, 19, 64, 67, 80, 83),
+    Values(1, 3, 4, 7, 16, 64),
+    Values(0, 1),
+    Values(1.f, -0.5f)
+));
 
 }} // namespace


### PR DESCRIPTION
### Summary

`fastGemmThin` is the thin-GEMM path taken by MatMul with a constant 2-D weight
and M <= 12 — the GEMV-like shapes of transformer token generation (M = 1..4
decoded tokens against a K x N projection).

On fixed-width SIMD targets its per-row accumulators live in a
`v_float32 acc[]` array, i.e. in registers. Scalable-vector targets (RISC-V V)
cannot form arrays of sizeless vector types, so the existing
`#elif CV_SIMD_SCALABLE` fallback backs every accumulator with a scalar scratch
buffer and reloads/restores it on every k step. Disassembling the current 5.x
inner loop (riscv64, VLEN=256, LMUL=2) shows the cost directly: **58 `vle32` +
67 `vse32` per 43 `vfmacc`**, with every load stack-relative (`acc_buf`) —
about three vector load/stores per FMA in a loop that should be doing FMAs.

### Implementation

Replace the scratch-buffer fallback with `fast_gemm_thin_block<MR>` (MR = 1..4):
the MR row accumulators are named variables `c0..c3` selected by the
compile-time template constant, so no array of sizeless vectors is needed and
the accumulators stay in registers across the whole K loop. The `if (MR > n)`
guards fold away at compile time (plain C++11, no `if constexpr`). One
`vx_load` of the packed-B strip feeds all MR rows per k step. M <= 4 is a
single register-resident pass; M = 5..12 runs block by block. MR is capped at
4 so the block fits the vector register file at any VLEN.

Scope and safety:
* only the `#elif CV_SIMD_SCALABLE` branch of `fast_gemm_thin_strip` changes;
  the fixed-width (`#if CV_SIMD`) and scalar branches, packing, dispatch,
  eligibility and parallelization are untouched — non-RISC-V builds compile to
  identical code;
* VLEN-agnostic universal intrinsics, no target-specific tuning, and the
  packed-B access pattern is identical to the old code (the change strictly
  removes memory traffic);
* bit-exact: every output column accumulates with the same `v_fma` in the same
  increasing-k order as before.

Tests added:
* accuracy — `DNN_FastGemmThin.MatMulAccuracy`: drives the thin path through
  the public MatMul layer (constant B blob); M = 1..5 covers every block width
  plus the multi-block remainder, N covers full strips and partial column
  tails for any VLEN <= 512, K up to 64, transA and alpha variants; inputs are
  generated in-process (no opencv_extra data needed);
* performance — five token-generation configs (M = 1/2/4 against 768/3072-wide
  projections) in `perf_gemm.cpp`; the existing configs only cover ViT shapes
  (M = 50/197) and never reach this path.

## Performance

Board: SpacemiT K1 (riscv64 rv64gcv, VLEN=256, 8 x 1.6 GHz), performance
governor. Build: `-DCPU_BASELINE=RVV -DRISCV_RVV_SCALABLE=ON`, Release.
Method: official `opencv_perf_dnn --gtest_filter=Gemm*:MatMul*` with
`OPENCV_FORCE_DNN_ENGINE=1`; base = current 5.x, cand = this
patch; identical test binary and dependencies, only `libopencv_dnn.so`
swapped (sha256-verified); runs interleaved base/cand and repeated twice;

Single thread (`--perf_threads=1`), token-generation cases:

|Name of Test|base|cand|cand vs base (x-factor)|
|---|:-:|:-:|:-:|
|matmul::MatMul::(A=[1, 1, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|0.706|0.512|1.38|
|matmul::MatMul::(A=[1, 1, 768], B=[1, 768, 3072], trans_a=0, trans_b=0, OCV/CPU)|3.016|1.919|1.57|
|matmul::MatMul::(A=[1, 1, 3072], B=[1, 3072, 768], trans_a=0, trans_b=0, OCV/CPU)|2.860|1.765|1.62|
|matmul::MatMul::(A=[1, 2, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|1.248|0.596|2.09|
|matmul::MatMul::(A=[1, 4, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|2.600|1.040|2.50|

The second interleaved round reproduces this within noise
(1.32 / 1.51 / 1.50 / 1.97 / 2.43). The gain growing with M matches the
mechanism: the old path spilled M accumulator rows per k step, the new one
spills none. At 8 threads the same cases give 1.01-1.17x — these shapes
saturate memory bandwidth with all cores active.

Control group: the other 33 official configs — ViT-shape MatMul (M = 50/197,
outside the thin path), `Gemm` (MLAS path) and `InnerProduct` (FC path),
including the *same five shapes* through InnerProduct — are all 0.99-1.01x in
both threading modes. The speedup appears exactly and only where the modified
kernel executes.

<details>
<summary>Full single-thread summary.py table (38 tests, ms)</summary>

|Name of Test|base|cand|cand vs base (x-factor)|
|---|:-:|:-:|:-:|
|gemm::Gemm::(A=[50, 768], B=[768, 2304], trans_a=0, trans_b=0, OCV/CPU)|116.143|116.397|1.00|
|gemm::Gemm::(A=[50, 1024], B=[1024, 3072], trans_a=0, trans_b=0, OCV/CPU)|211.562|211.528|1.00|
|gemm::Gemm::(A=[197, 768], B=[768, 2304], trans_a=0, trans_b=0, OCV/CPU)|472.520|471.832|1.00|
|gemm::Gemm::(A=[197, 1024], B=[1024, 3072], trans_a=0, trans_b=0, OCV/CPU)|847.839|848.334|1.00|
|gemm::Gemm::(A=[768, 768], B=[768, 768], C=[768], trans_a=0, trans_b=0, OCV/CPU)|613.622|614.440|1.00|
|gemm::Gemm::(A=[1024, 1024], B=[1024, 1024], C=[1024], trans_a=0, trans_b=0, OCV/CPU)|1481.877|1483.401|1.00|
|innerproduct::Gemm::(A=[50, 768], B=[768, 2304], trans_a=0, trans_b=0, OCV/CPU)|775.144|773.777|1.00|
|innerproduct::Gemm::(A=[50, 1024], B=[1024, 3072], trans_a=0, trans_b=0, OCV/CPU)|2059.299|2059.646|1.00|
|innerproduct::Gemm::(A=[197, 768], B=[768, 2304], trans_a=0, trans_b=0, OCV/CPU)|3066.720|3057.618|1.00|
|innerproduct::Gemm::(A=[197, 1024], B=[1024, 3072], trans_a=0, trans_b=0, OCV/CPU)|8415.979|8414.286|1.00|
|innerproduct::Gemm::(A=[768, 768], B=[768, 768], C=[768], trans_a=0, trans_b=0, OCV/CPU)|3946.510|3940.238|1.00|
|innerproduct::Gemm::(A=[1024, 1024], B=[1024, 1024], C=[1024], trans_a=0, trans_b=0, OCV/CPU)|14617.891|14607.404|1.00|
|innerproduct::MatMul::(A=[1, 1, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|5.260|5.246|1.00|
|innerproduct::MatMul::(A=[1, 1, 768], B=[1, 768, 3072], trans_a=0, trans_b=0, OCV/CPU)|20.849|20.846|1.00|
|innerproduct::MatMul::(A=[1, 1, 3072], B=[1, 3072, 768], trans_a=0, trans_b=0, OCV/CPU)|7.100|7.022|1.01|
|innerproduct::MatMul::(A=[1, 2, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|10.362|10.315|1.00|
|innerproduct::MatMul::(A=[1, 4, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|20.608|20.622|1.00|
|innerproduct::MatMul::(A=[12, 50, 50], B=[12, 50, 64], trans_a=0, trans_b=0, OCV/CPU)|2.745|2.728|1.01|
|innerproduct::MatMul::(A=[12, 50, 64], B=[12, 64, 50], trans_a=0, trans_b=0, OCV/CPU)|2.191|2.208|0.99|
|innerproduct::MatMul::(A=[12, 197, 64], B=[12, 64, 197], trans_a=0, trans_b=0, OCV/CPU)|48.861|48.927|1.00|
|innerproduct::MatMul::(A=[12, 197, 197], B=[12, 197, 64], trans_a=0, trans_b=0, OCV/CPU)|53.441|53.070|1.01|
|innerproduct::MatMul::(A=[16, 50, 50], B=[16, 50, 64], trans_a=0, trans_b=0, OCV/CPU)|3.793|3.780|1.00|
|innerproduct::MatMul::(A=[16, 50, 64], B=[16, 64, 50], trans_a=0, trans_b=0, OCV/CPU)|3.039|3.060|0.99|
|innerproduct::MatMul::(A=[16, 197, 64], B=[16, 64, 197], trans_a=0, trans_b=0, OCV/CPU)|64.953|64.829|1.00|
|innerproduct::MatMul::(A=[16, 197, 197], B=[16, 197, 64], trans_a=0, trans_b=0, OCV/CPU)|71.775|71.261|1.01|
|matmul::MatMul::(A=[1, 1, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|0.706|0.512|1.38|
|matmul::MatMul::(A=[1, 1, 768], B=[1, 768, 3072], trans_a=0, trans_b=0, OCV/CPU)|3.016|1.919|1.57|
|matmul::MatMul::(A=[1, 1, 3072], B=[1, 3072, 768], trans_a=0, trans_b=0, OCV/CPU)|2.860|1.765|1.62|
|matmul::MatMul::(A=[1, 2, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|1.248|0.596|2.09|
|matmul::MatMul::(A=[1, 4, 768], B=[1, 768, 768], trans_a=0, trans_b=0, OCV/CPU)|2.600|1.040|2.50|
|matmul::MatMul::(A=[12, 50, 50], B=[12, 50, 64], trans_a=0, trans_b=0, OCV/CPU)|4.870|4.896|0.99|
|matmul::MatMul::(A=[12, 50, 64], B=[12, 64, 50], trans_a=0, trans_b=0, OCV/CPU)|5.205|5.205|1.00|
|matmul::MatMul::(A=[12, 197, 64], B=[12, 64, 197], trans_a=0, trans_b=0, OCV/CPU)|62.600|62.622|1.00|
|matmul::MatMul::(A=[12, 197, 197], B=[12, 197, 64], trans_a=0, trans_b=0, OCV/CPU)|70.549|70.668|1.00|
|matmul::MatMul::(A=[16, 50, 50], B=[16, 50, 64], trans_a=0, trans_b=0, OCV/CPU)|6.621|6.609|1.00|
|matmul::MatMul::(A=[16, 50, 64], B=[16, 64, 50], trans_a=0, trans_b=0, OCV/CPU)|7.024|7.019|1.00|
|matmul::MatMul::(A=[16, 197, 64], B=[16, 64, 197], trans_a=0, trans_b=0, OCV/CPU)|83.457|83.473|1.00|
|matmul::MatMul::(A=[16, 197, 197], B=[16, 197, 64], trans_a=0, trans_b=0, OCV/CPU)|94.202|94.132|1.00|

</details>

## Correctness

Official `opencv_test_dnn` with official `opencv_extra` testdata on the same
board, filter `*Gemm*:*MatMul*:*FullyConnected*:*InnerProduct*:*Einsum*` plus
the new `DNN_FastGemmThin.MatMulAccuracy`:

* classic engine (`OPENCV_FORCE_DNN_ENGINE=1`): baseline **254/254**, patched
  **254/254**;
* default engine: identical failure lists on both builds (24 pre-existing
  attention-conformance failures) — **zero new failures**.

The kernel is bit-exact with the previous scalable code by construction (same
`v_fma`, same accumulation order), so no tolerance changes were needed
anywhere.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
