### PR TITLE
imgcodecs: fix pointer overflow in 16u icvCvt helpers (4.x)

### DIFF
--- a/modules/imgcodecs/src/utils.cpp
+++ b/modules/imgcodecs/src/utils.cpp
@@ -169,13 +169,13 @@ void icvCvt_Gray2BGR_16u_C1C3R( const ushort* gray, int gray_step,
                               ushort* bgr, int bgr_step, Size size )
 {
     int i;
-    for( ; size.height--; gray += gray_step/sizeof(gray[0]) )
+    for( ; size.height--; gray += gray_step/(int)sizeof(gray[0]) )
     {
         for( i = 0; i < size.width; i++, bgr += 3 )
         {
             bgr[0] = bgr[1] = bgr[2] = gray[i];
         }
-        bgr += bgr_step/sizeof(bgr[0]) - size.width*3;
+        bgr += bgr_step/(int)sizeof(bgr[0]) - size.width*3;
     }
 }
 
@@ -214,8 +214,8 @@ void icvCvt_BGRA2BGR_16u_C4C3R( const ushort* bgra, int bgra_step,
             bgr[0] = t0; bgr[1] = t1;
             t0 = bgra[swap_rb^2]; bgr[2] = t0;
         }
-        bgr += bgr_step/sizeof(bgr[0]) - size.width*3;
-        bgra += bgra_step/sizeof(bgra[0]) - size.width*4;
+        bgr += bgr_step/(int)sizeof(bgr[0]) - size.width*3;
+        bgra += bgra_step/(int)sizeof(bgra[0]) - size.width*4;
     }
 }
 
@@ -252,8 +252,8 @@ void icvCvt_BGRA2RGBA_16u_C4R( const ushort* bgra, int bgra_step,
          rgba[0] = t2; rgba[1] = t1;
          rgba[2] = t0; rgba[3] = t3;
      }
-     bgra += bgra_step/sizeof(bgra[0]) - size.width*4;
-     rgba += rgba_step/sizeof(rgba[0]) - size.width*4;
+     bgra += bgra_step/(int)sizeof(bgra[0]) - size.width*4;
+     rgba += rgba_step/(int)sizeof(rgba[0]) - size.width*4;
  }
 }
 

--- a/modules/imgcodecs/test/test_tiff.cpp
+++ b/modules/imgcodecs/test/test_tiff.cpp
@@ -689,6 +689,28 @@ TEST(Imgcodecs_Tiff, readWrite_unsigned)
     EXPECT_EQ(0, remove(filenameOutput.c_str()));
 }
 
+// See https://github.com/opencv/opencv/issues/29615
+// Decoding a 16-bit 4-channel TIFF used to form an out of range pointer in
+// icvCvt_BGRA2RGBA_16u_C4R because the byte step was divided by an unsigned
+// sizeof and then had size.width*4 subtracted, which wraps around for a zero
+// step. This just checks that a 16UC4 TIFF round-trips correctly; the value is
+// mainly that the sanitizer builds no longer report the pointer overflow.
+TEST(Imgcodecs_Tiff, regression_29615_16UC4)
+{
+    Mat img(4, 3, CV_16UC4);
+    randu(img, Scalar::all(0), Scalar::all(65535));
+
+    vector<uchar> buf;
+    ASSERT_NO_THROW(ASSERT_TRUE(imencode(".tiff", img, buf)));
+
+    Mat decoded;
+    ASSERT_NO_THROW(decoded = imdecode(buf, IMREAD_UNCHANGED));
+    ASSERT_FALSE(decoded.empty());
+    ASSERT_EQ(CV_16UC4, decoded.type());
+    ASSERT_EQ(img.size(), decoded.size());
+    EXPECT_EQ(0, cvtest::norm(img, decoded, NORM_INF));
+}
+
 TEST(Imgcodecs_Tiff, readWrite_32FC1)
 {
     const string root = cvtest::TS::ptr()->get_data_path();


### PR DESCRIPTION
Fixes #29615

Same fix as #29620, backported to 4.x as requested there.

The 16-bit `icvCvt_*` helpers in `utils.cpp` move the row pointer with `step/sizeof(x[0]) - size.width*N`. `sizeof` is unsigned, so this is done in unsigned math. When the caller passes `step == 0`, it underflows to a huge value and the pointer goes out of range, which is undefined behavior (UBSan flags it).

The TIFF decoder hits this: it walks rows itself and calls these helpers with `step = 0`, so reading a 16-bit 4-channel TIFF triggers the bug.

Fix: cast `sizeof(...)` to `int` so the math is signed. Same result for normal calls, no overflow when the step is 0. Done for all six spots in the three 16-bit helpers.

Added a test that encodes and decodes a `CV_16UC4` TIFF in memory and checks the result matches.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable