### PR TITLE
features: fix MSER discarding stable regions via minDiversity (#29652)

### DIFF
--- a/modules/features/src/mser.cpp
+++ b/modules/features/src/mser.cpp
@@ -264,7 +264,7 @@ public:
             if( checked )
                 return;
             checked = true;
-            if( size < wp.p.minArea || size > wp.p.maxArea || var < wp.p.minDiversity || var > wp.p.maxVariation )
+            if( size < wp.p.minArea || size > wp.p.maxArea || var < 0.f || var > wp.p.maxVariation )
                 return;
             if( child_ )
             {

--- a/modules/features/test/test_mser.cpp
+++ b/modules/features/test/test_mser.cpp
@@ -182,27 +182,19 @@ TEST(Features2d_MSER, history_update_regression)
 }
 
 
-TEST(Features2d_MSER, bug_5630)
+TEST(Features2d_MSER, default_params_regression_29652)
 {
-    String dataPath = cvtest::TS::ptr()->get_data_path() + "mser/";
-    Mat img = imread(dataPath + "mser_test.png", IMREAD_GRAYSCALE);
-    Ptr<MSER> mser = MSER::create(1, 1);
-    vector<vector<Point> > mserContours;
-    vector<Rect> boxRects;
+    Mat img = Mat::zeros(200, 200, CV_8U);
+    rectangle(img, Point(40, 40), Point(160, 160), Scalar(255), -1);
+    circle(img, Point(100, 100), 30, Scalar(0), -1);
 
-    // set min diversity and run detection
-    mser->setMinDiversity(0.1);
-    mser->detectRegions(img, mserContours, boxRects);
-    size_t originalNumberOfContours = mserContours.size();
+    Ptr<MSER> mser = MSER::create();
+    vector<vector<Point> > regions;
+    vector<Rect> bboxes;
+    mser->detectRegions(img, regions, bboxes);
 
-    // increase min diversity and run detection again
-    mser->setMinDiversity(0.2);
-    mser->detectRegions(img, mserContours, boxRects);
-    size_t newNumberOfContours = mserContours.size();
-
-    // there should be fewer regions detected with a higher min diversity
-    ASSERT_LT(newNumberOfContours, originalNumberOfContours);
-
+    ASSERT_FALSE(regions.empty());
+    ASSERT_EQ(regions.size(), bboxes.size());
 }
 
 }} // namespace


### PR DESCRIPTION
`MSER::detectRegions()` returns no regions on OpenCV 5.x for images where 4.x finds them with the same default parameters. A filled square with a hole, for instance, yields two regions on 4.13.0 but zero on 5.0.0.

The cause is in the grayscale MSER path. PR #20170 changed the stability check to reject a region when `var < minDiversity`, but `var` is the region's variation, not its diversity. With the default `minDiversity` of 0.2 this drops every low-variation region, which are exactly the most stable ones MSER should keep. The 4.x branch never took that change, so only 5.x is affected.

This restores the original `var < 0.f` guard, which makes the grayscale path match 4.x again. The `bug_5630` test encoded the incorrect behavior, so it is replaced with a regression test that checks default-parameter detection on a synthetic image.

Fixes #29652.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
