### PR TITLE
photo: accept CV_Bool masks in inpaint (#25895)

### DIFF
--- a/modules/photo/src/inpaint.cpp
+++ b/modules/photo/src/inpaint.cpp
@@ -709,8 +709,8 @@ icvInpaint( const Mat &input_img, const Mat &inpaint_mask, Mat &output_img,
         CV_Error( cv::Error::StsUnsupportedFormat,
         "8-bit, 16-bit unsigned or 32-bit float 1-channel and 8-bit 3-channel input/output images are supported" );
 
-    if( inpaint_mask.type() != CV_8UC1 )
-        CV_Error( cv::Error::StsUnsupportedFormat, "The mask must be 8-bit 1-channel image" );
+    if( inpaint_mask.type() != CV_8UC1 && inpaint_mask.type() != CV_BoolC1 )
+        CV_Error( cv::Error::StsUnsupportedFormat, "The mask must be 8-bit or boolean 1-channel image" );
 
     range = MAX(range,1);
     range = MIN(range,100);

--- a/modules/photo/test/test_inpaint.cpp
+++ b/modules/photo/test/test_inpaint.cpp
@@ -183,4 +183,36 @@ TEST_P(Photo_InpaintSmallBorders, regression)
 
 INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintSmallBorders,  Values(CV_8UC1, CV_8UC3));
 
+CV_ENUM(InpaintAlgo, cv::INPAINT_NS, cv::INPAINT_TELEA)
+
+typedef testing::TestWithParam<tuple<perf::MatType, InpaintAlgo>> Photo_InpaintBoolMask;
+
+TEST_P(Photo_InpaintBoolMask, accepts_bool_mask)
+{
+    const int type = get<0>(GetParam());
+    const int flag = get<1>(GetParam());
+    Mat img(21, 21, type, Scalar::all(128));
+
+    Mat_<bool> mask_bool(img.size(), false);
+    mask_bool(Rect(8, 8, 5, 5)) = true;
+    ASSERT_EQ(mask_bool.depth(), CV_Bool);
+
+    Mat mask_uchar(img.size(), CV_8UC1, Scalar::all(0));
+    mask_uchar(Rect(8, 8, 5, 5)) = 255;
+
+    img.setTo(Scalar::all(0), mask_uchar);
+
+    Mat inpainted_bool, inpainted_uchar;
+    ASSERT_NO_THROW(inpaint(img, mask_bool, inpainted_bool, 3, flag));
+    inpaint(img, mask_uchar, inpainted_uchar, 3, flag);
+
+    EXPECT_EQ(inpainted_bool.type(), inpainted_uchar.type());
+    Mat diff;
+    cv::absdiff(inpainted_bool, inpainted_uchar, diff);
+    EXPECT_EQ(countNonZero(diff.reshape(1)), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Photo_InpaintBoolMask,
+                        Combine(Values(CV_8UC1, CV_8UC3), InpaintAlgo::all()));
+
 }} // namespace


### PR DESCRIPTION
### Problem

`cv::Mat_<bool>::depth()` returns `CV_Bool` in 5.0, where it returned `CV_8U` in 4.x. `inpaint.cpp:712` gates the mask on `inpaint_mask.type() != CV_8UC1`, so a boolean mask that worked in 4.x now fails in 5.0 with:

```
(-210:Unsupported format or combination of formats) The mask must be 8-bit 1-channel image
in function 'icvInpaint'
```

A binary mask is the natural input for inpainting, so this is a usability regression against 4.x.

### Fix

Allow `CV_BoolC1` in the type check, and update the message accordingly.

No conversion is needed. `COPY_MASK_BORDER1_C1` and the FMM helpers read the mask with `Mat::at<uchar>`, and `Mat::at` only asserts that the element size matches (`CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1()`). `CV_Bool` is one byte like `CV_8U`, so those reads are already correct for a boolean mask.

### Test

`Photo_InpaintBoolMask.accepts_bool_mask` runs the same mask as `Mat_<bool>` and as `CV_8UC1` through both `INPAINT_TELEA` and `INPAINT_NS`, over `CV_8UC1` and `CV_8UC3` images, and requires identical output.

Verified locally on 5.x: both parameter cases fail without the change (throwing the error above) and pass with it. The full `opencv_test_photo` `*Inpaint*` set, 10 tests, passes with `OPENCV_TEST_DATA_PATH` set. No test data is needed for the new test itself, it is synthetic.

Part of #25895, and follows the same approach as #29580, #29597 and #29622.

---

*Note on an earlier revision of this PR: the first version converted the mask to `CV_8UC1` with `convertTo`, and justified it by claiming that `Mat::at<uchar>` would otherwise trip a type assert in debug builds. That justification was wrong. `Mat::at` checks element size, not depth, and `CV_Bool` is one byte, so the conversion was unnecessary. The patch has been simplified to just relax the type check, which removes a needless mask copy.*

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
