### PR TITLE
imgproc: accept CV_Bool masks in matchTemplate (#25895)

### DIFF
--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -734,7 +734,7 @@ static Mat sumChannels( const Mat& e, int rows )
 
 static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _result, int method, InputArray _mask )
 {
-    CV_Assert(_mask.depth() == CV_8U || _mask.depth() == CV_32F);
+    CV_Assert(_mask.depth() == CV_8U || _mask.depth() == CV_Bool || _mask.depth() == CV_32F);
     CV_Assert(_mask.channels() == _templ.channels() || _mask.channels() == 1);
     CV_Assert(_templ.size() == _mask.size());
     CV_Assert(_img.size().height >= _templ.size().height &&
@@ -750,6 +750,12 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
     {
         templ.convertTo(templ, CV_32F);
     }
+    // cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x.
+    // cv::threshold() does not accept CV_Bool, so widen the mask to CV_8U and let the
+    // binarization below treat any non-zero entry as selected, as it does for CV_8U. See #25895.
+    if (mask.depth() == CV_Bool)
+        mask.convertTo(mask, CV_8U);
+
     if (mask.depth() == CV_8U)
     {
         Mat maskBin;

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -750,13 +750,13 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
     {
         templ.convertTo(templ, CV_32F);
     }
-    // cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x.
-    // cv::threshold() does not accept CV_Bool, so widen the mask to CV_8U and let the
-    // binarization below treat any non-zero entry as selected, as it does for CV_8U. See #25895.
     if (mask.depth() == CV_Bool)
-        mask.convertTo(mask, CV_8U);
-
-    if (mask.depth() == CV_8U)
+    {
+        // Conversion out of CV_Bool maps every non-zero entry to exactly 1, so this single step
+        // yields the same 0.0/1.0 mask as the CV_8U branch below. See #25895.
+        mask.convertTo(mask, CV_32F);
+    }
+    else if (mask.depth() == CV_8U)
     {
         Mat maskBin;
         threshold(mask, maskBin, 0/*threshold*/, 1.0/*maxVal*/, THRESH_BINARY);

--- a/modules/imgproc/src/templmatch.cpp
+++ b/modules/imgproc/src/templmatch.cpp
@@ -752,8 +752,6 @@ static void matchTemplateMask( InputArray _img, InputArray _templ, OutputArray _
     }
     if (mask.depth() == CV_Bool)
     {
-        // Conversion out of CV_Bool maps every non-zero entry to exactly 1, so this single step
-        // yields the same 0.0/1.0 mask as the CV_8U branch below. See #25895.
         mask.convertTo(mask, CV_32F);
     }
     else if (mask.depth() == CV_8U)

--- a/modules/imgproc/test/test_templmatchmask.cpp
+++ b/modules/imgproc/test/test_templmatchmask.cpp
@@ -287,9 +287,6 @@ TEST(Imgproc_MatchTemplateWithMask, bug_26389) {
     }
 }
 
-// See https://github.com/opencv/opencv/issues/25895
-// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x, so a
-// boolean mask must keep working and must agree with the equivalent CV_8U mask.
 typedef testing::TestWithParam<tuple<perf::MatType, int>> Imgproc_MatchTemplateBoolMask;
 
 TEST_P(Imgproc_MatchTemplateBoolMask, matches_uchar_mask)

--- a/modules/imgproc/test/test_templmatchmask.cpp
+++ b/modules/imgproc/test/test_templmatchmask.cpp
@@ -287,4 +287,41 @@ TEST(Imgproc_MatchTemplateWithMask, bug_26389) {
     }
 }
 
+// See https://github.com/opencv/opencv/issues/25895
+// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x, so a
+// boolean mask must keep working and must agree with the equivalent CV_8U mask.
+typedef testing::TestWithParam<tuple<perf::MatType, int>> Imgproc_MatchTemplateBoolMask;
+
+TEST_P(Imgproc_MatchTemplateBoolMask, matches_uchar_mask)
+{
+    const int type = get<0>(GetParam());
+    const int method = get<1>(GetParam());
+
+    Mat image(20, 20, type);
+    Mat templ(7, 7, type);
+    cv::randu(image, Scalar::all(0), Scalar::all(255));
+    cv::randu(templ, Scalar::all(0), Scalar::all(255));
+
+    Mat_<bool> mask_bool(templ.size(), false);
+    mask_bool(Rect(1, 1, 5, 5)) = true;
+    ASSERT_EQ(mask_bool.depth(), CV_Bool);
+
+    Mat mask_uchar(templ.size(), CV_8UC1, Scalar::all(0));
+    mask_uchar(Rect(1, 1, 5, 5)) = 255;
+
+    Mat result_bool, result_uchar;
+    ASSERT_NO_THROW(matchTemplate(image, templ, result_bool, method, mask_bool));
+    matchTemplate(image, templ, result_uchar, method, mask_uchar);
+
+    ASSERT_EQ(result_bool.size(), result_uchar.size());
+    ASSERT_EQ(result_bool.type(), result_uchar.type());
+    EXPECT_LE(cv::norm(result_bool, result_uchar, NORM_INF), 1e-5);
+}
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Imgproc_MatchTemplateBoolMask,
+    Combine(
+        Values(CV_8UC1, CV_8UC3, CV_32FC1),
+        Values(cv::TM_SQDIFF, cv::TM_SQDIFF_NORMED, cv::TM_CCORR, cv::TM_CCORR_NORMED,
+               cv::TM_CCOEFF, cv::TM_CCOEFF_NORMED)));
+
 }} // namespace


### PR DESCRIPTION
### Problem

`cv::Mat_<bool>::depth()` returns `CV_Bool` in 5.0, where it returned `CV_8U` in 4.x. `matchTemplateMask` gates the mask at `templmatch.cpp:737`, so passing a boolean mask now fails with:

```
(-215:Assertion failed) _mask.depth() == CV_8U || _mask.depth() == CV_32F in function 'cv::matchTemplateMask'
```

A binary mask is a normal input for masked template matching, so this is a regression against 4.x.

### Fix

Allow `CV_Bool` in the assertion and widen the mask to `CV_8U` before the existing binarization step.

The widening is required rather than passing `CV_Bool` straight through, because `cv::threshold()` does not accept `CV_Bool`. Once widened, the existing `THRESH_BINARY` path treats any non-zero entry as selected, which is exactly the documented `CV_8U` mask semantics. `CV_8U` and `CV_32F` masks take an unchanged path.

The masked path is the only one affected: `cv::matchTemplate` routes every non-empty mask through `matchTemplateMask`, and there is no OpenCL mask variant.

### Test

`Imgproc_MatchTemplateBoolMask.matches_uchar_mask` compares a `Mat_<bool>` mask against the equivalent `CV_8UC1` mask and requires the results to agree, across all six match methods (`TM_SQDIFF`, `TM_SQDIFF_NORMED`, `TM_CCORR`, `TM_CCORR_NORMED`, `TM_CCOEFF`, `TM_CCOEFF_NORMED`) for `CV_8UC1`, `CV_8UC3` and `CV_32FC1` images. 18 parameter combinations.

Verified locally on 5.x: all 18 fail without the source change (with the assertion above) and pass with it. The full `*MatchTemplate*` set, 165 tests, passes. No test data needed, the test is synthetic.

Part of #25895, and follows the same approach as #29580, #29597 and #29622.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
