### PR TITLE
Fix GCC 14 floating-point associativity bug in v_cvt_f64

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_avx.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx.hpp
@@ -1569,6 +1569,9 @@ inline v_float64x4 v_cvt_f64(const v_int64x4& v)
             v_hi         = _mm256_xor_si256(v_hi, magic_i_hi32);
     // Compute in double precision
     __m256d v_hi_dbl     = _mm256_sub_pd(_mm256_castsi256_pd(v_hi), magic_d_all);
+#if defined(__GNUC__)
+    __asm__ __volatile__ ("" : "+x" (v_hi_dbl));
+#endif
     // (v_hi - magic_d_all) + v_lo  Do not assume associativity of floating point addition
     __m256d result       = _mm256_add_pd(v_hi_dbl, _mm256_castsi256_pd(v_lo));
     return v_float64x4(result);

--- a/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_avx512.hpp
@@ -1604,6 +1604,9 @@ inline v_float64x8 v_cvt_f64(const v_int64x8& v)
             v_hi         = _mm512_xor_si512(v_hi, magic_i_hi32);
     // Compute in double precision
     __m512d v_hi_dbl     = _mm512_sub_pd(_mm512_castsi512_pd(v_hi), magic_d_all);
+#if defined(__GNUC__)
+    __asm__ __volatile__ ("" : "+x" (v_hi_dbl));
+#endif
     // (v_hi - magic_d_all) + v_lo  Do not assume associativity of floating point addition
     __m512d result       = _mm512_add_pd(v_hi_dbl, _mm512_castsi512_pd(v_lo));
     return v_float64x8(result);

--- a/modules/core/include/opencv2/core/hal/intrin_sse.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_sse.hpp
@@ -3052,6 +3052,9 @@ inline v_float64x2 v_cvt_f64(const v_int64x2& v)
             v_hi         = _mm_xor_si128(v_hi, magic_i_hi32);
     // Compute in double precision
     __m128d v_hi_dbl     = _mm_sub_pd(_mm_castsi128_pd(v_hi), magic_d_all);
+#if defined(__GNUC__)
+    __asm__ __volatile__ ("" : "+x" (v_hi_dbl));
+#endif
     // (v_hi - magic_d_all) + v_lo  Do not assume associativity of floating point addition
     __m128d result       = _mm_add_pd(v_hi_dbl, _mm_castsi128_pd(v_lo));
     return v_float64x2(result);

--- a/modules/core/test/test_intrin_utils.hpp
+++ b/modules/core/test/test_intrin_utils.hpp
@@ -1493,18 +1493,24 @@ template<typename R> struct TheTest
         Data<R> dataA(std::numeric_limits<LaneType>::max()),
                 dataB(std::numeric_limits<LaneType>::min());
         dataB += VTraits<R>::vlanes();
+        
+        Data<R> dataC_in;
+        for (int i = 0; i < VTraits<R>::vlanes(); ++i)
+            dataC_in[i] = (LaneType)-1;
 
-        R a = dataA, b = dataB;
-        v_float64 c = v_cvt_f64(a), d = v_cvt_f64(b);
+        R a = dataA, b = dataB, c_in = dataC_in;
+        v_float64 c = v_cvt_f64(a), d = v_cvt_f64(b), e = v_cvt_f64(c_in);
 
         Data<v_float64> resC = c;
         Data<v_float64> resD = d;
+        Data<v_float64> resE = e;
 
         for (int i = 0; i < VTraits<R>::vlanes(); ++i)
         {
             SCOPED_TRACE(cv::format("i=%d", i));
             EXPECT_EQ((double)dataA[i], resC[i]);
             EXPECT_EQ((double)dataB[i], resD[i]);
+            EXPECT_EQ((double)dataC_in[i], resE[i]);
         }
 #endif
         return *this;


### PR DESCRIPTION
Fixes #29634. GCC 14 with -O3 reassociates the floating-point addition in the magic float conversion trick used by `v_cvt_f64` in SSE/AVX/AVX512 intrinsics, leading to precision loss and incorrect results (e.g. in `createHanningWindow`). This adds a compiler barrier (`__asm__ __volatile__("" : "+x"(v_hi_dbl))`) to prevent reassociation, similar to how PyTorch fixed the same issue.