### PR TITLE
photo: fix OOB read in Domain_Filter::compute_NCfilter for degenerate masks 🤖🤖🤖

### DIFF
--- a/modules/photo/src/npr.hpp
+++ b/modules/photo/src/npr.hpp
@@ -310,6 +310,12 @@ void Domain_Filter::compute_NCfilter(Mat &output, Mat &hz, Mat &psketch, float r
     int w = output.cols;
     int channel = output.channels();
 
+    // A single column has no neighbor to convolve across, so leave output
+    // unchanged, matching compute_Rfilter's no-op for w==1. Without this,
+    // the box-filter index math below reads out of bounds. See #29614.
+    if (w < 2)
+        return;
+
     compute_boxfilter(output,hz,psketch,radius);
 
     Mat box_filter = Mat::zeros(h,w+1,CV_32FC3);

--- a/modules/photo/src/npr.hpp
+++ b/modules/photo/src/npr.hpp
@@ -310,9 +310,6 @@ void Domain_Filter::compute_NCfilter(Mat &output, Mat &hz, Mat &psketch, float r
     int w = output.cols;
     int channel = output.channels();
 
-    // A single column has no neighbor to convolve across, so leave output
-    // unchanged, matching compute_Rfilter's no-op for w==1. Without this,
-    // the box-filter index math below reads out of bounds. See #29614.
     if (w < 2)
         return;
 

--- a/modules/photo/test/test_npr.cpp
+++ b/modules/photo/test/test_npr.cpp
@@ -138,12 +138,6 @@ TEST(Photo_NPR_Stylization, regression)
 }
 
 // See https://github.com/opencv/opencv/issues/29614
-// Domain_Filter::compute_NCfilter (npr.hpp) indexes a summed-area-table
-// buffer using arithmetic that goes out of bounds when the matrix passed to
-// it has a single column. cv::stylization always uses NORMCONV_FILTER, so a
-// single-column source triggers this directly; a single-row source triggers
-// the same bug through the internal transposed pass. cv::edgePreservingFilter
-// reaches the identical code path when called with NORMCONV_FILTER.
 TEST(Photo_NPR_Stylization, degenerate_dimension_29614)
 {
     Mat colSrc(5, 1, CV_8UC3, Scalar(100, 150, 200));

--- a/modules/photo/test/test_npr.cpp
+++ b/modules/photo/test/test_npr.cpp
@@ -137,4 +137,35 @@ TEST(Photo_NPR_Stylization, regression)
 
 }
 
+// See https://github.com/opencv/opencv/issues/29614
+// Domain_Filter::compute_NCfilter (npr.hpp) indexes a summed-area-table
+// buffer using arithmetic that goes out of bounds when the matrix passed to
+// it has a single column. cv::stylization always uses NORMCONV_FILTER, so a
+// single-column source triggers this directly; a single-row source triggers
+// the same bug through the internal transposed pass. cv::edgePreservingFilter
+// reaches the identical code path when called with NORMCONV_FILTER.
+TEST(Photo_NPR_Stylization, degenerate_dimension_29614)
+{
+    Mat colSrc(5, 1, CV_8UC3, Scalar(100, 150, 200));
+    Mat rowSrc(1, 5, CV_8UC3, Scalar(100, 150, 200));
+
+    Mat colResult, rowResult;
+    ASSERT_NO_THROW(stylization(colSrc, colResult, 100.0f, 0.5f));
+    ASSERT_NO_THROW(stylization(rowSrc, rowResult, 100.0f, 0.5f));
+    EXPECT_EQ(colResult.size(), colSrc.size());
+    EXPECT_EQ(rowResult.size(), rowSrc.size());
+}
+
+TEST(Photo_NPR_EdgePreserveSmoothing_NormConvFilter, degenerate_dimension_29614)
+{
+    Mat colSrc(5, 1, CV_8UC3, Scalar(100, 150, 200));
+    Mat rowSrc(1, 5, CV_8UC3, Scalar(100, 150, 200));
+
+    Mat colResult, rowResult;
+    ASSERT_NO_THROW(edgePreservingFilter(colSrc, colResult, 2 /* NORMCONV_FILTER */));
+    ASSERT_NO_THROW(edgePreservingFilter(rowSrc, rowResult, 2 /* NORMCONV_FILTER */));
+    EXPECT_EQ(colResult.size(), colSrc.size());
+    EXPECT_EQ(rowResult.size(), rowSrc.size());
+}
+
 }} // namespace


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

Closes #29614.

## Problem

`cv::stylization()` always drives `Domain_Filter::filter()` with `NORMCONV_FILTER`, which calls `compute_NCfilter()` (`modules/photo/src/npr.hpp`) on the working matrix once per iteration, and again on its transpose. `compute_NCfilter` builds a summed-area-table buffer sized `(w+1)` columns and then decodes `(p, q, r)` indices into it. When the matrix passed in has a single column, that decode can drive `r` to `-1`, producing a column index one past the end of the buffer -- a heap-buffer-overflow read, confirmed by the reporter with ASan (stack trace in the issue).

## Fix

A single column has no neighboring column to convolve with, so the mathematically correct result is simply "leave it unchanged." `compute_Rfilter` (the `RECURS_FILTER` sibling, used identically elsewhere in the same file) already does exactly this for `w==1` -- its two smoothing loops (`for(j=1;j<w;j++)` and `for(j=w-2;j>=0;j--)`) both degenerate to no-ops when `w==1`, leaving `output` byte-for-byte unchanged. I verified this by reading the loop bounds directly rather than assuming it.

`compute_NCfilter` gets the same early return: if `w < 2`, return without touching `output`.

## Why the fix is in `compute_NCfilter`, not `cv::stylization`

The issue's own suggested fix (guard in `cv::stylization` on `I.cols < 2`) is incomplete in two ways I found while tracing the callers:

1. `compute_NCfilter` is called **twice** per iteration in `Domain_Filter::filter()` -- once on the matrix, once on its transpose (`O_t = O.t()`). A single-**row** source (not just single-column) hits the identical bug through the transposed call, since `O_t` then has 1 column. A guard on the original image's `.cols` alone would miss this.
2. `Domain_Filter::filter()` is also reachable from the public `cv::edgePreservingFilter(src, dst, flags, ...)` with a caller-supplied `flags` -- passing `NORMCONV_FILTER` (2) hits the exact same code path and wasn't covered by a `stylization`-only guard.

Fixing `compute_NCfilter` itself covers both call sites and both degenerate dimensions in one place, and there are no other callers of `compute_NCfilter` in the codebase (confirmed by grep).

## Testing

Added `degenerate_dimension_29614` to `modules/photo/test/test_npr.cpp`, covering both `cv::stylization` and `cv::edgePreservingFilter(..., NORMCONV_FILTER)` with single-column and single-row inputs, built in-code (no `opencv_extra` data needed).

Verified locally (Ninja + MinGW-w64 g++ 15.2, `BUILD_LIST=imgproc,ts,imgcodecs,photo`):
- New tests pass with the fix; full `opencv_test_photo` suite has no new failures (remaining failures are all pre-existing `OPENCV_TEST_DATA_PATH not set` / missing `opencv_extra` errors, unrelated to this module).
- I could **not** reproduce a hard crash locally with the fix reverted -- this MinGW toolchain has no ASan/page-heap available, so the 4-byte overread silently lands on adjacent heap memory instead of faulting. I'm flagging this rather than overclaiming: my confidence the bug is real rests on the reporter's own verified ASan trace plus my own manual trace of the index arithmetic (both agree on the exact overrun), not on a local repro. The correctness of the fix itself is verified independently, via `compute_Rfilter`'s already-established `w==1` no-op behavior in the same file.

---

_Authored with AI assistance, tagged per the note in the PR template. All claims above were verified directly (loop bounds read, caller graph grepped, tests built and run) rather than assumed; the one thing I could not verify locally (a hard crash) is called out explicitly above rather than glossed over._