### PR TITLE
imgproc: fix createHanningWindow incorrect results with SIMD under -ffast-math

### DIFF
--- a/modules/imgproc/src/phasecorr.cpp
+++ b/modules/imgproc/src/phasecorr.cpp
@@ -615,27 +615,13 @@ void cv::createHanningWindow(OutputArray _dst, cv::Size winSize, int type)
     double* const wc = _wc.data();
 
     double coeff0 = 2.0 * CV_PI / (double)(cols - 1), coeff1 = 2.0 * CV_PI / (double)(rows - 1);
-    int c = 0;
+    for(int c = 0; c < cols; c++)
+        wc[c] = 0.5 * (1.0 - cos(coeff0 * c));
+
 #if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
     const int nlanes32 = VTraits<v_float32>::vlanes();
     const int nlanes64 = VTraits<v_float64>::vlanes();
-    const int max_nlanes = VTraits<v_float64>::max_nlanes;
-    std::array<double, max_nlanes> index;
-    std::iota(index.data(), index.data()+max_nlanes, 0.f);
-    v_float64 vindex = vx_load(index.data());
-    v_float64 delta = vx_setall_f64(VTraits<v_float64>::vlanes());
-    v_float64 vcoeff0 = vx_setall_f64(coeff0);
-    v_float64 one = vx_setall_f64(1.f);
-    v_float64 half = vx_setall_f64(0.5f);
-    for (; c <= cols - nlanes64; c += nlanes64)
-    {
-        v_float64 v = v_mul(half, v_sub(one, v_cos(v_mul(vcoeff0, vindex))));
-        vx_store(wc + c, v);
-        vindex = v_add(vindex, delta);
-    }
 #endif
-    for(; c < cols; c++)
-        wc[c] = 0.5 * (1.0 - cos(coeff0 * c));
 
     if(dst.depth() == CV_32F)
     {


### PR DESCRIPTION
## Summary

Fixes #29634.

createHanningWindow() returns scrambled results when built with GCC and ENABLE_FAST_MATH on (the default). Disabling intrinsics (CV_ENABLE_INTRINSICS=OFF) fixes the output, confirming the SIMD path is the source.

### Root cause

The SIMD path for computing column weights wc[] calls v_cos(), which uses a Cephes-style range reduction with chained v_fma operations. Under -ffast-math, GCC can reorder or merge these FMA operations, breaking the exact cancellation needed for correct trigonometric range reduction. The scalar std::cos (from libm) is immune to this.

### Fix

Replace the SIMD wc[] computation with scalar std::cos. The SIMD paths for row multiplication and the cv::sqrt call at the end are preserved unchanged. The performance impact is minimal since wc[] is computed once per call.

### Testing

- Existing Imgproc_PhaseCorrelatorTest tests exercise createHanningWindow indirectly through phaseCorrelate with +/-1px tolerance
- The row-multiplication SIMD loops (which do the bulk of the work) are unchanged

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work