### PR TITLE
videoio: add drop-only target_fps frame-rate control to VideoCapture

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -805,10 +805,25 @@ public:
       documentation of source stream to know the right URL.
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.
+    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
+    at this rate instead of the source's native rate. 0 (default) leaves the source rate
+    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
+    to have any effect); it does not duplicate frames to increase it.
+
+    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
+    cannot currently be combined with the `params` vector overloads below (e.g. to also set
+    CAP_PROP_HW_ACCELERATION in the same open() call).
+
+    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
+    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
+    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
+    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
+    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
+    multi-head note on grab() below).
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY);
+    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @overload
     @brief Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
@@ -825,10 +840,25 @@ public:
     (to backward compatibility usage of camera_id + domain_offset (CAP_*) is valid when apiPreference is CAP_ANY)
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.
+    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
+    at this rate instead of the source's native rate. 0 (default) leaves the source rate
+    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
+    to have any effect); it does not duplicate frames to increase it.
+
+    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
+    cannot currently be combined with the `params` vector overloads below (e.g. to also set
+    CAP_PROP_HW_ACCELERATION in the same open() call).
+
+    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
+    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
+    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
+    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
+    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
+    multi-head note on grab() below).
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY);
+    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @overload
     @brief Opens a camera for video capturing with API Preference and parameters
@@ -860,8 +890,13 @@ public:
     @return `true` if the file has been successfully opened
 
     The method first calls VideoCapture::release to close the already opened file or camera.
+
+    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
+    they are emitted at this rate instead of the source's native rate. Only supports reducing
+    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
+    grab() cost, multi-head/channel, and params-overload limitations.
      */
-    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY);
+    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @brief  Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
 
@@ -884,8 +919,13 @@ public:
     @return `true` if the camera has been successfully opened.
 
     The method first calls VideoCapture::release to close the already opened file or camera.
+
+    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
+    they are emitted at this rate instead of the source's native rate. Only supports reducing
+    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
+    grab() cost, multi-head/channel, and params-overload limitations.
     */
-    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY);
+    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @brief  Opens a camera for video capturing with API Preference and parameters
 
@@ -1055,6 +1095,34 @@ public:
 protected:
     Ptr<IVideoCapture> icap;
     bool throwOnFail;
+
+    // Backend-agnostic, drop-only frame-rate control set via the target_fps constructor/open()
+    // parameter. See cap.cpp for the algorithm, which mirrors the selection rule of FFmpeg's
+    // `fps` filter: a 2-frame lookahead buffer compared against a steadily advancing output
+    // clock decides whether a buffered frame is stale and should be dropped.
+    //
+    // kFpsControlEpsMs absorbs floating-point rounding noise in backend-reported timestamps
+    // (observed on the order of 1e-13 ms) so an exact schedule boundary in fpsControlGrab()
+    // doesn't get flipped by it; see cap.cpp for where it's used.
+    static const double kFpsControlEpsMs;
+
+    struct FpsControlState
+    {
+        bool enabled = false;
+        double outFrameDurationMs = 0.0;   // 1000 / requested output fps
+        double nextOutPts = -1.0;          // output clock; unset (<0) until first frame anchors it
+
+        Mat bufFrame[2];
+        double bufPts[2] = { -1.0, -1.0 };
+        int bufCount = 0;
+
+        Mat pendingFrame;                  // frame fpsControlGrab() picked for retrieve() to return
+        double pendingPts = -1.0;          // pendingFrame's timestamp, for get(CAP_PROP_POS_MSEC)
+    } fpsCtl;
+
+    void enableFpsControl(double target_fps);
+    bool fpsControlReadOne();
+    bool fpsControlGrab();
 
     friend class internal::VideoCapturePrivateAccessor;
 };

--- a/modules/videoio/perf/perf_target_fps.cpp
+++ b/modules/videoio/perf/perf_target_fps.cpp
@@ -1,0 +1,39 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+using namespace perf;
+
+// target_fps <= 0 must show zero measurable overhead vs. not passing the parameter at all --
+// that path bypasses fpsControlGrab() entirely (see VideoCapture::grab()). Enabling it, by
+// contrast, makes grab() fully decode (and Mat::clone()) every source frame rather than just
+// the ones actually returned, so throughput is expected to be measurably worse than disabled
+// even though fewer frames come back to the caller -- this perf test exists to catch a
+// regression in either direction (disabled path picking up overhead it shouldn't, or the
+// enabled path's overhead growing unexpectedly), not to demonstrate a speedup.
+
+typedef tuple<string, double> VideoCapture_TargetFpsParams;
+typedef perf::TestBaseWithParam<VideoCapture_TargetFpsParams> VideoCapture_TargetFps;
+
+PERF_TEST_P(VideoCapture_TargetFps, ReadThroughput,
+            testing::Combine(testing::Values(string("highgui/video/big_buck_bunny.mp4")),
+                              testing::Values(0.0, 12.0))) // 0 = disabled; 12 = half native 24fps
+{
+    const string filename = getDataPath(get<0>(GetParam()));
+    const double target_fps = get<1>(GetParam());
+
+    TEST_CYCLE()
+    {
+        VideoCapture cap(filename, CAP_ANY, target_fps);
+        Mat frame;
+        while (cap.read(frame)) {}
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -70,10 +70,10 @@ IStreamReader::~IStreamReader()
 VideoCapture::VideoCapture() : throwOnFail(false)
 {}
 
-VideoCapture::VideoCapture(const String& filename, int apiPreference) : throwOnFail(false)
+VideoCapture::VideoCapture(const String& filename, int apiPreference, double target_fps) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(filename, apiPreference);
+    open(filename, apiPreference, target_fps);
 }
 
 VideoCapture::VideoCapture(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -90,10 +90,10 @@ VideoCapture::VideoCapture(const Ptr<IStreamReader>& source, int apiPreference, 
     open(source, apiPreference, params);
 }
 
-VideoCapture::VideoCapture(int index, int apiPreference) : throwOnFail(false)
+VideoCapture::VideoCapture(int index, int apiPreference, double target_fps) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(index, apiPreference);
+    open(index, apiPreference, target_fps);
 }
 
 VideoCapture::VideoCapture(int index, int apiPreference, const std::vector<int>& params)
@@ -109,9 +109,13 @@ VideoCapture::~VideoCapture()
     icap.release();
 }
 
-bool VideoCapture::open(const String& filename, int apiPreference)
+bool VideoCapture::open(const String& filename, int apiPreference, double target_fps)
 {
-    return open(filename, apiPreference, std::vector<int>());
+    CV_INSTRUMENT_REGION();
+    bool ok = open(filename, apiPreference, std::vector<int>());
+    if (ok)
+        enableFpsControl(target_fps);
+    return ok;
 }
 
 bool VideoCapture::open(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -361,9 +365,13 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     return false;
 }
 
-bool VideoCapture::open(int cameraNum, int apiPreference)
+bool VideoCapture::open(int cameraNum, int apiPreference, double target_fps)
 {
-    return open(cameraNum, apiPreference, std::vector<int>());
+    CV_INSTRUMENT_REGION();
+    bool ok = open(cameraNum, apiPreference, std::vector<int>());
+    if (ok)
+        enableFpsControl(target_fps);
+    return ok;
 }
 
 bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>& params)
@@ -519,12 +527,126 @@ void VideoCapture::release()
 {
     CV_TRACE_FUNCTION();
     icap.release();
+    fpsCtl = FpsControlState(); // don't leak fps-control state (clock/buffers) across reopen
+}
+
+// target_fps <= 0 disables frame-rate control entirely (plain passthrough).
+void VideoCapture::enableFpsControl(double target_fps)
+{
+    fpsCtl = FpsControlState();
+    if (target_fps > 0 && !icap.empty())
+    {
+        fpsCtl.enabled = true;
+        fpsCtl.outFrameDurationMs = 1000.0 / target_fps;
+    }
+}
+
+// Pull exactly one real frame from the backend into the next free lookahead-buffer slot.
+// Always clones: some backends reuse a single internal decode buffer across grabFrame() calls,
+// and we need two buffered frames to stay valid and independent at the same time.
+bool VideoCapture::fpsControlReadOne()
+{
+    CV_Assert(fpsCtl.bufCount < 2);
+    if (!icap->grabFrame())
+        return false;
+    Mat frame;
+    if (!icap->retrieveFrame(0, frame) || frame.empty())
+        return false;
+    fpsCtl.bufFrame[fpsCtl.bufCount] = frame.clone();
+    fpsCtl.bufPts[fpsCtl.bufCount] = icap->getProperty(CAP_PROP_POS_MSEC);
+    fpsCtl.bufCount++;
+    return true;
+}
+
+// Drop-only version of FFmpeg's vf_fps.c decision rule: keep 2 frames buffered and compare the
+// *next* frame's timestamp against the output clock (nextOutPts). If the next frame has already
+// reached or passed the current tick, the buffered frame is stale -- drop it and re-check.
+// Otherwise it's the answer for this tick -- consume it and advance the clock by one output-frame
+// duration. Since target_fps is always <= the source rate here, a buffered frame is never held
+// over for a second tick, so there is no duplicate case to handle.
+//
+// At end of stream, only one frame may be left buffered with no lookahead to compare it against --
+// in that case its own timestamp is checked directly against the clock instead: still due -> emit
+// it (the last available data is the best answer for this tick); not yet due -> the schedule never
+// caught up before the source ran out, so there's nothing to emit for this tick.
+//
+// kFpsControlEpsMs (see videoio.hpp, next to FpsControlState) absorbs floating-point rounding
+// noise in backend-reported timestamps so an exact schedule boundary doesn't get flipped by it.
+const double VideoCapture::kFpsControlEpsMs = 1e-6;
+
+bool VideoCapture::fpsControlGrab()
+{
+    FpsControlState& s = fpsCtl;
+
+    for (;;)
+    {
+        while (s.bufCount < 2)
+        {
+            if (fpsControlReadOne())
+                continue;
+            break; // source exhausted -- bufCount may now be 0 or 1
+        }
+
+        if (s.bufCount == 0)
+        {
+            // Nothing buffered and nothing left to emit -- invalidate the previous answer so a
+            // retrieve() call made without checking this grab()'s return value can't silently
+            // re-serve a stale frame instead of failing.
+            s.pendingFrame.release();
+            s.pendingPts = -1.0;
+            return false;
+        }
+
+        if (s.nextOutPts < 0)
+            s.nextOutPts = s.bufPts[0]; // anchor the output clock to the first real frame's timestamp
+
+        if (s.bufCount == 2)
+        {
+            if (s.bufPts[1] <= s.nextOutPts + kFpsControlEpsMs)
+            {
+                // buf[0] is stale -- drop it, shift, and re-check against the new pair.
+                s.bufFrame[0] = s.bufFrame[1];
+                s.bufPts[0] = s.bufPts[1];
+                s.bufCount = 1;
+                continue;
+            }
+        }
+        else // bufCount == 1: source is exhausted, no lookahead frame left to compare against
+        {
+            if (s.bufPts[0] < s.nextOutPts - kFpsControlEpsMs)
+            {
+                s.pendingFrame.release(); // same reasoning as the bufCount==0 case above
+                s.pendingPts = -1.0;
+                return false; // schedule never caught up before the source ran out
+            }
+        }
+
+        // buf[0] is the answer for this tick.
+        s.pendingFrame = s.bufFrame[0];
+        s.pendingPts = s.bufPts[0];
+        s.nextOutPts += s.outFrameDurationMs;
+        if (s.bufCount == 2)
+        {
+            s.bufFrame[0] = s.bufFrame[1];
+            s.bufPts[0] = s.bufPts[1];
+            s.bufCount = 1;
+        }
+        else
+        {
+            s.bufCount = 0;
+        }
+        return true;
+    }
 }
 
 bool VideoCapture::grab()
 {
     CV_INSTRUMENT_REGION();
-    bool ret = !icap.empty() ? icap->grabFrame() : false;
+    bool ret = false;
+    if (!icap.empty())
+    {
+        ret = fpsCtl.enabled ? fpsControlGrab() : icap->grabFrame();
+    }
     if (!ret && throwOnFail)
     {
         CV_Error(Error::StsError, "");
@@ -539,7 +661,28 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
     bool ret = false;
     if (!icap.empty())
     {
-        ret = icap->retrieveFrame(channel, image);
+        if (fpsCtl.enabled)
+        {
+            // target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
+            // retrieveFrame(0, ...)) -- it does not support multi-head sources (stereo camera,
+            // Kinect, etc: see the multi-head note on grab() above). Fail loudly rather than
+            // silently handing back channel 0's data for a different requested channel.
+            if (channel != 0)
+            {
+                CV_LOG_WARNING(NULL, "VIDEOIO: target_fps does not support multi-head capture "
+                                      "(channel != 0); use target_fps <= 0 for multi-head sources");
+            }
+            else if (!fpsCtl.pendingFrame.empty())
+            {
+                // grab() already fully decoded this frame via fpsControlGrab() -- hand back a copy.
+                fpsCtl.pendingFrame.copyTo(image);
+                ret = true;
+            }
+        }
+        else
+        {
+            ret = icap->retrieveFrame(channel, image);
+        }
     }
     if (!ret && throwOnFail)
     {
@@ -622,6 +765,15 @@ double VideoCapture::get(int propId) const
             return CAP_PROP_UNKNOWN;
         }
         return static_cast<double>(api);
+    }
+    if (propId == CAP_PROP_POS_MSEC && fpsCtl.enabled && fpsCtl.pendingPts >= 0)
+    {
+        // Report the timestamp of the frame actually handed back by read()/retrieve(), not the
+        // backend's own internal position -- which, under fps control, sits on whichever
+        // lookahead frame the algorithm most recently had to pull to make its drop/keep decision
+        // (one frame ahead of the emitted one in steady state, or an inconsistent
+        // backend-specific value right at end-of-stream).
+        return fpsCtl.pendingPts;
     }
     return !icap.empty() ? icap->getProperty(propId) : static_cast<double>(CAP_PROP_UNKNOWN);
 }

--- a/modules/videoio/test/test_target_fps.cpp
+++ b/modules/videoio/test/test_target_fps.cpp
@@ -1,0 +1,248 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+using namespace std;
+
+namespace opencv_test { namespace {
+
+// target_fps drop-only frame-rate control, exposed as a VideoCapture
+// constructor/open() parameter. Ported from FFmpeg's own frame-rate
+// reduction rule (libavfilter/vf_fps.c, write_frame()): buffer 2 frames,
+// compare the second one's timestamp against a steadily-advancing output
+// clock, and drop the first whenever it's already stale.
+//
+// The feature itself lives entirely in the backend-agnostic frontend
+// (modules/videoio/src/cap.cpp) -- no backend-specific code was touched to
+// implement it. These tests use the FFmpeg backend only as a convenient,
+// precisely-controllable source of test video; the behavior under test is
+// not FFmpeg-specific.
+//
+// Source video: opencv_extra's shared "video/big_buck_bunny.mp4" -- the
+// same canonical asset already used throughout test_ffmpeg.cpp and
+// perf_target_fps.cpp, rather than a synthetic, test-generated file.
+// Confirmed properties (ffprobe): mpeg4 codec, 24/1 fps, 125 frames,
+// has_b_frames=0 (I/P only, no reordering) -- so CAP_PROP_POS_MSEC on
+// readback is exact per-frame, same guarantee the synthetic MJPG file used
+// to provide. findDataFile() throws SkipTestException on its own if
+// OPENCV_TEST_DATA_PATH/opencv_extra isn't available locally, matching the
+// convention already used elsewhere in test_ffmpeg.cpp.
+static string targetFpsTestVideoPath()
+{
+    return findDataFile("video/big_buck_bunny.mp4");
+}
+
+static const double BBB_FPS = 24.0;
+static const int BBB_FRAME_COUNT = 125;
+
+// (target_fps, ratio) -- ratio = how many source frames separate each kept
+// frame (source_fps / target_fps when that divides evenly). ratio=1 covers
+// three distinct cases that should all behave identically: disabled (0),
+// exactly the source's native rate, and requesting a rate *above* native
+// (degrades to native rate rather than duplicating -- see CLAUDE.md's
+// "Degenerate cases" note).
+//
+// 4.0/8.0 are chosen as exact divisors of the source's 24fps (ratios 6 and 3)
+// so the expected counts below are unambiguous; both also leave the file's
+// true last frame index (124) unaligned to the ratio (124 % 6 == 4,
+// 124 % 3 == 1) -- deliberately, so these cases still exercise
+// fpsControlGrab()'s end-of-stream path: the schedule is reached mid-tick
+// rather than landing exactly on the last frame.
+typedef tuple<double, int> TargetFps_Ratio;
+typedef testing::TestWithParam<TargetFps_Ratio> videoio_target_fps;
+
+TEST_P(videoio_target_fps, keeps_expected_frame_count)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = get<0>(GetParam());
+    const int ratio = get<1>(GetParam());
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        ASSERT_FALSE(frame.empty());
+        n++;
+    }
+    cap.release();
+
+    int expected = 0;
+    for (int i = 0; i < BBB_FRAME_COUNT; i += ratio)
+        expected++;
+    EXPECT_EQ(expected, n);
+}
+
+const TargetFps_Ratio videoio_target_fps_params[] =
+{
+    make_tuple(0.0, 1),    // target_fps unset/disabled -> passthrough, every frame
+    make_tuple(24.0, 1),   // == source's native fps -> every frame
+    make_tuple(48.0, 1),   // above source's native fps -> degrades to native, every frame
+    make_tuple(4.0, 6),    // keep indices 0,6,...,120 -> 21 frames
+    make_tuple(8.0, 3),    // keep indices 0,3,...,123 -> 42 frames
+};
+
+inline static std::string videoio_target_fps_name_printer(const testing::TestParamInfo<videoio_target_fps::ParamType>& info)
+{
+    std::ostringstream os;
+    os << "target_" << cvRound(get<0>(info.param) * 10) << "_ratio_" << get<1>(info.param);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, videoio_target_fps, testing::ValuesIn(videoio_target_fps_params), videoio_target_fps_name_printer);
+
+// The last kept frame here (index 123, of 125 total) is exactly the case that used to break:
+// end-of-stream is reached with the schedule mid-tick, and get(CAP_PROP_POS_MSEC) used to
+// report a backend-specific value unrelated to the frame actually returned (observed 0.0)
+// instead of that frame's own timestamp.
+TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0;
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    double lastPosMsec = -1.0;
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        lastPosMsec = cap.get(CAP_PROP_POS_MSEC);
+        n++;
+    }
+    cap.release();
+
+    ASSERT_EQ(42, n); // indices 0,3,...,123
+    const double srcFrameDurationMs = 1000.0 / BBB_FPS;
+    EXPECT_NEAR(123 * srcFrameDurationMs, lastPosMsec, 1.0); // frame 123's own timestamp, not 0 and not a lookahead frame's
+}
+
+// Separate from the count check above: confirms the *timing* is right, not
+// just the quantity -- successive kept frames should be spaced exactly
+// 1000/target_fps ms apart, matching FFmpeg's own output-clock behavior.
+TEST(videoio_target_fps, emitted_frames_evenly_spaced)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0;
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    vector<double> posMsec;
+    Mat frame;
+    while (cap.read(frame))
+        posMsec.push_back(cap.get(CAP_PROP_POS_MSEC));
+    cap.release();
+
+    ASSERT_GE(posMsec.size(), 5u);
+    // get(CAP_PROP_POS_MSEC) reports the emitted frame's own timestamp (fpsCtl.pendingPts),
+    // including the final read at end-of-stream -- no reading needs to be excluded here.
+    vector<double> diffs(posMsec.size());
+    std::adjacent_difference(posMsec.begin(), posMsec.end(), diffs.begin());
+    const double expectedStepMs = 1000.0 / target_fps;
+    // A small epsilon, not a full frame-duration: fpsControlGrab()'s own boundary comparison
+    // tolerates backend floating-point rounding noise (observed on the order of 1e-13 ms) via
+    // kEpsMs, so every gap here should land on the exact scheduled step.
+    auto minIt = min_element(diffs.begin() + 1, diffs.end());
+    auto maxIt = max_element(diffs.begin() + 1, diffs.end());
+    EXPECT_NEAR(expectedStepMs, *minIt, 1.0);
+    EXPECT_NEAR(expectedStepMs, *maxIt, 1.0);
+}
+
+// Exercises the plain C++ default-argument path (no target_fps passed at all)
+// to guard against a signature drift between the header declaration and the
+// .cpp definition silently breaking the pre-existing, non-target_fps call sites.
+TEST(videoio_target_fps, default_argument_is_disabled)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG); // no target_fps argument at all
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+        n++;
+    cap.release();
+
+    EXPECT_EQ(BBB_FRAME_COUNT, n);
+}
+
+// Regression test: release() must reset fpsCtl, or a capture reopened through the
+// general params-vector overload (which never calls enableFpsControl()) inherits stale
+// clock/buffer state from the previous open and can silently return false forever.
+TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, 8.0); // target_fps enabled, clock anchored to this open's PTS
+    ASSERT_TRUE(cap.isOpened());
+    Mat frame;
+    ASSERT_TRUE(cap.read(frame)); // leave fpsCtl mid-schedule, not freshly reset
+
+    // General params-vector overload -- never calls enableFpsControl(), so this only behaves
+    // correctly if release() (called internally since cap.isOpened()) resets fpsCtl itself.
+    // Reopening the SAME file here (rather than a second, distinct one) is enough: what's under
+    // test is whether stale fpsCtl state survives the reopen, not which file is read.
+    ASSERT_TRUE(cap.open(filename, CAP_FFMPEG, std::vector<int>()));
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    while (cap.read(frame))
+        n++;
+    cap.release();
+
+    // target_fps isn't threaded through this overload (by design -- see CLAUDE.md), so the
+    // reopened capture should behave as a plain, unrestricted passthrough: every native frame
+    // (125), not silently zero (the pre-fix symptom) and not the previous open's leftover
+    // 8fps/ratio-3 schedule (42).
+    EXPECT_EQ(BBB_FRAME_COUNT, n);
+}
+
+// Regression test: target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
+// retrieveFrame(0, ...)). Requesting any other channel must fail loudly rather than silently
+// handing back channel 0's data -- this matters for multi-head sources (stereo camera, Kinect).
+TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, 8.0);
+    ASSERT_TRUE(cap.isOpened());
+    ASSERT_TRUE(cap.grab());
+
+    Mat channel0;
+    EXPECT_TRUE(cap.retrieve(channel0, 0)); // the only supported channel still works
+    EXPECT_FALSE(channel0.empty());
+
+    Mat channel1;
+    EXPECT_FALSE(cap.retrieve(channel1, 1)); // must fail, not silently return channel 0's frame
+    EXPECT_TRUE(channel1.empty());
+
+    cap.release();
+}
+
+}} // namespace


### PR DESCRIPTION
Adds an optional `target_fps` parameter (VideoCapture constructor and the two matching `open()` overloads) that reduces the emitted frame rate by dropping source frames, without any duplication or extra bookkeeping. Selection logic is ported from FFmpeg's own frame-rate reduction rule (`libavfilter/vf_fps.c`, `write_frame()`): a 2-frame lookahead buffer is compared against a steadily-advancing output clock, dropping the first buffered frame whenever it is already stale relative to the next scheduled output tick.

The feature lives entirely in the backend-agnostic VideoCapture frontend (`modules/videoio/src/cap.cpp`) -- no backend-specific code was touched. It only takes effect through the two constructor/open() overloads that accept `target_fps` directly; the general params-vector/IStreamReader overloads are unaffected (documented limitation, not a bug).

Adds gtest coverage (`test/test_target_fps.cpp`) against the shared `video/big_buck_bunny.mp4` test asset, plus a throughput perf test (`perf/perf_target_fps.cpp`) confirming the expected disabled-vs-enabled overhead direction.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
