### PR TITLE
highgui: expose saveWindowParameters and loadWindowParameters to Python

### DIFF
--- a/modules/highgui/include/opencv2/highgui.hpp
+++ b/modules/highgui/include/opencv2/highgui.hpp
@@ -739,7 +739,7 @@ location of the window windowName.
 
 @param windowName Name of the window.
  */
-CV_EXPORTS void saveWindowParameters(const String& windowName);
+CV_EXPORTS_W void saveWindowParameters(const String& windowName);
 
 /** @brief Loads parameters of the specified window.
 
@@ -748,7 +748,7 @@ location of the window windowName.
 
 @param windowName Name of the window.
  */
-CV_EXPORTS void loadWindowParameters(const String& windowName);
+CV_EXPORTS_W void loadWindowParameters(const String& windowName);
 
 CV_EXPORTS  int startLoop(int (*pt2Func)(int argc, char *argv[]), int argc, char* argv[]);
 

--- a/modules/highgui/misc/python/test/test_window_parameters.py
+++ b/modules/highgui/misc/python/test/test_window_parameters.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+from __future__ import print_function
+
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+class window_parameters_test(NewOpenCVTests):
+
+    def test_save_load_window_parameters(self):
+        window_name = "test_save_load_window_parameters"
+        try:
+            cv.namedWindow(window_name, cv.WINDOW_NORMAL)
+        except cv.error:
+            self.skipTest("No GUI backend available in this build/environment")
+
+        try:
+            # Should not raise when the library is built with a backend that
+            # supports persisting window state (currently: Qt).
+            cv.saveWindowParameters(window_name)
+            cv.loadWindowParameters(window_name)
+        except cv.error as e:
+            # Expected on builds without Qt support (see NO_QT_ERR_MSG in window.cpp)
+            self.skipTest("saveWindowParameters/loadWindowParameters require the Qt "
+                           "highgui backend: " + str(e))
+        finally:
+            cv.destroyWindow(window_name)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/highgui/misc/python/test/test_window_parameters.py
+++ b/modules/highgui/misc/python/test/test_window_parameters.py
@@ -1,6 +1,16 @@
 #!/usr/bin/env python
 from __future__ import print_function
 
+import os
+
+# Force Qt's headless-safe platform plugin when nothing else is already
+# configured. Without this, namedWindow() on a Qt-enabled build with no
+# display server available (e.g. CI workers, which do not run the Python
+# test suite under a virtual framebuffer) aborts the whole process instead
+# of raising a catchable exception -- so this must be set *before* the
+# first GUI call, and a plain try/except around namedWindow is not enough.
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
 import cv2 as cv
 
 from tests_common import NewOpenCVTests


### PR DESCRIPTION
### What
`cv::saveWindowParameters` and `cv::loadWindowParameters` (`modules/highgui/include/opencv2/highgui.hpp`) persist/restore a window's size, position, flags, trackbar values, and zoom/pan state on the Qt highgui backend. Both are fully implemented and documented, take only a plain `String`, but are declared `CV_EXPORTS` instead of `CV_EXPORTS_W` and are therefore unreachable from `cv2`.

This is the same category of gap as historical issue #4678 (exposing `displayOverlay`/`displayStatusBar`, which are already `CV_EXPORTS_W` in this header) — this PR closes the same gap for the two window-parameter-persistence functions. Practical use case: Python scripts building trackbar-based tuning UIs (very common OpenCV pattern) currently have no way to persist slider/window state between runs.

### Testing
Added `modules/highgui/misc/python/test/test_window_parameters.py`. Since these functions require the Qt highgui backend (and a real window), the test:
- creates a window, calls `saveWindowParameters`/`loadWindowParameters`,
- and gracefully skips (rather than fails) if no GUI backend or no Qt support is available, mirroring how other environment-dependent tests in this suite (e.g. CUDA) already skip.

Verified locally end-to-end:
- Built `opencv_python3` from this branch (`WITH_QT=OFF` in this environment); confirmed `cv2.saveWindowParameters` / `cv2.loadWindowParameters` are present on the built module.
- Calling them correctly raises the existing "The library is compiled without QT support" error (same `NO_QT_ERR_MSG` path already used by sibling Qt-only functions), proving the binding reaches the C++ implementation correctly end-to-end. A Qt-enabled build would exercise the non-error path via the same mechanism already trusted for `displayOverlay`/`displayStatusBar`.

### PR checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.
- [x] The PR is proposed to the proper branch (5.x).
- [x] Test included (see above), with an environment-aware skip since it depends on the Qt backend.
- [x] The feature is already documented (existing Doxygen comments); no sample code changes needed since this is a direct binding-generator addition.