### PR TITLE
samples: fix HoughLines/HoughLinesP Python sample for 5.0 shape change (fixes #29637)

### DIFF
--- a/samples/python/snippets/houghlines.py
+++ b/samples/python/snippets/houghlines.py
@@ -29,24 +29,21 @@ def main():
 
     if True: # HoughLinesP
         lines = cv.HoughLinesP(dst, 1, math.pi/180.0, 40, np.array([]), 50, 10)
-        a, b, _c = lines.shape
-        for i in range(a):
-            cv.line(cdst, (lines[i][0][0], lines[i][0][1]), (lines[i][0][2], lines[i][0][3]), (0, 0, 255), 3, cv.LINE_AA)
+        if lines is not None:
+            for x1, y1, x2, y2 in np.asarray(lines).reshape(-1, 4):
+                cv.line(cdst, (x1, y1), (x2, y2), (0, 0, 255), 3, cv.LINE_AA)
 
     else:    # HoughLines
         lines = cv.HoughLines(dst, 1, math.pi/180.0, 50, np.array([]), 0, 0)
         if lines is not None:
-            a, b, _c = lines.shape
-            for i in range(a):
-                rho = lines[i][0][0]
-                theta = lines[i][0][1]
+            for rho, theta in np.asarray(lines).reshape(-1, 2):
                 a = math.cos(theta)
                 b = math.sin(theta)
                 x0, y0 = a*rho, b*rho
                 pt1 = ( int(x0+1000*(-b)), int(y0+1000*(a)) )
                 pt2 = ( int(x0-1000*(-b)), int(y0-1000*(a)) )
                 cv.line(cdst, pt1, pt2, (0, 0, 255), 3, cv.LINE_AA)
-
+                
     cv.imshow("detected lines", cdst)
 
     cv.imshow("source", src)

--- a/samples/python/snippets/houghlines.py
+++ b/samples/python/snippets/houghlines.py
@@ -29,14 +29,17 @@ def main():
 
     if True: # HoughLinesP
         lines = cv.HoughLinesP(dst, 1, math.pi/180.0, 40, np.array([]), 50, 10)
-        if lines is not None:
-            for x1, y1, x2, y2 in np.asarray(lines).reshape(-1, 4):
-                cv.line(cdst, (x1, y1), (x2, y2), (0, 0, 255), 3, cv.LINE_AA)
+        a, b = lines.shape
+        for i in range(a):
+            cv.line(cdst, (lines[i][0], lines[i][1]), (lines[i][2], lines[i][3]), (0, 0, 255), 3, cv.LINE_AA)
 
     else:    # HoughLines
         lines = cv.HoughLines(dst, 1, math.pi/180.0, 50, np.array([]), 0, 0)
         if lines is not None:
-            for rho, theta in np.asarray(lines).reshape(-1, 2):
+            num_lines, _ = lines.shape
+            for i in range(num_lines):
+                rho = lines[i][0]
+                theta = lines[i][1]
                 a = math.cos(theta)
                 b = math.sin(theta)
                 x0, y0 = a*rho, b*rho

--- a/samples/python/snippets/houghlines.py
+++ b/samples/python/snippets/houghlines.py
@@ -43,7 +43,7 @@ def main():
                 pt1 = ( int(x0+1000*(-b)), int(y0+1000*(a)) )
                 pt2 = ( int(x0-1000*(-b)), int(y0-1000*(a)) )
                 cv.line(cdst, pt1, pt2, (0, 0, 255), 3, cv.LINE_AA)
-                
+
     cv.imshow("detected lines", cdst)
 
     cv.imshow("source", src)

--- a/samples/python/tutorial_code/ImgTrans/HoughLine/hough_lines.py
+++ b/samples/python/tutorial_code/ImgTrans/HoughLine/hough_lines.py
@@ -39,7 +39,7 @@ def main(argv):
     ## [draw_lines]
     # Draw the lines
     if lines is not None:
-        for rho, theta in np.asarray(lines).reshape(-1, 2):
+        for rho, theta in lines.reshape(-1, 2):
             a = math.cos(theta)
             b = math.sin(theta)
             x0 = a * rho
@@ -57,8 +57,10 @@ def main(argv):
     ## [draw_lines_p]
     # Draw the lines
     if linesP is not None:
-        for x1, y1, x2, y2 in np.asarray(linesP).reshape(-1, 4):
-            cv.line(cdstP, (x1, y1), (x2, y2), (0,0,255), 3, cv.LINE_AA)
+        num_lines, _ = linesP.shape
+        for i in range(num_lines):
+            l = linesP[i]
+            cv.line(cdstP, (l[0], l[1]), (l[2], l[3]), (0,0,255), 3, cv.LINE_AA)
     ## [draw_lines_p]
     ## [imshow]
     # Show results

--- a/samples/python/tutorial_code/ImgTrans/HoughLine/hough_lines.py
+++ b/samples/python/tutorial_code/ImgTrans/HoughLine/hough_lines.py
@@ -39,9 +39,7 @@ def main(argv):
     ## [draw_lines]
     # Draw the lines
     if lines is not None:
-        for i in range(0, len(lines)):
-            rho = lines[i][0][0]
-            theta = lines[i][0][1]
+        for rho, theta in np.asarray(lines).reshape(-1, 2):
             a = math.cos(theta)
             b = math.sin(theta)
             x0 = a * rho
@@ -59,9 +57,8 @@ def main(argv):
     ## [draw_lines_p]
     # Draw the lines
     if linesP is not None:
-        for i in range(0, len(linesP)):
-            l = linesP[i][0]
-            cv.line(cdstP, (l[0], l[1]), (l[2], l[3]), (0,0,255), 3, cv.LINE_AA)
+        for x1, y1, x2, y2 in np.asarray(linesP).reshape(-1, 4):
+            cv.line(cdstP, (x1, y1), (x2, y2), (0,0,255), 3, cv.LINE_AA)
     ## [draw_lines_p]
     ## [imshow]
     # Show results

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
@@ -6,7 +6,7 @@ gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 
 lines = cv.HoughLines(edges,1,np.pi/180,200)
-for rho, theta in np.asarray(lines).reshape(-1, 2):
+for rho, theta in lines.reshape(-1, 2):
     a = np.cos(theta)
     b = np.sin(theta)
     x0 = a*rho

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/hough_line_transform.py
@@ -6,8 +6,7 @@ gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 
 lines = cv.HoughLines(edges,1,np.pi/180,200)
-for line in lines:
-    rho,theta = line[0]
+for rho, theta in np.asarray(lines).reshape(-1, 2):
     a = np.cos(theta)
     b = np.sin(theta)
     x0 = a*rho

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
@@ -5,8 +5,7 @@ img = cv.imread(cv.samples.findFile('sudoku.png'))
 gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 lines = cv.HoughLinesP(edges,1,np.pi/180,100,minLineLength=100,maxLineGap=10)
-for line in lines:
-    x1,y1,x2,y2 = line[0]
+for x1, y1, x2, y2 in np.asarray(lines).reshape(-1, 4):
     cv.line(img,(x1,y1),(x2,y2),(0,255,0),2)
-
+    
 cv.imwrite('houghlines5.jpg',img)

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
@@ -5,7 +5,9 @@ img = cv.imread(cv.samples.findFile('sudoku.png'))
 gray = cv.cvtColor(img,cv.COLOR_BGR2GRAY)
 edges = cv.Canny(gray,50,150,apertureSize = 3)
 lines = cv.HoughLinesP(edges,1,np.pi/180,100,minLineLength=100,maxLineGap=10)
-for x1, y1, x2, y2 in np.asarray(lines).reshape(-1, 4):
+num_lines, _ = lines.shape
+for i in range(num_lines):
+    x1, y1, x2, y2 = lines[i]
     cv.line(img,(x1,y1),(x2,y2),(0,255,0),2)
 
 cv.imwrite('houghlines5.jpg',img)

--- a/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
+++ b/samples/python/tutorial_code/imgProc/hough_line_transform/probabilistic_hough_line_transform.py
@@ -7,5 +7,5 @@ edges = cv.Canny(gray,50,150,apertureSize = 3)
 lines = cv.HoughLinesP(edges,1,np.pi/180,100,minLineLength=100,maxLineGap=10)
 for x1, y1, x2, y2 in np.asarray(lines).reshape(-1, 4):
     cv.line(img,(x1,y1),(x2,y2),(0,255,0),2)
-    
+
 cv.imwrite('houghlines5.jpg',img)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->

Fixes #29637.

OpenCV 5.0 changed vector-backed Mat/OutputArray to true 1D arrays (see 
migration guide: 1D and 0D array semantics). This changes HoughLines/
HoughLinesP Python return shape from (N,1,X) to (N,X), breaking the old 
indexing pattern used in the tutorial sample.

Tested locally against opencv-python 5.0 — script runs without error, 
lines drawn correctly on samples/data/sudoku.png.