### PR TITLE
Fix AKAZE descriptor subsampling for fewer channels

### DIFF
--- a/modules/features2d/src/kaze/AKAZEFeatures.cpp
+++ b/modules/features2d/src/kaze/AKAZEFeatures.cpp
@@ -2609,9 +2609,9 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 1) && samples(j, 2) == fullcopy(k, 2)) {
         n = false;
-        comps(i*nchannels, 0) = nchannels*j;
-        comps(i*nchannels + 1, 0) = nchannels*j + 1;
-        comps(i*nchannels + 2, 0) = nchannels*j + 2;
+        for (int channel = 0; channel < nchannels; channel++) {
+          comps(i*nchannels + channel, 0) = nchannels*j + channel;
+        }
         break;
       }
     }
@@ -2620,9 +2620,9 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 1);
       samples(count, 2) = fullcopy(k, 2);
-      comps(i*nchannels, 0) = nchannels*count;
-      comps(i*nchannels + 1, 0) = nchannels*count + 1;
-      comps(i*nchannels + 2, 0) = nchannels*count + 2;
+      for (int channel = 0; channel < nchannels; channel++) {
+        comps(i*nchannels + channel, 0) = nchannels*count + channel;
+      }
       count++;
     }
 
@@ -2630,9 +2630,9 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
     for (int j = 0; j < count; j++) {
       if (samples(j, 0) == fullcopy(k, 0) && samples(j, 1) == fullcopy(k, 3) && samples(j, 2) == fullcopy(k, 4)) {
         n = false;
-        comps(i*nchannels, 1) = nchannels*j;
-        comps(i*nchannels + 1, 1) = nchannels*j + 1;
-        comps(i*nchannels + 2, 1) = nchannels*j + 2;
+        for (int channel = 0; channel < nchannels; channel++) {
+          comps(i*nchannels + channel, 1) = nchannels*j + channel;
+        }
         break;
       }
     }
@@ -2641,9 +2641,9 @@ void generateDescriptorSubsample(Mat& sampleList, Mat& comparisons, int nbits,
       samples(count, 0) = fullcopy(k, 0);
       samples(count, 1) = fullcopy(k, 3);
       samples(count, 2) = fullcopy(k, 4);
-      comps(i*nchannels, 1) = nchannels*count;
-      comps(i*nchannels + 1, 1) = nchannels*count + 1;
-      comps(i*nchannels + 2, 1) = nchannels*count + 2;
+      for (int channel = 0; channel < nchannels; channel++) {
+        comps(i*nchannels + channel, 1) = nchannels*count + channel;
+      }
       count++;
     }
 

--- a/modules/features2d/test/test_akaze.cpp
+++ b/modules/features2d/test/test_akaze.cpp
@@ -25,6 +25,20 @@ TEST(Features2d_AKAZE, detect_and_compute_split)
         ASSERT_EQ(detKps[i].hash(), detAndCompKps[i].hash());
 }
 
+// Test for https://github.com/opencv/opencv/issues/29613
+TEST(Features2d_AKAZE, descriptor_channel_count)
+{
+    Mat testImg(48, 48, CV_8U, Scalar::all(128));
+
+    for (int channels = 1; channels <= 3; channels++)
+    {
+        Ptr<Feature2D> akaze = AKAZE::create(AKAZE::DESCRIPTOR_MLDB, 32, channels);
+        vector<KeyPoint> keypoints;
+        Mat descriptors;
+        akaze->detectAndCompute(testImg, noArray(), keypoints, descriptors);
+    }
+}
+
 /**
  * This test is here to guard propagation of NaNs that happens on this image. NaNs are guarded
  * by debug asserts in AKAZE, which should fire for you if you are lucky.


### PR DESCRIPTION
### Summary

Prevent `generateDescriptorSubsample` from writing three channel entries when `descriptor_channels` is one or two.

### Root cause

The comparison matrix is allocated for `nchannels * npicks` rows, but four code paths unconditionally wrote offsets `0`, `1`, and `2`. Valid one- and two-channel AKAZE configurations therefore wrote past the end of the matrix. The issue report includes an AddressSanitizer heap-buffer-overflow for the documented two-channel configuration.

The writes now iterate over the requested channel count, preserving the existing three-channel behavior while keeping the allocation and writes consistent for all supported values.

### Validation

- Added a regression test covering one, two, and three descriptor channels.
- `git diff --check` passes.
- A complete native OpenCV build was not available in this Windows environment; the OpenCV CI will provide the compiler and sanitizer coverage.

Closes #29613