### PR TITLE
imgcodecs: name the parameter setReadOptions actually takes 🤖🤖🤖

### DIFF
--- a/modules/imgcodecs/src/grfmt_base.hpp
+++ b/modules/imgcodecs/src/grfmt_base.hpp
@@ -119,7 +119,7 @@ public:
      * during image decoding. The flags can be combined using bitwise OR to enable
      * multiple options simultaneously.
      *
-     * @param options Bitwise OR of read option flags to enable.
+     * @param read_options Bitwise OR of read option flags to enable.
      *
      * @return The previous value of the read options flags.
      *


### PR DESCRIPTION
### The problem

`BaseImageDecoder::setReadOptions` documents a parameter named `options`, and the one it takes is `read_options`:

```cpp
/**
 * @param options Bitwise OR of read option flags to enable.
 */
int setReadOptions(int read_options);
```

Doxygen drops a `@param` whose name matches nothing, so the description of the only argument is not rendered at all. The rest of the block is accurate: the function does return the previous value.

One word, no behaviour touched.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
