### PR TITLE
core(test): fix unbalanced GCC diagnostic pragma suppressing -Warray-bounds #22218 🤖🤖🤖

### DIFF
--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -601,7 +601,7 @@ static void setValue(SparseMat& M, const int* idx, double value, RNG& rng)
         CV_Error(cv::Error::StsUnsupportedFormat, "");
 }
 
-#if defined(__GNUC__) && (__GNUC__ >= 11)
+#if defined(__GNUC__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
 #endif
@@ -628,7 +628,7 @@ struct InitializerFunctor5D{
     }
 };
 
-#if defined(__GNUC__) && (__GNUC__ == 11 || __GNUC__ == 12)
+#if defined(__GNUC__)
 #pragma GCC diagnostic pop
 #endif
 


### PR DESCRIPTION
Resolves #22218.

### Problem
The `-Warray-bounds` suppression added around `InitializerFunctor` / `InitializerFunctor5D` in `modules/core/test/test_mat.cpp` uses **mismatched version guards**:

```cpp
#if defined(__GNUC__) && (__GNUC__ >= 11)          // push
...
#if defined(__GNUC__) && (__GNUC__ == 11 || __GNUC__ == 12)   // pop
```

- **GCC >= 13**: `push` fires but `pop` does not, so the `-Warray-bounds` *ignore* leaks past the functors into the rest of `test_mat.cpp`, hiding genuine warnings.
- **GCC <= 10** (the GCC 10.2 in the original report): neither guard fires, so the warning is **not suppressed** and the build still emits it — which is why the issue is still reproducible.

The warning itself is a false positive, as diagnosed by @asmorkalov in the thread: `rowCall2()` (the 2D path, whose `Index` union has `body[2]`) is *instantiated but never called* for the 3D/5D test matrices, yet the compiler cannot prove it and flags the functors reading `idx[2..4]`.

### Fix
Make the `push`/`pop` guards symmetric with `#if defined(__GNUC__)`, so the suppression is always balanced and also covers GCC 10 and Clang.

### Testing
- `-DBUILD_LIST=core,ts -DBUILD_TESTS=ON`, `CMAKE_BUILD_TYPE=Release`, `opencv_test_core` builds clean (AppleClang 17).
- `Core_Array.basic_operations` (which exercises `cv::Mat::forEach` via both functors) passes.
- The guard imbalance is preprocessor-provable: for `__GNUC__ == 15` the old `push` condition is true while the old `pop` condition is false; the new guards evaluate identically.

This is a build-diagnostic correctness fix in a test file; no new runtime test is added because the existing `Core_Array.basic_operations` already covers the `forEach` behavior and there is no runtime behavior change.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original bug report and related work (#22218)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (n/a — build-diagnostic fix; existing `Core_Array.basic_operations` covers `forEach`)
- [x] The feature is well documented and sample code can be built with the project CMake