### PR TITLE
imgproc: document that color conversion depth support varies by code

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -3793,14 +3793,15 @@ If conversion adds the alpha channel, its value will set to the maximum of corre
 range: 255 for CV_8U, 65535 for CV_16U, 1 for CV_32F.
 
 @param src input image: 8-bit unsigned, 16-bit unsigned ( CV_16UC... ), or single-precision
-floating-point.
+floating-point. The accepted depths differ between conversions and are listed with each code in
+#ColorConversionCodes: for example #COLOR_BGR2GRAY is marked `[8U/16U/32F]`, while
+#COLOR_BGR2HSV is marked `[8U/32F]` and rejects `CV_16U`.
 @param dst output image of the same size and depth as src.
 @param code color space conversion code (see #ColorConversionCodes).
 @param dstCn number of channels in the destination image; if the parameter is 0, the number of the
 channels is derived automatically from src and code.
 @param hint Implementation modfication flags. See #AlgorithmHint
 
-@note The source image (src) must be of an appropriate type for the desired color conversion. see ColorConversionCodes
 @see @ref imgproc_color_conversions
  */
 CV_EXPORTS_W void cvtColor( InputArray src, OutputArray dst, int code, int dstCn = 0, AlgorithmHint hint = cv::ALGO_HINT_DEFAULT );
@@ -3828,7 +3829,10 @@ CV_EXPORTS_W void cvtColorTwoPlane( InputArray src1, InputArray src2, OutputArra
 
 /** @brief main function for all demosaicing processes
 
-@param src input image: 8-bit unsigned or 16-bit unsigned.
+@param src input image: 8-bit unsigned or 16-bit unsigned. The accepted depths differ between
+codes and are listed with each code in #ColorConversionCodes: the Variable Number of Gradients
+codes such as #COLOR_BayerBG2BGR_VNG are marked `[8U]` and reject `CV_16U`, while for example
+#COLOR_BayerBG2BGR is marked `[8U/16U]`.
 @param dst output image of the same size and depth as src.
 @param code Color space conversion code (see the description below).
 @param dstCn number of channels in the destination image; if the parameter is 0, the number of the
@@ -3854,7 +3858,6 @@ The function can do the following transformations:
 
     #COLOR_BayerBG2BGRA , #COLOR_BayerGB2BGRA , #COLOR_BayerRG2BGRA , #COLOR_BayerGR2BGRA
 
-@note The source image (src) must be of an appropriate type for the desired color conversion. see ColorConversionCodes
 @sa cvtColor
 */
 CV_EXPORTS_W void demosaicing(InputArray src, OutputArray dst, int code, int dstCn = 0);


### PR DESCRIPTION
Fixes #26447

### Problem

`cvtColor`'s `src` parameter is documented as accepting 8U, 16U and 32F unconditionally:

> input image: 8-bit unsigned, 16-bit unsigned ( CV_16UC... ), or single-precision floating-point.

but the accepted depths depend on the conversion code. `COLOR_BGR2HSV` with a `CV_16U` input throws, which is what #26447 reported.

The opposite claim — that `CV_16U` is simply unsupported — is also wrong, which is why #28135 was not merged: `BGR<->GRAY`, `BGR<->XYZ`, `BGR<->YUV` and `BGR<->BGR` all accept it.

#28138 already solved the underlying documentation problem by tagging every code in `ColorConversionCodes` with its supported depths (`[8U/16U/32F]`, `[8U/32F]`, `[8U]`). It did not update the `cvtColor` parameter description, so the blanket claim is still there and still contradicts the table directly above it. This patch points the parameter description at that table instead of restating depths in prose that can drift out of sync.

### Second commit: `demosaicing`

While checking for other instances, `demosaicing()` has the same imprecision — documented as "8-bit unsigned or 16-bit unsigned", but the Variable Number of Gradients path asserts `CV_8U` ([demosaicing.cpp#L1804](https://github.com/opencv/opencv/blob/4.x/modules/imgproc/src/demosaicing.cpp#L1804)), so the 16 `_VNG` codes reject 16U while the other 56 Bayer codes accept it. `ColorConversionCodes` already tags these correctly.

It is kept as a **separate commit** since it is a different function — happy to drop it or move it to its own PR if you would rather keep this to a single issue.

### Verification

The `ColorConversionCodes` tags are the thing this patch now points users at, so I verified them rather than assuming. I generated a probe over all 149 non-alias conversion codes, called `cvtColor` with each at 8U/16U/32F against a local 4.x build, and compared the observed accept/reject behaviour to the documented tag:

```
== 149 match, 0 MISMATCH, 0 untestable (of 149) ==
```

The two examples cited in the new text, confirmed directly:

```
BGR2GRAY   CV_8U -> OK      CV_16U -> OK       CV_32F -> OK
BGR2HSV    CV_8U -> OK      CV_16U -> THROWS   CV_32F -> OK

demosaicing(COLOR_BayerBG2BGR_VNG, CV_16U) -> THROWS
demosaicing(COLOR_BayerBG2BGR_EA,  CV_16U) -> OK
```

Doxygen was built locally: both hunks render, no new warnings on the touched regions, and all `#ColorConversionCodes` / `#COLOR_*` references resolve to anchors.

Documentation only — no functional change, so no accuracy or performance test applies.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
