### PR TITLE
docs: clarify Mat_ constructor output

### DIFF
--- a/modules/core/include/opencv2/core/mat.hpp
+++ b/modules/core/include/opencv2/core/mat.hpp
@@ -2340,7 +2340,7 @@ public:
     Mat_(const Mat_& m, const std::vector<Range>& ranges);
     //! from a matrix expression
     explicit Mat_(const MatExpr& e);
-    //! makes a matrix out of Vec, std::vector, Point_ or Point3_. The matrix will have a single column
+    //! makes a matrix out of Vec, std::vector, Point_ or Point3_. The matrix will be a 1D array
     explicit Mat_(const std::vector<_Tp>& vec, bool copyData=false);
     template<int n> explicit Mat_(const Vec<typename DataType<_Tp>::channel_type, n>& vec, bool copyData=true);
     template<int m, int n> explicit Mat_(const Matx<typename DataType<_Tp>::channel_type, m, n>& mtx, bool copyData=true);


### PR DESCRIPTION
This updates the Mat_ constructor documentation to reflect the 1D array behavior in OpenCV 5.

The previous description said the matrix would have a single column, which describes the old 4.x behavior. OpenCV 5 now represents vector-backed Mat objects as 1D arrays. :contentReference[oaicite:0]{index=0}

Related issue: #27862