### PR TITLE
allow cv::resize to support more than 4 channels in AREA path

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -3848,7 +3848,7 @@ void resize(int src_type,
             }
 
             ResizeAreaFunc func = area_tab[depth];
-            CV_Assert( func != 0 && cn <= 4 );
+            CV_Assert( func != 0 );
 
             AutoBuffer<DecimateAlpha> _xytab((src_width + src_height)*2);
             DecimateAlpha* xtab = _xytab.data(), *ytab = xtab + src_width*2;

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1275,6 +1275,29 @@ TEST(Imgproc_resize_area, regression)
     check_resize_area<ushort>(expected, actual, 1.0);
 }
 
+TEST(Imgproc_Resize, regression_29651_multichannel)
+{
+    // Regression test for https://github.com/opencv/opencv/issues/29651
+    // cv::resize used to reject images with more than 4 channels.
+    for (int cn = 1; cn <= 8; cn++)
+    {
+        cv::Mat src = cv::Mat::zeros(8, 8, CV_8UC(cn));
+        cv::Mat dst;
+
+        // Exact 2x downscale with INTER_LINEAR internally redirects to the
+        // INTER_AREA fast path, which previously asserted cn <= 4.
+        ASSERT_NO_THROW(cv::resize(src, dst, cv::Size(4, 4), 0, 0, cv::INTER_LINEAR));
+        EXPECT_EQ(dst.channels(), cn);
+        EXPECT_EQ(dst.size(), cv::Size(4, 4));
+
+        // Also exercise INTER_AREA directly (non-exact-2x case).
+        cv::Mat dst2;
+        ASSERT_NO_THROW(cv::resize(src, dst2, cv::Size(3, 3), 0, 0, cv::INTER_AREA));
+        EXPECT_EQ(dst2.channels(), cn);
+        EXPECT_EQ(dst2.size(), cv::Size(3, 3));
+    }
+}
+
 TEST(Imgproc_resize_area, regression_half_round)
 {
     static uchar input_data[32 * 32];

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1275,41 +1275,44 @@ TEST(Imgproc_resize_area, regression)
     check_resize_area<ushort>(expected, actual, 1.0);
 }
 
-TEST(Imgproc_Resize, regression_29651_multichannel)
+CV_ENUM(MultiChannelResizeInter, cv::INTER_LINEAR, cv::INTER_AREA);
+typedef testing::TestWithParam<testing::tuple<MultiChannelResizeInter, int>> Imgproc_ResizeMultiChannel;
+
+TEST_P(Imgproc_ResizeMultiChannel, smoke)
 {
-    // Regression test for https://github.com/opencv/opencv/issues/29651
-    // cv::resize used to reject images with more than 4 channels.
-    // 1-4 channels are already covered elsewhere; this covers 5 and 8.
-    for (int cn : {5, 8})
-    {
-        cv::Mat src(8, 8, CV_8UC(cn));
-        cv::randu(src, 0, 255);
+    int mode = get<0>(GetParam());
+    int cn = get<1>(GetParam());
 
-        std::vector<cv::Mat> srcChannels;
-        cv::split(src, srcChannels);
+    cv::Mat src(64, 64, CV_8UC(cn));
+    cv::randu(src, 0, 255);
 
-        for (int mode : {cv::INTER_LINEAR, cv::INTER_AREA})
-        {
-            cv::Size dsize = (mode == cv::INTER_LINEAR) ? cv::Size(4, 4) : cv::Size(3, 3);
+    std::vector<cv::Mat> srcChannels;
+    cv::split(src, srcChannels);
 
-            cv::Mat dstMulti;
-            ASSERT_NO_THROW(cv::resize(src, dstMulti, dsize, 0, 0, mode));
-            EXPECT_EQ(dstMulti.channels(), cn);
-            EXPECT_EQ(dstMulti.size(), dsize);
+    cv::Size dsize = (mode == cv::INTER_LINEAR) ? cv::Size(32, 32) : cv::Size(31, 31);
 
-            std::vector<cv::Mat> dstChannels(cn);
-            for (int i = 0; i < cn; i++)
-                cv::resize(srcChannels[i], dstChannels[i], dsize, 0, 0, mode);
+    cv::Mat dstMulti;
+    ASSERT_NO_THROW(cv::resize(src, dstMulti, dsize, 0, 0, mode));
+    EXPECT_EQ(dstMulti.channels(), cn);
+    EXPECT_EQ(dstMulti.size(), dsize);
 
-            cv::Mat dstMerged;
-            cv::merge(dstChannels, dstMerged);
+    std::vector<cv::Mat> dstChannels(cn);
+    for (int i = 0; i < cn; i++)
+        cv::resize(srcChannels[i], dstChannels[i], dsize, 0, 0, mode);
 
-            EXPECT_LE(cv::norm(dstMulti, dstMerged, cv::NORM_INF), 1)
-                << "Multi-channel resize (cn=" << cn << ", mode=" << mode
-                << ") does not match per-channel resize";
-        }
-    }
+    cv::Mat dstMerged;
+    cv::merge(dstChannels, dstMerged);
+
+    EXPECT_LE(cv::norm(dstMulti, dstMerged, cv::NORM_INF), 1)
+        << "Multi-channel resize (cn=" << cn << ", mode=" << mode
+        << ") does not match per-channel resize";
 }
+
+INSTANTIATE_TEST_CASE_P(/**/,
+    Imgproc_ResizeMultiChannel,
+        testing::Combine(
+            testing::Values(cv::INTER_LINEAR, cv::INTER_AREA),
+            testing::Values(5, 8)));
 
 TEST(Imgproc_resize_area, regression_half_round)
 {

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1304,7 +1304,7 @@ TEST(Imgproc_Resize, regression_29651_multichannel)
             cv::Mat dstMerged;
             cv::merge(dstChannels, dstMerged);
 
-            EXPECT_EQ(cv::norm(dstMulti, dstMerged, cv::NORM_INF), 0)
+            EXPECT_LE(cv::norm(dstMulti, dstMerged, cv::NORM_INF), 1)
                 << "Multi-channel resize (cn=" << cn << ", mode=" << mode
                 << ") does not match per-channel resize";
         }

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1279,22 +1279,35 @@ TEST(Imgproc_Resize, regression_29651_multichannel)
 {
     // Regression test for https://github.com/opencv/opencv/issues/29651
     // cv::resize used to reject images with more than 4 channels.
-    for (int cn = 1; cn <= 8; cn++)
+    // 1-4 channels are already covered elsewhere; this covers 5 and 8.
+    for (int cn : {5, 8})
     {
-        cv::Mat src = cv::Mat::zeros(8, 8, CV_8UC(cn));
-        cv::Mat dst;
+        cv::Mat src(8, 8, CV_8UC(cn));
+        cv::randu(src, 0, 255);
 
-        // Exact 2x downscale with INTER_LINEAR internally redirects to the
-        // INTER_AREA fast path, which previously asserted cn <= 4.
-        ASSERT_NO_THROW(cv::resize(src, dst, cv::Size(4, 4), 0, 0, cv::INTER_LINEAR));
-        EXPECT_EQ(dst.channels(), cn);
-        EXPECT_EQ(dst.size(), cv::Size(4, 4));
+        std::vector<cv::Mat> srcChannels;
+        cv::split(src, srcChannels);
 
-        // Also exercise INTER_AREA directly (non-exact-2x case).
-        cv::Mat dst2;
-        ASSERT_NO_THROW(cv::resize(src, dst2, cv::Size(3, 3), 0, 0, cv::INTER_AREA));
-        EXPECT_EQ(dst2.channels(), cn);
-        EXPECT_EQ(dst2.size(), cv::Size(3, 3));
+        for (int mode : {cv::INTER_LINEAR, cv::INTER_AREA})
+        {
+            cv::Size dsize = (mode == cv::INTER_LINEAR) ? cv::Size(4, 4) : cv::Size(3, 3);
+
+            cv::Mat dstMulti;
+            ASSERT_NO_THROW(cv::resize(src, dstMulti, dsize, 0, 0, mode));
+            EXPECT_EQ(dstMulti.channels(), cn);
+            EXPECT_EQ(dstMulti.size(), dsize);
+
+            std::vector<cv::Mat> dstChannels(cn);
+            for (int i = 0; i < cn; i++)
+                cv::resize(srcChannels[i], dstChannels[i], dsize, 0, 0, mode);
+
+            cv::Mat dstMerged;
+            cv::merge(dstChannels, dstMerged);
+
+            EXPECT_EQ(cv::norm(dstMulti, dstMerged, cv::NORM_INF), 0)
+                << "Multi-channel resize (cn=" << cn << ", mode=" << mode
+                << ") does not match per-channel resize";
+        }
     }
 }
 


### PR DESCRIPTION
Fixes  #29651

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
