### PR TITLE
objdetect: fix out-of-bounds write in HOG gaussian weights #23580 🤖🤖🤖

### DIFF
--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -723,7 +723,7 @@ void HOGCache::init(const HOGDescriptor* _descriptor,
     #if CV_SIMD128
         idx = v_float32x4(0.0f, 1.0f, 2.0f, 3.0f);
 
-        for (; j <= blockSize.height - 4; j += 4)
+        for (; j <= blockSize.width - 4; j += 4)
         {
             v_float32x4 t = v_sub(idx, _bw);
             t = v_mul(t, t);

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -1364,4 +1364,22 @@ TEST(Objdetect_CascadeDetector, small_img)
     }
 }
 
+// See https://github.com/opencv/opencv/issues/23580
+// HOGDescriptor::compute() overflowed the gaussian weights buffer when the block
+// was taller than it was wide: the SIMD store loop for the width buffer (_dj) was
+// bounded by blockSize.height instead of blockSize.width. The block is chosen wide
+// enough that the buffer is heap allocated, so the overflow is a real out-of-bounds
+// write. "Done" is simply that compute() runs without crashing.
+TEST(Objdetect_HOGDescriptor, issue_23580_tall_block_no_overflow)
+{
+    Size winSize(272, 2048); // height > width, width > AutoBuffer stack size
+    HOGDescriptor hog(winSize, /*blockSize*/ winSize, /*blockStride*/ Size(8, 8),
+                      /*cellSize*/ Size(8, 8), /*nbins*/ 9);
+
+    Mat src(winSize, CV_8UC1, Scalar::all(0));
+    std::vector<float> descriptors;
+    ASSERT_NO_THROW(hog.compute(src, descriptors));
+    EXPECT_FALSE(descriptors.empty());
+}
+
 }} // namespace


### PR DESCRIPTION
Resolves #23580.

### Problem
In `HOGCache::init` (`modules/objdetect/src/hog.cpp`) the block gaussian weights are computed into two separate buffers:

```cpp
AutoBuffer<float> di(blockSize.height), dj(blockSize.width);
```

The vectorized (`CV_SIMD128`) loop that fills `dj` (the **width**-sized buffer) was bounded by `blockSize.height`:

```cpp
for (; j <= blockSize.height - 4; j += 4)   // wrong bound
{
    ...
    v_store(_dj + j, t);                     // dj has blockSize.width elements
}
```

When the block is **taller than it is wide**, `v_store(_dj + j, ...)` writes past the end of `dj`, causing a heap buffer overflow / access violation. This reproduces with the reporter's `HOGDescriptor` whose window is `198x281` (block `192x280`), and the `2399x2400` case they cite.

### Fix
Bound the `dj` loop by `blockSize.width` so it matches the buffer size and the scalar tail loop. This is a one-token copy/paste fix and keeps the SIMD path (the workaround suggested in the issue disabled vectorization instead).

### Testing
Added `Objdetect_HOGDescriptor.issue_23580_tall_block_no_overflow`, which computes a HOG descriptor with a tall block (`272x2048`, wide enough that `dj` is heap-allocated).

- With the fix: `opencv_test_objdetect` builds and the test passes (Release and Debug).
- Without the fix, under AddressSanitizer, the test fails with:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... WRITE of size 16
    #1 cv::HOGCache::init(...) hog.cpp:731
    #4 cv::HOGDescriptor::compute(...) hog.cpp:1484
```

confirming the overflow is on the real `HOGDescriptor::compute` path. The fix makes ASan clean.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original bug report and related work (#23580)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (regression test added; no external data needed)
- [x] The feature is well documented and sample code can be built with the project CMake