### PR TITLE
features: fix test build when dnn module is disabled

### DIFF
--- a/modules/features/test/test_aliked_lightglue.cpp
+++ b/modules/features/test/test_aliked_lightglue.cpp
@@ -6,10 +6,12 @@
 #include "npy_blob.hpp"
 
 #ifdef HAVE_OPENCV_DNN
-
 #include "opencv2/dnn.hpp"
+#endif
 
 namespace opencv_test { namespace {
+
+#ifdef HAVE_OPENCV_DNN
 
 TEST(Features2d_ALIKED, Regression)
 {


### PR DESCRIPTION
### Problem

`modules/features/test/test_aliked_lightglue.cpp` opens the test namespace inside the `HAVE_OPENCV_DNN` branch:

```cpp
#ifdef HAVE_OPENCV_DNN
#include "opencv2/dnn.hpp"

namespace opencv_test { namespace {      // <-- opened only when dnn is available
...
#else  // !HAVE_OPENCV_DNN
    // two not_available tests
#endif

}}  // namespace opencv_test             // <-- closed unconditionally
```

The closing braces are compiled unconditionally while the opening ones are not. When OpenCV is built without the dnn module, the two `not_available` tests in the `#else` branch land at global scope and the translation unit fails to compile:

```
error C2065: 'required_opencv_test_namespace': undeclared identifier
error C2653: 'ALIKED': is not a class or namespace name
error C3861: 'create': identifier not found
error C2059: syntax error: '}'
```

So `opencv_test_features` cannot be built at all in any configuration that excludes dnn.

### Fix

Move `namespace opencv_test { namespace {` so it wraps both branches, and guard only the `dnn.hpp` include. This is the layout `test_disk.cpp` already uses.

`ALIKED` and `LightGlueMatcher` are declared unconditionally in `features.hpp` (only one `create` overload is behind `HAVE_OPENCV_DNN`), so the `#else` tests are valid as written. They just needed to be inside the namespace. No test was removed.

### Test

Configured with `-DBUILD_LIST=imgproc,features,stitching,video,photo,ts`, which excludes dnn.

Before: `opencv_test_features` fails to compile with the errors above.
After: it builds clean, and the two previously unbuildable tests run and pass.

```
[ RUN      ] Features2d_ALIKED.not_available
[       OK ] Features2d_ALIKED.not_available (0 ms)
[ RUN      ] Features2d_LightGlueMatcher.not_available
[       OK ] Features2d_LightGlueMatcher.not_available (0 ms)
[  PASSED  ] 2 tests.
```

Builds with dnn enabled are unaffected: the preprocessor output for that branch is unchanged apart from where the namespace opens.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
