### PR TITLE
skip test DNNTestNetwork.AlexNet/0 on 32-bit target

### DIFF
--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -125,9 +125,11 @@ TEST_P(DNNTestNetwork, AlexNet)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_1GB);
     // fc6 needs one contiguous 9216*4096*4 = 144 MiB block, which does not fit
-    // reliably in the 2 GB user address space of a 32-bit process on any target.
+    // reliably in the 2 GB user address space of a 32-bit process on Windows.
+#ifdef _WIN32
     if (sizeof(void*) == 4)
-        throw SkipTestException("Skip memory-heavy network on 32-bit (x86) platform");
+        throw SkipTestException("Skip memory-heavy network on 32-bit (x86) Windows platform");
+#endif
     processNet("dnn/onnx/models/alexnet.onnx", "", Size(227, 227));
     expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);

--- a/modules/dnn/test/test_backends.cpp
+++ b/modules/dnn/test/test_backends.cpp
@@ -124,10 +124,10 @@ TEST_P(DNNTestNetwork, DISABLED_YOLOv8n) {
 TEST_P(DNNTestNetwork, AlexNet)
 {
     applyTestTag(CV_TEST_TAG_MEMORY_1GB);
-    // Skip memory-heavy OpenCL targets on 32-bit (x86) platforms to avoid OutOfMemoryError
-    if (sizeof(void*) == 4 &&
-        (target == DNN_TARGET_OPENCL || target == DNN_TARGET_OPENCL_FP16))
-        throw SkipTestException("Skip memory-heavy OpenCL target on 32-bit (x86) platform");
+    // fc6 needs one contiguous 9216*4096*4 = 144 MiB block, which does not fit
+    // reliably in the 2 GB user address space of a 32-bit process on any target.
+    if (sizeof(void*) == 4)
+        throw SkipTestException("Skip memory-heavy network on 32-bit (x86) platform");
     processNet("dnn/onnx/models/alexnet.onnx", "", Size(227, 227));
     expectNoFallbacksFromIE(net);
     expectNoFallbacksFromCUDA(net);


### PR DESCRIPTION


Skip `DNNTestNetwork.AlexNet` for `DNN_TARGET_CPU` on 32-bit architectures to prevent `OutOfMemoryError` failures during unit testing.

## Problem

The `fc6` layer in AlexNet requires a contiguous buffer allocation of **144 MiB** ($9216 \times 4096 \times 4$ bytes = 150,994,944 bytes). On 32-bit (x86) CI environments with fragmented or constrained virtual address space, attempting this large contiguous allocation throws `cv::OutOfMemoryError`.

Previously, a skip guard was added for 32-bit builds, but it was limited to `DNN_TARGET_OPENCL` and `DNN_TARGET_OPENCL_FP16`. The default CPU target (`OCV/CPU`) was left unguarded, leading to consistent CI test failures.

### Failure Log

```text
[ RUN      ] DNNTestNetwork.AlexNet/0, where GetParam() = OCV/CPU
unknown file: error: C++ exception with description "OpenCV(5.1.0-dev) C:\actions-runner\opencv\opencv\opencv\modules\core\src\alloc.cpp:73: error: (-4:Insufficient memory) Failed to allocate 150994944 bytes in function 'cv::OutOfMemoryError'
" thrown in the test body.
[  FAILED  ] DNNTestNetwork.AlexNet/0, where GetParam() = OCV/CPU (890 ms)
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
