### PR TITLE
dnn: enable the existing SIMD attention-softmax on scalable RVV

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/fast_attn.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_attn.cpp
@@ -102,7 +102,7 @@ void run_fused_softmax(
             const int tmax = is_causal ? std::min(past_seq_len + tq + 1, seq_len_kv) : seq_len_kv;
             float maxVal = -FLT_MAX;
             int tk = 0;
-#if CV_SIMD
+#if (CV_SIMD || CV_SIMD_SCALABLE)
             const int w = VTraits<v_float32>::vlanes();
             v_float32 v_max_val = vx_setall_f32(maxVal);
             v_float32 v_softcap = vx_setall_f32(softcap);
@@ -173,7 +173,7 @@ void run_fused_softmax(
             if (do_softmax) {
             float sum = 0.f;
             tk = 0;
-#if CV_SIMD
+#if (CV_SIMD || CV_SIMD_SCALABLE)
             v_float32 v_sum = vx_setzero_f32();
             v_float32 v_max_val_shift = vx_setall_f32(maxVal);
             for (; tk <= seq_len_kv - w; tk += w) {
@@ -192,7 +192,7 @@ void run_fused_softmax(
 
             float inv_sum = 1.f / sum;
             tk = 0;
-#if CV_SIMD
+#if (CV_SIMD || CV_SIMD_SCALABLE)
             v_float32 v_inv_sum = vx_setall_f32(inv_sum);
             for (; tk <= seq_len_kv - w; tk += w) {
                 v_float32 v_val = vx_load(&data[offset + tk]);


### PR DESCRIPTION
### Summary
On scalable-vector targets (RISC-V RVV built with RISCV_RVV_SCALABLE=ON) the intrinsics header sets CV_SIMD = 0 and CV_SIMD_SCALABLE = 1, so all three guarded blocks are compiled out and the kernel runs fully scalar — one expf() per element in the softmax, and two per element in the scalar softcap tanh. This kernel is used by the new-engine AttentionOnnxAi layer (ONNX Attention-23), so every such Attention op runs its softmax scalar on RVV.


### Performance 
(SpacemiT K1, rv64gcv, VLEN=256, gcc 14.2.1)

Measured on a single new-engine `AttentionOnnxAi` layer via `readNetFromONNX(model, ENGINE_NEW)`; the baseline and patched libraries differ only in this file, so the whole forward-time delta is attributable to this kernel.

| config (heads × seq × head_size) | 8 threads (default) | 1 thread |
| :------------------------------- | :------------------ | :------- |
| plain 12×128×64                  | 1.45×               | 1.65×    |
| plain 12×512×64                  | 1.38×               | 1.69×    |
| plain 24×512×16                  | 1.53×               | 2.23×    |
| mask 12×512×64                   | 1.45×               | 1.78×    |
| softcap 12×512×64                | 2.62×               | 2.99×    |
| softcap 24×512×16                | 3.01×               | 4.42×    |



These are single-`AttentionOnnxAi`-layer figures and are not extrapolated to whole models. As an end-to-end reference, the `KV_Cache/TESTKVCache.layouts` test — which also spends most of its time in the QK/AV GEMMs, KV-cache management and input setup — runs ~1.02–1.05× faster patched vs baseline.

------

### Accuracy

The `KV_Cache/TESTKVCache.layouts` test (which exercises this kernel, sequence length 523) passes on both the baseline and patched libraries, and the full `*Attention*` filter reports no new failures vs baseline under both the default AUTO engine and `OPENCV_FORCE_DNN_ENGINE=2`.


------

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
