### PR TITLE
videoio(ffmpeg): FFmpeg 9 compatibility for AVCodec::supported_framerates

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -2629,6 +2629,39 @@ static AVCodecContext * icv_configure_video_stream_FFMPEG(AVFormatContext *oc,
     c->time_base.den = frame_rate;
     c->time_base.num = frame_rate_base;
     /* adjust time base for supported framerates */
+    // AVCodec::supported_framerates was deprecated in FFmpeg 7.1 and removed in
+    // FFmpeg 9. avcodec_get_supported_config() returns the same list together
+    // with its entry count, so use it when available.
+#if LIBAVCODEC_BUILD >= CALC_FFMPEG_VERSION(61, 13, 100)
+    const AVRational *supported_framerates = NULL;
+    int num_supported_framerates = 0;
+    if (codec)
+        avcodec_get_supported_config(NULL, codec, AV_CODEC_CONFIG_FRAME_RATE, 0,
+                                     (const void **)&supported_framerates, &num_supported_framerates);
+    if (supported_framerates && num_supported_framerates > 0){
+        AVRational req = {frame_rate, frame_rate_base};
+        const AVRational *best=NULL;
+        AVRational best_error= {INT_MAX, 1};
+        for(int i = 0; i < num_supported_framerates; i++){
+            const AVRational *p = &supported_framerates[i];
+            AVRational error= av_sub_q(req, *p);
+            if(error.num <0) error.num *= -1;
+            if(av_cmp_q(error, best_error) < 0){
+                best_error= error;
+                best= p;
+            }
+        }
+        if (best == NULL)
+        {
+#ifdef CV_FFMPEG_CODECPAR
+            avcodec_free_context(&c);
+#endif
+            return NULL;
+        }
+        c->time_base.den= best->num;
+        c->time_base.num= best->den;
+    }
+#else
     if(codec && codec->supported_framerates){
         const AVRational *p= codec->supported_framerates;
         AVRational req = {frame_rate, frame_rate_base};
@@ -2652,6 +2685,7 @@ static AVCodecContext * icv_configure_video_stream_FFMPEG(AVFormatContext *oc,
         c->time_base.den= best->num;
         c->time_base.num= best->den;
     }
+#endif
 
     c->gop_size = 12; /* emit one intra frame every twelve frames at most */
     c->pix_fmt = pixel_format;


### PR DESCRIPTION
### Fixes #29655

`AVCodec::supported_framerates` was deprecated in FFmpeg 7.1 and removed in FFmpeg 9. `modules/videoio/src/cap_ffmpeg_impl.hpp` reads that field directly in `icv_configure_video_stream_FFMPEG`, so the module no longer builds against FFmpeg 9.

### Change

When building against libavcodec 61.13.100 or newer (FFmpeg 7.1+), read the supported frame rate list through `avcodec_get_supported_config()` with `AV_CODEC_CONFIG_FRAME_RATE`. That call returns both the list pointer and its entry count.

The issue asked whether to keep sentinel-based iteration or move to the count returned by the new API. This uses the count, since the new API always provides it and there is no sentinel to rely on. The selection logic (pick the supported frame rate closest to the requested one) is unchanged. When the codec places no restriction on frame rates the returned list is NULL and the block is skipped, same as before.

Older FFmpeg keeps the previous field access behind the version guard, so existing builds are unaffected.

### Notes

- Version guard uses `CALC_FFMPEG_VERSION(61, 13, 100)`, the libavcodec version that added `avcodec_get_supported_config()` and `enum AVCodecConfig` (per FFmpeg APIchanges, 2024-09-08). Both the field and the new call exist from 7.1 through 8.x, so the new path is safe there too.
- Follows the existing pattern in this file for FFmpeg API migrations (for example the `av_stream_get_side_data` guard in `get_rotation_angle`).

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work