### PR TITLE
imgproc: fix incorrect createHanningWindow() results under -ffast-math

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_math.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_math.hpp
@@ -407,7 +407,20 @@ inline _TpVec64F v_log_default_64f(const _TpVec64F &x) {
 
 //! @name Sine and Cosine
 //! @{
+// The range reduction below relies on exact (non-reassociated) cancellation
+// between x and the split DP1/DP2/DP3 constants. -ffast-math (in particular
+// -fassociative-math) allows the compiler to reorder/fuse that arithmetic,
+// which destroys the cancellation and yields grossly wrong results for
+// arguments away from zero. Force strict math for these functions regardless
+// of the translation unit's optimization flags.
+#if defined __GNUC__ && !defined __clang__
+#define CV_HAL_INTRIN_SINCOS_NO_FAST_MATH __attribute__((optimize("no-fast-math")))
+#else
+#define CV_HAL_INTRIN_SINCOS_NO_FAST_MATH
+#endif
+
 template<typename _TpVec16F, typename _TpVec16S>
+CV_HAL_INTRIN_SINCOS_NO_FAST_MATH
 inline void v_sincos_default_16f(const _TpVec16F &x, _TpVec16F &ysin, _TpVec16F &ycos) {
     const _TpVec16F v_cephes_FOPI = v_setall_<_TpVec16F>(hfloat(1.27323954473516f)); // 4 / M_PI
     const _TpVec16F v_minus_DP1 = v_setall_<_TpVec16F>(hfloat(-0.78515625f));
@@ -484,6 +497,7 @@ inline _TpVec16F v_cos_default_16f(const _TpVec16F &x) {
 
 
 template<typename _TpVec32F, typename _TpVec32S>
+CV_HAL_INTRIN_SINCOS_NO_FAST_MATH
 inline void v_sincos_default_32f(const _TpVec32F &x, _TpVec32F &ysin, _TpVec32F &ycos) {
     const _TpVec32F v_cephes_FOPI = v_setall_<_TpVec32F>(1.27323954473516f); // 4 / M_PI
     const _TpVec32F v_minus_DP1 = v_setall_<_TpVec32F>(-0.78515625f);
@@ -559,6 +573,7 @@ inline _TpVec32F v_cos_default_32f(const _TpVec32F &x) {
 }
 
 template<typename _TpVec64F, typename _TpVec64S>
+CV_HAL_INTRIN_SINCOS_NO_FAST_MATH
 inline void v_sincos_default_64f(const _TpVec64F &x, _TpVec64F &ysin, _TpVec64F &ycos) {
     const _TpVec64F v_cephes_FOPI = v_setall_<_TpVec64F>(1.2732395447351626861510701069801148); // 4 / M_PI
     const _TpVec64F v_minus_DP1 = v_setall_<_TpVec64F>(-7.853981554508209228515625E-1);
@@ -644,6 +659,7 @@ inline _TpVec64F v_cos_default_64f(const _TpVec64F &x) {
     v_sincos_default_64f<_TpVec64F, _TpVec64S>(x, ysin, ycos);
     return ycos;
 }
+#undef CV_HAL_INTRIN_SINCOS_NO_FAST_MATH
 //! @}
 
 

--- a/modules/imgproc/test/test_pc.cpp
+++ b/modules/imgproc/test/test_pc.cpp
@@ -151,6 +151,45 @@ TEST(Imgproc_PhaseCorrelatorTest, float32_overflow) {
     EXPECT_NEAR(std::abs(phaseShift.y), 0.0, 1.0);
 }
 
+// Regression test for https://github.com/opencv/opencv/issues/29634
+// createHanningWindow must match the analytical separable Hann window
+// w(x, y) = sqrt(wr(y) * wc(x)), regardless of the SIMD path taken.
+static void checkHanningWindow(const Mat& hann, Size winSize)
+{
+    ASSERT_EQ(hann.size(), winSize);
+    const double coeff0 = 2.0 * CV_PI / (double)(winSize.width - 1);
+    const double coeff1 = 2.0 * CV_PI / (double)(winSize.height - 1);
+
+    for (int y = 0; y < winSize.height; y++)
+    {
+        const double wr = 0.5 * (1.0 - std::cos(coeff1 * y));
+        for (int x = 0; x < winSize.width; x++)
+        {
+            const double wc = 0.5 * (1.0 - std::cos(coeff0 * x));
+            const double expected = std::sqrt(wr * wc);
+            const double actual = hann.depth() == CV_32F
+                ? (double)hann.at<float>(y, x)
+                : hann.at<double>(y, x);
+            ASSERT_NEAR(expected, actual, 1e-4) << "at (" << x << ", " << y << ") for size " << winSize;
+        }
+    }
+}
+
+TEST(Imgproc_HanningWindow, accuracy)
+{
+    // Sizes are chosen to exercise both the SIMD-processed portion and the
+    // scalar remainder of createHanningWindow's internal loops.
+    const Size sizes[] = { Size(12, 12), Size(13, 7), Size(2, 2), Size(33, 17) };
+    for (const Size& sz : sizes)
+    {
+        Mat hann32f, hann64f;
+        createHanningWindow(hann32f, sz, CV_32F);
+        createHanningWindow(hann64f, sz, CV_64F);
+        checkHanningWindow(hann32f, sz);
+        checkHanningWindow(hann64f, sz);
+    }
+}
+
 ////////////////////// DivSpectrums ////////////////////////
 class CV_DivSpectrumsTest : public cvtest::ArrayTest
 {


### PR DESCRIPTION
## Summary

Fixes #29634.

`createHanningWindow()` was returning scrambled results when built with GCC and `ENABLE_FAST_MATH` on (the default), even though the reporter tried to explicitly disable fast-math with `-fno-fast-math`.

**Root cause**: for GCC/Clang, `cmake/OpenCVCompilerOptions.cmake` unconditionally appends `-ffast-math -fno-finite-math-only` whenever `ENABLE_FAST_MATH` is on, with no check for a user-supplied `-fno-fast-math` (unlike the ICX branch, which does check). Since the user's `-fno-fast-math` came earlier on the command line and OpenCV's own `-ffast-math` came after, the last flag wins and fast-math ends up silently re-enabled — visible in the reporter's build config, which lists both flags with `-ffast-math` last.

The vectorized `cos`/`sin` implementation in `intrin_math.hpp` is a Cephes-style range reduction that depends on exact, non-reassociated cancellation between the input `x` and split `DP1`/`DP2`/`DP3` constants. `-ffast-math` (via `-fassociative-math`) permits the compiler to reorder/fuse that subtraction, destroying the cancellation. This explains the reported symptom exactly: results are correct near the edges of the window (small angles) and increasingly wrong toward the middle (angles near π), and disabling `CV_ENABLE_INTRINSICS` (bypassing this code entirely) "fixes" it by falling back to scalar `std::cos`.

**Fix**: add a GCC-only `__attribute__((optimize("no-fast-math")))` to the three `v_sincos_default_{16f,32f,64f}` template functions, forcing strict math for just this range reduction regardless of the translation unit's flags — mirroring the existing precedent in `modules/imgproc/src/moments.cpp` for a similar GCC-optimization correctness issue.

## Test plan

- [x] Added `Imgproc_HanningWindow.accuracy` in `modules/imgproc/test/test_pc.cpp`, validating `createHanningWindow()` output against the analytical `sqrt(wr(y) * wc(x))` formula for both `CV_32F`/`CV_64F` and sizes chosen to exercise both the SIMD and scalar-remainder code paths.
- [x] Built `opencv_core` + `opencv_imgproc` + `opencv_test_imgproc` locally (MSVC) — builds clean, new test passes.
- [x] Ran the full existing `test_pc.cpp` suite; no regressions (2 unrelated pre-existing failures reproduce identically on unmodified `4.x` — missing/mismatched local test-data path, not caused by this change).
- [ ] Not yet verified on the actual affected toolchain (GCC 15 + `-ffast-math` on Linux) — no such environment available to me. Would appreciate confirmation from @VasilevIvanVladimirovich or CI that this resolves the original repro.

Note: this GCC-only `optimize` attribute can prevent GCC from inlining `v_cos`/`v_sin` into callers, since functions with differing `optimize` attributes generally aren't inlined into each other. Flagging as a possible (correctness-over-performance) trade-off for reviewers to weigh in on.