### PR TITLE
Document filter2D integer kernel support 🤖🤖🤖

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1720,9 +1720,9 @@ larger) and the direct algorithm for small kernels.
 @param src input image.
 @param dst output image of the same size and the same number of channels as src.
 @param ddepth desired depth of the destination image, see @ref filter_depths "combinations"
-@param kernel convolution kernel (or rather a correlation kernel), a single-channel floating point
-matrix; if you want to apply different kernels to different channels, split the image into
-separate color planes using split and process them individually.
+@param kernel convolution kernel (or rather a correlation kernel), a single-channel matrix; if you
+want to apply different kernels to different channels, split the image into separate color planes
+using split and process them individually.
 @param anchor anchor of the kernel that indicates the relative position of a filtered point within
 the kernel; the anchor should lie within the kernel; default value (-1,-1) means that the anchor
 is at the kernel center.

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -1940,6 +1940,46 @@ INSTANTIATE_TEST_CASE_P(/**/, Imgproc_FilterSupportedFormats,
     )
 );
 
+typedef testing::TestWithParam<perf::MatDepth> Imgproc_Filter2DKernelDepth;
+
+TEST_P(Imgproc_Filter2DKernelDepth, direct_and_dft)
+{
+    Mat src(32, 32, CV_8U);
+    RNG rng(0);
+    rng.fill(src, RNG::UNIFORM, 0, 16);
+
+    const int kernelSizes[] = { 3, 13 };  // direct and DFT paths, respectively
+    for (int ksize : kernelSizes)
+    {
+        SCOPED_TRACE(cv::format("kernel depth=%d, size=%dx%d", int(GetParam()), ksize, ksize));
+
+        Mat kernel32s = Mat::zeros(ksize, ksize, CV_32S);
+        kernel32s.at<int>(0, 0) = 1;
+        kernel32s.at<int>(ksize / 2, ksize / 2) = 2;
+        kernel32s.at<int>(ksize - 1, ksize - 1) = 1;
+
+        Mat kernel, referenceKernel, dst, reference;
+        kernel32s.convertTo(kernel, GetParam());
+        kernel.convertTo(referenceKernel, CV_64F);
+
+        cv::filter2D(src, dst, CV_32F, kernel, Point(-1, -1), 0, BORDER_REPLICATE);
+        cvtest::filter2D(src, reference, CV_32F, referenceKernel,
+                         Point(-1, -1), 0, BORDER_REPLICATE);
+
+        EXPECT_LE(cvtest::norm(dst, reference, NORM_INF), 1e-4);
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(Integer, Imgproc_Filter2DKernelDepth,
+    testing::Values(
+        perf::MatDepth(CV_8U),
+        perf::MatDepth(CV_8S),
+        perf::MatDepth(CV_16U),
+        perf::MatDepth(CV_16S),
+        perf::MatDepth(CV_32S)
+    )
+);
+
 TEST(Imgproc_Blur, borderTypes)
 {
     Size kernelSize(3, 3);


### PR DESCRIPTION
Fixes #22243.

Updates the `filter2D` documentation to reflect that kernels are not restricted to floating-point matrices.

Adds parameterized regression tests for `CV_8U`, `CV_8S`, `CV_16U`, `CV_16S`, and `CV_32S` kernels. The tests use 3x3 and 13x13 kernels to exercise the direct and DFT paths respectively.

Tests: full `opencv_test_imgproc` suite passes with zero failures.
