### PR TITLE
Dynamic KV-cache support

### DIFF
--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1034,7 +1034,17 @@ CV__DNN_INLINE_NS_BEGIN
          *
          * Call after enableKVCache() and before the prefill forward. Reserving the
          * full generation length up front keeps the cache buffers fixed, so no page
-         * allocation happens during token-by-token generation. */
+         * allocation happens during token-by-token generation.
+         *
+         * The reservation is applied when the cache is filled for the first time, so calling
+         * this after the prefill forward has no effect until the cache is cleared. It is a
+         * hint, not a limit: generating past @p maxSequenceLength still grows the cache.
+         *
+         * resetKVCache() drops the reservation, so it has to be re-issued for every generation.
+         *
+         * Only models whose attention is imported as a single fused op (ONNX Attention,
+         * com.microsoft MultiHeadAttention / GroupQueryAttention) use the paged cache. On a
+         * model with decomposed attention this logs a warning and does nothing. */
         CV_WRAP void reserveKVCache(int maxSequenceLength);
         /** @brief Returns profiling data captured during the last forward pass.
          *

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1029,6 +1029,13 @@ CV__DNN_INLINE_NS_BEGIN
 
         /** @brief Resets KV-Cache for all AttentionOnnxI layers */
         CV_WRAP void resetKVCache();
+
+        /** @brief Pre-allocates KV-Cache pages for up to @p maxSequenceLength tokens.
+         *
+         * Call after enableKVCache() and before the prefill forward. Reserving the
+         * full generation length up front keeps the cache buffers fixed, so no page
+         * allocation happens during token-by-token generation. */
+        CV_WRAP void reserveKVCache(int maxSequenceLength);
         /** @brief Returns profiling data captured during the last forward pass.
          *
          * Entries are sorted by time in descending order. Empty vectors are returned

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -1032,19 +1032,13 @@ CV__DNN_INLINE_NS_BEGIN
 
         /** @brief Pre-allocates KV-Cache pages for up to @p maxSequenceLength tokens.
          *
-         * Call after enableKVCache() and before the prefill forward. Reserving the
-         * full generation length up front keeps the cache buffers fixed, so no page
-         * allocation happens during token-by-token generation.
+         * Call after enableKVCache() and before the prefill forward, so no page allocation
+         * happens during generation. A hint, not a limit: going past @p maxSequenceLength
+         * still grows the cache. resetKVCache() drops the reservation.
          *
-         * The reservation is applied when the cache is filled for the first time, so calling
-         * this after the prefill forward has no effect until the cache is cleared. It is a
-         * hint, not a limit: generating past @p maxSequenceLength still grows the cache.
-         *
-         * resetKVCache() drops the reservation, so it has to be re-issued for every generation.
-         *
-         * Only models whose attention is imported as a single fused op (ONNX Attention,
-         * com.microsoft MultiHeadAttention / GroupQueryAttention) use the paged cache. On a
-         * model with decomposed attention this logs a warning and does nothing. */
+         * Only models whose attention imports as a single fused op (ONNX Attention,
+         * com.microsoft MultiHeadAttention / GroupQueryAttention) use the paged cache;
+         * otherwise this warns and does nothing. */
         CV_WRAP void reserveKVCache(int maxSequenceLength);
         /** @brief Returns profiling data captured during the last forward pass.
          *

--- a/modules/dnn/perf/perf_layer.cpp
+++ b/modules/dnn/perf/perf_layer.cpp
@@ -781,6 +781,64 @@ PERF_TEST_P_(Layer_Attention, VisionTransformer) {
     test_layer({1, 197, 768}, {768, 768, 768}, 12);
 }
 
+struct Layer_AttentionOnnxAi : public TestBaseWithParam<int>
+{
+    void decode_step(const std::string& layout, int nq, int nkv)
+    {
+        int past = GetParam();
+        bool is3d = layout == "3d";
+
+        std::string model = "dnn/onnx/models/test_attention_kv_cache_" + layout + ".onnx";
+        Net net = readNetFromONNX(findDataFile(model, true), ENGINE_OPENCV);
+
+        auto qkv = [&](int n, int t) {
+            return is3d ? std::vector<int>{1, t, n * D} : std::vector<int>{1, n, t, D};
+        };
+
+        Mat qp(qkv(nq, past), CV_32F), kp(qkv(nkv, past), CV_32F), vp(qkv(nkv, past), CV_32F);
+        Mat qd(qkv(nq, 1), CV_32F), kd(qkv(nkv, 1), CV_32F), vd(qkv(nkv, 1), CV_32F);
+        for (Mat* m : {&qp, &kp, &vp, &qd, &kd, &vd})
+            randu(*m, -1.f, 1.f);
+
+        std::vector<int> mp_sz{1, nq, past, past}, md_sz{1, nq, 1, past + 1};
+        Mat mp(mp_sz, CV_32S, Scalar(1)), md(md_sz, CV_32S, Scalar(1));
+
+        net.enableKVCache();
+
+        while (next())
+        {
+            // Reset, reserve and prefill stay outside the timer, so the measurement is one
+            // decode step against `past` cached tokens with the page pool already allocated.
+            net.resetKVCache();
+            net.reserveKVCache(past + 1);
+            net.setInput(qp, "Q");
+            net.setInput(kp, "K");
+            net.setInput(vp, "V");
+            net.setInput(mp, "Mask");
+            net.forward();
+
+            net.setInput(qd, "Q");
+            net.setInput(kd, "K");
+            net.setInput(vd, "V");
+            net.setInput(md, "Mask");
+
+            startTimer();
+            net.forward();
+            stopTimer();
+        }
+
+        SANITY_CHECK_NOTHING();
+    }
+
+    const int D = 256;
+};
+
+// 3D takes its head counts from the model attributes (q_num_heads=8, kv_num_heads=4);
+// 4D takes them from the [batch, heads, seq, head_dim] layout, so both ratios are drivable.
+PERF_TEST_P_(Layer_AttentionOnnxAi, decode_gqa_3d) { decode_step("3d", 8, 4); }
+PERF_TEST_P_(Layer_AttentionOnnxAi, decode_gqa_4d) { decode_step("4d", 8, 2); }
+PERF_TEST_P_(Layer_AttentionOnnxAi, decode_mha_4d) { decode_step("4d", 8, 8); }
+
 struct Layer_GroupNorm : public TestBaseWithParam<tuple<Backend, Target> >
 {
     void test_layer(const std::vector<int>& x_shape, int num_groups)
@@ -854,6 +912,7 @@ INSTANTIATE_TEST_CASE_P(/**/, Layer_LayerNormExpanded, testing::Values(std::make
 INSTANTIATE_TEST_CASE_P(/**/, Layer_GatherElements, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 INSTANTIATE_TEST_CASE_P(/**/, Layer_InstanceNorm, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 INSTANTIATE_TEST_CASE_P(/**/, Layer_Attention, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
+INSTANTIATE_TEST_CASE_P(/**/, Layer_AttentionOnnxAi, testing::Values(1, 64, 512));
 INSTANTIATE_TEST_CASE_P(/**/, Layer_GroupNorm, testing::Values(std::make_tuple(DNN_BACKEND_OPENCV, DNN_TARGET_CPU)));
 
 typedef TestBaseWithParam<tuple<Vec4i, int, bool, tuple<Backend, Target> > > Layer_FullyConnected;

--- a/modules/dnn/src/kv_cache_manager.cpp
+++ b/modules/dnn/src/kv_cache_manager.cpp
@@ -42,6 +42,9 @@ void setKVCacheManager(Ptr<Net::Impl> netimpl)
 {
     CV_Assert(netimpl != nullptr);
 
+    // readNetFromONNX() returns an empty Net on unsupported ops; don't walk a null graph.
+    CV_CheckTrue(!netimpl->mainGraph.empty(),
+                 "enableKVCache() requires a successfully loaded model");
     CV_Assert(!netimpl->layers.empty());
 
     auto manager = KVCacheManager();
@@ -172,7 +175,7 @@ void KVCache::grow(const Mat& newData) {
     if (pages.empty()) {
         // Prefill: allocate the page pool, honouring any reserved capacity.
         int neededPages   = (T + pageSize - 1) / pageSize;
-        int reservedPages = (reservedTokens + pageSize - 1) / pageSize;
+        int reservedPages = (int)(((int64_t)reservedTokens + pageSize - 1) / pageSize);
         int totalPages    = std::max(neededPages, reservedPages);
         for (int i = 0; i < totalPages; i++) {
             int page_size = isKCache ?

--- a/modules/dnn/src/kv_cache_manager.cpp
+++ b/modules/dnn/src/kv_cache_manager.cpp
@@ -134,6 +134,12 @@ void KVCacheManager::applyRoutes()
     }
 }
 
+void KVCacheManager::reserve(int maxTokens)
+{
+    for (auto& kv : kData) kv.second.reserve(maxTokens);
+    for (auto& kv : vData) kv.second.reserve(maxTokens);
+}
+
 void KVCache::grow(const Mat& newData) {
     CV_Assert(newData.dims == 4 || newData.dims == 3);
 
@@ -163,16 +169,11 @@ void KVCache::grow(const Mat& newData) {
 
     int T = newData.dims == 4 ? newData.size[2] : newData.size[1];
 
-    if (T > 1 || pages.empty()) {
-        // prefetch
-        if(!pages.empty())
-            CV_Error(
-                cv::Error::StsNotImplemented,
-                "storing multiple tokens to a non-empty cache is not supported yet. Either clear the cache (to reenter the prefetch phase) or provide tokens one-by-one"
-            );
-
-        // add pages
-        int totalPages = (T + pageSize - 1) / pageSize;
+    if (pages.empty()) {
+        // Prefill: allocate the page pool, honouring any reserved capacity.
+        int neededPages   = (T + pageSize - 1) / pageSize;
+        int reservedPages = (reservedTokens + pageSize - 1) / pageSize;
+        int totalPages    = std::max(neededPages, reservedPages);
         for (int i = 0; i < totalPages; i++) {
             int page_size = isKCache ?
                 (int)fastGemmPackBSize(pageSize, headDim, opt):
@@ -183,11 +184,25 @@ void KVCache::grow(const Mat& newData) {
             );
         }
         growPrefill(newData, T);
-    } else{
-        // generate
-        growGenerate(newData);
+    } else {
+        // Non-empty cache: append T (>=1) tokens (T>1 = chunked prefill / speculative decode).
+        appendTokens(newData, T);
     }
 
+}
+
+void KVCache::appendTokens(const Mat& newData, int T) {
+    if (T == 1) {
+        growGenerate(newData);
+        return;
+    }
+    const int seqAxis = newData.dims == 4 ? 2 : 1;
+    std::vector<Range> ranges(newData.dims, Range::all());
+    for (int t = 0; t < T; t++) {
+        ranges[seqAxis] = Range(t, t + 1);
+        Mat token = newData(ranges).clone(); // contiguous single-token slice
+        growGenerate(token);
+    }
 }
 
 void KVCache::growPrefill(const Mat& newData, int T){

--- a/modules/dnn/src/kv_cache_manager.hpp
+++ b/modules/dnn/src/kv_cache_manager.hpp
@@ -11,6 +11,7 @@
 #include <opencv2/core.hpp>
 #include <opencv2/dnn/dnn.hpp>
 
+#include <algorithm>
 #include <map>
 #include <string>
 #include <vector>
@@ -19,6 +20,9 @@
 
 namespace cv { namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
+
+// Upper bound for reserveKVCache(); keeps the page-count arithmetic in range.
+enum { KV_CACHE_MAX_RESERVED_TOKENS = 1 << 24 };
 
 class KVCache
 {
@@ -33,7 +37,6 @@ class KVCache
         }
         // Reserve the page pool for up to maxTokens (static cache); applied at prefill.
         void reserve(int maxTokens) { reservedTokens = std::max(reservedTokens, maxTokens); }
-        const std::vector<Mat>& getPages() const { return pages; }
         int getActivePageCount() const { return pageSize > 0 ? (nTokens + pageSize - 1) / pageSize : 0; }
         // Pages holding tokens. The paged kernels size the last page from the page count,
         // so reserved empty trailing pages must not be passed to them.
@@ -111,6 +114,7 @@ struct KVCacheManager
     void initPastTensors();
     // Pre-reserve every per-layer K/V cache for up to maxTokens total sequence length.
     void reserve(int maxTokens);
+    bool empty() const { return kData.empty() && vData.empty(); }
 };
 
 void setKVCacheManager(Ptr<Net::Impl> netimpl);

--- a/modules/dnn/src/kv_cache_manager.hpp
+++ b/modules/dnn/src/kv_cache_manager.hpp
@@ -31,11 +31,22 @@ class KVCache
             pages.clear();
             nTokens = 0;
         }
+        // Reserve the page pool for up to maxTokens (static cache); applied at prefill.
+        void reserve(int maxTokens) { reservedTokens = std::max(reservedTokens, maxTokens); }
         const std::vector<Mat>& getPages() const { return pages; }
+        int getActivePageCount() const { return pageSize > 0 ? (nTokens + pageSize - 1) / pageSize : 0; }
+        // Pages holding tokens. The paged kernels size the last page from the page count,
+        // so reserved empty trailing pages must not be passed to them.
+        std::vector<Mat> getActivePages() const {
+            size_t n = std::min((size_t)getActivePageCount(), pages.size());
+            return std::vector<Mat>(pages.begin(), pages.begin() + n);
+        }
         int getPageSize() const { return pageSize; }
         int getNumTokens() const { return nTokens; }
     protected:
         void growPrefill(const Mat& newData, int T);
+        // Append T (>=1) tokens to a non-empty cache one column at a time.
+        void appendTokens(const Mat& newData, int T);
 
         virtual void growGenerate(const Mat& newData) = 0;
         std::vector<Mat> pages;
@@ -46,6 +57,7 @@ class KVCache
         int headDim;
         int batchSize = -1;
         int offset;
+        int reservedTokens = 0;
         bool isKCache = false;
         FastGemmOpt opt;
 };
@@ -97,6 +109,8 @@ struct KVCacheManager
     void buildRoutes();
     void applyRoutes();
     void initPastTensors();
+    // Pre-reserve every per-layer K/V cache for up to maxTokens total sequence length.
+    void reserve(int maxTokens);
 };
 
 void setKVCacheManager(Ptr<Net::Impl> netimpl);

--- a/modules/dnn/src/layers/attention_onnxai_layer.cpp
+++ b/modules/dnn/src/layers/attention_onnxai_layer.cpp
@@ -266,7 +266,7 @@ class AttentionOnnxAiLayerImpl CV_FINAL : public AttentionOnnxAiLayer {
 
             kData.grow(inputs[1]);
 
-            const std::vector<Mat>& kCachePages = kData.getPages();
+            const std::vector<Mat> kCachePages = kData.getActivePages();
             seq_len_kv = kData.getNumTokens();
 
             pagedAttnQKGemm(
@@ -292,7 +292,7 @@ class AttentionOnnxAiLayerImpl CV_FINAL : public AttentionOnnxAiLayer {
             seq_len_kv = vData.getNumTokens();
 
             pagedAttnAVGemm(
-                attention_prob, vData.getPages(), outputs[0],
+                attention_prob, vData.getActivePages(), outputs[0],
                 seq_len_q, nhq, nhkv, vData.getPageSize() , v_head_size, seq_len_kv,
                 opt
             );

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -521,6 +521,15 @@ void Net::reserveKVCache(int maxSequenceLength)
     CV_CheckTrue(impl->useKVCache && impl->kvCacheManager.isInitialized,
                  "reserveKVCache() requires enableKVCache() to be called first");
     CV_CheckGE(maxSequenceLength, 0, "maxSequenceLength must be non-negative");
+    CV_CheckLE(maxSequenceLength, KV_CACHE_MAX_RESERVED_TOKENS,
+               "maxSequenceLength is unreasonably large");
+    if (impl->kvCacheManager.empty())
+    {
+        CV_LOG_WARNING(NULL, "DNN: reserveKVCache() has no effect, the model has no paged attention "
+                             "layers (no Attention/MultiHeadAttention/GroupQueryAttention op was imported). "
+                             "Only the present.* -> past_key_values.* routing is active.");
+        return;
+    }
     impl->kvCacheManager.reserve(maxSequenceLength);
 }
 

--- a/modules/dnn/src/net.cpp
+++ b/modules/dnn/src/net.cpp
@@ -515,6 +515,15 @@ void Net::resetKVCache()
     setKVCacheManager(impl);
 }
 
+void Net::reserveKVCache(int maxSequenceLength)
+{
+    CV_Assert(impl);
+    CV_CheckTrue(impl->useKVCache && impl->kvCacheManager.isInitialized,
+                 "reserveKVCache() requires enableKVCache() to be called first");
+    CV_CheckGE(maxSequenceLength, 0, "maxSequenceLength must be non-negative");
+    impl->kvCacheManager.reserve(maxSequenceLength);
+}
+
 
 Ptr<Graph> Net::getMainGraph() const
 {

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -277,6 +277,7 @@ protected:
     void parseMultiHeadAttention   (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseGroupQueryAttention  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSimplifiedLayerNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseSkipSimplifiedLayerNorm(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseCausalConvWithState  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSDPA                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseDequantizeLinear     (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
@@ -2773,6 +2774,10 @@ static bool hasInput(const opencv_onnx::NodeProto& node, int i) {
     return i < node.input_size() && !node.input(i).empty();
 }
 
+static bool hasOutput(const opencv_onnx::NodeProto& node, int i) {
+    return i < node.output_size() && !node.output(i).empty();
+}
+
 // com.microsoft MultiHeadAttention (unpacked Q/K/V) -> AttentionOnnxAi.
 void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
     CV_CheckTrue(params.has("num_heads"), "MultiHeadAttention: num_heads is required");
@@ -2782,9 +2787,13 @@ void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_on
         "MultiHeadAttention: bias / key_padding_mask / cache_indirection inputs are not supported");
 
     // inputs: query, key, value, bias, key_padding_mask, attention_bias, past_key, past_value, ...
+    const bool has_past_k = hasInput(node_proto, 6), has_past_v = hasInput(node_proto, 7);
+    CV_CheckTrue(has_past_k == has_past_v,
+                 "MultiHeadAttention: past_key and past_value must be provided as a pair");
+
     std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
     if (hasInput(node_proto, 5)) ins.push_back(node_inputs[5]);  // attention_bias -> mask
-    if (hasInput(node_proto, 6) && hasInput(node_proto, 7)) { ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]); }
+    if (has_past_k) { ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]); }
     node_inputs = ins;
 
     params.type = "AttentionOnnxAi";
@@ -2797,8 +2806,6 @@ void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_on
 }
 
 // com.microsoft GroupQueryAttention (grouped, causal) -> AttentionOnnxAi.
-// Dynamic-cache export: past_key/past_value carry the real length; seqlens_k and
-// total_sequence_length are dropped.
 void ONNXImporter2::parseGroupQueryAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
     CV_CheckTrue(params.has("num_heads") && params.has("kv_num_heads"),
                  "GroupQueryAttention: num_heads and kv_num_heads are required");
@@ -2810,8 +2817,21 @@ void ONNXImporter2::parseGroupQueryAttention(LayerParams& params, const opencv_o
         CV_CheckFalse(hasInput(node_proto, i), "GroupQueryAttention: only query/key/value/past_key/past_value are supported");
 
     // inputs: query, key, value, past_key, past_value, seqlens_k, total_sequence_length, ...
+    const bool has_past_k = hasInput(node_proto, 3), has_past_v = hasInput(node_proto, 4);
+    CV_CheckTrue(has_past_k == has_past_v,
+                 "GroupQueryAttention: past_key and past_value must be provided as a pair");
+
     std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
-    if (hasInput(node_proto, 3) && hasInput(node_proto, 4)) { ins.push_back(node_inputs[3]); ins.push_back(node_inputs[4]); }
+    if (has_past_k) {
+        // Dropping seqlens_k is only sound for a growing past. A fixed past seq dim means a
+        // shared-buffer cache whose real length lives in seqlens_k, so it would be mis-read.
+        const MatShape& pk = netimpl->args.at(node_inputs[3].idx).shape;
+        if (pk.dims >= 2)
+            CV_CheckLE(pk[pk.dims - 2], 0,
+                "GroupQueryAttention: past_key has a fixed sequence length (shared-buffer / static "
+                "cache export); only dynamic-cache exports are supported");
+        ins.push_back(node_inputs[3]); ins.push_back(node_inputs[4]);
+    }
     node_inputs = ins;
 
     params.type = "AttentionOnnxAi";
@@ -2820,6 +2840,46 @@ void ONNXImporter2::parseGroupQueryAttention(LayerParams& params, const opencv_o
     params.set("is_causal", true);
 
     addLayer(params, node_proto, (int)node_inputs.size());
+}
+
+// SkipSimplifiedLayerNormalization = RMSNorm(input + skip [+ bias]) * gamma, decomposed here.
+// outputs: output, mean?, inv_std_var?, input_skip_bias_sum?
+void ONNXImporter2::parseSkipSimplifiedLayerNorm(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
+                 "SkipSimplifiedLayerNormalization: skip and gamma are required");
+    CV_CheckFalse(hasOutput(node_proto, 1) || hasOutput(node_proto, 2),
+                  "SkipSimplifiedLayerNormalization: mean / inv_std_var outputs are not supported");
+
+    const std::vector<Arg> ins = node_inputs, outs = node_outputs;
+    const bool has_bias = hasInput(node_proto, 3);
+    // input_skip_bias_sum is the next block's residual, so produce it when asked for.
+    const bool want_sum = hasOutput(node_proto, 3) && outs.size() > 3;
+
+    LayerParams add;
+    add.name = params.name + "/skip_add";
+    add.type = "NaryEltwise";
+    add.set("operation", "add");
+    Arg sum = (want_sum && !has_bias) ? outs[3] : net.getArg(add.name + "/out");
+    node_inputs = {ins[0], ins[1]};
+    node_outputs = {sum};
+    addLayer(add, node_proto, 2);
+
+    if (has_bias) {
+        LayerParams addb;
+        addb.name = params.name + "/bias_add";
+        addb.type = "NaryEltwise";
+        addb.set("operation", "add");
+        Arg biased = want_sum ? outs[3] : net.getArg(addb.name + "/out");
+        node_inputs = {sum, ins[3]};
+        node_outputs = {biased};
+        addLayer(addb, node_proto, 2);
+        sum = biased;
+    }
+
+    params.type = "RMSNormalization";
+    node_inputs = {sum, ins[2]};
+    node_outputs = {outs[0]};
+    addLayer(params, node_proto, 2);
 }
 
 void ONNXImporter2::parseCausalConvWithState(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
@@ -2969,6 +3029,7 @@ void ONNXImporter2::buildDispatchMap_ONNX_AI()
     dispatch["Attention"] = &ONNXImporter2::parseAttentionOnnxAi;
     dispatch["CausalConvWithState"] = &ONNXImporter2::parseCausalConvWithState;
     dispatch["SimplifiedLayerNormalization"] = &ONNXImporter2::parseSimplifiedLayerNormalization;
+    dispatch["SkipSimplifiedLayerNormalization"] = &ONNXImporter2::parseSkipSimplifiedLayerNorm;
 
     domain_dispatch_map[str_domain_ai_onnx] = dispatch;
 }
@@ -2992,6 +3053,7 @@ void ONNXImporter2::buildDispatchMap_COM_MICROSOFT()
     dispatch["MultiHeadAttention"] = &ONNXImporter2::parseMultiHeadAttention;
     dispatch["GroupQueryAttention"] = &ONNXImporter2::parseGroupQueryAttention;
     dispatch["SimplifiedLayerNormalization"] = &ONNXImporter2::parseSimplifiedLayerNormalization;
+    dispatch["SkipSimplifiedLayerNormalization"] = &ONNXImporter2::parseSkipSimplifiedLayerNorm;
     dispatch["MatMulNBits"] = &ONNXImporter2::parseMatMulNBits;
 
     domain_dispatch_map[str_domain_com_microsoft] = dispatch;

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -274,6 +274,8 @@ protected:
     // URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
     void parseAttention            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseAttentionOnnxAi      (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseMultiHeadAttention   (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGroupQueryAttention  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSimplifiedLayerNormalization(LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseCausalConvWithState  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSDPA                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
@@ -2766,6 +2768,60 @@ void ONNXImporter2::parseSDPA(LayerParams& params, const opencv_onnx::NodeProto&
     addLayer(params, node_proto, 3);
 }
 
+// True if node input i exists and is not an omitted optional ("").
+static bool hasInput(const opencv_onnx::NodeProto& node, int i) {
+    return i < node.input_size() && !node.input(i).empty();
+}
+
+// com.microsoft MultiHeadAttention (unpacked Q/K/V) -> AttentionOnnxAi.
+void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(params.has("num_heads"), "MultiHeadAttention: num_heads is required");
+    CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
+                 "MultiHeadAttention: separate key and value are required");
+    CV_CheckFalse(hasInput(node_proto, 3) || hasInput(node_proto, 4) || hasInput(node_proto, 9),
+        "MultiHeadAttention: bias / key_padding_mask / cache_indirection inputs are not supported");
+
+    // inputs: query, key, value, bias, key_padding_mask, attention_bias, past_key, past_value, ...
+    std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
+    if (hasInput(node_proto, 5)) ins.push_back(node_inputs[5]);  // attention_bias -> mask
+    if (hasInput(node_proto, 6) && hasInput(node_proto, 7)) { ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]); }
+    node_inputs = ins;
+
+    params.type = "AttentionOnnxAi";
+    params.set("q_num_heads", params.get<int>("num_heads"));   // MHA is not grouped
+    params.set("kv_num_heads", params.get<int>("num_heads"));
+    if (params.get<int>("unidirectional", 0))
+        params.set("is_causal", true);
+
+    addLayer(params, node_proto, (int)node_inputs.size());
+}
+
+// com.microsoft GroupQueryAttention (grouped, causal) -> AttentionOnnxAi.
+// Dynamic-cache export: past_key/past_value carry the real length; seqlens_k and
+// total_sequence_length are dropped.
+void ONNXImporter2::parseGroupQueryAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(params.has("num_heads") && params.has("kv_num_heads"),
+                 "GroupQueryAttention: num_heads and kv_num_heads are required");
+    CV_CheckEQ(params.get<int>("do_rotary", 0), 0, "GroupQueryAttention: do_rotary=1 is not supported");
+    CV_CheckEQ(params.get<int>("local_window_size", -1), -1, "GroupQueryAttention: sliding window is not supported");
+    CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
+                 "GroupQueryAttention: separate key and value are required");
+    for (int i = 7; i < node_proto.input_size(); i++)  // rotary / bias / KV-quant / QK-norm inputs
+        CV_CheckFalse(hasInput(node_proto, i), "GroupQueryAttention: only query/key/value/past_key/past_value are supported");
+
+    // inputs: query, key, value, past_key, past_value, seqlens_k, total_sequence_length, ...
+    std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
+    if (hasInput(node_proto, 3) && hasInput(node_proto, 4)) { ins.push_back(node_inputs[3]); ins.push_back(node_inputs[4]); }
+    node_inputs = ins;
+
+    params.type = "AttentionOnnxAi";
+    params.set("q_num_heads", params.get<int>("num_heads"));
+    params.set("kv_num_heads", params.get<int>("kv_num_heads"));
+    params.set("is_causal", true);
+
+    addLayer(params, node_proto, (int)node_inputs.size());
+}
+
 void ONNXImporter2::parseCausalConvWithState(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
     params.type = "CausalConvWithState";
     addLayer(params, node_proto);
@@ -2933,6 +2989,8 @@ void ONNXImporter2::buildDispatchMap_COM_MICROSOFT()
     dispatch["QGemm"] = &ONNXImporter2::parseQGemm;
     dispatch["QLinearSoftmax"] = &ONNXImporter2::parseQSoftmax;
     dispatch["Attention"] = &ONNXImporter2::parseAttention;
+    dispatch["MultiHeadAttention"] = &ONNXImporter2::parseMultiHeadAttention;
+    dispatch["GroupQueryAttention"] = &ONNXImporter2::parseGroupQueryAttention;
     dispatch["SimplifiedLayerNormalization"] = &ONNXImporter2::parseSimplifiedLayerNormalization;
     dispatch["MatMulNBits"] = &ONNXImporter2::parseMatMulNBits;
 

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -2783,8 +2783,11 @@ void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_on
     CV_CheckTrue(params.has("num_heads"), "MultiHeadAttention: num_heads is required");
     CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
                  "MultiHeadAttention: separate key and value are required");
-    CV_CheckFalse(hasInput(node_proto, 3) || hasInput(node_proto, 4) || hasInput(node_proto, 9),
-        "MultiHeadAttention: bias / key_padding_mask / cache_indirection inputs are not supported");
+    CV_CheckFalse(hasInput(node_proto, 3) || hasInput(node_proto, 4),
+        "MultiHeadAttention: bias / key_padding_mask inputs are not supported");
+    for (int i = 8; i < node_proto.input_size(); i++)  // past_sequence_length / cache_indirection
+        CV_CheckFalse(hasInput(node_proto, i),
+            "MultiHeadAttention: only query/key/value/attention_bias/past_key/past_value are supported");
 
     // inputs: query, key, value, bias, key_padding_mask, attention_bias, past_key, past_value, ...
     const bool has_past_k = hasInput(node_proto, 6), has_past_v = hasInput(node_proto, 7);
@@ -2793,7 +2796,17 @@ void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_on
 
     std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
     if (hasInput(node_proto, 5)) ins.push_back(node_inputs[5]);  // attention_bias -> mask
-    if (has_past_k) { ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]); }
+    if (has_past_k) {
+        // The past length is read back off past_key's shape. A fixed seq dim means a shared-buffer
+        // cache whose real length lives in past_sequence_length, so the unwritten tail would be
+        // taken as history.
+        const MatShape& pk = netimpl->args.at(node_inputs[6].idx).shape;
+        if (pk.dims >= 2)
+            CV_CheckLE(pk[pk.dims - 2], 0,
+                "MultiHeadAttention: past_key has a fixed sequence length (shared-buffer / static "
+                "cache export); only dynamic-cache exports are supported");
+        ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]);
+    }
     node_inputs = ins;
 
     params.type = "AttentionOnnxAi";

--- a/modules/dnn/src/onnx/onnx_importer2.cpp
+++ b/modules/dnn/src/onnx/onnx_importer2.cpp
@@ -287,6 +287,8 @@ protected:
     // URL: https://github.com/microsoft/onnxruntime/blob/master/docs/ContribOperators.md
     void parseAttention            (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseAttentionOnnxAi      (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseMultiHeadAttention   (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
+    void parseGroupQueryAttention  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseCausalConvWithState  (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseSDPA                 (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
     void parseDequantizeLinear     (LayerParams& layerParams, const opencv_onnx::NodeProto& node_proto);
@@ -2695,6 +2697,60 @@ void ONNXImporter2::parseSDPA(LayerParams& params, const opencv_onnx::NodeProto&
     addLayer(params, node_proto, 3);
 }
 
+// True if node input i exists and is not an omitted optional ("").
+static bool hasInput(const opencv_onnx::NodeProto& node, int i) {
+    return i < node.input_size() && !node.input(i).empty();
+}
+
+// com.microsoft MultiHeadAttention (unpacked Q/K/V) -> AttentionOnnxAi.
+void ONNXImporter2::parseMultiHeadAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(params.has("num_heads"), "MultiHeadAttention: num_heads is required");
+    CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
+                 "MultiHeadAttention: separate key and value are required");
+    CV_CheckFalse(hasInput(node_proto, 3) || hasInput(node_proto, 4) || hasInput(node_proto, 9),
+        "MultiHeadAttention: bias / key_padding_mask / cache_indirection inputs are not supported");
+
+    // inputs: query, key, value, bias, key_padding_mask, attention_bias, past_key, past_value, ...
+    std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
+    if (hasInput(node_proto, 5)) ins.push_back(node_inputs[5]);  // attention_bias -> mask
+    if (hasInput(node_proto, 6) && hasInput(node_proto, 7)) { ins.push_back(node_inputs[6]); ins.push_back(node_inputs[7]); }
+    node_inputs = ins;
+
+    params.type = "AttentionOnnxAi";
+    params.set("q_num_heads", params.get<int>("num_heads"));   // MHA is not grouped
+    params.set("kv_num_heads", params.get<int>("num_heads"));
+    if (params.get<int>("unidirectional", 0))
+        params.set("is_causal", true);
+
+    addLayer(params, node_proto, (int)node_inputs.size());
+}
+
+// com.microsoft GroupQueryAttention (grouped, causal) -> AttentionOnnxAi.
+// Dynamic-cache export: past_key/past_value carry the real length; seqlens_k and
+// total_sequence_length are dropped.
+void ONNXImporter2::parseGroupQueryAttention(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
+    CV_CheckTrue(params.has("num_heads") && params.has("kv_num_heads"),
+                 "GroupQueryAttention: num_heads and kv_num_heads are required");
+    CV_CheckEQ(params.get<int>("do_rotary", 0), 0, "GroupQueryAttention: do_rotary=1 is not supported");
+    CV_CheckEQ(params.get<int>("local_window_size", -1), -1, "GroupQueryAttention: sliding window is not supported");
+    CV_CheckTrue(hasInput(node_proto, 1) && hasInput(node_proto, 2),
+                 "GroupQueryAttention: separate key and value are required");
+    for (int i = 7; i < node_proto.input_size(); i++)  // rotary / bias / KV-quant / QK-norm inputs
+        CV_CheckFalse(hasInput(node_proto, i), "GroupQueryAttention: only query/key/value/past_key/past_value are supported");
+
+    // inputs: query, key, value, past_key, past_value, seqlens_k, total_sequence_length, ...
+    std::vector<Arg> ins{node_inputs[0], node_inputs[1], node_inputs[2]};
+    if (hasInput(node_proto, 3) && hasInput(node_proto, 4)) { ins.push_back(node_inputs[3]); ins.push_back(node_inputs[4]); }
+    node_inputs = ins;
+
+    params.type = "AttentionOnnxAi";
+    params.set("q_num_heads", params.get<int>("num_heads"));
+    params.set("kv_num_heads", params.get<int>("kv_num_heads"));
+    params.set("is_causal", true);
+
+    addLayer(params, node_proto, (int)node_inputs.size());
+}
+
 void ONNXImporter2::parseCausalConvWithState(LayerParams& params, const opencv_onnx::NodeProto& node_proto) {
     params.type = "CausalConvWithState";
     addLayer(params, node_proto);
@@ -2861,6 +2917,8 @@ void ONNXImporter2::buildDispatchMap_COM_MICROSOFT()
     dispatch["QGemm"] = &ONNXImporter2::parseQGemm;
     dispatch["QLinearSoftmax"] = &ONNXImporter2::parseQSoftmax;
     dispatch["Attention"] = &ONNXImporter2::parseAttention;
+    dispatch["MultiHeadAttention"] = &ONNXImporter2::parseMultiHeadAttention;
+    dispatch["GroupQueryAttention"] = &ONNXImporter2::parseGroupQueryAttention;
 
     domain_dispatch_map[str_domain_com_microsoft] = dispatch;
 }

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2541,11 +2541,82 @@ public:
         std::string msg = "Attention generate " + layout + ": KV vs standard";
         normAssert(Y, Yref, msg.c_str(), 1e-3, 1e-3);
     }
+
+    // Generate in multi-token chunks (chunked prefill / speculative decode) with the
+    // page pool pre-reserved via reserveKVCache(). Must match the non-cached full run.
+    void testKVCacheChunkedReserve(const std::string& layout)
+    {
+        std::string model_path = "dnn/onnx/models/test_attention_kv_cache_" + layout + ".onnx";
+
+        Net netWithKVCache = readNetFromONNX(findDataFile(model_path, true), cv::dnn::ENGINE_OPENCV);
+        netWithKVCache.enableKVCache();
+        Net netWithoutKVCache = readNetFromONNX(findDataFile(model_path, true), cv::dnn::ENGINE_OPENCV);
+
+        int T = 523, Nq = 8, Nkv = 4, D = 256;
+        int T_pref = T - 37;    // generate the tail in chunks, incl. a partial last chunk
+        int chunk = 5;
+
+        netWithKVCache.reserveKVCache(T);   // static pre-allocation
+
+        std::vector<int> q_sz, k_sz, v_sz;
+        if (layout == "3d") { q_sz = {1, T, Nq * D}; k_sz = {1, T, Nkv * D}; v_sz = {1, T, Nkv * D}; }
+        else                { q_sz = {1, Nq, T, D}; k_sz = {1, Nkv, T, D}; v_sz = {1, Nkv, T, D}; }
+
+        Mat Q_all(q_sz, CV_32F), K_all(k_sz, CV_32F), V_all(v_sz, CV_32F);
+        cv::randn(Q_all, 0.0, 1.0); cv::randn(K_all, 0.0, 1.0); cv::randn(V_all, 0.0, 1.0);
+
+        std::vector<int> mask_sz = {1, Nq, T, T};
+        Mat mask(mask_sz, CV_32S, cv::Scalar(0));
+        int* mask_ptr = (int*)mask.data;
+        for (int n = 0; n < Nq; n++)
+            for (int i = 0; i < T; i++)
+                for (int j = 0; j < T; j++) {
+                    int idx = n * T * T + i * T + j;
+                    if (i < T_pref) { if (j < T_pref) mask_ptr[idx] = 1; }
+                    else            { if (j <= i)      mask_ptr[idx] = 1; }
+                }
+
+        Mat Y(q_sz, CV_32F); Y.setTo(0);
+
+        // Prefill (lo=0) then generate in multi-token chunks. A chunk needs within-chunk
+        // causality supplied explicitly (this model is not is_causal), so feed the reference
+        // mask restricted to queries [lo,hi) against the cache [0,hi).
+        for (int lo = 0; lo < T; )
+        {
+            int hi = (lo == 0) ? T_pref : std::min(lo + chunk, T);
+            std::vector<Range> qr;
+            if (layout == "3d") qr = { Range::all(), Range(lo, hi), Range::all() };
+            else                qr = { Range::all(), Range::all(), Range(lo, hi), Range::all() };
+            std::vector<Range> mr = { Range::all(), Range::all(), Range(lo, hi), Range(0, hi) };
+
+            netWithKVCache.setInput(Q_all(qr), "Q");
+            netWithKVCache.setInput(K_all(qr), "K");
+            netWithKVCache.setInput(V_all(qr), "V");
+            netWithKVCache.setInput(mask(mr).clone(), "Mask");
+            netWithKVCache.forward().copyTo(Y(qr));
+            lo = hi;
+        }
+
+        // 3. Reference: full sequence, no cache
+        netWithoutKVCache.setInput(Q_all, "Q");
+        netWithoutKVCache.setInput(K_all, "K");
+        netWithoutKVCache.setInput(V_all, "V");
+        netWithoutKVCache.setInput(mask, "Mask");
+        Mat Yref = netWithoutKVCache.forward();
+
+        std::string msg = "Attention chunked+reserve " + layout + ": KV vs standard";
+        normAssert(Y, Yref, msg.c_str(), 1e-3, 1e-3);
+    }
 };
 
 TEST_P(TESTKVCache, layouts)
 {
     testKVCache(GetParam());
+}
+
+TEST_P(TESTKVCache, chunked_reserve)
+{
+    testKVCacheChunkedReserve(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(KV_Cache, TESTKVCache, testing::Values("3d", "4d"));

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2542,9 +2542,10 @@ public:
         normAssert(Y, Yref, msg.c_str(), 1e-3, 1e-3);
     }
 
-    // Generate in multi-token chunks (chunked prefill / speculative decode) with the
-    // page pool pre-reserved via reserveKVCache(). Must match the non-cached full run.
-    void testKVCacheChunkedReserve(const std::string& layout)
+    // Generate in multi-token chunks (chunked prefill / speculative decode) with the page pool
+    // pre-reserved. Must match the non-cached full run; reserveTokens below the full length
+    // exercises reservation as a hint rather than a limit.
+    void testKVCacheChunkedReserve(const std::string& layout, int reserveTokens)
     {
         std::string model_path = "dnn/onnx/models/test_attention_kv_cache_" + layout + ".onnx";
 
@@ -2556,7 +2557,7 @@ public:
         int T_pref = T - 37;    // generate the tail in chunks, incl. a partial last chunk
         int chunk = 5;
 
-        netWithKVCache.reserveKVCache(T);   // static pre-allocation
+        netWithKVCache.reserveKVCache(reserveTokens);   // static pre-allocation
 
         std::vector<int> q_sz, k_sz, v_sz;
         if (layout == "3d") { q_sz = {1, T, Nq * D}; k_sz = {1, T, Nkv * D}; v_sz = {1, T, Nkv * D}; }
@@ -2616,7 +2617,24 @@ TEST_P(TESTKVCache, layouts)
 
 TEST_P(TESTKVCache, chunked_reserve)
 {
-    testKVCacheChunkedReserve(GetParam());
+    testKVCacheChunkedReserve(GetParam(), 523);
+}
+
+// Reservation is a hint, not a cap: the pool still grows past it.
+TEST_P(TESTKVCache, reserve_underrun)
+{
+    testKVCacheChunkedReserve(GetParam(), 100);
+}
+
+TEST_P(TESTKVCache, reserve_requires_enable)
+{
+    std::string model_path = "dnn/onnx/models/test_attention_kv_cache_" + GetParam() + ".onnx";
+    Net net = readNetFromONNX(findDataFile(model_path, true), cv::dnn::ENGINE_OPENCV);
+    EXPECT_THROW(net.reserveKVCache(128), cv::Exception);
+
+    net.enableKVCache();
+    EXPECT_NO_THROW(net.reserveKVCache(128));
+    EXPECT_THROW(net.reserveKVCache(-1), cv::Exception);
 }
 
 INSTANTIATE_TEST_CASE_P(KV_Cache, TESTKVCache, testing::Values("3d", "4d"));

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -2500,11 +2500,82 @@ public:
         std::string msg = "Attention generate " + layout + ": KV vs standard";
         normAssert(Y, Yref, msg.c_str(), 1e-3, 1e-3);
     }
+
+    // Generate in multi-token chunks (chunked prefill / speculative decode) with the
+    // page pool pre-reserved via reserveKVCache(). Must match the non-cached full run.
+    void testKVCacheChunkedReserve(const std::string& layout)
+    {
+        std::string model_path = "dnn/onnx/models/test_attention_kv_cache_" + layout + ".onnx";
+
+        Net netWithKVCache = readNetFromONNX(findDataFile(model_path, true), cv::dnn::ENGINE_OPENCV);
+        netWithKVCache.enableKVCache();
+        Net netWithoutKVCache = readNetFromONNX(findDataFile(model_path, true), cv::dnn::ENGINE_OPENCV);
+
+        int T = 523, Nq = 8, Nkv = 4, D = 256;
+        int T_pref = T - 37;    // generate the tail in chunks, incl. a partial last chunk
+        int chunk = 5;
+
+        netWithKVCache.reserveKVCache(T);   // static pre-allocation
+
+        std::vector<int> q_sz, k_sz, v_sz;
+        if (layout == "3d") { q_sz = {1, T, Nq * D}; k_sz = {1, T, Nkv * D}; v_sz = {1, T, Nkv * D}; }
+        else                { q_sz = {1, Nq, T, D}; k_sz = {1, Nkv, T, D}; v_sz = {1, Nkv, T, D}; }
+
+        Mat Q_all(q_sz, CV_32F), K_all(k_sz, CV_32F), V_all(v_sz, CV_32F);
+        cv::randn(Q_all, 0.0, 1.0); cv::randn(K_all, 0.0, 1.0); cv::randn(V_all, 0.0, 1.0);
+
+        std::vector<int> mask_sz = {1, Nq, T, T};
+        Mat mask(mask_sz, CV_32S, cv::Scalar(0));
+        int* mask_ptr = (int*)mask.data;
+        for (int n = 0; n < Nq; n++)
+            for (int i = 0; i < T; i++)
+                for (int j = 0; j < T; j++) {
+                    int idx = n * T * T + i * T + j;
+                    if (i < T_pref) { if (j < T_pref) mask_ptr[idx] = 1; }
+                    else            { if (j <= i)      mask_ptr[idx] = 1; }
+                }
+
+        Mat Y(q_sz, CV_32F); Y.setTo(0);
+
+        // Prefill (lo=0) then generate in multi-token chunks. A chunk needs within-chunk
+        // causality supplied explicitly (this model is not is_causal), so feed the reference
+        // mask restricted to queries [lo,hi) against the cache [0,hi).
+        for (int lo = 0; lo < T; )
+        {
+            int hi = (lo == 0) ? T_pref : std::min(lo + chunk, T);
+            std::vector<Range> qr;
+            if (layout == "3d") qr = { Range::all(), Range(lo, hi), Range::all() };
+            else                qr = { Range::all(), Range::all(), Range(lo, hi), Range::all() };
+            std::vector<Range> mr = { Range::all(), Range::all(), Range(lo, hi), Range(0, hi) };
+
+            netWithKVCache.setInput(Q_all(qr), "Q");
+            netWithKVCache.setInput(K_all(qr), "K");
+            netWithKVCache.setInput(V_all(qr), "V");
+            netWithKVCache.setInput(mask(mr).clone(), "Mask");
+            netWithKVCache.forward().copyTo(Y(qr));
+            lo = hi;
+        }
+
+        // 3. Reference: full sequence, no cache
+        netWithoutKVCache.setInput(Q_all, "Q");
+        netWithoutKVCache.setInput(K_all, "K");
+        netWithoutKVCache.setInput(V_all, "V");
+        netWithoutKVCache.setInput(mask, "Mask");
+        Mat Yref = netWithoutKVCache.forward();
+
+        std::string msg = "Attention chunked+reserve " + layout + ": KV vs standard";
+        normAssert(Y, Yref, msg.c_str(), 1e-3, 1e-3);
+    }
 };
 
 TEST_P(TESTKVCache, layouts)
 {
     testKVCache(GetParam());
+}
+
+TEST_P(TESTKVCache, chunked_reserve)
+{
+    testKVCacheChunkedReserve(GetParam());
 }
 
 INSTANTIATE_TEST_CASE_P(KV_Cache, TESTKVCache, testing::Values("3d", "4d"));

--- a/samples/dnn/gemma3_inference.py
+++ b/samples/dnn/gemma3_inference.py
@@ -54,19 +54,15 @@ Run the script:
 
 Paged KV-cache and reserveKVCache():
 
-    OpenCV keeps K/V in a paged, pre-packed cache only for models whose attention imports as
-    a single fused op. The optimum-cli exports above decompose attention into MatMul/Softmax,
-    so they fall back to carrying state through present.* -> past_key_values.* and
-    reserveKVCache() logs a warning and does nothing.
+    The paged cache needs attention to import as a single fused op. The optimum-cli exports
+    above decompose it into MatMul/Softmax, so they carry state through
+    present.* -> past_key_values.* instead and reserveKVCache() does nothing.
 
-    To get the paged cache, export with the dynamo exporter at opset 23, which lowers
-    scaled_dot_product_attention to a single ai.onnx Attention node (needs onnxscript).
-    See samples/dnn/qwen_inference.py for the full recipe; the same approach applies here.
-    Export without past_key_values - the paged cache holds K/V across forwards, so the graph
-    only ever sees the current chunk.
+    For the paged cache, export with the dynamo exporter at opset 23 and without
+    past_key_values - see samples/dnn/qwen_inference.py for the recipe.
 
-    With --use_kv_cache the script then calls reserveKVCache(prompt_len + max_new_tokens)
-    before prefill, sizing the page pool once so the decode loop allocates nothing.
+    With --use_kv_cache the script calls reserveKVCache(prompt_len + max_new_tokens) before
+    prefill, so the decode loop allocates nothing.
 '''
 
 import numpy as np

--- a/samples/dnn/gemma3_inference.py
+++ b/samples/dnn/gemma3_inference.py
@@ -50,6 +50,23 @@ Run the script:
 
     The tokenizer_path should point to an OpenCV-format config.json (e.g., from
     opencv_extra/testdata/dnn/llm/gemma3/config.json), NOT the HuggingFace tokenizer_config.json.
+
+
+Paged KV-cache and reserveKVCache():
+
+    OpenCV keeps K/V in a paged, pre-packed cache only for models whose attention imports as
+    a single fused op. The optimum-cli exports above decompose attention into MatMul/Softmax,
+    so they fall back to carrying state through present.* -> past_key_values.* and
+    reserveKVCache() logs a warning and does nothing.
+
+    To get the paged cache, export with the dynamo exporter at opset 23, which lowers
+    scaled_dot_product_attention to a single ai.onnx Attention node (needs onnxscript).
+    See samples/dnn/qwen_inference.py for the full recipe; the same approach applies here.
+    Export without past_key_values - the paged cache holds K/V across forwards, so the graph
+    only ever sees the current chunk.
+
+    With --use_kv_cache the script then calls reserveKVCache(prompt_len + max_new_tokens)
+    before prefill, sizing the page pool once so the decode loop allocates nothing.
 '''
 
 import numpy as np
@@ -66,6 +83,14 @@ def parse_args():
     parser.add_argument('--use_kv_cache', action='store_true', default=False, help='Enable KV-cache for faster inference (requires causal-lm-with-past export).')
     parser.add_argument('--seed', type=int, default=0, help='Random seed.')
     return parser.parse_args()
+
+def set_optional_input(net, name, value):
+    '''setInput() for a graph input the model may not declare. Returns True if it took.'''
+    try:
+        net.setInput(value, name)
+        return True
+    except cv.error:
+        return False
 
 def build_gemma3_prompt(user_prompt):
     '''Wrap user prompt in Gemma3 chat format.'''
@@ -91,9 +116,14 @@ def gemma3_inference(net, prompt, max_new_tokens, tokenizer, use_kv_cache=True):
         net.enableKVCache()
         prompt_len = input_ids.shape[1]
 
+        # Pre-size the cache so the decode loop allocates no pages. Must precede prefill.
+        net.reserveKVCache(prompt_len + max_new_tokens)
+
         # Prefill: process full prompt once to populate KV-cache
         net.setInput(input_ids, 'input_ids')
-        net.setInput(np.ones((1, prompt_len), dtype=np.int64), 'attention_mask')
+        # opset-23 dynamo exports take only input_ids; optimum ones also want a mask.
+        has_mask = set_optional_input(net, 'attention_mask',
+                                      np.ones((1, prompt_len), dtype=np.int64))
         logits = net.forward()
         new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
         generated = [new_id]
@@ -103,7 +133,8 @@ def gemma3_inference(net, prompt, max_new_tokens, tokenizer, use_kv_cache=True):
             if new_id in stop_ids:
                 break
             net.setInput(np.array([[new_id]], dtype=np.int64), 'input_ids')
-            net.setInput(np.ones((1, prompt_len + len(generated)), dtype=np.int64), 'attention_mask')
+            if has_mask:
+                net.setInput(np.ones((1, prompt_len + len(generated)), dtype=np.int64), 'attention_mask')
             logits = net.forward()
             new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
             generated.append(new_id)
@@ -111,7 +142,7 @@ def gemma3_inference(net, prompt, max_new_tokens, tokenizer, use_kv_cache=True):
         # Without KV-cache: feed full growing sequence each step
         for _ in range(max_new_tokens):
             net.setInput(input_ids, 'input_ids')
-            net.setInput(np.ones((1, input_ids.shape[1]), dtype=np.int64), 'attention_mask')
+            set_optional_input(net, 'attention_mask', np.ones((1, input_ids.shape[1]), dtype=np.int64))
             logits = net.forward()
             new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
             if new_id in stop_ids:
@@ -130,6 +161,9 @@ if __name__ == '__main__':
     tokenizer = cv.dnn.Tokenizer.load(args.tokenizer_path)
 
     net = cv.dnn.readNetFromONNX(args.model, cv.dnn.ENGINE_OPENCV)
+    if net.empty():
+        raise SystemExit('Failed to load the model - readNetFromONNX() only warns, it does not raise. '
+                         'Re-run with OPENCV_LOG_LEVEL=INFO to see which node was rejected and why.')
 
     gemma3_prompt = build_gemma3_prompt(args.prompt)
     print(f"Prompt:\n{gemma3_prompt}")

--- a/samples/dnn/qwen_inference.py
+++ b/samples/dnn/qwen_inference.py
@@ -45,13 +45,12 @@ Run the script:
 
 Paged KV-cache and reserveKVCache():
 
-    OpenCV keeps K/V in a paged, pre-packed cache only for models whose attention imports as
-    a single fused op. The optimum-cli exports above decompose attention into MatMul/Softmax,
-    so they fall back to carrying state through present.* -> past_key_values.* and
-    reserveKVCache() logs a warning and does nothing.
+    The paged cache needs attention to import as a single fused op. The optimum-cli exports
+    above decompose it into MatMul/Softmax, so they carry state through
+    present.* -> past_key_values.* instead and reserveKVCache() does nothing.
 
-    To get the paged cache, export with the dynamo exporter at opset 23, which lowers
-    scaled_dot_product_attention to a single ai.onnx Attention node (needs onnxscript):
+    For the paged cache, export with the dynamo exporter at opset 23, which lowers
+    scaled_dot_product_attention to one ai.onnx Attention node (needs onnxscript):
 
         import torch
         from transformers import AutoModelForCausalLM
@@ -75,11 +74,11 @@ Paged KV-cache and reserveKVCache():
                           input_names=['input_ids', 'position_ids'],
                           output_names=['logits'])
 
-    Export without past_key_values: the paged cache holds K/V across forwards, so the graph
-    only ever sees the current chunk. Pass position_ids explicitly instead.
+    Export without past_key_values - the cache holds K/V across forwards, so the graph only
+    sees the current chunk. Pass position_ids explicitly instead.
 
-    With --use_kv_cache the script then calls reserveKVCache(prompt_len + max_new_tokens)
-    before prefill, sizing the page pool once so the decode loop allocates nothing.
+    With --use_kv_cache the script calls reserveKVCache(prompt_len + max_new_tokens) before
+    prefill, so the decode loop allocates nothing.
 '''
 
 import numpy as np

--- a/samples/dnn/qwen_inference.py
+++ b/samples/dnn/qwen_inference.py
@@ -41,6 +41,45 @@ Run the script:
                                  --tokenizer_path=<path-to-qwen2.5-config.json> \
                                  --prompt="What is OpenCV?" \
                                  --use_kv_cache
+
+
+Paged KV-cache and reserveKVCache():
+
+    OpenCV keeps K/V in a paged, pre-packed cache only for models whose attention imports as
+    a single fused op. The optimum-cli exports above decompose attention into MatMul/Softmax,
+    so they fall back to carrying state through present.* -> past_key_values.* and
+    reserveKVCache() logs a warning and does nothing.
+
+    To get the paged cache, export with the dynamo exporter at opset 23, which lowers
+    scaled_dot_product_attention to a single ai.onnx Attention node (needs onnxscript):
+
+        import torch
+        from transformers import AutoModelForCausalLM
+        from torch.export import Dim
+
+        m = AutoModelForCausalLM.from_pretrained('Qwen/Qwen2.5-0.5B-Instruct',
+                                                 dtype=torch.float32,
+                                                 attn_implementation='sdpa').eval()
+
+        class W(torch.nn.Module):
+            def __init__(self, m): super().__init__(); self.m = m
+            def forward(self, input_ids, position_ids):
+                return self.m(input_ids=input_ids, position_ids=position_ids,
+                              use_cache=False).logits
+
+        T = Dim('T', min=1, max=2048)
+        torch.onnx.export(W(m).eval(),
+                          (torch.randint(0, 1000, (1, 8)), torch.arange(8).unsqueeze(0)),
+                          'qwen25_op23/model.onnx', dynamo=True, opset_version=23,
+                          dynamic_shapes=({1: T}, {1: T}),
+                          input_names=['input_ids', 'position_ids'],
+                          output_names=['logits'])
+
+    Export without past_key_values: the paged cache holds K/V across forwards, so the graph
+    only ever sees the current chunk. Pass position_ids explicitly instead.
+
+    With --use_kv_cache the script then calls reserveKVCache(prompt_len + max_new_tokens)
+    before prefill, sizing the page pool once so the decode loop allocates nothing.
 '''
 
 import numpy as np
@@ -57,6 +96,14 @@ def parse_args():
     parser.add_argument('--use_kv_cache', action='store_true', default=False, help='Enable KV-cache for faster inference (requires causal-lm-with-past export).')
     parser.add_argument('--seed', type=int, default=0, help='Random seed.')
     return parser.parse_args()
+
+def set_optional_input(net, name, value):
+    '''setInput() for a graph input the model may not declare. Returns True if it took.'''
+    try:
+        net.setInput(value, name)
+        return True
+    except cv.error:
+        return False
 
 def build_chatml_prompt(user_prompt):
     '''Wrap user prompt in Qwen2.5 ChatML format.'''
@@ -80,21 +127,27 @@ def qwen_inference(net, prompt, max_new_tokens, tokenizer, use_kv_cache=True):
         net.enableKVCache()
         prompt_len = input_ids.shape[1]
 
+        # Pre-size the cache so the decode loop allocates no pages. Must precede prefill.
+        net.reserveKVCache(prompt_len + max_new_tokens)
+
         # Prefill: process full prompt once to populate KV-cache
         net.setInput(input_ids, 'input_ids')
-        net.setInput(np.ones((1, prompt_len), dtype=np.int64), 'attention_mask')
+        # opset-23 dynamo exports take only input_ids/position_ids; optimum ones also want a mask.
+        has_mask = set_optional_input(net, 'attention_mask',
+                                      np.ones((1, prompt_len), dtype=np.int64))
         net.setInput(np.arange(prompt_len, dtype=np.int64).reshape(1, -1), 'position_ids')
         logits = net.forward()
         new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
         generated = [new_id]
 
-        # Generate: feed one new token per step; OpenCV routes present.* -> past_key_values.*
+        # Generate: feed one new token per step; the cache supplies all previous keys/values
         for _ in range(max_new_tokens - 1):
             if new_id in stop_ids:
                 break
             cur_len = prompt_len + len(generated)
             net.setInput(np.array([[new_id]], dtype=np.int64), 'input_ids')
-            net.setInput(np.ones((1, cur_len), dtype=np.int64), 'attention_mask')
+            if has_mask:
+                net.setInput(np.ones((1, cur_len), dtype=np.int64), 'attention_mask')
             net.setInput(np.array([[cur_len - 1]], dtype=np.int64), 'position_ids')
             logits = net.forward()
             new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
@@ -104,7 +157,7 @@ def qwen_inference(net, prompt, max_new_tokens, tokenizer, use_kv_cache=True):
         for _ in range(max_new_tokens):
             seq_len = input_ids.shape[1]
             net.setInput(input_ids, 'input_ids')
-            net.setInput(np.ones((1, seq_len), dtype=np.int64), 'attention_mask')
+            set_optional_input(net, 'attention_mask', np.ones((1, seq_len), dtype=np.int64))
             net.setInput(np.arange(seq_len, dtype=np.int64).reshape(1, -1), 'position_ids')
             logits = net.forward()
             new_id = int(np.argmax(logits[:, -1, :].reshape(-1)))
@@ -124,6 +177,9 @@ if __name__ == '__main__':
     tokenizer = cv.dnn.Tokenizer.load(args.tokenizer_path)
 
     net = cv.dnn.readNetFromONNX(args.model, cv.dnn.ENGINE_OPENCV)
+    if net.empty():
+        raise SystemExit('Failed to load the model - readNetFromONNX() only warns, it does not raise. '
+                         'Re-run with OPENCV_LOG_LEVEL=INFO to see which node was rejected and why.')
 
     chatml_prompt = build_chatml_prompt(args.prompt)
     print(f"Prompt:\n{chatml_prompt}")


### PR DESCRIPTION
The core idea is: reserveKVCache() API to pre-allocate memory for attention caches upfront, which eliminates allocation overhead during token decoding. For LLM inference, simply call reserveKVCache(prompt_len + max_new_tokens) before the prefill stage so the decode loop runs without page allocations, significantly reducing per-token latency for models like Gemma3 and Qwen.

Speedups after this PR on AMD Ryzen 9 9950X 16-Core Processor device:

Qwen2.5-0.5B-Instruct, fp32, CPU, tok/s:

```
Tokens	   Before   After	Speedup
64	       12.49	23.72	1.90×
128	       10.37	23.14	2.23×
256	       7.20	    22.40	3.11×
512	       4.25	    21.03	4.95×

```

Gemma 3 1B-it, fp32, CPU, 512 tokens :

```
Tokens	Before	After	Speedup
64	    6.99	11.84	1.69×
128	    5.84	11.72	2.01×
256	    4.17	11.50	2.76×
512	    2.47	11.15	4.51×
```

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
