### PR TITLE
core: expose cv::RNG in Python bindings

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -2344,9 +2344,23 @@ separate random number generator, so you can use the function safely in multi-th
 If you just need to get a single random number using this generator or initialize an array, you can
 use randu or randn instead. But if you are going to generate many random numbers inside a loop, it
 is much faster to use this function to retrieve the generator and then use RNG::operator _Tp() .
+
+@note In Python the function returns a reference-counted handle to the default generator of the
+calling thread, not a copy of it, i.e. the numbers generated from the returned object do affect
+the default generator.
 @sa RNG, randu, randn
 */
 CV_EXPORTS RNG& theRNG();
+
+/** @brief Returns the default random number generator as a shared pointer.
+
+The function is the counterpart of cv::theRNG that shares the ownership of the generator with the
+caller. The generator is created on demand for each thread, exactly as in cv::theRNG, but it stays
+alive as long as at least one returned pointer refers to it, even after the thread that created it
+has finished. It is used to implement the Python binding of cv::theRNG.
+@sa RNG, theRNG
+*/
+CV_EXPORTS Ptr<RNG> theRNGPtr();
 
 /** @brief Sets state of default random number generator.
 
@@ -2835,7 +2849,7 @@ Gaussian-distribution random numbers are generated using the Ziggurat
 algorithm ( <http://en.wikipedia.org/wiki/Ziggurat_algorithm> ),
 introduced by G. Marsaglia and W. W. Tsang.
 */
-class CV_EXPORTS RNG
+class CV_EXPORTS_W RNG
 {
 public:
     enum { UNIFORM = 0,
@@ -2850,14 +2864,14 @@ public:
     , the constructor uses the above default value instead to avoid the
     singular random number sequence, consisting of all zeros.
     */
-    RNG();
+    CV_WRAP RNG();
     /** @overload
     @param state 64-bit value used to initialize the RNG.
     */
-    RNG(uint64 state);
+    CV_WRAP RNG(uint64 state);
     /**The method updates the state using the MWC algorithm and returns the
     next 32-bit random number.*/
-    unsigned next();
+    CV_WRAP unsigned next();
 
     /**Each of the methods updates the state using the MWC algorithm and
     returns the next random number of the specified type. In case of integer
@@ -2927,14 +2941,17 @@ public:
     want a floating-point random number, but the range boundaries are
     integer numbers, either put dots in the end, if they are constants, or
     use explicit type cast operators, as in the a1 initialization above.
+    In Python only the integer and the double-precision variants are available; the one to use is
+    chosen by the types of a and b, e.g. rng.uniform(0, 10) returns an integer, whereas
+    rng.uniform(0.0, 10.0) returns a floating-point number.
     @param a lower inclusive boundary of the returned random number.
     @param b upper non-inclusive boundary of the returned random number.
     */
-    int uniform(int a, int b);
+    CV_WRAP int uniform(int a, int b);
     /** @overload */
     float uniform(float a, float b);
     /** @overload */
-    double uniform(double a, double b);
+    CV_WRAP double uniform(double a, double b);
 
     /** @brief Fills arrays with random numbers.
 
@@ -2970,7 +2987,7 @@ public:
     with zero mean and identity covariation matrix, and then transforms them
     using transform to get samples from the specified Gaussian distribution.
     */
-    void fill( InputOutputArray mat, int distType, InputArray a, InputArray b, bool saturateRange = false );
+    CV_WRAP void fill( InputOutputArray mat, int distType, InputArray a, InputArray b, bool saturateRange = false );
 
     /** @brief Returns the next random number sampled from the Gaussian distribution
     @param sigma standard deviation of the distribution.
@@ -2980,9 +2997,9 @@ public:
     the mean value of the returned random numbers is zero and the standard
     deviation is the specified sigma .
     */
-    double gaussian(double sigma);
+    CV_WRAP double gaussian(double sigma);
 
-    uint64 state;
+    CV_PROP_RW uint64 state;
 
     bool operator ==(const RNG& other) const;
 };

--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -6,7 +6,8 @@
         "FileStorage",
         "KDTree",
         "KeyPoint",
-        "DMatch"
+        "DMatch",
+        "RNG"
     ],
     "missing_consts" : {
         "Core" : {

--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -5,7 +5,8 @@
         "FileStorage",
         "KDTree",
         "KeyPoint",
-        "DMatch"
+        "DMatch",
+        "RNG"
     ],
     "missing_consts" : {
         "Core" : {

--- a/modules/core/misc/python/pyopencv_core.hpp
+++ b/modules/core/misc/python/pyopencv_core.hpp
@@ -230,6 +230,36 @@ static int DLPackTypeToCVType(const DLDataType& dtype, int channels) {
     return -1;
 }
 
+// cv::RNG is wrapped as a smart pointer, so an 'RNG*' argument (cv::randShuffle) is converted
+// to the pointer to the very same generator the passed Python object refers to. This way the
+// state of the caller's generator is properly updated by the called function.
+template<>
+struct PyOpenCV_Converter<RNG*>
+{
+    static bool to(PyObject* obj, RNG*& value, const ArgInfo& info)
+    {
+        if (!obj || obj == Py_None)
+            return true;
+        Ptr<RNG>* holder = NULL;
+        if (pyopencv_RNG_getp(obj, holder))
+        {
+            value = holder->get();
+            return true;
+        }
+        failmsg("Expected cv::RNG for argument '%s'", info.name);
+        return false;
+    }
+};
+
+// implementation of the cv.theRNG() binding declared in
+// modules/core/misc/python/shadow_rng.hpp; the returned smart pointer shares the ownership
+// of the thread-local generator, so that the Python object refers to the very same generator
+// (and keeps it alive) instead of getting a copy of it
+static Ptr<RNG> cv_theRNG()
+{
+    return theRNGPtr();
+}
+
 #define PYOPENCV_EXTRA_METHODS_CV \
   {"CV_MAKETYPE", CV_PY_FN_WITH_KW(pycvMakeType), "CV_MAKETYPE(depth, channels) -> retval"}, \
   {"CV_8UC", (PyCFunction)(pycvMakeTypeCh<CV_8U>), METH_O, "CV_8UC(channels) -> retval"}, \

--- a/modules/core/misc/python/shadow_rng.hpp
+++ b/modules/core/misc/python/shadow_rng.hpp
@@ -1,0 +1,12 @@
+#error This is a shadow header file, which is not intended for processing by any compiler. \
+       Only bindings parser should handle this file.
+
+namespace cv
+{
+
+//! cv::theRNG() returns a reference to the thread-local generator, which can not be represented
+//! in Python. The binding is implemented on top of cv::theRNGPtr() instead, see cv_theRNG()
+//! in modules/core/misc/python/pyopencv_core.hpp
+CV_WRAP_PHANTOM(Ptr<RNG> theRNG());
+
+} // namespace cv

--- a/modules/core/src/precomp.hpp
+++ b/modules/core/src/precomp.hpp
@@ -498,6 +498,7 @@ struct ImplCollector
 struct CoreTLSData
 {
     CoreTLSData() :
+        rng(makePtr<RNG>()),
 //#ifdef HAVE_OPENCL
         oclExecutionContextInitialized(false), useOpenCL(-1),
 //#endif
@@ -505,7 +506,9 @@ struct CoreTLSData
         useIPP_NE(-1)
     {}
 
-    RNG rng;
+    // the generator is heap-allocated, so that cv::theRNGPtr() can share its ownership
+    // and keep it alive even after the owning thread has finished
+    Ptr<RNG> rng;
 //#ifdef HAVE_OPENCL
     ocl::OpenCLExecutionContext oclExecutionContext;
     bool oclExecutionContextInitialized;

--- a/modules/core/src/rand.cpp
+++ b/modules/core/src/rand.cpp
@@ -764,6 +764,11 @@ void RNG::fill( InputOutputArray _mat, int disttype,
 
 cv::RNG& cv::theRNG()
 {
+    return *getCoreTlsData().rng;
+}
+
+cv::Ptr<cv::RNG> cv::theRNGPtr()
+{
     return getCoreTlsData().rng;
 }
 

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -33,7 +33,7 @@ else:
 
 forbidden_arg_types = ["void*"]
 
-ignored_arg_types = ["RNG*"]
+ignored_arg_types = []
 
 pass_by_val_types = ["Point*", "Point2f*", "Rect*", "String*", "double*", "float*", "int*"]
 

--- a/modules/python/src2/typing_stubs_generation/predefined_types.py
+++ b/modules/python/src2/typing_stubs_generation/predefined_types.py
@@ -28,6 +28,8 @@ _PREDEFINED_TYPES = (
     PrimitiveTypeNode.int_("uint32_t"),
     PrimitiveTypeNode.int_("size_t"),
     PrimitiveTypeNode.int_("int64_t"),
+    PrimitiveTypeNode.int_("uint64"),
+    PrimitiveTypeNode.int_("uint64_t"),
     PrimitiveTypeNode.int_("long long"),
     PrimitiveTypeNode.float_("float"),
     PrimitiveTypeNode.float_("double"),

--- a/modules/python/test/test_rng.py
+++ b/modules/python/test/test_rng.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python
+
+'''
+Tests for the cv.RNG bindings: per-instance random number generators.
+
+See https://github.com/opencv/opencv/issues/29591
+'''
+
+import threading
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+class rng_test(NewOpenCVTests):
+
+    def test_constructors(self):
+        # the default constructor uses the documented 2**32-1 state
+        self.assertEqual(cv.RNG().state, 0xffffffff)
+        self.assertEqual(cv.RNG(137).state, 137)
+        # zero state is replaced by the default one to avoid the singular sequence
+        self.assertEqual(cv.RNG(0).state, 0xffffffff)
+        # 64-bit states are supported
+        self.assertEqual(cv.RNG(0x123456789abcdef).state, 0x123456789abcdef)
+
+    def test_distribution_type_constants(self):
+        # cv::RNG::UNIFORM and cv::RNG::NORMAL
+        self.assertEqual(cv.RNG_UNIFORM, 0)
+        self.assertEqual(cv.RNG_NORMAL, 1)
+
+    def test_same_seed_gives_same_sequence(self):
+        rng_a = cv.RNG(137)
+        rng_b = cv.RNG(137)
+
+        for _ in range(10):
+            self.assertEqual(rng_a.next(), rng_b.next())
+            self.assertEqual(rng_a.uniform(0, 100), rng_b.uniform(0, 100))
+            self.assertEqual(rng_a.uniform(0.0, 1.0), rng_b.uniform(0.0, 1.0))
+            self.assertEqual(rng_a.gaussian(2.0), rng_b.gaussian(2.0))
+
+        self.assertEqual(rng_a.state, rng_b.state)
+
+    def test_uniform_overloads(self):
+        rng = cv.RNG(137)
+
+        for _ in range(100):
+            i = rng.uniform(3, 7)
+            self.assertIsInstance(i, int)
+            self.assertTrue(3 <= i < 7)
+
+            # the floating-point overload must be selected by the type of the
+            # boundaries, otherwise the result would always be truncated to 3
+            f = rng.uniform(3.0, 7.0)
+            self.assertIsInstance(f, float)
+            self.assertTrue(3.0 <= f < 7.0)
+
+    def test_state_is_read_write(self):
+        rng = cv.RNG(137)
+        saved = rng.state
+        first = [rng.next() for _ in range(5)]
+
+        # rewinding the generator by restoring the state repeats the sequence
+        rng.state = saved
+        self.assertEqual(first, [rng.next() for _ in range(5)])
+
+        # ... and so does a fresh generator initialized with the same state
+        rewound = cv.RNG(saved)
+        self.assertEqual(first, [rewound.next() for _ in range(5)])
+
+    def test_fill_uniform(self):
+        shape = (7, 11)
+        dst_a = np.zeros(shape, np.uint8)
+        dst_b = np.zeros(shape, np.uint8)
+
+        dst_a = cv.RNG(137).fill(dst_a, cv.RNG_UNIFORM, 0, 256)
+        dst_b = cv.RNG(137).fill(dst_b, cv.RNG_UNIFORM, 0, 256)
+
+        self.assertEqual(dst_a.shape, shape)
+        np.testing.assert_array_equal(dst_a, dst_b)
+        # a 77-element uniformly distributed array is not expected to be constant
+        self.assertGreater(dst_a.max(), dst_a.min())
+
+    def test_fill_normal(self):
+        dst = np.zeros((1000, 1000), np.float32)
+        dst = cv.RNG(137).fill(dst, cv.RNG_NORMAL, 10.0, 2.0)
+
+        self.assertAlmostEqual(dst.mean(), 10.0, delta=0.05)
+        self.assertAlmostEqual(dst.std(), 2.0, delta=0.05)
+
+    def test_fill_matches_the_seeded_global_generator(self):
+        shape = (16, 16)
+
+        cv.setRNGSeed(137)
+        expected_u = cv.randu(np.zeros(shape, np.float32), 0.0, 1.0)
+        expected_n = cv.randn(np.zeros(shape, np.float32), 0.0, 1.0)
+
+        rng = cv.RNG(137)
+        actual_u = rng.fill(np.zeros(shape, np.float32), cv.RNG_UNIFORM, 0.0, 1.0)
+        actual_n = rng.fill(np.zeros(shape, np.float32), cv.RNG_NORMAL, 0.0, 1.0)
+
+        np.testing.assert_array_equal(actual_u, expected_u)
+        np.testing.assert_array_equal(actual_n, expected_n)
+
+    def test_generator_passed_to_a_function_is_updated(self):
+        rng = cv.RNG(137)
+        dst = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0, rng)
+
+        # the generator is passed by reference, so the swaps performed by
+        # randShuffle() must be reflected in the caller's generator
+        self.assertNotEqual(rng.state, 137)
+        self.assertEqual(sorted(dst.tolist()), list(range(64)))
+
+        # ... and the very same sequence of swaps is reproduced by an equally
+        # seeded generator, which proves that randShuffle() got the state, too
+        expected = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0, cv.RNG(137))
+        np.testing.assert_array_equal(dst, expected)
+
+        # two consecutive calls must not repeat themselves: the state moved on
+        again = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0, rng)
+        self.assertFalse(np.array_equal(dst, again))
+
+    def test_function_with_explicit_generator_does_not_touch_the_global_one(self):
+        cv.setRNGSeed(137)
+        expected = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0)
+
+        cv.setRNGSeed(137)
+        cv.randShuffle(np.arange(64, dtype=np.float32), 1.0, cv.RNG(42))
+        actual = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0)
+
+        np.testing.assert_array_equal(actual, expected)
+
+        # while without the argument randShuffle() uses (and advances) the default one
+        cv.setRNGSeed(137)
+        before = cv.theRNG().state
+        cv.randShuffle(np.arange(64, dtype=np.float32), 1.0)
+        self.assertNotEqual(cv.theRNG().state, before)
+
+    def test_function_can_take_the_default_generator(self):
+        cv.setRNGSeed(137)
+        expected = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0)
+
+        # passing theRNG() explicitly must be equivalent to omitting the argument
+        cv.setRNGSeed(137)
+        actual = cv.randShuffle(np.arange(64, dtype=np.float32), 1.0, cv.theRNG())
+
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_instances_are_independent(self):
+        rng_a = cv.RNG(137)
+        rng_b = cv.RNG(137)
+
+        expected = [rng_a.next() for _ in range(4)]
+
+        # interleaving the calls to other generators does not change the sequence
+        actual = []
+        for i in range(4):
+            cv.RNG(i + 1).gaussian(1.0)
+            actual.append(rng_b.next())
+
+        self.assertEqual(expected, actual)
+
+    def test_instances_do_not_affect_the_global_generator(self):
+        shape = (8, 8)
+
+        cv.setRNGSeed(137)
+        expected = cv.randu(np.zeros(shape, np.float32), 0.0, 1.0)
+
+        cv.setRNGSeed(137)
+        rng = cv.RNG(42)
+        rng.next()
+        rng.gaussian(1.0)
+        rng.fill(np.zeros(shape, np.float32), cv.RNG_UNIFORM, 0.0, 1.0)
+        actual = cv.randu(np.zeros(shape, np.float32), 0.0, 1.0)
+
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_global_generator_does_not_affect_instances(self):
+        rng = cv.RNG(137)
+        expected = [rng.next() for _ in range(4)]
+
+        rng = cv.RNG(137)
+        actual = []
+        for _ in range(4):
+            cv.setRNGSeed(1234)
+            cv.randu(np.zeros((4, 4), np.float32), 0.0, 1.0)
+            actual.append(rng.next())
+
+        self.assertEqual(expected, actual)
+
+    def test_the_rng_refers_to_the_default_generator(self):
+        cv.setRNGSeed(137)
+        self.assertEqual(cv.theRNG().state, 137)
+
+        # theRNG() is a handle to the default generator, not a copy of it:
+        # advancing it must advance the generator used by cv.randu()
+        cv.setRNGSeed(137)
+        rng = cv.theRNG()
+        rng.next()
+        expected = cv.randu(np.zeros((8, 8), np.float32), 0.0, 1.0)
+
+        cv.setRNGSeed(137)
+        cv.theRNG().next()
+        actual = cv.randu(np.zeros((8, 8), np.float32), 0.0, 1.0)
+
+        np.testing.assert_array_equal(actual, expected)
+
+        # ... and cv.randu() in turn advances the object returned by theRNG()
+        cv.setRNGSeed(137)
+        rng = cv.theRNG()
+        cv.randu(np.zeros((8, 8), np.float32), 0.0, 1.0)
+        self.assertNotEqual(rng.state, 137)
+        self.assertEqual(rng.state, cv.theRNG().state)
+
+    def test_the_rng_outlives_its_thread(self):
+        result = {}
+
+        def worker():
+            cv.setRNGSeed(137)
+            result['rng'] = cv.theRNG()
+
+        t = threading.Thread(target=worker)
+        t.start()
+        t.join()
+
+        # the returned object shares the ownership of the generator, so it stays
+        # valid even though the thread that created it has already finished
+        rng = result['rng']
+        self.assertEqual(rng.state, 137)
+
+        reference = cv.RNG(137)
+        self.assertEqual([rng.next() for _ in range(4)],
+                         [reference.next() for _ in range(4)])
+
+        # each thread has its own default generator, so the one of the finished
+        # thread is not the default generator of this thread anymore
+        cv.setRNGSeed(42)
+        self.assertNotEqual(cv.theRNG().state, rng.state)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Closes #29591

### Problem

Python callers can only seed OpenCV's default random number generator via `cv.setRNGSeed()`,
which is process-wide state. `hasattr(cv2, "RNG")` is `False`, so there is no way to get an
independent, reproducible generator. Libraries that need reproducibility (e.g. AlbumentationsX)
have to draw a seed from their own generator and call `cv.setRNGSeed()` before every OpenCV
call, which breaks any other pipeline running in the same process.

### Solution

`cv::RNG` is wrapped as a Python class:

```python
rng_a = cv.RNG(137)
rng_b = cv.RNG(137)
rng_a.fill(dst_a, cv.RNG_NORMAL, mean, stddev)
rng_b.fill(dst_b, cv.RNG_NORMAL, mean, stddev)   # same numbers, own state
```

The exported API mirrors the C++ one 1:1, no new methods are introduced:

| Python | C++ |
| --- | --- |
| `cv.RNG()`, `cv.RNG(state)` | `RNG::RNG()`, `RNG::RNG(uint64)` |
| `rng.state` (read/write) | `RNG::state` |
| `rng.next()` | `RNG::next()` |
| `rng.uniform(a, b)` | `RNG::uniform(int, int)` / `RNG::uniform(double, double)` |
| `rng.fill(mat, distType, a, b[, saturateRange])` | `RNG::fill()` |
| `rng.gaussian(sigma)` | `RNG::gaussian()` |
| `cv.RNG_UNIFORM`, `cv.RNG_NORMAL` | `RNG::UNIFORM`, `RNG::NORMAL` |
| `cv.theRNG()` | `theRNG()` |
| `cv.randShuffle(dst, iterFactor, rng)` | `randShuffle()` |

The overload of `RNG::uniform` to call is selected by the types of the boundaries, exactly as in
C++: `rng.uniform(0, 10)` returns an `int`, `rng.uniform(0.0, 10.0)` returns a `float`.
`RNG::uniform(float, float)` is deliberately left unwrapped, otherwise it would shadow the
double-precision variant for any Python float and silently reduce the precision of the result.

### Reference semantics

The class is wrapped as `Ptr<RNG>` (`CV_EXPORTS_W`) rather than as a "simple" by-value type
(`CV_EXPORTS_W_SIMPLE`). With the by-value wrapping the generated converter is

```cpp
static bool to(PyObject* src, cv::RNG& dst, const ArgInfo& info)
{
    cv::RNG* dst_;
    if (pyopencv_RNG_getp(src, dst_)) { dst = *dst_; return true; }   // a copy
    ...
}
```

i.e. a generator passed to a function would be copied and the advance of its state lost, and
`theRNG()` would return a snapshot of the default generator instead of the generator itself.
Both are fixed by the smart pointer wrapping:

* **passing a generator to a function.** `"RNG*"` is removed from `ignored_arg_types` in
  `gen2.py` (`cv::randShuffle` was the only wrapped function affected by it) and a
  `PyOpenCV_Converter<RNG*>` is added, which returns a pointer to the very generator the passed
  Python object refers to. `cv.randShuffle(dst, iterFactor, rng)` now shuffles with the given
  generator and advances its state.

* **`cv.theRNG()`.** `cv::theRNG()` returns a reference to a thread-local generator, which can
  not be represented by a Python object that owns its value. The thread-local generator is now
  heap-allocated (`Ptr<RNG>` in the private `CoreTLSData`) and a new
  `CV_EXPORTS Ptr<RNG> cv::theRNGPtr()` shares its ownership. The binding is declared as a
  phantom in `modules/core/misc/python/shadow_rng.hpp` and implemented by `cv_theRNG()` in
  `modules/core/misc/python/pyopencv_core.hpp`. As a result `cv.theRNG()` refers to the default
  generator of the calling thread in both directions, and the returned object stays valid even
  after the thread that created it has finished.

### Other changes

* `"uint64"` / `"uint64_t"` are registered in the typing stubs generator. Without them
  `RNG.state` and `RNG.__init__(state)` fail to resolve and no `.pyi` file is produced at all.
* `RNG` is added to the class ignore lists of the Java and Objective-C generators. Both process
  `core.hpp`, so marking the class with `CV_EXPORTS_W` would otherwise silently add a new class
  to those APIs; this PR is intentionally limited to the Python bindings.

### Tests

`modules/python/test/test_rng.py`, 16 test cases:

* constructors, the documented default state, read/write access to `state`;
* equally seeded generators produce equal sequences of `next()`, `uniform()` and `gaussian()`;
* the `uniform()` overloads are dispatched by the types of the boundaries;
* `fill()` for both distributions, cross-checked against `cv.setRNGSeed()` + `cv.randu()` /
  `cv.randn()`;
* instances are independent from each other and from the default generator, in both directions;
* `cv.randShuffle()` with an explicit generator updates it, does not touch the default one, and
  reproduces the same permutation for an equally seeded generator;
* `cv.theRNG()` is a handle to the default generator, not a copy of it, and the returned object
  outlives the thread it was obtained in.

### Verification

* `opencv_test_core`: 24149 tests passed.
* Python test suite: 183 tests, the only failure is the pre-existing
  `test_umat_optical_flow` (missing `samples/data/right01.jpg` in the test data).

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
