### PR TITLE
dnn: (bug fix )preserve Cast semantics after ONNX Gather

### DIFF
--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1561,19 +1561,6 @@ public:
     }
 };
 
-class MulCastSubgraph : public Subgraph
-{
-public:
-    MulCastSubgraph()
-    {
-        int input = addNodeToMatch("");
-        int scaleNode = addNodeToMatch("Constant");
-        int mul = addNodeToMatch("Mul", input, scaleNode);
-        addNodeToMatch("Cast", mul);
-        setFusedNode("Mul", input, scaleNode);
-    }
-};
-
 class ExtractScalesSubgraph : public Subgraph
 {
 public:
@@ -1854,7 +1841,6 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net, const std::string& basePath
     subgraphs.push_back(makePtr<GeluSubGraph>());
     subgraphs.push_back(makePtr<GeluApproximationSubGraph>());
     subgraphs.push_back(makePtr<LayerNormSubGraph>());
-    subgraphs.push_back(makePtr<MulCastSubgraph>());
     subgraphs.push_back(makePtr<UpsampleSubgraph>());
     subgraphs.push_back(makePtr<ResizeSubgraph1>());
     subgraphs.push_back(makePtr<ResizeSubgraph2>());

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1402,74 +1402,6 @@ public:
     }
 };
 
-class GatherCastSubgraph : public Subgraph
-{
-public:
-    GatherCastSubgraph()
-    {
-        int input = addNodeToMatch("");
-        int index = addNodeToMatch("Constant");
-        gather = addNodeToMatch("Gather", input, index);
-        cast = addNodeToMatch("Cast", gather);
-        setFusedNode("Gather", input, index);
-    }
-
-    virtual bool match(const Ptr<ImportGraphWrapper>& net, int nodeId,
-                       std::vector<int>& matchedNodesIds) CV_OVERRIDE
-    {
-        bool retVal = Subgraph::match(net, nodeId, matchedNodesIds);
-        size_t matchedNodesNum = matchedNodesIds.size();
-        // Now we check if merging can be made for these Gather and Cast nodes
-        if (!retVal || matchedNodesNum < 2)
-            return retVal;
-        else {
-            int nodeToMatch = matchedNodesIds[cast];
-            const Ptr<ImportNodeWrapper> node = net->getNode(nodeToMatch);
-            if (node->getType() == "Cast") {
-                int inpNodeId = matchedNodesIds[gather];
-                const Ptr<ImportNodeWrapper> inpNode = net->getNode(inpNodeId);
-                if (inpNode->getType() == "Gather") {
-                    int numNodes = net->getNumNodes();
-                    std::string inpNodeName = node->getInputName(0);
-                    for (int i = 0; i < numNodes; ++i) {
-                        const Ptr<ImportNodeWrapper> node_to_check = net->getNode(i);
-                        int numInp = node_to_check->getNumInputs();
-                        for (int inp = 0; inp < numInp; ++inp) {
-                            if (i != nodeToMatch && inpNodeName == node_to_check->getInputName(inp)) {
-                                // Another node has the same input node, so it cannot be merged.
-                                return false;
-                            }
-                        }
-                    }
-                    // extract axis from original Gather node
-                    axis = 0;
-                    opencv_onnx::NodeProto* origGatherNode =
-                        inpNode.dynamicCast<ONNXNodeWrapper>()->node;
-                    for (int i = 0; i < origGatherNode->attribute_size(); i++) {
-                        opencv_onnx::AttributeProto attr = origGatherNode->attribute(i);
-                        if (attr.name() == "axis")
-                            axis = attr.i();
-                    }
-                }
-            }
-        }
-        return retVal;
-    }
-
-    virtual void finalize(const Ptr<ImportGraphWrapper>& net,
-                          const Ptr<ImportNodeWrapper>& fusedNode,
-                          std::vector<Ptr<ImportNodeWrapper> >& /*inputs*/) CV_OVERRIDE
-    {
-        opencv_onnx::NodeProto* node = fusedNode.dynamicCast<ONNXNodeWrapper>()->node;
-        opencv_onnx::AttributeProto* new_attr = node->add_attribute();
-        new_attr->set_name("axis");
-        new_attr->set_i(axis);
-    }
-
-private:
-    int cast, gather, axis;
-};
-
 /*  Constant folding shape for Expand.
 
     Before fusion:
@@ -1922,7 +1854,6 @@ void simplifySubgraphs(opencv_onnx::GraphProto& net, const std::string& basePath
     subgraphs.push_back(makePtr<GeluSubGraph>());
     subgraphs.push_back(makePtr<GeluApproximationSubGraph>());
     subgraphs.push_back(makePtr<LayerNormSubGraph>());
-    subgraphs.push_back(makePtr<GatherCastSubgraph>());
     subgraphs.push_back(makePtr<MulCastSubgraph>());
     subgraphs.push_back(makePtr<UpsampleSubgraph>());
     subgraphs.push_back(makePtr<ResizeSubgraph1>());

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2347,6 +2347,34 @@ TEST(Layer_Size, onnx_0d_scalar)
     EXPECT_EQ(outs[0].at<int64_t>(0), 1);
 }
 
+TEST(Layer_GatherCast, preserves_float_cast)
+{
+    auto engine_forced = static_cast<cv::dnn::EngineType>(
+        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", cv::dnn::ENGINE_AUTO));
+    if (engine_forced == cv::dnn::ENGINE_ORT)
+    {
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
+        return;
+    }
+
+    const std::string modelname = findDataFile("dnn/onnx/models/gather_cast_float.onnx", true);
+    Net net = readNetFromONNX(modelname, ENGINE_OPENCV);
+    ASSERT_FALSE(net.empty());
+    ASSERT_TRUE(net.getMainGraph());
+
+    int inputShape[] = {2, 3};
+    Mat input(2, inputShape, CV_32F, Scalar(0));
+    net.setInput(input, "input");
+
+    std::vector<Mat> outputs;
+    net.forward(outputs, std::vector<String>{"output"});
+
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs[0].total(), (size_t)1);
+    EXPECT_EQ(outputs[0].type(), CV_32F);
+    EXPECT_FLOAT_EQ(outputs[0].ptr<float>()[0], 2.f);
+}
+
 TEST(ConvolutionWinograd, Accuracy)
 {
     Mat weights({2, 1, 3, 3}, CV_32F);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2375,6 +2375,35 @@ TEST(Layer_GatherCast, preserves_float_cast)
     EXPECT_FLOAT_EQ(outputs[0].ptr<float>()[0], 2.f);
 }
 
+TEST(Layer_MulCast, preserves_float_cast)
+{
+    auto engine_forced = static_cast<cv::dnn::EngineType>(
+        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", cv::dnn::ENGINE_AUTO));
+    if (engine_forced == cv::dnn::ENGINE_ORT)
+    {
+        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
+        return;
+    }
+
+    const std::string modelname = findDataFile("dnn/onnx/models/mul_cast_float.onnx", true);
+    Net net = readNetFromONNX(modelname, ENGINE_OPENCV);
+    ASSERT_FALSE(net.empty());
+    ASSERT_TRUE(net.getMainGraph());
+
+    int inputShape[] = {2, 3};
+    Mat input(2, inputShape, CV_32F, Scalar(0));
+    net.setInput(input, "input");
+
+    std::vector<Mat> outputs;
+    net.forward(outputs, std::vector<String>{"output"});
+
+    ASSERT_EQ(outputs.size(), 1u);
+    EXPECT_EQ(outputs[0].total(), (size_t)2);
+    EXPECT_EQ(outputs[0].type(), CV_32F);
+    EXPECT_FLOAT_EQ(outputs[0].ptr<float>()[0], 2.f);
+    EXPECT_FLOAT_EQ(outputs[0].ptr<float>()[1], 2.f);
+}
+
 TEST(ConvolutionWinograd, Accuracy)
 {
     Mat weights({2, 1, 3, 3}, CV_32F);

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2349,14 +2349,6 @@ TEST(Layer_Size, onnx_0d_scalar)
 
 TEST(Layer_GatherCast, preserves_float_cast)
 {
-    auto engine_forced = static_cast<cv::dnn::EngineType>(
-        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", cv::dnn::ENGINE_AUTO));
-    if (engine_forced == cv::dnn::ENGINE_ORT)
-    {
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
-        return;
-    }
-
     const std::string modelname = findDataFile("dnn/onnx/models/gather_cast_float.onnx", true);
     Net net = readNetFromONNX(modelname, ENGINE_OPENCV);
     ASSERT_FALSE(net.empty());
@@ -2377,14 +2369,6 @@ TEST(Layer_GatherCast, preserves_float_cast)
 
 TEST(Layer_MulCast, preserves_float_cast)
 {
-    auto engine_forced = static_cast<cv::dnn::EngineType>(
-        cv::utils::getConfigurationParameterSizeT("OPENCV_FORCE_DNN_ENGINE", cv::dnn::ENGINE_AUTO));
-    if (engine_forced == cv::dnn::ENGINE_ORT)
-    {
-        applyTestTag(CV_TEST_TAG_DNN_SKIP_PARSER);
-        return;
-    }
-
     const std::string modelname = findDataFile("dnn/onnx/models/mul_cast_float.onnx", true);
     Net net = readNetFromONNX(modelname, ENGINE_OPENCV);
     ASSERT_FALSE(net.empty());


### PR DESCRIPTION
### Motivation

  This fixes an ONNX importer issue exposed while validating the DISK/LightGlue work in #29392.

  It is an independent DNN fix, not a Git-history dependency on #29392.  #29392's
  `Features2d_LightGlue_DISK.Regression` exposed the problem because the
  `disk_lightglue.onnx` graph relies on an explicit type conversion after `Gather`.

  `GatherCastSubgraph` simplified every `Gather -> Cast` pair into a `Gather`
  node. The simplification preserved `Gather.axis`, but discarded the `Cast.to`
  attribute and changed the graph's type semantics.

  For the affected graph:

  ```text
  Shape(int64) -> Gather(int64) -> Cast(float) -> Pow(float) -> Div(float)
  ```

  the simplifier removed Cast(to=float). Pow then received an int64 value
  and Div received mixed float / int64 inputs, failing with:

  All inputs should have equal types
  inputs[0] is CV_32FC1; input is CV_64SC1

  ### Changes

  - Remove the unsafe Gather -> Cast graph-simplifier fusion.
  - Add a regression test for:

    Shape -> Gather -> Cast(to=float) -> Pow -> Div

    The test verifies successful inference, CV_32F output type, and the
    expected output value.

  ### Validation

  - Full opencv_test_dnn: 5,057 tests passed (existing tagged/data-dependent
    tests were skipped).

  - Layer_GatherCast.preserves_float_cast
  - Related ONNX Gather/Cast/Pow/Div tests
  - Features2d_LightGlue_DISK.Regression passed locally with this same DNN
    change applied to a temporary #29392 worktree, without forcing the Classic
    DNN engine.

  ### Companion test data

  This PR requires the matching opencv_extra:5.x PR 
 https://github.com/opencv/opencv_extra/pull/1400 
 that adds
  dnn/onnx/models/gather_cast_float.onnx.
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
