### PR TITLE
fix: in jas_icctxtdesc_input(), the asclen value is ... in jas_icc.c

### DIFF
--- a/3rdparty/libjasper/jas_icc.c
+++ b/3rdparty/libjasper/jas_icc.c
@@ -1090,6 +1090,8 @@ static int jas_icctxtdesc_input(jas_iccattrval_t *attrval, jas_stream_t *in,
     txtdesc->ucdata = 0;
     if (jas_iccgetuint32(in, &txtdesc->asclen))
         goto error;
+    if (!txtdesc->asclen)
+        goto error;
     if (!(txtdesc->ascdata = jas_malloc(txtdesc->asclen)))
         goto error;
     if (jas_stream_read(in, txtdesc->ascdata, txtdesc->asclen) !=


### PR DESCRIPTION
## Summary
Fix high severity security issue in `3rdparty/libjasper/jas_icc.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-002 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-002` |
| **File** | `3rdparty/libjasper/jas_icc.c:553` |
| **Assessment** | Likely exploitable |

**Description**: In jas_icctxtdesc_input(), the asclen value is read directly from the ICC profile stream (untrusted input) and used to allocate a buffer and read data. If asclen is 0, the malloc(0) may return a valid pointer or NULL, and then txtdesc->ascdata[txtdesc->asclen - 1] becomes txtdesc->ascdata[-1] which is an out-of-bounds write.

## Evidence

**Exploitation scenario**: An attacker crafts a JPEG2000 image with an embedded ICC profile containing a textDescription tag where asclen is set to 0.

**Scanner confirmation**: multi_agent_ai rule `V-002` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is embedded firmware - exploitation requires physical access or a compromised network peer on the same bus/LAN segment.

## Changes
- `3rdparty/libjasper/jas_icc.c`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
