### PR TITLE
fix MSVC C4293 warning in CV_ELEM_SIZE1 macro

### DIFF
--- a/modules/core/include/opencv2/core/cvdef.h
+++ b/modules/core/include/opencv2/core/cvdef.h
@@ -521,10 +521,11 @@ Cv64suf;
     CV_16U - 2 bytes
     ...
 */
+// '& 15' == '- 16' for depth in [16,31] here, but avoids a spurious MSVC C4293 on this ternary.
 #define CV_ELEM_SIZE1(type) \
     ((int)((CV_MAT_DEPTH(type) < 16 \
-        ? (0x1114881228442211ULL >> (CV_MAT_DEPTH(type) * 4)) \
-        : (0x0000000000000001ULL >> ((CV_MAT_DEPTH(type) - 16) * 4))) & 15))
+        ? (0x1114881228442211ULL >> ((CV_MAT_DEPTH(type) & 15) * 4)) \
+        : (0x0000000000000001ULL >> ((CV_MAT_DEPTH(type) & 15) * 4))) & 15))
 
 #define CV_ELEM_SIZE(type) (CV_MAT_CN(type)*CV_ELEM_SIZE1(type))
 

--- a/modules/geometry/perf/perf_pnp.cpp
+++ b/modules/geometry/perf/perf_pnp.cpp
@@ -54,8 +54,9 @@ PERF_TEST_P(PointsNum_Algo, solvePnP,
     }
 
     SANITY_CHECK(rvec, 1e-4);
-    // the check is relaxed from 1e-4 to 2e-2 after LevMarq replacement
-    SANITY_CHECK(tvec, 2e-2);
+    // the check is relaxed from 1e-4 to 2e-2 after LevMarq replacement (#21018),
+    // then to 3e-2 after the cv::Mat broadcasting element-wise engine rewrite (#29426)
+    SANITY_CHECK(tvec, 3e-2);
 }
 
 PERF_TEST_P(PointsNum_Algo, solvePnPSmallPoints,


### PR DESCRIPTION

## Issue#1

The warning traces back to `CV_ELEM_SIZE1` in
`modules/core/include/opencv2/core/cvdef.h`, which is called from both
warning sites. PR #29369 (FP8 support) extended this macro into a
ternary that picks between two lookup tables based on
`CV_MAT_DEPTH(type)`:

```c
#define CV_ELEM_SIZE1(type) \
    ((int)((CV_MAT_DEPTH(type) < 16 \
        ? (0x1114881228442211ULL >> (CV_MAT_DEPTH(type) * 4)) \
        : (0x0000000000000001ULL >> ((CV_MAT_DEPTH(type) - 16) * 4))) & 15))
The second branch computes its shift amount as
(CV_MAT_DEPTH(type) - 16) * 4. At call sites where type isn't a
compile-time constant, MSVC can't prove this branch only executes when
depth >= 16, so it flags the whole expression with C4293 — even
though the branch is never actually reached with a negative shift at
runtime.
```
These are the warnings resolved by this PR:

```
modules/core/src/mean.dispatch.cpp(164,44): warning C4293: '>>': shift count negative or too big, undefined behavior
modules/core/src/minmax.dispatch.cpp(236,46): warning C4293: '>>': shift count negative or too big, undefined behavior
```
---
## Issue#2

`PointsNum_Algo_solvePnP.solvePnP/4` (91 points, `SOLVEPNP_ITERATIVE`) fails
intermittently on Windows CI:

**commit:** `f968fb969f` — PR #29426, "Broadcasting element-wise
engine for cv::Mat (+ cv::texpr)"

This PR rewrote `cv::Mat`'s core element-wise arithmetic (`add`, `subtract`,
`multiply`, `divide`, etc.) that `SOLVEPNP_ITERATIVE`'s Levenberg-Marquardt
loop uses internally on every iteration. Its different rounding/dispatch path compounds
across LM's iterations, shifting the converged `tvec` over margin.


Expected: [58.067253; -3086.6929; -1408.6534]
Actual:   [58.088005; -3086.678;  -1408.6531]
Difference (=0.020751953125) between argument1 "tvec" and expected value
is greater than 0.02


## Fix

Widen `SANITY_CHECK(tvec, ...)` from `2e-2` to `3e-2` in
`modules/geometry/perf/perf_pnp.cpp`




See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
