### PR TITLE
imgproc: accept CV_Bool masks in distanceTransform 🤖🤖🤖

### DIFF
--- a/modules/imgproc/src/distransform.cpp
+++ b/modules/imgproc/src/distransform.cpp
@@ -957,8 +957,6 @@ static void distanceTransform_L1_8U(InputArray _src, OutputArray _dst)
 
     Mat src = _src.getMat();
 
-    // CV_Bool is a 1-byte mask type (added in 5.0) and is only ever zero-tested
-    // here, so accept it wherever a CV_8UC1 mask was accepted. See #29596.
     CV_Assert( src.type() == CV_8UC1 || src.type() == CV_BoolC1);
 
     _dst.create( src.size(), CV_8UC1);
@@ -980,8 +978,6 @@ void cv::distanceTransform( InputArray _src, OutputArray _dst, OutputArray _labe
     Mat src = _src.getMat(), labels;
     bool need_labels = _labels.needed();
 
-    // CV_Bool is a 1-byte mask type (added in 5.0) and is only ever zero-tested
-    // here, so accept it wherever a CV_8UC1 mask was accepted. See #29596.
     CV_Assert( src.type() == CV_8UC1 || src.type() == CV_BoolC1);
 
     _dst.create( src.size(), CV_32F);

--- a/modules/imgproc/src/distransform.cpp
+++ b/modules/imgproc/src/distransform.cpp
@@ -830,7 +830,7 @@ trueDistTrans( const Mat& src, Mat& dst )
 
     CV_Assert( src.size() == dst.size() );
 
-    CV_Assert( src.type() == CV_8UC1 && dst.type() == CV_32FC1 );
+    CV_Assert( (src.type() == CV_8UC1 || src.type() == CV_BoolC1) && dst.type() == CV_32FC1 );
     int i, m = src.rows, n = src.cols;
 
     cv::AutoBuffer<uchar> _buf(std::max(m*2*sizeof(int) + (m*3+1)*sizeof(int), n*2*sizeof(float)));
@@ -886,7 +886,7 @@ distanceATS_L1_8u( const Mat& src, Mat& dst )
     int srcstep = (int)src.step;
     int dststep = (int)dst.step;
 
-    CV_Assert( src.type() == CV_8UC1 && dst.type() == CV_8UC1 );
+    CV_Assert( (src.type() == CV_8UC1 || src.type() == CV_BoolC1) && dst.type() == CV_8UC1 );
     CV_Assert( src.size() == dst.size() );
 
     ////////////////////// forward scan ////////////////////////
@@ -957,7 +957,9 @@ static void distanceTransform_L1_8U(InputArray _src, OutputArray _dst)
 
     Mat src = _src.getMat();
 
-    CV_Assert( src.type() == CV_8UC1);
+    // CV_Bool is a 1-byte mask type (added in 5.0) and is only ever zero-tested
+    // here, so accept it wherever a CV_8UC1 mask was accepted. See #29596.
+    CV_Assert( src.type() == CV_8UC1 || src.type() == CV_BoolC1);
 
     _dst.create( src.size(), CV_8UC1);
     Mat dst = _dst.getMat();
@@ -978,7 +980,9 @@ void cv::distanceTransform( InputArray _src, OutputArray _dst, OutputArray _labe
     Mat src = _src.getMat(), labels;
     bool need_labels = _labels.needed();
 
-    CV_Assert( src.type() == CV_8UC1);
+    // CV_Bool is a 1-byte mask type (added in 5.0) and is only ever zero-tested
+    // here, so accept it wherever a CV_8UC1 mask was accepted. See #29596.
+    CV_Assert( src.type() == CV_8UC1 || src.type() == CV_BoolC1);
 
     _dst.create( src.size(), CV_32F);
     Mat dst = _dst.getMat();

--- a/modules/imgproc/test/test_distancetransform.cpp
+++ b/modules/imgproc/test/test_distancetransform.cpp
@@ -209,4 +209,49 @@ TEST(Imgproc_DistanceTransform, ipp_deterministic)
     }
 }
 
+// See https://github.com/opencv/opencv/issues/29596
+// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x, so
+// distanceTransform started rejecting boolean masks. CV_Bool is a 1-byte type
+// whose values are only ever zero-tested here, so the result must match the one
+// produced by an equivalent CV_8UC1 mask.
+TEST(Imgproc_DistanceTransform, bool_mask_29596)
+{
+    Mat_<bool> mask(7, 7, true);
+    mask(3, 3) = false;
+    mask(0, 6) = false;
+
+    Mat_<uchar> ref(7, 7, (uchar)255);
+    ref(3, 3) = 0;
+    ref(0, 6) = 0;
+
+    ASSERT_EQ(mask.depth(), CV_Bool);
+
+    // CV_32F output: 3x3 and 5x5 kernels, plus the precise (trueDistTrans) path
+    const int maskSizes[] = { DIST_MASK_3, DIST_MASK_5, DIST_MASK_PRECISE };
+    for (size_t i = 0; i < sizeof(maskSizes)/sizeof(maskSizes[0]); i++)
+    {
+        Mat dist_bool, dist_ref;
+        ASSERT_NO_THROW(distanceTransform(mask, dist_bool, DIST_L2, maskSizes[i]));
+        distanceTransform(ref, dist_ref, DIST_L2, maskSizes[i]);
+        EXPECT_EQ(cv::norm(dist_bool, dist_ref, NORM_INF), 0) << "maskSize = " << maskSizes[i];
+    }
+
+    // CV_8U output path (distanceTransform_L1_8U -> distanceATS_L1_8u)
+    {
+        Mat dist_bool, dist_ref;
+        ASSERT_NO_THROW(distanceTransform(mask, dist_bool, DIST_L1, DIST_MASK_3, CV_8U));
+        distanceTransform(ref, dist_ref, DIST_L1, DIST_MASK_3, CV_8U);
+        EXPECT_EQ(cv::norm(dist_bool, dist_ref, NORM_INF), 0);
+    }
+
+    // labels overload
+    {
+        Mat dist_bool, labels_bool, dist_ref, labels_ref;
+        ASSERT_NO_THROW(distanceTransform(mask, dist_bool, labels_bool, DIST_L2, DIST_MASK_5));
+        distanceTransform(ref, dist_ref, labels_ref, DIST_L2, DIST_MASK_5);
+        EXPECT_EQ(cv::norm(dist_bool, dist_ref, NORM_INF), 0);
+        EXPECT_EQ(cv::norm(labels_bool, labels_ref, NORM_INF), 0);
+    }
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Closes #29596.

## Problem

`cv::Mat_<bool>::depth()` returns `CV_Bool` in 5.0, where it returned `CV_8U` in 4.x. `distanceTransform` therefore rejects boolean masks that worked in 4.x:

```
error: (-215:Assertion failed) src.type() == CV_8UC1 in function 'distanceTransform'
```

This contradicts the [4→5 migration guide](https://github.com/opencv/opencv/wiki/OpenCV-4-to-5-migration#new-data-types), which states that `CV_Bool` matrices can be used as masks wherever a `CV_8U` or `CV_8S` mask was previously accepted.

## Change

`CV_Bool` is a 1-byte type (`CV_ELEM_SIZE1(CV_Bool) == 1`) and every read of `src` on these paths is a plain zero-test (`if (!s[j])`, `srcptr[j] == 0`, `sbase[0] == 0 ? 0 : 255`), never a use of the stored value. So a `CV_Bool` mask is byte-compatible and semantically identical to a `CV_8UC1` mask here.

The type checks are relaxed to accept `CV_BoolC1`, following the existing convention in `accum.cpp`, `histogram.cpp`, `homography_decomp.cpp`, `levmarq.cpp`, `ptsetreg.cpp` and the recently merged #29580.

The issue only names the assert at `distransform.cpp:981`, but there are **four** reachable type checks; relaxing only the reported one moves the failure deeper instead of fixing it:

| Location | Reached via |
|---|---|
| `cv::distanceTransform` (public wrapper) | all calls |
| `distanceTransform_L1_8U` | `DIST_L1` + `dstType == CV_8U` |
| `trueDistTrans` | `DIST_MASK_PRECISE` |
| `distanceATS_L1_8u` | `DIST_L1` + `dstType == CV_8U` |

## Testing

Added `Imgproc_DistanceTransform.bool_mask_29596`, which exercises all four paths and asserts the `CV_Bool` result is identical to the equivalent `CV_8UC1` mask result (float output for `DIST_MASK_3`/`5`/`PRECISE`, the `CV_8U` output path, and the labels overload).

Verified against a local build (Ninja + MinGW-w64 g++ 15.2, `BUILD_LIST=imgproc,ts,imgcodecs`):

- The new test **fails without the source change**, reproducing exactly the assertion from the report (`distransform.cpp:981: (-215:Assertion failed) src.type() == CV_8UC1`), and passes with it.
- Full `opencv_test_imgproc` suite (1592 tests): no new failures. 5 pre-existing failures (`Imgproc_AdaptiveThreshold.*`, `GaussianBlur_Bitexact.regression_9863`) reproduce identically on unmodified `5.x` in this environment and are unrelated to this change.

No `opencv_extra` data is needed — the test builds its masks in-code.

---

_Authored with AI assistance, tagged per the note in the PR template. All claims above were verified empirically against a local build rather than assumed; the accompanying analysis (1-byte element size, zero-test-only usage, and the four reachable assert sites) was checked directly against the source._