### PR TITLE
Fixed MSVS warning in the new odometry sample.

### DIFF
--- a/samples/slam/visual_odometry.cpp
+++ b/samples/slam/visual_odometry.cpp
@@ -268,7 +268,7 @@ int main(int argc, char** argv)
     PoseFilenameTracker poseTracker;
     int nEmitted = 0;
 
-    const int nDigits = std::to_string(imgFiles.size()).size();
+    const int nDigits = static_cast<int>(std::to_string(imgFiles.size()).size());
     const int64 t0 = getTickCount();
     for (size_t i = 0; i < imgFiles.size(); ++i)
     {


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
