### PR TITLE
dnn: fix the parameter names documented for memset 🤖🤖🤖

### DIFF
--- a/modules/dnn/src/cuda4dnn/csl/memory.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/memory.hpp
@@ -178,8 +178,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
     /** sets device memory block to a specific 8-bit value
      *
-     * \param[in]   src     device pointer
-     * \param[out]  ch      8-bit value to fill the device memory with
+     * \param[out]  dest    device pointer
+     * \param[in]   ch      8-bit value to fill the device memory with
      *
      * Exception Guarantee: Basic
      */
@@ -243,8 +243,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
     /** sets device memory block to a specific 8-bit value asynchronously
      *
-     * \param[in]   src     device pointer
-     * \param[out]  ch      8-bit value to fill the device memory with
+     * \param[out]  dest    device pointer
+     * \param[in]   ch      8-bit value to fill the device memory with
      * \param       stream  CUDA stream that has to be used for the memory operation
      *
      * Exception Guarantee: Basic

--- a/modules/dnn/src/cuda4dnn/csl/pointer.hpp
+++ b/modules/dnn/src/cuda4dnn/csl/pointer.hpp
@@ -307,8 +307,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
     /** sets \p n elements to \p ch in \p dest
      *
-     * \param[in]   src     device pointer
-     * \param[out]  ch      8-bit value to fill the device memory with
+     * \param[out]  dest    device pointer
+     * \param[in]   ch      8-bit value to fill the device memory with
      *
      * Pre-conditions:
      * - memory pointed by \p dest must be large enough to hold \p n elements
@@ -388,8 +388,8 @@ namespace cv { namespace dnn { namespace cuda4dnn { namespace csl {
 
     /** sets \p n elements to \p ch in \p dest asynchronously
      *
-     * \param[in]   src     device pointer
-     * \param[out]  ch      8-bit value to fill the device memory with
+     * \param[out]  dest    device pointer
+     * \param[in]   ch      8-bit value to fill the device memory with
      * \param       stream  CUDA stream that has to be used for the memory operation
      *
      * Pre-conditions:


### PR DESCRIPTION
### The problem

The four `memset` overloads in `cuda4dnn/csl` document a parameter that does not exist, and label the two that do exist backwards:

```cpp
/** sets device memory block to a specific 8-bit value
 *
 * \param[in]   src     device pointer
 * \param[out]  ch      8-bit value to fill the device memory with
 */
template <class T>
void memset(const ManagedPtr<T>& dest, std::int8_t ch)
```

Three things at once:

- there is no `src`, the parameter is `dest`;
- `dest` is where the function writes, so it is `[out]`, not `[in]`;
- `ch` is the value being written in, so it is `[in]`, not `[out]`.

Reading the tags alone gives you the direction of the copy backwards.

The prose right above two of them already gets it right: `pointer.hpp` says "sets \p n elements to \p ch in \p dest". Only the tags disagree, which suggests the block was copied from the neighbouring `memcpy` and the names were never updated.

### The change

`src` becomes `dest`, and `[in]` / `[out]` swap. Four blocks:

- `modules/dnn/src/cuda4dnn/csl/memory.hpp:181` and `:246`
- `modules/dnn/src/cuda4dnn/csl/pointer.hpp:310` and `:391`

Comments only, no code touched. Column alignment in those blocks is kept.

### How I found it

I wrote a small checker that compares Doxygen tags against the declaration below them and ran it over the tree. Most of what it reported here was noise on function pointers, which it does not parse; these four I read by hand before touching anything.
