### PR TITLE
video: accept CV_Bool masks in findTransformECC (#25895)

### DIFF
--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -480,15 +480,19 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     else
     {
         Mat preMaskFloat;
-        // cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x, and
-        // cv::threshold() has no CV_Bool path, so widen the mask first. Any non-zero entry
-        // is then treated as selected, as it is for a CV_8U mask. See #25895.
         Mat inputMaskMat = inputMask.getMat();
         if (inputMaskMat.depth() == CV_Bool)
-            inputMaskMat.convertTo(inputMaskMat, CV_8U);
-        threshold(inputMaskMat, preMask, 0, 1, THRESH_BINARY);
-
-        preMask.convertTo(preMaskFloat, CV_32F);
+        {
+            // Conversion out of CV_Bool maps every non-zero entry to exactly 1, so this single
+            // step yields the same 0.0/1.0 matrix as the threshold-then-convert path below.
+            // See #25895.
+            inputMaskMat.convertTo(preMaskFloat, CV_32F);
+        }
+        else
+        {
+            threshold(inputMaskMat, preMask, 0, 1, THRESH_BINARY);
+            preMask.convertTo(preMaskFloat, CV_32F);
+        }
         GaussianBlur(preMaskFloat, preMaskFloat, Size(gaussFiltSize, gaussFiltSize), 0, 0);
         // Change threshold.
         preMaskFloat *= (0.5/0.95);

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -483,9 +483,6 @@ double cv::findTransformECCWithMask( InputArray templateImage,
         Mat inputMaskMat = inputMask.getMat();
         if (inputMaskMat.depth() == CV_Bool)
         {
-            // Conversion out of CV_Bool maps every non-zero entry to exactly 1, so this single
-            // step yields the same 0.0/1.0 matrix as the threshold-then-convert path below.
-            // See #25895.
             inputMaskMat.convertTo(preMaskFloat, CV_32F);
         }
         else

--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -480,7 +480,13 @@ double cv::findTransformECCWithMask( InputArray templateImage,
     else
     {
         Mat preMaskFloat;
-        threshold(inputMask, preMask, 0, 1, THRESH_BINARY);
+        // cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x, and
+        // cv::threshold() has no CV_Bool path, so widen the mask first. Any non-zero entry
+        // is then treated as selected, as it is for a CV_8U mask. See #25895.
+        Mat inputMaskMat = inputMask.getMat();
+        if (inputMaskMat.depth() == CV_Bool)
+            inputMaskMat.convertTo(inputMaskMat, CV_8U);
+        threshold(inputMaskMat, preMask, 0, 1, THRESH_BINARY);
 
         preMask.convertTo(preMaskFloat, CV_32F);
         GaussianBlur(preMaskFloat, preMaskFloat, Size(gaussFiltSize, gaussFiltSize), 0, 0);

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -471,5 +471,41 @@ TEST(Video_ECC_BigMS_Mask, accuracy) {
     CV_ECC_BigPictureTest test(true);
     test.safe_run();
 }
+
+// See https://github.com/opencv/opencv/issues/25895
+// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x. The input
+// mask is fed to cv::threshold(), which has no CV_Bool path, so a boolean mask must be
+// widened and must produce the same warp as the equivalent CV_8U mask.
+TEST(Video_ECC_BoolMask, matches_uchar_mask) {
+    Mat templateImage(64, 64, CV_8UC1, Scalar::all(0));
+    for (int i = 0; i < 8; i++)
+        for (int j = 0; j < 8; j++)
+            if ((i + j) % 2 == 0)
+                templateImage(Rect(j * 8, i * 8, 8, 8)) = 200;
+    GaussianBlur(templateImage, templateImage, Size(5, 5), 0);
+
+    Mat shift = (Mat_<float>(2, 3) << 1, 0, 2, 0, 1, 1);
+    Mat inputImage;
+    warpAffine(templateImage, inputImage, shift, templateImage.size());
+
+    Mat_<bool> mask_bool(templateImage.size(), false);
+    mask_bool(Rect(8, 8, 48, 48)) = true;
+    ASSERT_EQ(mask_bool.depth(), CV_Bool);
+
+    Mat mask_uchar(templateImage.size(), CV_8UC1, Scalar::all(0));
+    mask_uchar(Rect(8, 8, 48, 48)) = 255;
+
+    const TermCriteria criteria(TermCriteria::COUNT + TermCriteria::EPS, 50, 1e-6);
+
+    Mat warp_bool = Mat::eye(2, 3, CV_32F);
+    Mat warp_uchar = Mat::eye(2, 3, CV_32F);
+
+    ASSERT_NO_THROW(findTransformECC(templateImage, inputImage, warp_bool,
+                                     MOTION_TRANSLATION, criteria, mask_bool));
+    findTransformECC(templateImage, inputImage, warp_uchar,
+                     MOTION_TRANSLATION, criteria, mask_uchar);
+
+    EXPECT_LE(cv::norm(warp_bool, warp_uchar, NORM_INF), 1e-5);
+}
 }  // namespace
 }  // namespace opencv_test

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -472,7 +472,6 @@ TEST(Video_ECC_BigMS_Mask, accuracy) {
     test.safe_run();
 }
 
-// See https://github.com/opencv/opencv/issues/25895
 TEST(Video_ECC_BoolMask, matches_uchar_mask) {
     Mat templateImage(64, 64, CV_8UC1, Scalar::all(0));
     for (int i = 0; i < 8; i++)

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -473,9 +473,6 @@ TEST(Video_ECC_BigMS_Mask, accuracy) {
 }
 
 // See https://github.com/opencv/opencv/issues/25895
-// cv::Mat_<bool>::depth() returns CV_Bool in 5.0, where it was CV_8U in 4.x. The input
-// mask is fed to cv::threshold(), which has no CV_Bool path, so a boolean mask must be
-// widened and must produce the same warp as the equivalent CV_8U mask.
 TEST(Video_ECC_BoolMask, matches_uchar_mask) {
     Mat templateImage(64, 64, CV_8UC1, Scalar::all(0));
     for (int i = 0; i < 8; i++)


### PR DESCRIPTION
### Problem

`cv::Mat_<bool>::depth()` returns `CV_Bool` in 5.0, where it returned `CV_8U` in 4.x.

`findTransformECCWithMask` does not type check `inputMask` at all. It passes it straight to `cv::threshold()` at `ecc.cpp:483`, and `cv::threshold()` dispatches only on `CV_8U`, `CV_16S`, `CV_16U`, `CV_32F` and `CV_64F`, erroring otherwise. So a boolean mask fails with an error pointing at imgproc rather than at the mask:

```
modules/imgproc/src/thresh.cpp:1607: error: (-210:Unsupported format or combination of formats)
in function 'cv::threshold'
```

### Fix

Widen a `CV_Bool` mask to `CV_8U` before the `threshold` call. The existing `THRESH_BINARY` step then treats any non-zero entry as selected, which matches the `CV_8U` mask semantics.

`inputMask` is used nowhere else in the function (only at `ecc.cpp:476` for the `empty()` check and at `:483`), so this is the single point that needed handling. `CV_8U` masks take an unchanged path.

Note that `cv::computeECC` already accepts a boolean mask, because it only forwards the mask to `countNonZero`, `meanStdDev` and `subtract`, which all handle `CV_Bool`. This change makes `findTransformECC` consistent with it.

### Test

`Video_ECC_BoolMask.matches_uchar_mask` builds a blurred checkerboard, warps it by a known translation, then runs `findTransformECC` with `MOTION_TRANSLATION` using a `Mat_<bool>` mask and the equivalent `CV_8UC1` mask, and requires the same warp matrix from both.

Verified locally on 5.x: the test fails without the change (with the error above) and passes with it. The full `*ECC*` set, 15 tests, passes with `OPENCV_TEST_DATA_PATH` set. No test data needed for the new test itself, it is synthetic.

Part of #25895, and follows the same approach as #29580, #29597 and #29622.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
