### PR TITLE
calib3d: recompute solvePnPRansac inliers against the returned pose 🤖🤖🤖

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -384,10 +384,19 @@ bool solvePnPRansac(InputArray _opoints, InputArray _ipoints,
 
     if(_inliers.needed())
     {
+        // The returned pose is refined on the consensus set, so the RANSAC-stage
+        // inlier mask may disagree with it. Recompute the mask w.r.t. the returned
+        // pose, using the same error metric as the RANSAC stage (see issue #29573).
+        Mat final_model, err;
+        hconcat(rvec, tvec, final_model);
+        cb->computeError(opoints, ipoints, final_model, err);
+        CV_Assert( err.isContinuous() && err.type() == CV_32F && (int)err.total() == npoints );
+        const float* errptr = err.ptr<float>();
+        const float thresh = (float)(param1*param1); // computeError() returns squared distances
         Mat _local_inliers;
         for (int i = 0; i < npoints; ++i)
         {
-            if((int)_mask_local_inliers.at<uchar>(i) != 0) // inliers mask
+            if(errptr[i] <= thresh)
                 _local_inliers.push_back(i);    // output inliers vector
         }
         _local_inliers.copyTo(_inliers);

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -904,6 +904,78 @@ TEST(Calib3d_SolvePnPRansac, bad_input_points_19253)
     EXPECT_TRUE(result);
 }
 
+TEST(Calib3d_SolvePnPRansac, inliers_consistent_with_returned_pose_29573)
+{
+    // The returned pose is refined using the consensus set, so the inlier
+    // indices must be recomputed against the returned pose: every returned
+    // inlier reprojects within the threshold and every point within the
+    // threshold is returned as an inlier.
+
+    Matx33d intrinsics(800.0, 0.0, 640.0,
+                       0.0, 800.0, 480.0,
+                       0.0, 0.0, 1.0);
+    const double threshold = 4.0;
+    RNG rng(20260722);
+
+    for (int iter = 0; iter < 100; iter++)
+    {
+        const int npoints = rng.uniform(6, 10);
+        const int noutliers = rng.uniform(1, 3);
+
+        vector<Point3d> p3d;
+        for (int i = 0; i < npoints; i++)
+            p3d.push_back(Point3d(rng.uniform(-400.0, 400.0), rng.uniform(-400.0, 400.0), rng.uniform(-100.0, 100.0)));
+
+        Mat rvec_gt(3, 1, CV_64FC1), tvec_gt(3, 1, CV_64FC1);
+        for (int i = 0; i < 3; i++)
+            rvec_gt.at<double>(i) = rng.uniform(-0.4, 0.4);
+        tvec_gt.at<double>(0) = rng.uniform(-100.0, 100.0);
+        tvec_gt.at<double>(1) = rng.uniform(-100.0, 100.0);
+        tvec_gt.at<double>(2) = rng.uniform(1200.0, 2000.0);
+
+        vector<Point2d> p2d;
+        projectPoints(p3d, rvec_gt, tvec_gt, intrinsics, noArray(), p2d);
+        for (int i = 0; i < npoints; i++)
+        {
+            p2d[i].x += rng.gaussian(2.0);
+            p2d[i].y += rng.gaussian(2.0);
+        }
+        for (int i = 0; i < noutliers; i++)
+        {
+            int idx = rng.uniform(0, npoints);
+            p2d[idx].x += rng.uniform(30.0, 80.0) * (rng.uniform(0, 2) ? 1 : -1);
+            p2d[idx].y += rng.uniform(30.0, 80.0) * (rng.uniform(0, 2) ? 1 : -1);
+        }
+
+        Mat rvec, tvec;
+        vector<int> inliers;
+        bool result = solvePnPRansac(p3d, p2d, intrinsics, noArray(), rvec, tvec, false,
+                                     100, (float)threshold, 0.999, inliers, SOLVEPNP_ITERATIVE);
+        if (!result)
+            continue;
+
+        vector<Point2d> projected;
+        projectPoints(p3d, rvec, tvec, intrinsics, noArray(), projected);
+        vector<int> expected_inliers;
+        bool near_threshold = false;
+        for (int i = 0; i < npoints; i++)
+        {
+            double err = cv::norm(p2d[i] - projected[i]);
+            // skip borderline scenes: the implementation computes reprojection
+            // errors in single precision, so points essentially on the threshold
+            // may legitimately fall on either side
+            if (std::abs(err - threshold) < 0.05)
+                near_threshold = true;
+            if (err <= threshold)
+                expected_inliers.push_back(i);
+        }
+        if (near_threshold)
+            continue;
+
+        EXPECT_EQ(expected_inliers, inliers) << "iteration " << iter;
+    }
+}
+
 TEST(Calib3d_SolvePnP, input_type)
 {
     Matx33d intrinsics(5.4794130238156129e+002, 0., 2.9835545700043139e+002, 0.,


### PR DESCRIPTION
Fixes #29573

### What

`solvePnPRansac()` refines the final pose on the RANSAC consensus set (`solvePnP` on the inlier subset), returns that **refined** pose — but fills `inliers` from the **hypothesis-stage** mask. The two can disagree, in both directions:

- points are omitted from `inliers` even though they reproject within `reprojectionError` under the returned pose (the issue's reproducer: point 4, error 3.67 < 4.0);
- points are listed in `inliers` even though they reproject **outside** the threshold under the returned pose (e.g. a returned "inlier" with error 4.5 against a threshold of 4.0 — observed with 4.13 on synthetic scenes below).

So the returned inlier set describes a different pose than the one returned.

### Fix

After the final pose is determined, recompute the inlier indices against it, using the same `PnPRansacCallback::computeError()` and the same squared-threshold comparison as the RANSAC stage (`err <= reprojectionError²`, matching `RANSACPointSetRegistrator::findInliers`). In the DLT-fallback path (#19253), where the returned pose *is* the hypothesis model, the recomputed set equals the previous behavior.

The USAC path (`USAC_*` flags) is not touched.

### Evidence

The issue's reproducer triggers on 4.10 but not on the current 4.x by RNG luck; the inconsistency is structural and still present. A sweep of 4000 random synthetic scenes (6–9 points, 1–2 gross outliers, σ=2px noise) against the 4.13.0 wheel produced mismatches within the first 130 scenes, including returned inliers with reprojection errors of 4.05–4.50 against a 4.0 threshold.

### Test

`Calib3d_SolvePnPRansac.inliers_consistent_with_returned_pose_29573` — 100 seeded synthetic scenes; asserts set equality between the returned inliers and the points whose reprojection error under the returned pose is within the threshold (with a small guard band against float/double boundary flips). Before the fix the test fails on multiple iterations; after, it passes.

Local verification: `opencv_test_calib3d --gtest_filter=*SolvePnP*` (all pass; the new test fails on unpatched source, passes on patched).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
