### PR TITLE
Fix silent loss of high-channel NumPy dimensions

### DIFF
--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -165,7 +165,7 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
 
     CV_LOG_DEBUG(NULL, "Incoming ndarray '" << info.name << "': ndims=" << ndims << "  _sizes=" << pycv_dumpArray(_sizes, ndims) << "  _strides=" << pycv_dumpArray(_strides, ndims));
 
-    bool ismultichannel = ndims == 3 && _sizes[2] <= CV_CN_MAX && !info.nd_mat;
+    bool ismultichannel = ndims == 3 && !info.nd_mat;
     if (pyopencv_Mat_TypePtr && PyObject_TypeCheck(o, pyopencv_Mat_TypePtr))
     {
         bool wrapChannels = false;

--- a/modules/python/test/test_mat.py
+++ b/modules/python/test/test_mat.py
@@ -89,6 +89,19 @@ try:
                 print(res1)
 
 
+        def test_ndarray_channel_limit_is_reported(self):
+            map_x, map_y = np.meshgrid(
+                np.arange(8, dtype=np.float32),
+                np.arange(8, dtype=np.float32),
+            )
+            data = np.broadcast_to(
+                np.arange(129, dtype=np.uint8),
+                (8, 8, 129),
+            ).copy()
+
+            with self.assertRaisesRegex(cv.error, "unable to wrap channels"):
+                cv.remap(data, map_x, map_y, cv.INTER_NEAREST)
+
         def test_mat_wrap_channels_zero(self):
             # Passing a 0-channel array must raise cv.error, not segfault.
             data = np.zeros((100, 100, 0), dtype=np.uint8)


### PR DESCRIPTION
## Summary
OpenCV 5.x silently treats ordinary three-dimensional NumPy arrays with more than `CV_CN_MAX` channels as n-dimensional single-channel matrices. Image operations can then discard the final axis without raising an error. This is particularly harmful for synchronized masks and feature tensors because the returned array still looks valid.

The converter now classifies every three-dimensional non-`nd_mat` input as a multichannel input before applying the channel-limit check. Inputs above `CV_CN_MAX` therefore produce the existing descriptive `unable to wrap channels` conversion error instead of silently losing their channel dimension.

## Root cause
The previous condition included `_sizes[2] <= CV_CN_MAX` in the multichannel heuristic. When the channel count was 129 or greater, the converter skipped the multichannel branch and created a three-dimensional single-channel `Mat`; functions such as `cv.remap` then ignored the extra dimension.

## Validation
- Reproduced the regression with `opencv-python==5.0.0`: a `(8, 8, 129)` input returned `(8, 8)` and was not equal to the input, while 128 channels worked.
- Added a Python regression test requiring `cv.remap` to report the channel-limit conversion error for 129 channels.
- Python test source was syntax-checked locally; the C++/Python integration test should run in OpenCV CI.

## AI assistance disclosure

I identified and reproduced the issue, then used OpenAI Codex to assist with the implementation and regression-test work. I personally reviewed the resulting diff and ran the validation commands listed above to verify the fix. Any full-suite or local-environment limitations are documented in the validation section.
Fixes #29586