### PR TITLE
imgproc: fix connectedComponents assert on boolean mask

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -5659,7 +5659,7 @@ namespace cv{
         const char *currentParallelFramework = cv::currentParallelFramework();
         const int nThreads = cv::getNumThreads();
 
-        CV_Assert(iDepth == CV_8U || iDepth == CV_8S);
+        CV_Assert(iDepth == CV_8U || iDepth == CV_8S || iDepth == CV_Bool);
 
         //Run parallel labeling only if the rows of the image are at least twice the number of available threads
         const bool is_parallel = currentParallelFramework != NULL && nThreads > 1 && L.rows / nThreads >= 2;

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -795,8 +795,13 @@ TEST(Imgproc_ConnectedComponents, regression_27568)
     }
 }
 
-TEST(Imgproc_ConnectedComponents, bool_mask_29593)
+typedef testing::TestWithParam<std::tuple<int, int>> Imgproc_ConnectedComponents_BoolMask;
+
+TEST_P(Imgproc_ConnectedComponents_BoolMask, bool_mask_29593)
 {
+    const int connectivity = std::get<0>(GetParam());
+    const int ccltype = std::get<1>(GetParam());
+
     cv::Mat_<bool> mask = (cv::Mat_<bool>(3, 4) <<
         true,  true,  false, true,
         false, false, false, true,
@@ -808,20 +813,19 @@ TEST(Imgproc_ConnectedComponents, bool_mask_29593)
           0,   0,   0, 255,
         255,   0, 255, 255);
 
-    for (const int connectivity : {4, 8})
-    {
-        for (const int ccltype : {CCL_DEFAULT, CCL_WU, CCL_GRANA, CCL_BOLELLI, CCL_SAUF, CCL_BBDT, CCL_SPAGHETTI})
-        {
-            Mat1i labels_mask, labels_ref, stats;
-            Mat1d centroids;
-            int n_mask = 0, n_ref = 0;
-            ASSERT_NO_THROW(n_mask = connectedComponentsWithStats(mask, labels_mask, stats, centroids, connectivity, CV_32S, ccltype));
-            ASSERT_NO_THROW(n_ref = connectedComponentsWithStats(ref, labels_ref, stats, centroids, connectivity, CV_32S, ccltype));
-            EXPECT_EQ(n_mask, n_ref);
-            EXPECT_EQ(cv::countNonZero(labels_mask != labels_ref), 0);
-        }
-    }
+    Mat1i labels_mask, labels_ref, stats;
+    Mat1d centroids;
+    int n_mask = 0, n_ref = 0;
+    ASSERT_NO_THROW(n_mask = connectedComponentsWithStats(mask, labels_mask, stats, centroids, connectivity, CV_32S, ccltype));
+    ASSERT_NO_THROW(n_ref = connectedComponentsWithStats(ref, labels_ref, stats, centroids, connectivity, CV_32S, ccltype));
+    EXPECT_EQ(n_mask, n_ref);
+    EXPECT_EQ(cv::countNonZero(labels_mask != labels_ref), 0);
 }
+
+INSTANTIATE_TEST_CASE_P(/**/, Imgproc_ConnectedComponents_BoolMask,
+    testing::Combine(
+        testing::Values(4, 8),
+        testing::Values(CCL_DEFAULT, CCL_WU, CCL_GRANA, CCL_BOLELLI, CCL_SAUF, CCL_BBDT, CCL_SPAGHETTI)));
 
 }
 } // namespace

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -795,5 +795,33 @@ TEST(Imgproc_ConnectedComponents, regression_27568)
     }
 }
 
+TEST(Imgproc_ConnectedComponents, bool_mask_29593)
+{
+    cv::Mat_<bool> mask = (cv::Mat_<bool>(3, 4) <<
+        true,  true,  false, true,
+        false, false, false, true,
+        true,  false, true,  true);
+    EXPECT_EQ(mask.depth(), CV_Bool);
+
+    cv::Mat1b ref = (cv::Mat1b(3, 4) <<
+        255, 255,   0, 255,
+          0,   0,   0, 255,
+        255,   0, 255, 255);
+
+    for (const int connectivity : {4, 8})
+    {
+        for (const int ccltype : {CCL_DEFAULT, CCL_WU, CCL_GRANA, CCL_BOLELLI, CCL_SAUF, CCL_BBDT, CCL_SPAGHETTI})
+        {
+            Mat1i labels_mask, labels_ref, stats;
+            Mat1d centroids;
+            int n_mask = 0, n_ref = 0;
+            ASSERT_NO_THROW(n_mask = connectedComponentsWithStats(mask, labels_mask, stats, centroids, connectivity, CV_32S, ccltype));
+            ASSERT_NO_THROW(n_ref = connectedComponentsWithStats(ref, labels_ref, stats, centroids, connectivity, CV_32S, ccltype));
+            EXPECT_EQ(n_mask, n_ref);
+            EXPECT_EQ(cv::countNonZero(labels_mask != labels_ref), 0);
+        }
+    }
+}
+
 }
 } // namespace


### PR DESCRIPTION
Fixes #29593

In 5.0 cv::Mat_<bool>::depth() returns CV_Bool instead of CV_8U, so connectedComponents_sub1 tripped its `iDepth == CV_8U || iDepth == CV_8S` assert and threw on boolean masks. This worked in 4.x.

CV_Bool is a 1-byte 0/1 type that the labeling code reads the same way as CV_8U/CV_8S, so the assert just needs to allow it through.

Added a test comparing a Mat_<bool> mask against the equivalent CV_8UC1 mask across every connectivity and CCL algorithm.