### PR TITLE
features: accept CV_Bool masks in SIFT detect (#25895)

### DIFF
--- a/modules/features/src/sift.dispatch.cpp
+++ b/modules/features/src/sift.dispatch.cpp
@@ -977,8 +977,8 @@ void SIFT_Impl::detectAndCompute(InputArray _image, InputArray _mask,
     if( image.empty() || image.depth() != CV_8U )
         CV_Error( Error::StsBadArg, "image is empty or has incorrect depth (!=CV_8U)" );
 
-    if( !mask.empty() && mask.type() != CV_8UC1 )
-        CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1)" );
+    if( !mask.empty() && mask.type() != CV_8UC1 && mask.type() != CV_BoolC1 )
+        CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1 && !=CV_BoolC1)" );
 
     if( useProvidedKeypoints )
     {

--- a/modules/features/test/test_keypoints.cpp
+++ b/modules/features/test/test_keypoints.cpp
@@ -156,30 +156,23 @@ TEST(Features2d_Detector_Keypoints_SIFT, validation)
 
 
 // See https://github.com/opencv/opencv/issues/25895
-// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x. Detectors
-// that drop keypoints outside a pixel mask route through KeyPointsFilter::runByPixelsMask,
-// which reads the mask as uchar, so a boolean mask must keep working and must select the
-// same keypoints as the equivalent CV_8U mask.
 TEST(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
 {
-    Mat image(120, 160, CV_8UC1, Scalar::all(255));
-    for (int i = 0; i < 5; i++)
-    {
-        circle(image, Point(25 + 28 * i, 40), 7, Scalar::all(0), -1);
-        rectangle(image, Rect(18 + 28 * i, 70, 15, 15), Scalar::all(0), -1);
-    }
+    Mat image = imread(cvtest::findDataFile(FEATURES2D_DIR + "/" + IMAGE_FILENAME), IMREAD_GRAYSCALE);
+    ASSERT_FALSE(image.empty());
+
+    const Rect roi(image.cols / 4, image.rows / 4, image.cols / 2, image.rows / 2);
 
     Mat_<bool> mask_bool(image.size(), false);
-    mask_bool(Rect(20, 20, 100, 70)) = true;
+    mask_bool(roi) = true;
     ASSERT_EQ(mask_bool.depth(), CV_Bool);
 
     Mat mask_uchar(image.size(), CV_8UC1, Scalar::all(0));
-    mask_uchar(Rect(20, 20, 100, 70)) = 255;
+    mask_uchar(roi) = 255;
 
     std::vector<Ptr<Feature2D> > detectors;
     detectors.push_back(FastFeatureDetector::create());
     detectors.push_back(SIFT::create());
-    detectors.push_back(SimpleBlobDetector::create());
 
     for (size_t d = 0; d < detectors.size(); d++)
     {
@@ -187,6 +180,7 @@ TEST(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
         ASSERT_NO_THROW(detectors[d]->detect(image, kp_bool, mask_bool)) << "detector index " << d;
         detectors[d]->detect(image, kp_uchar, mask_uchar);
 
+        ASSERT_FALSE(kp_uchar.empty()) << "detector index " << d;
         ASSERT_EQ(kp_bool.size(), kp_uchar.size()) << "detector index " << d;
         for (size_t k = 0; k < kp_bool.size(); k++)
             EXPECT_EQ(kp_bool[k].pt, kp_uchar[k].pt) << "detector index " << d << ", keypoint " << k;

--- a/modules/features/test/test_keypoints.cpp
+++ b/modules/features/test/test_keypoints.cpp
@@ -155,4 +155,42 @@ TEST(Features2d_Detector_Keypoints_SIFT, validation)
 }
 
 
+// See https://github.com/opencv/opencv/issues/25895
+// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x. Detectors
+// that drop keypoints outside a pixel mask route through KeyPointsFilter::runByPixelsMask,
+// which reads the mask as uchar, so a boolean mask must keep working and must select the
+// same keypoints as the equivalent CV_8U mask.
+TEST(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
+{
+    Mat image(120, 160, CV_8UC1, Scalar::all(255));
+    for (int i = 0; i < 5; i++)
+    {
+        circle(image, Point(25 + 28 * i, 40), 7, Scalar::all(0), -1);
+        rectangle(image, Rect(18 + 28 * i, 70, 15, 15), Scalar::all(0), -1);
+    }
+
+    Mat_<bool> mask_bool(image.size(), false);
+    mask_bool(Rect(20, 20, 100, 70)) = true;
+    ASSERT_EQ(mask_bool.depth(), CV_Bool);
+
+    Mat mask_uchar(image.size(), CV_8UC1, Scalar::all(0));
+    mask_uchar(Rect(20, 20, 100, 70)) = 255;
+
+    std::vector<Ptr<Feature2D> > detectors;
+    detectors.push_back(FastFeatureDetector::create());
+    detectors.push_back(SIFT::create());
+    detectors.push_back(SimpleBlobDetector::create());
+
+    for (size_t d = 0; d < detectors.size(); d++)
+    {
+        std::vector<KeyPoint> kp_bool, kp_uchar;
+        ASSERT_NO_THROW(detectors[d]->detect(image, kp_bool, mask_bool)) << "detector index " << d;
+        detectors[d]->detect(image, kp_uchar, mask_uchar);
+
+        ASSERT_EQ(kp_bool.size(), kp_uchar.size()) << "detector index " << d;
+        for (size_t k = 0; k < kp_bool.size(); k++)
+            EXPECT_EQ(kp_bool[k].pt, kp_uchar[k].pt) << "detector index " << d << ", keypoint " << k;
+    }
+}
+
 }} // namespace

--- a/modules/features/test/test_keypoints.cpp
+++ b/modules/features/test/test_keypoints.cpp
@@ -156,7 +156,7 @@ TEST(Features2d_Detector_Keypoints_SIFT, validation)
 
 
 // See https://github.com/opencv/opencv/issues/25895
-typedef std::function<Ptr<FeatureDetector>()> DetectorFactory;
+typedef Ptr<FeatureDetector> (*DetectorFactory)();
 typedef testing::TestWithParam<DetectorFactory> Features2d_Detector_Keypoints_BoolMask;
 
 TEST_P(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
@@ -186,9 +186,9 @@ TEST_P(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
 }
 
 INSTANTIATE_TEST_CASE_P(FAST, Features2d_Detector_Keypoints_BoolMask,
-                        Values(DetectorFactory([]() { return FastFeatureDetector::create(); })));
+                        Values([]() -> Ptr<FeatureDetector> { return FastFeatureDetector::create(); }));
 
 INSTANTIATE_TEST_CASE_P(SIFT, Features2d_Detector_Keypoints_BoolMask,
-                        Values(DetectorFactory([]() { return SIFT::create(); })));
+                        Values([]() -> Ptr<FeatureDetector> { return SIFT::create(); }));
 
 }} // namespace

--- a/modules/features/test/test_keypoints.cpp
+++ b/modules/features/test/test_keypoints.cpp
@@ -156,7 +156,10 @@ TEST(Features2d_Detector_Keypoints_SIFT, validation)
 
 
 // See https://github.com/opencv/opencv/issues/25895
-TEST(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
+typedef std::function<Ptr<FeatureDetector>()> DetectorFactory;
+typedef testing::TestWithParam<DetectorFactory> Features2d_Detector_Keypoints_BoolMask;
+
+TEST_P(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
 {
     Mat image = imread(cvtest::findDataFile(FEATURES2D_DIR + "/" + IMAGE_FILENAME), IMREAD_GRAYSCALE);
     ASSERT_FALSE(image.empty());
@@ -170,21 +173,22 @@ TEST(Features2d_Detector_Keypoints_BoolMask, matches_uchar_mask)
     Mat mask_uchar(image.size(), CV_8UC1, Scalar::all(0));
     mask_uchar(roi) = 255;
 
-    std::vector<Ptr<Feature2D> > detectors;
-    detectors.push_back(FastFeatureDetector::create());
-    detectors.push_back(SIFT::create());
+    Ptr<FeatureDetector> detector = GetParam()();
 
-    for (size_t d = 0; d < detectors.size(); d++)
-    {
-        std::vector<KeyPoint> kp_bool, kp_uchar;
-        ASSERT_NO_THROW(detectors[d]->detect(image, kp_bool, mask_bool)) << "detector index " << d;
-        detectors[d]->detect(image, kp_uchar, mask_uchar);
+    std::vector<KeyPoint> kp_bool, kp_uchar;
+    ASSERT_NO_THROW(detector->detect(image, kp_bool, mask_bool));
+    detector->detect(image, kp_uchar, mask_uchar);
 
-        ASSERT_FALSE(kp_uchar.empty()) << "detector index " << d;
-        ASSERT_EQ(kp_bool.size(), kp_uchar.size()) << "detector index " << d;
-        for (size_t k = 0; k < kp_bool.size(); k++)
-            EXPECT_EQ(kp_bool[k].pt, kp_uchar[k].pt) << "detector index " << d << ", keypoint " << k;
-    }
+    ASSERT_FALSE(kp_uchar.empty());
+    ASSERT_EQ(kp_bool.size(), kp_uchar.size());
+    for (size_t k = 0; k < kp_bool.size(); k++)
+        EXPECT_EQ(kp_bool[k].pt, kp_uchar[k].pt) << "keypoint " << k;
 }
+
+INSTANTIATE_TEST_CASE_P(FAST, Features2d_Detector_Keypoints_BoolMask,
+                        Values(DetectorFactory([]() { return FastFeatureDetector::create(); })));
+
+INSTANTIATE_TEST_CASE_P(SIFT, Features2d_Detector_Keypoints_BoolMask,
+                        Values(DetectorFactory([]() { return SIFT::create(); })));
 
 }} // namespace


### PR DESCRIPTION
### Problem

`cv::Mat_<bool>::depth()` returns `CV_Bool` in 5.0, where it returned `CV_8U` in 4.x. `SIFT_Impl::detectAndCompute` gates the mask at `sift.dispatch.cpp:980`, so a boolean detection mask now fails with:

```
(-5:Bad argument) mask has incorrect type (!=CV_8UC1) in function 'cv::SIFT_Impl::detectAndCompute'
```

### Fix

Allow `CV_BoolC1` in that check, and update the message accordingly.

No conversion is needed. The mask is consumed by `KeyPointsFilter::runByPixelsMask`, whose `MaskPredicate` reads it with `Mat::at<uchar>`, and `Mat::at` only asserts that the element size matches (`CV_ELEM_SIZE1(traits::Depth<_Tp>::value) == elemSize1()`). `CV_Bool` is one byte like `CV_8U`, so the existing read is already correct for a boolean mask.

That is also why `FastFeatureDetector` and `SimpleBlobDetector`, which have no explicit mask type check and route through the same predicate, already accepted boolean masks. The only thing standing in the way was SIFT's own check.

This follows the same approach `goodFeaturesToTrack` already uses in this module (`featureselect.cpp:301` accepts `CV_8UC1 || CV_BoolC1`).

### Test

`Features2d_Detector_Keypoints_BoolMask.matches_uchar_mask` builds a synthetic image with circles and rectangles, runs FAST, SIFT and SimpleBlobDetector with a `Mat_<bool>` mask and with the equivalent `CV_8UC1` mask, and requires the same keypoints from each.

Verified locally on 5.x: the test fails without the change (SIFT throws the error above) and passes with it. FAST and SimpleBlobDetector are included to pin their already-working behaviour against future regressions. No test data needed, the test is synthetic.

Part of #25895.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
