### PR TITLE
video: fix out-of-bounds read in DISOpticalFlow with patch_size larger than the border #20185 🤖🤖🤖

### DIFF
--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -244,6 +244,11 @@ void DISOpticalFlowImpl::prepareBuffers(Mat &I0, Mat &I1, Mat &flow, bool use_fl
 {
     CV_INSTRUMENT_REGION();
 
+    /* The inverse search may place a patch up to patch_size - 1 pixels outside of I1,
+       so the border of I1s_ext has to be at least patch_size wide for the search limits
+       in PatchInverseSearch to stay inside the buffer. patch_size is user controlled. */
+    border_size = max(16, patch_size);
+
     I0s.resize(coarsest_scale + 1);
     I1s.resize(coarsest_scale + 1);
     I1s_ext.resize(coarsest_scale + 1);
@@ -1219,6 +1224,9 @@ void DISOpticalFlowImpl::ocl_prepareBuffers(UMat &I0, UMat &I1, InputArray flow,
 {
     CV_INSTRUMENT_REGION();
     // not pure OpenCV code: CV_INSTRUMENT_REGION_OPENCL();
+
+    /* See prepareBuffers(): the border has to be at least patch_size wide. */
+    border_size = max(16, patch_size);
 
     u_I0s.resize(coarsest_scale + 1);
     u_I1s.resize(coarsest_scale + 1);

--- a/modules/video/test/test_OF_accuracy.cpp
+++ b/modules/video/test/test_OF_accuracy.cpp
@@ -197,4 +197,35 @@ TEST(DenseOpticalFlow_DIS, ManualCoarsestScale)
     EXPECT_EQ(dis->getCoarsestScale(), -1);
 }
 
+// See https://github.com/opencv/opencv/issues/20185
+// DISOpticalFlow pads I1 with a fixed 16 pixel border, while the search limits in
+// PatchInverseSearch let a patch hang up to patch_size - 1 pixels outside of the image.
+// With a patch larger than the border, the clamped position is itself outside of the
+// padded buffer and computeSSD*() reads out of bounds (AddressSanitizer:
+// heap-buffer-overflow in cv::computeSSDMeanNorm). Here the search is pushed against
+// those limits with an initial flow field larger than the border; "done" is that calc()
+// does not read out of bounds and returns a flow field of the expected size.
+TEST(DenseOpticalFlow_DIS, regression_20185_patch_larger_than_border)
+{
+    Mat prev(240, 320, CV_8UC1), next(240, 320, CV_8UC1);
+    RNG rng(42);
+    rng.fill(prev, RNG::UNIFORM, 0, 256);
+    rng.fill(next, RNG::UNIFORM, 0, 256);
+
+    Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
+    dis->setPatchStride(10);
+
+    // flow of the previous frame pair, used as a temporal candidate; it is larger than
+    // the border, so the patch search is pushed against its limits
+    Mat flow(prev.size(), CV_32FC2, Scalar(60.f, 60.f));
+    ASSERT_NO_THROW(dis->calc(prev, next, flow)); // default patch size, fits the border
+    EXPECT_EQ(flow.size(), prev.size());
+
+    // the padded buffers have to be re-created when the patch grows past the border
+    dis->setPatchSize(25);
+    flow.setTo(Scalar(60.f, 60.f));
+    ASSERT_NO_THROW(dis->calc(prev, next, flow));
+    EXPECT_EQ(flow.size(), prev.size());
+}
+
 }} // namespace


### PR DESCRIPTION
Resolves #20185.

### Problem

`DISOpticalFlowImpl` pads `I1` of every pyramid level with a **fixed 16 pixel border** (`border_size`), while `PatchInverseSearch` clamps the position of a patch to

```cpp
float i_lower_limit = bsz - psz + 1.0f;   // bsz = border_size, psz = patch_size
float i_upper_limit = bsz + dis->h - 1.0f;
```

i.e. a patch may hang up to `patch_size - 1` pixels outside of the image. `computeSSD()` / `computeSSDMeanNorm()` then read `patch_size + 1` rows and columns starting at that position, which stays inside the padded buffer **only while `patch_size <= border_size`**.

With a larger patch — the reporter used `setPatchSize(25)` — the clamped position itself is outside of the buffer (the lower limit becomes `16 - 25 + 1 = -8`, and the upper limit lets the last read row reach `h + 2*bsz + 8`), so the SSD loop reads out of bounds. This is the overflow @asmorkalov reported in the issue; reproduced locally on 4.x:

```
ERROR: AddressSanitizer: heap-buffer-overflow READ of size 1
    #0 cv::computeSSDMeanNorm(...) dis_flow.cpp:755
    #1 cv::DISOpticalFlowImpl::PatchInverseSearch_ParBody::operator()(cv::Range const&) const dis_flow.cpp:894
    #5 cv::DISOpticalFlowImpl::calc(...) dis_flow.cpp:1501
0 bytes after 29184-byte region  <- I1s_ext of that level (152x192)
```

The limits exist precisely to bound arbitrary flow values, so this is hit whenever the flow (estimated or passed in as the flow of the previous frame pair) pushes a patch more than `border_size` outside of the image — which is why the report depends on the image pair, the direction and the patch size.

### Fix

Pad by `max(16, patch_size)`. Both limits then stay inside `I1s_ext` for any patch size: the lowest position becomes `1` and the highest read row becomes `border_size + h - 1 + patch_size = h + 2*border_size - 1`, i.e. the last row of the buffer.

`border_size` is set in `prepareBuffers()` / `ocl_prepareBuffers()`, which run on every `calc()` after `autoSelectPatchSizeAndScales()`, so a `setPatchSize()` between two `calc()` calls is picked up and the padded buffers are re-created. The default patch sizes (8 and 12) are below 16, so the padding, the memory consumption and the results of the default configurations are unchanged.

### Testing

Added `DenseOpticalFlow_DIS.regression_20185_patch_larger_than_border`, which drives the patch search against the limits: one `calc()` with the preset patch size (8, fits the border) and one with `setPatchSize(25)` after it, so the re-creation of the padded buffers is covered too.

- Without the fix, under AddressSanitizer, the test reproduces the overflow above.
- With the fix ASan is clean, and the existing `video` tests still pass against `opencv_extra` test data, also under ASan (`DenseOpticalFlow_DIS.*` accuracy and `MultithreadReproducibility` included; the unrelated `Video_OpticalFlowPyrLK.submat` fails on the unmodified 4.x here as well).

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original bug report and related work (#20185)
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (regression test added; no external data needed)
- [x] The feature is well documented and sample code can be built with the project CMake
