### PR TITLE
objdetect: fix out-of-bounds read in HOG detect for images smaller than the window #8793 🤖🤖🤖

### DIFF
--- a/modules/objdetect/src/hog.cpp
+++ b/modules/objdetect/src/hog.cpp
@@ -1147,6 +1147,11 @@ void HOGCache::normalizeBlockHistogram(float* _hist) const
 
 Size HOGCache::windowsInImage(const Size& imageSize, const Size& winStride) const
 {
+    // The window does not fit into the (padded) image even once: report zero
+    // windows instead of a negative count, which the callers store in a size_t.
+    if( imageSize.width < winSize.width || imageSize.height < winSize.height )
+        return Size(0, 0);
+
     return Size((imageSize.width - winSize.width)/winStride.width + 1,
         (imageSize.height - winSize.height)/winStride.height + 1);
 }

--- a/modules/objdetect/test/test_cascadeandhog.cpp
+++ b/modules/objdetect/test/test_cascadeandhog.cpp
@@ -1382,4 +1382,43 @@ TEST(Objdetect_HOGDescriptor, issue_23580_tall_block_no_overflow)
     EXPECT_FALSE(descriptors.empty());
 }
 
+// See https://github.com/opencv/opencv/issues/8793
+// When the image is smaller than the detection window even after padding,
+// HOGCache::windowsInImage() returned a negative number of window rows. Its area()
+// is negative and the callers keep it in a size_t, so the window loop of
+// HOGDescriptor::detect() ran ~2^64 times and read far outside the gradient
+// buffers (AddressSanitizer: heap-buffer-overflow read in HOGCache::getBlock).
+// 77x101 with padding 8x8 gives a padded size of 93x117, which is lower than the
+// 64x128 default window; padding 32x32 makes the window fit again.
+TEST(Objdetect_HOGDescriptor, issue_8793_small_image_no_out_of_bounds)
+{
+    HOGDescriptor hog;
+    hog.setSVMDetector(HOGDescriptor::getDefaultPeopleDetector());
+
+    Mat img(101, 77, CV_8UC3);
+    randu(img, Scalar::all(0), Scalar::all(255));
+
+    std::vector<Rect> found;
+    std::vector<double> weights;
+    ASSERT_NO_THROW(hog.detectMultiScale(img, found, weights, 0, Size(4, 4), Size(8, 8),
+                                         1.05, 2.0, true));
+    EXPECT_TRUE(found.empty()); // no window fits, so there is nothing to detect
+
+    // compute() takes the same window count, where it ended up in resize()
+    std::vector<float> descriptors;
+    ASSERT_NO_THROW(hog.compute(img, descriptors, Size(4, 4), Size(8, 8)));
+    EXPECT_TRUE(descriptors.empty());
+
+    // one side alone being smaller than the window is enough
+    Mat narrow(300, 40, CV_8UC3);
+    randu(narrow, Scalar::all(0), Scalar::all(255));
+    ASSERT_NO_THROW(hog.detectMultiScale(narrow, found, weights, 0, Size(4, 4), Size(8, 8),
+                                         1.05, 2.0, false));
+    EXPECT_TRUE(found.empty());
+
+    // Padding large enough to fit the window still goes through the regular path.
+    ASSERT_NO_THROW(hog.detectMultiScale(img, found, weights, 0, Size(4, 4), Size(32, 32),
+                                         1.05, 2.0, true));
+}
+
 }} // namespace


### PR DESCRIPTION
Resolves #8793.

Follow-up to #29583, which fixed a *different* HOG overflow (an out-of-bounds **write** in `HOGCache::init`, hog.cpp:731). As @asmorkalov [reported](https://github.com/opencv/opencv/issues/8793#issuecomment-5077525972), the reporter's case is still broken after that fix — it is an out-of-bounds **read** in `HOGCache::getBlock` (hog.cpp:921) with a different root cause.

### Problem

`HOGCache::windowsInImage()` computes the number of detection windows per axis:

```cpp
return Size((imageSize.width  - winSize.width )/winStride.width  + 1,
            (imageSize.height - winSize.height)/winStride.height + 1);
```

When the padded image is smaller than the detection window, the difference is negative, so the returned `Size` has a negative dimension and `Size::area()` is negative. All three callers (`HOGDescriptor::compute()`, `::detect()`, `::detectROI()`) store it in a `size_t`, so it wraps to a huge window count and the window loop walks far outside the gradient/angle buffers.

The reported repro (77x101 image, `padding=(8,8)`, default 64x128 window), instrumented:

```
img=77x101 padded=93x117 win=64x128 stride=4x4 -> windowsInImage=8x-1 area=-8
   -> nwindows=18446744073709551608
```

which is exactly the reported ASan failure (reproduced locally on the image attached to the issue):

```
ERROR: AddressSanitizer: heap-buffer-overflow READ of size 1
    #0 cv::HOGCache::getBlock(cv::Point_<int>, float*) hog.cpp:921
    #1 cv::HOGDescriptor::detect(...) hog.cpp:1592
    #2 cv::HOGInvoker::operator()(cv::Range const&) const hog.cpp:1681
    #5 cv::HOGDescriptor::detectMultiScale(...) hog.cpp:1934
```

`padding=(16,16)` works because the padded image (109x133) is then tall enough to hold the 64x128 window, which is why the reporter saw the crash depend on the padding value.

### Fix

Return an empty `Size` when the window does not fit into the (padded) image. This is the case `detectMultiScale()` already expects: it pushes the current pyramid level *before* checking that the image is still larger than the window, so the last level may legitimately be smaller than the window and must simply yield no detections. For every image that does fit at least one window the returned value is bit-identical to before, so no detection result changes.

### Testing

Added `Objdetect_HOGDescriptor.issue_8793_small_image_no_out_of_bounds` (next to the #23580 regression test), using the reported geometry: a 77x101 image with `padding=(8,8)` must produce no detections, `compute()` on it must return no descriptors, an image that is too small in one dimension only must be handled too, and the same image with `padding=(32,32)` must still go through the regular detection path.

I also went through the other entry points that use the same window count. Before the fix, 9 of 18 configurations of a too-small image failed: `detectMultiScale()` (padding 0/8/16, both `CV_8UC1` and `CV_8UC3`, 1x1 image), `detect()` without locations, and the padded size landing just below the window (e.g. 46x110 with `padding=(8,8)` -> 62x126) all give the ASan report above; `compute()` throws `std::length_error` from `descriptors.resize(dsize*nwindows)`; and an image that is too narrow but tall enough fails a `Mat` bounds assert in `blockCacheFlags` (an unchecked write in a release build). `detect()`/`compute()` with explicit locations, `detectROI()` and `detectMultiScaleROI()` were already safe - their location check rejects every window. All 18 are clean with this patch.

- Without the fix, under AddressSanitizer, the new test reproduces the report above (`heap-buffer-overflow READ ... hog.cpp:921`).
- With the fix ASan is clean, and the existing HOG tests (`Objdetect_HOGDetector.regression`, `Objdetect_HOGDetector_Strict.accuracy`, `Objdetect_HOGDetectorReadWrite.regression`) still pass against `opencv_extra` test data, also under ASan.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original bug report and related work (#8793, #29583)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (regression test added; no external data needed)
- [x] The feature is well documented and sample code can be built with the project CMake
