### PR TITLE
photo(npr): fix heap buffer overflow in cv::stylization for single column/row images

### DIFF
--- a/modules/photo/src/npr.cpp
+++ b/modules/photo/src/npr.cpp
@@ -133,8 +133,17 @@ void cv::stylization(InputArray _src, OutputArray _dst, float sigma_s, float sig
     CV_INSTRUMENT_REGION();
 
     Mat I = _src.getMat();
+    if (I.empty())
+        return;
+
     _dst.create(I.size(), CV_8UC3);
     Mat dst = _dst.getMat();
+
+    if (I.cols < 2 || I.rows < 2)
+    {
+        I.copyTo(dst);
+        return;
+    }
 
     Mat img;
     I.convertTo(img,CV_32FC3,1.0/255.0);

--- a/modules/photo/src/npr.hpp
+++ b/modules/photo/src/npr.hpp
@@ -362,20 +362,22 @@ void Domain_Filter::compute_NCfilter(Mat &output, Mat &hz, Mat &psketch, float r
 
                 r = (int) b.at<float>(i,j)/(h*(w+1));
                 rem = (int) b.at<float>(i,j) - r*h*(w+1);
-                q = rem/h;
-                p = rem - q*h;
-                if(q==0)
+                if (rem == 0)
                 {
-                    p=h;
-                    q=w;
-                    r=r-1;
+                    p = h;
+                    q = w;
+                    r = r - 1;
                 }
-                if(p==0)
+                else
                 {
-                    p=h;
-                    q=q-1;
+                    q = rem/h;
+                    p = rem - q*h;
+                    if (p == 0)
+                    {
+                        p = h;
+                        q = q - 1;
+                    }
                 }
-
                 r1 = (int) a.at<float>(i,j)/(h*(w+1));
                 rem1 = (int) a.at<float>(i,j) - r1*h*(w+1);
                 q1 = rem1/h;

--- a/modules/photo/test/test_npr.cpp
+++ b/modules/photo/test/test_npr.cpp
@@ -137,4 +137,19 @@ TEST(Photo_NPR_Stylization, regression)
 
 }
 
+TEST(Photo_NPR_Stylization, singleColumnRow_regression)
+{
+    // Test 1-column image (w=1, h=2)
+    Mat src1(2, 1, CV_8UC3, Scalar(128, 128, 128));
+    Mat dst1;
+    EXPECT_NO_THROW(cv::stylization(src1, dst1, 100.0f, 0.5f));
+    EXPECT_EQ(dst1.size(), src1.size());
+
+    // Test 1-row image (w=2, h=1)
+    Mat src2(1, 2, CV_8UC3, Scalar(128, 128, 128));
+    Mat dst2;
+    EXPECT_NO_THROW(cv::stylization(src2, dst2, 100.0f, 0.5f));
+    EXPECT_EQ(dst2.size(), src2.size());
+}
+
 }} // namespace


### PR DESCRIPTION
### Description

This PR fixes a heap-buffer-overflow crash in `cv::stylization()` (and domain filter normalized convolution path `compute_NCfilter`) when invoked on single-column (`w=1`) or single-row (`h=1`) 3-channel images (`CV_8UC3`).

### Root Cause Analysis

In `modules/photo/src/npr.hpp` (`Domain_Filter::compute_NCfilter`), 3D coordinate indices `(p, q, r)` are decoded from 1-based indexing modulo arithmetic. 

Previously, the condition:
```cpp
if (q == 0)
{
    p = h;
    q = w;
    r = r - 1;
}
