### PR TITLE
videoio: fix CAP_PROP_GAIN not working with ueye backend 

### DIFF
--- a/modules/videoio/src/cap_ueye.cpp
+++ b/modules/videoio/src/cap_ueye.cpp
@@ -212,8 +212,11 @@ bool VideoCapture_uEye::setProperty(int property_id, double value)
             ASSERT_UEYE(is_Exposure(cam_id, IS_EXPOSURE_CMD_SET_EXPOSURE, (void*)&value, sizeof(value)));
             break;
         case CAP_PROP_GAIN:
-            ASSERT_UEYE(is_SetHardwareGain(cam_id, static_cast<int>(value), IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER));
+        {
+            int master = std::min(100, std::max(0, static_cast<int>(value)));
+            ASSERT_UEYE(is_SetHardwareGain(cam_id, master, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER));
             break;
+        }
         }
         if(set_format)
         {

--- a/modules/videoio/src/cap_ueye.cpp
+++ b/modules/videoio/src/cap_ueye.cpp
@@ -175,8 +175,8 @@ double VideoCapture_uEye::getProperty(int property_id) const
         ASSERT_UEYE(is_Exposure(cam_id, IS_EXPOSURE_CMD_GET_EXPOSURE, (void*)&value, sizeof(value)));
         break;
     case CAP_PROP_GAIN:
-        auto gain = is_SetHWGainFactor(cam_id, IS_GET_MASTER_GAIN_FACTOR, 100);
-        value = static_cast<double>(gain)/100.0;
+        auto gain = is_SetHardwareGain(cam_id, IS_GET_MASTER_GAIN, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER);
+        value = static_cast<double>(gain);
         break;
     }
     return value;
@@ -212,7 +212,7 @@ bool VideoCapture_uEye::setProperty(int property_id, double value)
             ASSERT_UEYE(is_Exposure(cam_id, IS_EXPOSURE_CMD_SET_EXPOSURE, (void*)&value, sizeof(value)));
             break;
         case CAP_PROP_GAIN:
-            is_SetHWGainFactor(cam_id, IS_SET_MASTER_GAIN_FACTOR, static_cast<int>(value));
+            ASSERT_UEYE(is_SetHardwareGain(cam_id, static_cast<int>(value), IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER, IS_IGNORE_PARAMETER));
             break;
         }
         if(set_format)


### PR DESCRIPTION
is_SetHWGainFactor() does not actually change the applied gain on uEye cameras; use is_SetHardwareGain() instead, which the vendor SDK documents as the correct call for master gain and matches behavior confirmed by the issue reporter.

Fixes #22259

### Pull Request Readiness Checklist


- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
