### PR TITLE
features2d: fix heap buffer overflow in AKAZE generateDescriptorSubsample

### DIFF
--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -2597,6 +2597,12 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
   Mat_<int> fullcopy = fullM.clone();
   samples = -1;
 
+  auto assign_comps = [&](int row_idx, int col_idx, int base_idx) {
+    for (int ch = 0; ch < nchannels; ch++) {
+      comps(row_idx * nchannels + ch, col_idx) = base_idx + ch;
+    }
+  };
+
   for (int i = 0; i < npicks; i++) {
     int k = rng(fullM.rows - i);
     if (i < 6) {
@@ -2609,9 +2615,7 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 1) && samples(j, 2) == fullcopy(k, 2)) {
         n = false;
-        comps(i*nchannels, 0) = nchannels*j;
-        comps(i*nchannels + 1, 0) = nchannels*j + 1;
-        comps(i*nchannels + 2, 0) = nchannels*j + 2;
+        assign_comps(i, 0, nchannels * j);
         break;
       }
     }
@@ -2620,9 +2624,7 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 1);
       samples(count, 2) = fullcopy(k, 2);
-      comps(i*nchannels, 0) = nchannels*count;
-      comps(i*nchannels + 1, 0) = nchannels*count + 1;
-      comps(i*nchannels + 2, 0) = nchannels*count + 2;
+      assign_comps(i, 0, nchannels * count);
       count++;
     }
 
@@ -2630,9 +2632,7 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 3) && samples(j, 2) == fullcopy(k, 4)) {
         n = false;
-        comps(i*nchannels, 1) = nchannels*j;
-        comps(i*nchannels + 1, 1) = nchannels*j + 1;
-        comps(i*nchannels + 2, 1) = nchannels*j + 2;
+        assign_comps(i, 1, nchannels * j);
         break;
       }
     }
@@ -2641,9 +2641,7 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 3);
       samples(count, 2) = fullcopy(k, 4);
-      comps(i*nchannels, 1) = nchannels*count;
-      comps(i*nchannels + 1, 1) = nchannels*count + 1;
-      comps(i*nchannels + 2, 1) = nchannels*count + 2;
+      assign_comps(i, 1, nchannels * count);
       count++;
     }
 

--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -2597,12 +2597,6 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
   Mat_<int> fullcopy = fullM.clone();
   samples = -1;
 
-  auto assign_comps = [&](int row_idx, int col_idx, int base_idx) {
-    for (int ch = 0; ch < nchannels; ch++) {
-      comps(row_idx * nchannels + ch, col_idx) = base_idx + ch;
-    }
-  };
-
   for (int i = 0; i < npicks; i++) {
     int k = rng(fullM.rows - i);
     if (i < 6) {
@@ -2615,7 +2609,8 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 1) && samples(j, 2) == fullcopy(k, 2)) {
         n = false;
-        assign_comps(i, 0, nchannels * j);
+        for (int ch = 0; ch < nchannels; ch++)
+          comps(i*nchannels + ch, 0) = nchannels*j + ch;
         break;
       }
     }
@@ -2624,7 +2619,8 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 1);
       samples(count, 2) = fullcopy(k, 2);
-      assign_comps(i, 0, nchannels * count);
+      for (int ch = 0; ch < nchannels; ch++)
+        comps(i*nchannels + ch, 0) = nchannels*count + ch;
       count++;
     }
 
@@ -2632,7 +2628,8 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 3) && samples(j, 2) == fullcopy(k, 4)) {
         n = false;
-        assign_comps(i, 1, nchannels * j);
+        for (int ch = 0; ch < nchannels; ch++)
+          comps(i*nchannels + ch, 1) = nchannels*j + ch;
         break;
       }
     }
@@ -2641,7 +2638,8 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 3);
       samples(count, 2) = fullcopy(k, 4);
-      assign_comps(i, 1, nchannels * count);
+      for (int ch = 0; ch < nchannels; ch++)
+        comps(i*nchannels + ch, 1) = nchannels*count + ch;
       count++;
     }
 

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -88,6 +88,7 @@ TEST(Features2d_AKAZE, generateDescriptorSubsample_channels_overflow_29613)
 {
     Mat img(48, 48, CV_8UC1);
     randu(img, 0, 256);
+
     for (int channels = 1; channels <= 3; channels++)
     {
         Ptr<AKAZE> akaze = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 32, channels);

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -88,13 +88,15 @@ TEST(Features2D_AKAZE, Subsample_Channels_Overflow_Fix)
 {
     cv::Ptr<cv::AKAZE> akaze = cv::AKAZE::create(cv::AKAZE::DESCRIPTOR_MLDB, 32, 2);
 
-    cv::Mat img3(48, 48, CV_8UC3, cv::Scalar(128, 128, 128));
-    std::vector<cv::KeyPoint> keypoints3;
-    EXPECT_NO_THROW(akaze->detect(img3, keypoints3));
-    
-    cv::Mat img1(48, 48, CV_8UC1, cv::Scalar(128));
-    std::vector<cv::KeyPoint> keypoints1;
-    EXPECT_NO_THROW(akaze->detect(img1, keypoints1));
+    std::vector<cv::Mat> test_images = {
+        cv::Mat(48, 48, CV_8UC3, cv::Scalar(128, 128, 128)),
+        cv::Mat(48, 48, CV_8UC1, cv::Scalar(128))
+    };
+
+    for (const auto& img : test_images) {
+        std::vector<cv::KeyPoint> keypoints;
+        EXPECT_NO_THROW(akaze->detect(img, keypoints));
+    }
 }
 
 }} // namespace

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -84,4 +84,13 @@ TEST(Features2d_KAZE, diffusivity_charbonnier)
     ASSERT_EQ(desc_charbonnier.cols, desc_pm_g2.cols);
 }
 
+TEST(Features2D_AKAZE, Subsample_Channels_Overflow_Fix)
+{
+    cv::Mat img(48, 48, CV_8UC3, cv::Scalar(128, 128, 128));
+    cv::Ptr<cv::AKAZE> akaze = cv::AKAZE::create(cv::AKAZE::DESCRIPTOR_MLDB, 32, 2);
+
+    std::vector<cv::KeyPoint> keypoints;
+    EXPECT_NO_THROW(akaze->detect(img, keypoints));
+}
+
 }} // namespace

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -84,18 +84,19 @@ TEST(Features2d_KAZE, diffusivity_charbonnier)
     ASSERT_EQ(desc_charbonnier.cols, desc_pm_g2.cols);
 }
 
-TEST(Features2D_AKAZE, Subsample_Channels_Overflow_Fix)
+TEST(Features2d_AKAZE, generateDescriptorSubsample_channels_overflow_29613)
 {
-    cv::Ptr<cv::AKAZE> akaze = cv::AKAZE::create(cv::AKAZE::DESCRIPTOR_MLDB, 32, 2);
-
-    std::vector<cv::Mat> test_images = {
-        cv::Mat(48, 48, CV_8UC3, cv::Scalar(128, 128, 128)),
-        cv::Mat(48, 48, CV_8UC1, cv::Scalar(128))
-    };
-
-    for (const auto& img : test_images) {
-        std::vector<cv::KeyPoint> keypoints;
-        EXPECT_NO_THROW(akaze->detect(img, keypoints));
+    Mat img(48, 48, CV_8UC1);
+    randu(img, 0, 256);
+    for (int channels = 1; channels <= 3; channels++)
+    {
+        Ptr<AKAZE> akaze = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 32, channels);
+        std::vector<KeyPoint> kpts;
+        Mat desc;
+        ASSERT_NO_THROW(akaze->detectAndCompute(img, noArray(), kpts, desc)) << "channels=" << channels;
+        if (!kpts.empty()) {
+            EXPECT_EQ(desc.cols, divUp(32, 8)) << "channels=" << channels; // 32-bit descriptor -> 4 bytes
+        }
     }
 }
 

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -86,11 +86,15 @@ TEST(Features2d_KAZE, diffusivity_charbonnier)
 
 TEST(Features2D_AKAZE, Subsample_Channels_Overflow_Fix)
 {
-    cv::Mat img(48, 48, CV_8UC3, cv::Scalar(128, 128, 128));
     cv::Ptr<cv::AKAZE> akaze = cv::AKAZE::create(cv::AKAZE::DESCRIPTOR_MLDB, 32, 2);
 
-    std::vector<cv::KeyPoint> keypoints;
-    EXPECT_NO_THROW(akaze->detect(img, keypoints));
+    cv::Mat img3(48, 48, CV_8UC3, cv::Scalar(128, 128, 128));
+    std::vector<cv::KeyPoint> keypoints3;
+    EXPECT_NO_THROW(akaze->detect(img3, keypoints3));
+    
+    cv::Mat img1(48, 48, CV_8UC1, cv::Scalar(128));
+    std::vector<cv::KeyPoint> keypoints1;
+    EXPECT_NO_THROW(akaze->detect(img1, keypoints1));
 }
 
 }} // namespace


### PR DESCRIPTION
Prevent out-of-bounds write in `generateDescriptorSubsample()` during AKAZE MLDB descriptor generation when `nchannels < 3` (e.g. `nchannels = 2`).

Fixes #29613 

### Summary of Changes

- **Module:** `features2d` (AKAZE)
- **Problem:** When `generateDescriptorSubsample()` is called with `nchannels < 3`, the code hardcoded 3-channel matrix index offsets (`+ 0`, `+ 1`, `+ 2`). Since `comps` allocates rows based on `nchannels * npicks`, writing to index offset `+ 2` when `nchannels = 2` causes a heap buffer overflow past the last row of `comps`.
- **Fix:** Replaced hardcoded 3-channel matrix index assignments with a dynamic loop that iterates over `0` to `nchannels - 1`.
- **Regression Test:** Added `Features2D_AKAZE.Subsample_Channels_Overflow_Fix` in `modules/features2d/test/test_akaze.cpp`.
- 
### Acknowledgments

Thanks to @abhishek-gola for reviewing the test and suggesting the correct approach.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`)
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
