### PR TITLE
core, imgproc: fix build when AVX512_ICL is in the baseline

### DIFF
--- a/cmake/OpenCVCompilerOptimizations.cmake
+++ b/cmake/OpenCVCompilerOptimizations.cmake
@@ -872,20 +872,24 @@ macro(ocv_compiler_optimization_fill_cpu_config)
 #  define CV_CPU_HAS_SUPPORT_${OPT} 1
 #  define CV_CPU_CALL_${OPT}(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_${OPT}_(fn, args) return (opt_${OPT}::fn args)
+#  define CV_CPU_GET_FN_PTR_${OPT}(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_${OPT}
 #  define CV_TRY_${OPT} 1
 #  define CV_CPU_FORCE_${OPT} 0
 #  define CV_CPU_HAS_SUPPORT_${OPT} (cv::checkHardwareSupport(CV_CPU_${OPT}))
 #  define CV_CPU_CALL_${OPT}(fn, args) if (CV_CPU_HAS_SUPPORT_${OPT}) return (opt_${OPT}::fn args)
 #  define CV_CPU_CALL_${OPT}_(fn, args) if (CV_CPU_HAS_SUPPORT_${OPT}) return (opt_${OPT}::fn args)
+#  define CV_CPU_GET_FN_PTR_${OPT}(fn) if (CV_CPU_HAS_SUPPORT_${OPT}) return (opt_${OPT}::fn)
 #else
 #  define CV_TRY_${OPT} 0
 #  define CV_CPU_FORCE_${OPT} 0
 #  define CV_CPU_HAS_SUPPORT_${OPT} 0
 #  define CV_CPU_CALL_${OPT}(fn, args)
 #  define CV_CPU_CALL_${OPT}_(fn, args)
+#  define CV_CPU_GET_FN_PTR_${OPT}(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_${OPT}(fn, args, mode, ...)  CV_CPU_CALL_${OPT}(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_${OPT}(fn, mode, ...)  CV_CPU_GET_FN_PTR_${OPT}(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 ")
     endif()
   endforeach()
@@ -893,6 +897,8 @@ macro(ocv_compiler_optimization_fill_cpu_config)
   set(OPENCV_CPU_CONTROL_DEFINITIONS_CONFIGMAKE "${OPENCV_CPU_CONTROL_DEFINITIONS_CONFIGMAKE}
 #define CV_CPU_CALL_BASELINE(fn, args) return (cpu_baseline::fn args)
 #define __CV_CPU_DISPATCH_CHAIN_BASELINE(fn, args, mode, ...)  CV_CPU_CALL_BASELINE(fn, args) /* last in sequence */
+#define CV_CPU_GET_FN_PTR_BASELINE(fn) return (cpu_baseline::fn)
+#define __CV_CPU_DISPATCH_CHAIN_FN_BASELINE(fn, mode, ...)  CV_CPU_GET_FN_PTR_BASELINE(fn) /* last in sequence */
 ")
 
 

--- a/modules/core/include/opencv2/core/cv_cpu_dispatch.h
+++ b/modules/core/include/opencv2/core/cv_cpu_dispatch.h
@@ -24,6 +24,13 @@
 #define __CV_CPU_DISPATCH_EXPAND(fn, args, ...) __CV_EXPAND(__CV_CPU_DISPATCH(fn, args, __VA_ARGS__))
 #define CV_CPU_DISPATCH(fn, args, ...) __CV_CPU_DISPATCH_EXPAND(fn, args, __VA_ARGS__, END) // expand macros
 
+// Same as CV_CPU_DISPATCH, but returns a pointer to the selected implementation
+// instead of calling it. Use it to resolve a function pointer once and cache it.
+#define __CV_CPU_DISPATCH_CHAIN_FN_END(fn, mode, ...)  /* done */
+#define __CV_CPU_DISPATCH_FN(fn, mode, ...) __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_FN_EXPAND(fn, ...) __CV_EXPAND(__CV_CPU_DISPATCH_FN(fn, __VA_ARGS__))
+#define CV_CPU_DISPATCH_FN(fn, ...) __CV_CPU_DISPATCH_FN_EXPAND(fn, __VA_ARGS__, END) // expand macros
+
 
 #if defined CV_ENABLE_INTRINSICS \
     && !defined CV_DISABLE_OPTIMIZATION \

--- a/modules/core/include/opencv2/core/cv_cpu_helper.h
+++ b/modules/core/include/opencv2/core/cv_cpu_helper.h
@@ -6,20 +6,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSE 1
 #  define CV_CPU_CALL_SSE(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE_(fn, args) return (opt_SSE::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE
 #  define CV_TRY_SSE 1
 #  define CV_CPU_FORCE_SSE 0
 #  define CV_CPU_HAS_SUPPORT_SSE (cv::checkHardwareSupport(CV_CPU_SSE))
 #  define CV_CPU_CALL_SSE(fn, args) if (CV_CPU_HAS_SUPPORT_SSE) return (opt_SSE::fn args)
 #  define CV_CPU_CALL_SSE_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE) return (opt_SSE::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE(fn) if (CV_CPU_HAS_SUPPORT_SSE) return (opt_SSE::fn)
 #else
 #  define CV_TRY_SSE 0
 #  define CV_CPU_FORCE_SSE 0
 #  define CV_CPU_HAS_SUPPORT_SSE 0
 #  define CV_CPU_CALL_SSE(fn, args)
 #  define CV_CPU_CALL_SSE_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSE(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSE(fn, args, mode, ...)  CV_CPU_CALL_SSE(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSE(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSE(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE2
 #  define CV_TRY_SSE2 1
@@ -27,20 +31,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSE2 1
 #  define CV_CPU_CALL_SSE2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE2_(fn, args) return (opt_SSE2::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE2(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE2
 #  define CV_TRY_SSE2 1
 #  define CV_CPU_FORCE_SSE2 0
 #  define CV_CPU_HAS_SUPPORT_SSE2 (cv::checkHardwareSupport(CV_CPU_SSE2))
 #  define CV_CPU_CALL_SSE2(fn, args) if (CV_CPU_HAS_SUPPORT_SSE2) return (opt_SSE2::fn args)
 #  define CV_CPU_CALL_SSE2_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE2) return (opt_SSE2::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE2(fn) if (CV_CPU_HAS_SUPPORT_SSE2) return (opt_SSE2::fn)
 #else
 #  define CV_TRY_SSE2 0
 #  define CV_CPU_FORCE_SSE2 0
 #  define CV_CPU_HAS_SUPPORT_SSE2 0
 #  define CV_CPU_CALL_SSE2(fn, args)
 #  define CV_CPU_CALL_SSE2_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSE2(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSE2(fn, args, mode, ...)  CV_CPU_CALL_SSE2(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSE2(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSE2(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE3
 #  define CV_TRY_SSE3 1
@@ -48,20 +56,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSE3 1
 #  define CV_CPU_CALL_SSE3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE3_(fn, args) return (opt_SSE3::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE3(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE3
 #  define CV_TRY_SSE3 1
 #  define CV_CPU_FORCE_SSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSE3 (cv::checkHardwareSupport(CV_CPU_SSE3))
 #  define CV_CPU_CALL_SSE3(fn, args) if (CV_CPU_HAS_SUPPORT_SSE3) return (opt_SSE3::fn args)
 #  define CV_CPU_CALL_SSE3_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE3) return (opt_SSE3::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE3(fn) if (CV_CPU_HAS_SUPPORT_SSE3) return (opt_SSE3::fn)
 #else
 #  define CV_TRY_SSE3 0
 #  define CV_CPU_FORCE_SSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSE3 0
 #  define CV_CPU_CALL_SSE3(fn, args)
 #  define CV_CPU_CALL_SSE3_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSE3(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSE3(fn, args, mode, ...)  CV_CPU_CALL_SSE3(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSE3(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSE3(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSSE3
 #  define CV_TRY_SSSE3 1
@@ -69,20 +81,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSSE3 1
 #  define CV_CPU_CALL_SSSE3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSSE3_(fn, args) return (opt_SSSE3::fn args)
+#  define CV_CPU_GET_FN_PTR_SSSE3(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSSE3
 #  define CV_TRY_SSSE3 1
 #  define CV_CPU_FORCE_SSSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSSE3 (cv::checkHardwareSupport(CV_CPU_SSSE3))
 #  define CV_CPU_CALL_SSSE3(fn, args) if (CV_CPU_HAS_SUPPORT_SSSE3) return (opt_SSSE3::fn args)
 #  define CV_CPU_CALL_SSSE3_(fn, args) if (CV_CPU_HAS_SUPPORT_SSSE3) return (opt_SSSE3::fn args)
+#  define CV_CPU_GET_FN_PTR_SSSE3(fn) if (CV_CPU_HAS_SUPPORT_SSSE3) return (opt_SSSE3::fn)
 #else
 #  define CV_TRY_SSSE3 0
 #  define CV_CPU_FORCE_SSSE3 0
 #  define CV_CPU_HAS_SUPPORT_SSSE3 0
 #  define CV_CPU_CALL_SSSE3(fn, args)
 #  define CV_CPU_CALL_SSSE3_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSSE3(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSSE3(fn, args, mode, ...)  CV_CPU_CALL_SSSE3(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSSE3(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSSE3(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE4_1
 #  define CV_TRY_SSE4_1 1
@@ -90,20 +106,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 1
 #  define CV_CPU_CALL_SSE4_1(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args) return (opt_SSE4_1::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE4_1(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE4_1
 #  define CV_TRY_SSE4_1 1
 #  define CV_CPU_FORCE_SSE4_1 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 (cv::checkHardwareSupport(CV_CPU_SSE4_1))
 #  define CV_CPU_CALL_SSE4_1(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_1) return (opt_SSE4_1::fn args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_1) return (opt_SSE4_1::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE4_1(fn) if (CV_CPU_HAS_SUPPORT_SSE4_1) return (opt_SSE4_1::fn)
 #else
 #  define CV_TRY_SSE4_1 0
 #  define CV_CPU_FORCE_SSE4_1 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_1 0
 #  define CV_CPU_CALL_SSE4_1(fn, args)
 #  define CV_CPU_CALL_SSE4_1_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSE4_1(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSE4_1(fn, args, mode, ...)  CV_CPU_CALL_SSE4_1(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSE4_1(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSE4_1(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SSE4_2
 #  define CV_TRY_SSE4_2 1
@@ -111,20 +131,24 @@
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 1
 #  define CV_CPU_CALL_SSE4_2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args) return (opt_SSE4_2::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE4_2(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SSE4_2
 #  define CV_TRY_SSE4_2 1
 #  define CV_CPU_FORCE_SSE4_2 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 (cv::checkHardwareSupport(CV_CPU_SSE4_2))
 #  define CV_CPU_CALL_SSE4_2(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_2) return (opt_SSE4_2::fn args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args) if (CV_CPU_HAS_SUPPORT_SSE4_2) return (opt_SSE4_2::fn args)
+#  define CV_CPU_GET_FN_PTR_SSE4_2(fn) if (CV_CPU_HAS_SUPPORT_SSE4_2) return (opt_SSE4_2::fn)
 #else
 #  define CV_TRY_SSE4_2 0
 #  define CV_CPU_FORCE_SSE4_2 0
 #  define CV_CPU_HAS_SUPPORT_SSE4_2 0
 #  define CV_CPU_CALL_SSE4_2(fn, args)
 #  define CV_CPU_CALL_SSE4_2_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SSE4_2(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SSE4_2(fn, args, mode, ...)  CV_CPU_CALL_SSE4_2(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SSE4_2(fn, mode, ...)  CV_CPU_GET_FN_PTR_SSE4_2(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_POPCNT
 #  define CV_TRY_POPCNT 1
@@ -132,20 +156,24 @@
 #  define CV_CPU_HAS_SUPPORT_POPCNT 1
 #  define CV_CPU_CALL_POPCNT(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_POPCNT_(fn, args) return (opt_POPCNT::fn args)
+#  define CV_CPU_GET_FN_PTR_POPCNT(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_POPCNT
 #  define CV_TRY_POPCNT 1
 #  define CV_CPU_FORCE_POPCNT 0
 #  define CV_CPU_HAS_SUPPORT_POPCNT (cv::checkHardwareSupport(CV_CPU_POPCNT))
 #  define CV_CPU_CALL_POPCNT(fn, args) if (CV_CPU_HAS_SUPPORT_POPCNT) return (opt_POPCNT::fn args)
 #  define CV_CPU_CALL_POPCNT_(fn, args) if (CV_CPU_HAS_SUPPORT_POPCNT) return (opt_POPCNT::fn args)
+#  define CV_CPU_GET_FN_PTR_POPCNT(fn) if (CV_CPU_HAS_SUPPORT_POPCNT) return (opt_POPCNT::fn)
 #else
 #  define CV_TRY_POPCNT 0
 #  define CV_CPU_FORCE_POPCNT 0
 #  define CV_CPU_HAS_SUPPORT_POPCNT 0
 #  define CV_CPU_CALL_POPCNT(fn, args)
 #  define CV_CPU_CALL_POPCNT_(fn, args)
+#  define CV_CPU_GET_FN_PTR_POPCNT(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_POPCNT(fn, args, mode, ...)  CV_CPU_CALL_POPCNT(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_POPCNT(fn, mode, ...)  CV_CPU_GET_FN_PTR_POPCNT(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX
 #  define CV_TRY_AVX 1
@@ -153,20 +181,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX 1
 #  define CV_CPU_CALL_AVX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX_(fn, args) return (opt_AVX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX
 #  define CV_TRY_AVX 1
 #  define CV_CPU_FORCE_AVX 0
 #  define CV_CPU_HAS_SUPPORT_AVX (cv::checkHardwareSupport(CV_CPU_AVX))
 #  define CV_CPU_CALL_AVX(fn, args) if (CV_CPU_HAS_SUPPORT_AVX) return (opt_AVX::fn args)
 #  define CV_CPU_CALL_AVX_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX) return (opt_AVX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX(fn) if (CV_CPU_HAS_SUPPORT_AVX) return (opt_AVX::fn)
 #else
 #  define CV_TRY_AVX 0
 #  define CV_CPU_FORCE_AVX 0
 #  define CV_CPU_HAS_SUPPORT_AVX 0
 #  define CV_CPU_CALL_AVX(fn, args)
 #  define CV_CPU_CALL_AVX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX(fn, args, mode, ...)  CV_CPU_CALL_AVX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_FP16
 #  define CV_TRY_FP16 1
@@ -174,20 +206,24 @@
 #  define CV_CPU_HAS_SUPPORT_FP16 1
 #  define CV_CPU_CALL_FP16(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_FP16_(fn, args) return (opt_FP16::fn args)
+#  define CV_CPU_GET_FN_PTR_FP16(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_FP16
 #  define CV_TRY_FP16 1
 #  define CV_CPU_FORCE_FP16 0
 #  define CV_CPU_HAS_SUPPORT_FP16 (cv::checkHardwareSupport(CV_CPU_FP16))
 #  define CV_CPU_CALL_FP16(fn, args) if (CV_CPU_HAS_SUPPORT_FP16) return (opt_FP16::fn args)
 #  define CV_CPU_CALL_FP16_(fn, args) if (CV_CPU_HAS_SUPPORT_FP16) return (opt_FP16::fn args)
+#  define CV_CPU_GET_FN_PTR_FP16(fn) if (CV_CPU_HAS_SUPPORT_FP16) return (opt_FP16::fn)
 #else
 #  define CV_TRY_FP16 0
 #  define CV_CPU_FORCE_FP16 0
 #  define CV_CPU_HAS_SUPPORT_FP16 0
 #  define CV_CPU_CALL_FP16(fn, args)
 #  define CV_CPU_CALL_FP16_(fn, args)
+#  define CV_CPU_GET_FN_PTR_FP16(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_FP16(fn, args, mode, ...)  CV_CPU_CALL_FP16(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_FP16(fn, mode, ...)  CV_CPU_GET_FN_PTR_FP16(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX2
 #  define CV_TRY_AVX2 1
@@ -195,20 +231,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX2 1
 #  define CV_CPU_CALL_AVX2(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX2_(fn, args) return (opt_AVX2::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX2(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX2
 #  define CV_TRY_AVX2 1
 #  define CV_CPU_FORCE_AVX2 0
 #  define CV_CPU_HAS_SUPPORT_AVX2 (cv::checkHardwareSupport(CV_CPU_AVX2))
 #  define CV_CPU_CALL_AVX2(fn, args) if (CV_CPU_HAS_SUPPORT_AVX2) return (opt_AVX2::fn args)
 #  define CV_CPU_CALL_AVX2_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX2) return (opt_AVX2::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX2(fn) if (CV_CPU_HAS_SUPPORT_AVX2) return (opt_AVX2::fn)
 #else
 #  define CV_TRY_AVX2 0
 #  define CV_CPU_FORCE_AVX2 0
 #  define CV_CPU_HAS_SUPPORT_AVX2 0
 #  define CV_CPU_CALL_AVX2(fn, args)
 #  define CV_CPU_CALL_AVX2_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX2(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX2(fn, args, mode, ...)  CV_CPU_CALL_AVX2(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX2(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX2(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_FMA3
 #  define CV_TRY_FMA3 1
@@ -216,20 +256,24 @@
 #  define CV_CPU_HAS_SUPPORT_FMA3 1
 #  define CV_CPU_CALL_FMA3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_FMA3_(fn, args) return (opt_FMA3::fn args)
+#  define CV_CPU_GET_FN_PTR_FMA3(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_FMA3
 #  define CV_TRY_FMA3 1
 #  define CV_CPU_FORCE_FMA3 0
 #  define CV_CPU_HAS_SUPPORT_FMA3 (cv::checkHardwareSupport(CV_CPU_FMA3))
 #  define CV_CPU_CALL_FMA3(fn, args) if (CV_CPU_HAS_SUPPORT_FMA3) return (opt_FMA3::fn args)
 #  define CV_CPU_CALL_FMA3_(fn, args) if (CV_CPU_HAS_SUPPORT_FMA3) return (opt_FMA3::fn args)
+#  define CV_CPU_GET_FN_PTR_FMA3(fn) if (CV_CPU_HAS_SUPPORT_FMA3) return (opt_FMA3::fn)
 #else
 #  define CV_TRY_FMA3 0
 #  define CV_CPU_FORCE_FMA3 0
 #  define CV_CPU_HAS_SUPPORT_FMA3 0
 #  define CV_CPU_CALL_FMA3(fn, args)
 #  define CV_CPU_CALL_FMA3_(fn, args)
+#  define CV_CPU_GET_FN_PTR_FMA3(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_FMA3(fn, args, mode, ...)  CV_CPU_CALL_FMA3(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_FMA3(fn, mode, ...)  CV_CPU_GET_FN_PTR_FMA3(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX_512F
 #  define CV_TRY_AVX_512F 1
@@ -237,20 +281,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX_512F 1
 #  define CV_CPU_CALL_AVX_512F(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args) return (opt_AVX_512F::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX_512F(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX_512F
 #  define CV_TRY_AVX_512F 1
 #  define CV_CPU_FORCE_AVX_512F 0
 #  define CV_CPU_HAS_SUPPORT_AVX_512F (cv::checkHardwareSupport(CV_CPU_AVX_512F))
 #  define CV_CPU_CALL_AVX_512F(fn, args) if (CV_CPU_HAS_SUPPORT_AVX_512F) return (opt_AVX_512F::fn args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX_512F) return (opt_AVX_512F::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX_512F(fn) if (CV_CPU_HAS_SUPPORT_AVX_512F) return (opt_AVX_512F::fn)
 #else
 #  define CV_TRY_AVX_512F 0
 #  define CV_CPU_FORCE_AVX_512F 0
 #  define CV_CPU_HAS_SUPPORT_AVX_512F 0
 #  define CV_CPU_CALL_AVX_512F(fn, args)
 #  define CV_CPU_CALL_AVX_512F_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX_512F(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX_512F(fn, args, mode, ...)  CV_CPU_CALL_AVX_512F(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX_512F(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX_512F(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_COMMON
 #  define CV_TRY_AVX512_COMMON 1
@@ -258,20 +306,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_COMMON 1
 #  define CV_CPU_CALL_AVX512_COMMON(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_COMMON_(fn, args) return (opt_AVX512_COMMON::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_COMMON(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_COMMON
 #  define CV_TRY_AVX512_COMMON 1
 #  define CV_CPU_FORCE_AVX512_COMMON 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_COMMON (cv::checkHardwareSupport(CV_CPU_AVX512_COMMON))
 #  define CV_CPU_CALL_AVX512_COMMON(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_COMMON) return (opt_AVX512_COMMON::fn args)
 #  define CV_CPU_CALL_AVX512_COMMON_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_COMMON) return (opt_AVX512_COMMON::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_COMMON(fn) if (CV_CPU_HAS_SUPPORT_AVX512_COMMON) return (opt_AVX512_COMMON::fn)
 #else
 #  define CV_TRY_AVX512_COMMON 0
 #  define CV_CPU_FORCE_AVX512_COMMON 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_COMMON 0
 #  define CV_CPU_CALL_AVX512_COMMON(fn, args)
 #  define CV_CPU_CALL_AVX512_COMMON_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_COMMON(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_COMMON(fn, args, mode, ...)  CV_CPU_CALL_AVX512_COMMON(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_COMMON(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_COMMON(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_KNL
 #  define CV_TRY_AVX512_KNL 1
@@ -279,20 +331,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNL 1
 #  define CV_CPU_CALL_AVX512_KNL(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_KNL_(fn, args) return (opt_AVX512_KNL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNL(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_KNL
 #  define CV_TRY_AVX512_KNL 1
 #  define CV_CPU_FORCE_AVX512_KNL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNL (cv::checkHardwareSupport(CV_CPU_AVX512_KNL))
 #  define CV_CPU_CALL_AVX512_KNL(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_KNL) return (opt_AVX512_KNL::fn args)
 #  define CV_CPU_CALL_AVX512_KNL_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_KNL) return (opt_AVX512_KNL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNL(fn) if (CV_CPU_HAS_SUPPORT_AVX512_KNL) return (opt_AVX512_KNL::fn)
 #else
 #  define CV_TRY_AVX512_KNL 0
 #  define CV_CPU_FORCE_AVX512_KNL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNL 0
 #  define CV_CPU_CALL_AVX512_KNL(fn, args)
 #  define CV_CPU_CALL_AVX512_KNL_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNL(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_KNL(fn, args, mode, ...)  CV_CPU_CALL_AVX512_KNL(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_KNL(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_KNL(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_KNM
 #  define CV_TRY_AVX512_KNM 1
@@ -300,20 +356,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNM 1
 #  define CV_CPU_CALL_AVX512_KNM(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_KNM_(fn, args) return (opt_AVX512_KNM::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNM(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_KNM
 #  define CV_TRY_AVX512_KNM 1
 #  define CV_CPU_FORCE_AVX512_KNM 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNM (cv::checkHardwareSupport(CV_CPU_AVX512_KNM))
 #  define CV_CPU_CALL_AVX512_KNM(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_KNM) return (opt_AVX512_KNM::fn args)
 #  define CV_CPU_CALL_AVX512_KNM_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_KNM) return (opt_AVX512_KNM::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNM(fn) if (CV_CPU_HAS_SUPPORT_AVX512_KNM) return (opt_AVX512_KNM::fn)
 #else
 #  define CV_TRY_AVX512_KNM 0
 #  define CV_CPU_FORCE_AVX512_KNM 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_KNM 0
 #  define CV_CPU_CALL_AVX512_KNM(fn, args)
 #  define CV_CPU_CALL_AVX512_KNM_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_KNM(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_KNM(fn, args, mode, ...)  CV_CPU_CALL_AVX512_KNM(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_KNM(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_KNM(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_SKX
 #  define CV_TRY_AVX512_SKX 1
@@ -321,20 +381,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX 1
 #  define CV_CPU_CALL_AVX512_SKX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args) return (opt_AVX512_SKX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_SKX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_SKX
 #  define CV_TRY_AVX512_SKX 1
 #  define CV_CPU_FORCE_AVX512_SKX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX (cv::checkHardwareSupport(CV_CPU_AVX512_SKX))
 #  define CV_CPU_CALL_AVX512_SKX(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_SKX) return (opt_AVX512_SKX::fn args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_SKX) return (opt_AVX512_SKX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_SKX(fn) if (CV_CPU_HAS_SUPPORT_AVX512_SKX) return (opt_AVX512_SKX::fn)
 #else
 #  define CV_TRY_AVX512_SKX 0
 #  define CV_CPU_FORCE_AVX512_SKX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_SKX 0
 #  define CV_CPU_CALL_AVX512_SKX(fn, args)
 #  define CV_CPU_CALL_AVX512_SKX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_SKX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_SKX(fn, args, mode, ...)  CV_CPU_CALL_AVX512_SKX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_SKX(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_SKX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_CNL
 #  define CV_TRY_AVX512_CNL 1
@@ -342,20 +406,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_CNL 1
 #  define CV_CPU_CALL_AVX512_CNL(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_CNL_(fn, args) return (opt_AVX512_CNL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CNL(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_CNL
 #  define CV_TRY_AVX512_CNL 1
 #  define CV_CPU_FORCE_AVX512_CNL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_CNL (cv::checkHardwareSupport(CV_CPU_AVX512_CNL))
 #  define CV_CPU_CALL_AVX512_CNL(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_CNL) return (opt_AVX512_CNL::fn args)
 #  define CV_CPU_CALL_AVX512_CNL_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_CNL) return (opt_AVX512_CNL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CNL(fn) if (CV_CPU_HAS_SUPPORT_AVX512_CNL) return (opt_AVX512_CNL::fn)
 #else
 #  define CV_TRY_AVX512_CNL 0
 #  define CV_CPU_FORCE_AVX512_CNL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_CNL 0
 #  define CV_CPU_CALL_AVX512_CNL(fn, args)
 #  define CV_CPU_CALL_AVX512_CNL_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CNL(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_CNL(fn, args, mode, ...)  CV_CPU_CALL_AVX512_CNL(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_CNL(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_CNL(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_CLX
 #  define CV_TRY_AVX512_CLX 1
@@ -363,20 +431,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_CLX 1
 #  define CV_CPU_CALL_AVX512_CLX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_CLX_(fn, args) return (opt_AVX512_CLX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CLX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_CLX
 #  define CV_TRY_AVX512_CLX 1
 #  define CV_CPU_FORCE_AVX512_CLX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_CLX (cv::checkHardwareSupport(CV_CPU_AVX512_CLX))
 #  define CV_CPU_CALL_AVX512_CLX(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_CLX) return (opt_AVX512_CLX::fn args)
 #  define CV_CPU_CALL_AVX512_CLX_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_CLX) return (opt_AVX512_CLX::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CLX(fn) if (CV_CPU_HAS_SUPPORT_AVX512_CLX) return (opt_AVX512_CLX::fn)
 #else
 #  define CV_TRY_AVX512_CLX 0
 #  define CV_CPU_FORCE_AVX512_CLX 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_CLX 0
 #  define CV_CPU_CALL_AVX512_CLX(fn, args)
 #  define CV_CPU_CALL_AVX512_CLX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_CLX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_CLX(fn, args, mode, ...)  CV_CPU_CALL_AVX512_CLX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_CLX(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_CLX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_AVX512_ICL
 #  define CV_TRY_AVX512_ICL 1
@@ -384,20 +456,24 @@
 #  define CV_CPU_HAS_SUPPORT_AVX512_ICL 1
 #  define CV_CPU_CALL_AVX512_ICL(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_AVX512_ICL_(fn, args) return (opt_AVX512_ICL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_ICL(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_AVX512_ICL
 #  define CV_TRY_AVX512_ICL 1
 #  define CV_CPU_FORCE_AVX512_ICL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_ICL (cv::checkHardwareSupport(CV_CPU_AVX512_ICL))
 #  define CV_CPU_CALL_AVX512_ICL(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_ICL) return (opt_AVX512_ICL::fn args)
 #  define CV_CPU_CALL_AVX512_ICL_(fn, args) if (CV_CPU_HAS_SUPPORT_AVX512_ICL) return (opt_AVX512_ICL::fn args)
+#  define CV_CPU_GET_FN_PTR_AVX512_ICL(fn) if (CV_CPU_HAS_SUPPORT_AVX512_ICL) return (opt_AVX512_ICL::fn)
 #else
 #  define CV_TRY_AVX512_ICL 0
 #  define CV_CPU_FORCE_AVX512_ICL 0
 #  define CV_CPU_HAS_SUPPORT_AVX512_ICL 0
 #  define CV_CPU_CALL_AVX512_ICL(fn, args)
 #  define CV_CPU_CALL_AVX512_ICL_(fn, args)
+#  define CV_CPU_GET_FN_PTR_AVX512_ICL(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_AVX512_ICL(fn, args, mode, ...)  CV_CPU_CALL_AVX512_ICL(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_AVX512_ICL(fn, mode, ...)  CV_CPU_GET_FN_PTR_AVX512_ICL(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_SVE
 #  define CV_TRY_SVE 1
@@ -405,20 +481,24 @@
 #  define CV_CPU_HAS_SUPPORT_SVE 1
 #  define CV_CPU_CALL_SVE(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_SVE_(fn, args) return (opt_SVE::fn args)
+#  define CV_CPU_GET_FN_PTR_SVE(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_SVE
 #  define CV_TRY_SVE 1
 #  define CV_CPU_FORCE_SVE 0
 #  define CV_CPU_HAS_SUPPORT_SVE (cv::checkHardwareSupport(CV_CPU_SVE))
 #  define CV_CPU_CALL_SVE(fn, args) if (CV_CPU_HAS_SUPPORT_SVE) return (opt_SVE::fn args)
 #  define CV_CPU_CALL_SVE_(fn, args) if (CV_CPU_HAS_SUPPORT_SVE) return (opt_SVE::fn args)
+#  define CV_CPU_GET_FN_PTR_SVE(fn) if (CV_CPU_HAS_SUPPORT_SVE) return (opt_SVE::fn)
 #else
 #  define CV_TRY_SVE 0
 #  define CV_CPU_FORCE_SVE 0
 #  define CV_CPU_HAS_SUPPORT_SVE 0
 #  define CV_CPU_CALL_SVE(fn, args)
 #  define CV_CPU_CALL_SVE_(fn, args)
+#  define CV_CPU_GET_FN_PTR_SVE(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_SVE(fn, args, mode, ...)  CV_CPU_CALL_SVE(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_SVE(fn, mode, ...)  CV_CPU_GET_FN_PTR_SVE(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON
 #  define CV_TRY_NEON 1
@@ -426,20 +506,24 @@
 #  define CV_CPU_HAS_SUPPORT_NEON 1
 #  define CV_CPU_CALL_NEON(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_NEON_(fn, args) return (opt_NEON::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_NEON
 #  define CV_TRY_NEON 1
 #  define CV_CPU_FORCE_NEON 0
 #  define CV_CPU_HAS_SUPPORT_NEON (cv::checkHardwareSupport(CV_CPU_NEON))
 #  define CV_CPU_CALL_NEON(fn, args) if (CV_CPU_HAS_SUPPORT_NEON) return (opt_NEON::fn args)
 #  define CV_CPU_CALL_NEON_(fn, args) if (CV_CPU_HAS_SUPPORT_NEON) return (opt_NEON::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON(fn) if (CV_CPU_HAS_SUPPORT_NEON) return (opt_NEON::fn)
 #else
 #  define CV_TRY_NEON 0
 #  define CV_CPU_FORCE_NEON 0
 #  define CV_CPU_HAS_SUPPORT_NEON 0
 #  define CV_CPU_CALL_NEON(fn, args)
 #  define CV_CPU_CALL_NEON_(fn, args)
+#  define CV_CPU_GET_FN_PTR_NEON(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_NEON(fn, args, mode, ...)  CV_CPU_CALL_NEON(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_NEON(fn, mode, ...)  CV_CPU_GET_FN_PTR_NEON(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON_DOTPROD
 #  define CV_TRY_NEON_DOTPROD 1
@@ -447,20 +531,24 @@
 #  define CV_CPU_HAS_SUPPORT_NEON_DOTPROD 1
 #  define CV_CPU_CALL_NEON_DOTPROD(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_NEON_DOTPROD_(fn, args) return (opt_NEON_DOTPROD::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_DOTPROD(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_NEON_DOTPROD
 #  define CV_TRY_NEON_DOTPROD 1
 #  define CV_CPU_FORCE_NEON_DOTPROD 0
 #  define CV_CPU_HAS_SUPPORT_NEON_DOTPROD (cv::checkHardwareSupport(CV_CPU_NEON_DOTPROD))
 #  define CV_CPU_CALL_NEON_DOTPROD(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_DOTPROD) return (opt_NEON_DOTPROD::fn args)
 #  define CV_CPU_CALL_NEON_DOTPROD_(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_DOTPROD) return (opt_NEON_DOTPROD::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_DOTPROD(fn) if (CV_CPU_HAS_SUPPORT_NEON_DOTPROD) return (opt_NEON_DOTPROD::fn)
 #else
 #  define CV_TRY_NEON_DOTPROD 0
 #  define CV_CPU_FORCE_NEON_DOTPROD 0
 #  define CV_CPU_HAS_SUPPORT_NEON_DOTPROD 0
 #  define CV_CPU_CALL_NEON_DOTPROD(fn, args)
 #  define CV_CPU_CALL_NEON_DOTPROD_(fn, args)
+#  define CV_CPU_GET_FN_PTR_NEON_DOTPROD(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_NEON_DOTPROD(fn, args, mode, ...)  CV_CPU_CALL_NEON_DOTPROD(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_NEON_DOTPROD(fn, mode, ...)  CV_CPU_GET_FN_PTR_NEON_DOTPROD(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON_FP16
 #  define CV_TRY_NEON_FP16 1
@@ -468,20 +556,24 @@
 #  define CV_CPU_HAS_SUPPORT_NEON_FP16 1
 #  define CV_CPU_CALL_NEON_FP16(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_NEON_FP16_(fn, args) return (opt_NEON_FP16::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_FP16(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_NEON_FP16
 #  define CV_TRY_NEON_FP16 1
 #  define CV_CPU_FORCE_NEON_FP16 0
 #  define CV_CPU_HAS_SUPPORT_NEON_FP16 (cv::checkHardwareSupport(CV_CPU_NEON_FP16))
 #  define CV_CPU_CALL_NEON_FP16(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_FP16) return (opt_NEON_FP16::fn args)
 #  define CV_CPU_CALL_NEON_FP16_(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_FP16) return (opt_NEON_FP16::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_FP16(fn) if (CV_CPU_HAS_SUPPORT_NEON_FP16) return (opt_NEON_FP16::fn)
 #else
 #  define CV_TRY_NEON_FP16 0
 #  define CV_CPU_FORCE_NEON_FP16 0
 #  define CV_CPU_HAS_SUPPORT_NEON_FP16 0
 #  define CV_CPU_CALL_NEON_FP16(fn, args)
 #  define CV_CPU_CALL_NEON_FP16_(fn, args)
+#  define CV_CPU_GET_FN_PTR_NEON_FP16(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_NEON_FP16(fn, args, mode, ...)  CV_CPU_CALL_NEON_FP16(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_NEON_FP16(fn, mode, ...)  CV_CPU_GET_FN_PTR_NEON_FP16(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_NEON_BF16
 #  define CV_TRY_NEON_BF16 1
@@ -489,20 +581,24 @@
 #  define CV_CPU_HAS_SUPPORT_NEON_BF16 1
 #  define CV_CPU_CALL_NEON_BF16(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_NEON_BF16_(fn, args) return (opt_NEON_BF16::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_BF16(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_NEON_BF16
 #  define CV_TRY_NEON_BF16 1
 #  define CV_CPU_FORCE_NEON_BF16 0
 #  define CV_CPU_HAS_SUPPORT_NEON_BF16 (cv::checkHardwareSupport(CV_CPU_NEON_BF16))
 #  define CV_CPU_CALL_NEON_BF16(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_BF16) return (opt_NEON_BF16::fn args)
 #  define CV_CPU_CALL_NEON_BF16_(fn, args) if (CV_CPU_HAS_SUPPORT_NEON_BF16) return (opt_NEON_BF16::fn args)
+#  define CV_CPU_GET_FN_PTR_NEON_BF16(fn) if (CV_CPU_HAS_SUPPORT_NEON_BF16) return (opt_NEON_BF16::fn)
 #else
 #  define CV_TRY_NEON_BF16 0
 #  define CV_CPU_FORCE_NEON_BF16 0
 #  define CV_CPU_HAS_SUPPORT_NEON_BF16 0
 #  define CV_CPU_CALL_NEON_BF16(fn, args)
 #  define CV_CPU_CALL_NEON_BF16_(fn, args)
+#  define CV_CPU_GET_FN_PTR_NEON_BF16(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_NEON_BF16(fn, args, mode, ...)  CV_CPU_CALL_NEON_BF16(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_NEON_BF16(fn, mode, ...)  CV_CPU_GET_FN_PTR_NEON_BF16(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_MSA
 #  define CV_TRY_MSA 1
@@ -510,20 +606,24 @@
 #  define CV_CPU_HAS_SUPPORT_MSA 1
 #  define CV_CPU_CALL_MSA(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_MSA_(fn, args) return (opt_MSA::fn args)
+#  define CV_CPU_GET_FN_PTR_MSA(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_MSA
 #  define CV_TRY_MSA 1
 #  define CV_CPU_FORCE_MSA 0
 #  define CV_CPU_HAS_SUPPORT_MSA (cv::checkHardwareSupport(CV_CPU_MSA))
 #  define CV_CPU_CALL_MSA(fn, args) if (CV_CPU_HAS_SUPPORT_MSA) return (opt_MSA::fn args)
 #  define CV_CPU_CALL_MSA_(fn, args) if (CV_CPU_HAS_SUPPORT_MSA) return (opt_MSA::fn args)
+#  define CV_CPU_GET_FN_PTR_MSA(fn) if (CV_CPU_HAS_SUPPORT_MSA) return (opt_MSA::fn)
 #else
 #  define CV_TRY_MSA 0
 #  define CV_CPU_FORCE_MSA 0
 #  define CV_CPU_HAS_SUPPORT_MSA 0
 #  define CV_CPU_CALL_MSA(fn, args)
 #  define CV_CPU_CALL_MSA_(fn, args)
+#  define CV_CPU_GET_FN_PTR_MSA(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_MSA(fn, args, mode, ...)  CV_CPU_CALL_MSA(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_MSA(fn, mode, ...)  CV_CPU_GET_FN_PTR_MSA(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_VSX
 #  define CV_TRY_VSX 1
@@ -531,20 +631,24 @@
 #  define CV_CPU_HAS_SUPPORT_VSX 1
 #  define CV_CPU_CALL_VSX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_VSX_(fn, args) return (opt_VSX::fn args)
+#  define CV_CPU_GET_FN_PTR_VSX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_VSX
 #  define CV_TRY_VSX 1
 #  define CV_CPU_FORCE_VSX 0
 #  define CV_CPU_HAS_SUPPORT_VSX (cv::checkHardwareSupport(CV_CPU_VSX))
 #  define CV_CPU_CALL_VSX(fn, args) if (CV_CPU_HAS_SUPPORT_VSX) return (opt_VSX::fn args)
 #  define CV_CPU_CALL_VSX_(fn, args) if (CV_CPU_HAS_SUPPORT_VSX) return (opt_VSX::fn args)
+#  define CV_CPU_GET_FN_PTR_VSX(fn) if (CV_CPU_HAS_SUPPORT_VSX) return (opt_VSX::fn)
 #else
 #  define CV_TRY_VSX 0
 #  define CV_CPU_FORCE_VSX 0
 #  define CV_CPU_HAS_SUPPORT_VSX 0
 #  define CV_CPU_CALL_VSX(fn, args)
 #  define CV_CPU_CALL_VSX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_VSX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_VSX(fn, args, mode, ...)  CV_CPU_CALL_VSX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_VSX(fn, mode, ...)  CV_CPU_GET_FN_PTR_VSX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_VSX3
 #  define CV_TRY_VSX3 1
@@ -552,20 +656,24 @@
 #  define CV_CPU_HAS_SUPPORT_VSX3 1
 #  define CV_CPU_CALL_VSX3(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_VSX3_(fn, args) return (opt_VSX3::fn args)
+#  define CV_CPU_GET_FN_PTR_VSX3(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_VSX3
 #  define CV_TRY_VSX3 1
 #  define CV_CPU_FORCE_VSX3 0
 #  define CV_CPU_HAS_SUPPORT_VSX3 (cv::checkHardwareSupport(CV_CPU_VSX3))
 #  define CV_CPU_CALL_VSX3(fn, args) if (CV_CPU_HAS_SUPPORT_VSX3) return (opt_VSX3::fn args)
 #  define CV_CPU_CALL_VSX3_(fn, args) if (CV_CPU_HAS_SUPPORT_VSX3) return (opt_VSX3::fn args)
+#  define CV_CPU_GET_FN_PTR_VSX3(fn) if (CV_CPU_HAS_SUPPORT_VSX3) return (opt_VSX3::fn)
 #else
 #  define CV_TRY_VSX3 0
 #  define CV_CPU_FORCE_VSX3 0
 #  define CV_CPU_HAS_SUPPORT_VSX3 0
 #  define CV_CPU_CALL_VSX3(fn, args)
 #  define CV_CPU_CALL_VSX3_(fn, args)
+#  define CV_CPU_GET_FN_PTR_VSX3(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_VSX3(fn, args, mode, ...)  CV_CPU_CALL_VSX3(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_VSX3(fn, mode, ...)  CV_CPU_GET_FN_PTR_VSX3(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_RVV
 #  define CV_TRY_RVV 1
@@ -573,20 +681,24 @@
 #  define CV_CPU_HAS_SUPPORT_RVV 1
 #  define CV_CPU_CALL_RVV(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_RVV_(fn, args) return (opt_RVV::fn args)
+#  define CV_CPU_GET_FN_PTR_RVV(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_RVV
 #  define CV_TRY_RVV 1
 #  define CV_CPU_FORCE_RVV 0
 #  define CV_CPU_HAS_SUPPORT_RVV (cv::checkHardwareSupport(CV_CPU_RVV))
 #  define CV_CPU_CALL_RVV(fn, args) if (CV_CPU_HAS_SUPPORT_RVV) return (opt_RVV::fn args)
 #  define CV_CPU_CALL_RVV_(fn, args) if (CV_CPU_HAS_SUPPORT_RVV) return (opt_RVV::fn args)
+#  define CV_CPU_GET_FN_PTR_RVV(fn) if (CV_CPU_HAS_SUPPORT_RVV) return (opt_RVV::fn)
 #else
 #  define CV_TRY_RVV 0
 #  define CV_CPU_FORCE_RVV 0
 #  define CV_CPU_HAS_SUPPORT_RVV 0
 #  define CV_CPU_CALL_RVV(fn, args)
 #  define CV_CPU_CALL_RVV_(fn, args)
+#  define CV_CPU_GET_FN_PTR_RVV(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_RVV(fn, args, mode, ...)  CV_CPU_CALL_RVV(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_RVV(fn, mode, ...)  CV_CPU_GET_FN_PTR_RVV(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_LSX
 #  define CV_TRY_LSX 1
@@ -594,20 +706,24 @@
 #  define CV_CPU_HAS_SUPPORT_LSX 1
 #  define CV_CPU_CALL_LSX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_LSX_(fn, args) return (opt_LSX::fn args)
+#  define CV_CPU_GET_FN_PTR_LSX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_LSX
 #  define CV_TRY_LSX 1
 #  define CV_CPU_FORCE_LSX 0
 #  define CV_CPU_HAS_SUPPORT_LSX (cv::checkHardwareSupport(CV_CPU_LSX))
 #  define CV_CPU_CALL_LSX(fn, args) if (CV_CPU_HAS_SUPPORT_LSX) return (opt_LSX::fn args)
 #  define CV_CPU_CALL_LSX_(fn, args) if (CV_CPU_HAS_SUPPORT_LSX) return (opt_LSX::fn args)
+#  define CV_CPU_GET_FN_PTR_LSX(fn) if (CV_CPU_HAS_SUPPORT_LSX) return (opt_LSX::fn)
 #else
 #  define CV_TRY_LSX 0
 #  define CV_CPU_FORCE_LSX 0
 #  define CV_CPU_HAS_SUPPORT_LSX 0
 #  define CV_CPU_CALL_LSX(fn, args)
 #  define CV_CPU_CALL_LSX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_LSX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_LSX(fn, args, mode, ...)  CV_CPU_CALL_LSX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_LSX(fn, mode, ...)  CV_CPU_GET_FN_PTR_LSX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #if !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_COMPILE_LASX
 #  define CV_TRY_LASX 1
@@ -615,20 +731,26 @@
 #  define CV_CPU_HAS_SUPPORT_LASX 1
 #  define CV_CPU_CALL_LASX(fn, args) return (cpu_baseline::fn args)
 #  define CV_CPU_CALL_LASX_(fn, args) return (opt_LASX::fn args)
+#  define CV_CPU_GET_FN_PTR_LASX(fn) return (cpu_baseline::fn)
 #elif !defined CV_DISABLE_OPTIMIZATION && defined CV_ENABLE_INTRINSICS && defined CV_CPU_DISPATCH_COMPILE_LASX
 #  define CV_TRY_LASX 1
 #  define CV_CPU_FORCE_LASX 0
 #  define CV_CPU_HAS_SUPPORT_LASX (cv::checkHardwareSupport(CV_CPU_LASX))
 #  define CV_CPU_CALL_LASX(fn, args) if (CV_CPU_HAS_SUPPORT_LASX) return (opt_LASX::fn args)
 #  define CV_CPU_CALL_LASX_(fn, args) if (CV_CPU_HAS_SUPPORT_LASX) return (opt_LASX::fn args)
+#  define CV_CPU_GET_FN_PTR_LASX(fn) if (CV_CPU_HAS_SUPPORT_LASX) return (opt_LASX::fn)
 #else
 #  define CV_TRY_LASX 0
 #  define CV_CPU_FORCE_LASX 0
 #  define CV_CPU_HAS_SUPPORT_LASX 0
 #  define CV_CPU_CALL_LASX(fn, args)
 #  define CV_CPU_CALL_LASX_(fn, args)
+#  define CV_CPU_GET_FN_PTR_LASX(fn)
 #endif
 #define __CV_CPU_DISPATCH_CHAIN_LASX(fn, args, mode, ...)  CV_CPU_CALL_LASX(fn, args); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_ ## mode(fn, args, __VA_ARGS__))
+#define __CV_CPU_DISPATCH_CHAIN_FN_LASX(fn, mode, ...)  CV_CPU_GET_FN_PTR_LASX(fn); __CV_EXPAND(__CV_CPU_DISPATCH_CHAIN_FN_ ## mode(fn, __VA_ARGS__))
 
 #define CV_CPU_CALL_BASELINE(fn, args) return (cpu_baseline::fn args)
 #define __CV_CPU_DISPATCH_CHAIN_BASELINE(fn, args, mode, ...)  CV_CPU_CALL_BASELINE(fn, args) /* last in sequence */
+#define CV_CPU_GET_FN_PTR_BASELINE(fn) return (cpu_baseline::fn)
+#define __CV_CPU_DISPATCH_CHAIN_FN_BASELINE(fn, mode, ...)  CV_CPU_GET_FN_PTR_BASELINE(fn) /* last in sequence */

--- a/modules/core/src/lut.dispatch.cpp
+++ b/modules/core/src/lut.dispatch.cpp
@@ -17,20 +17,12 @@ typedef void (*LUT16uFunc)( const uchar*, const ushort*, ushort*, int, int, int 
 
 static LUT8uFunc resolveLUT8uFunc()
 {
-#if CV_TRY_AVX512_ICL
-    if (cv::checkHardwareSupport(CV_CPU_AVX512_ICL))
-        return opt_AVX512_ICL::LUT8u_;
-#endif
-    return cpu_baseline::LUT8u_;
+    CV_CPU_DISPATCH_FN(LUT8u_, CV_CPU_DISPATCH_MODES_ALL);
 }
 
 static LUT16uFunc resolveLUT16uFunc()
 {
-#if CV_TRY_AVX512_ICL
-    if (cv::checkHardwareSupport(CV_CPU_AVX512_ICL))
-        return opt_AVX512_ICL::LUT16u_;
-#endif
-    return cpu_baseline::LUT16u_;
+    CV_CPU_DISPATCH_FN(LUT16u_, CV_CPU_DISPATCH_MODES_ALL);
 }
 
 } // namespace

--- a/modules/imgproc/src/equalize_hist.dispatch.cpp
+++ b/modules/imgproc/src/equalize_hist.dispatch.cpp
@@ -16,11 +16,7 @@ typedef void (*EqualizeHistLutFunc)( const uchar*, uchar*, int, const uchar* );
 
 static EqualizeHistLutFunc resolveEqualizeHistLutFunc()
 {
-#if CV_TRY_AVX512_ICL
-    if (cv::checkHardwareSupport(CV_CPU_AVX512_ICL))
-        return opt_AVX512_ICL::equalizeHistLut_;
-#endif
-    return cpu_baseline::equalizeHistLut_;
+    CV_CPU_DISPATCH_FN(equalizeHistLut_, CV_CPU_DISPATCH_MODES_ALL);
 }
 
 } // namespace


### PR DESCRIPTION
Fixes #29694

### Root cause

The generated `cv_cpu_helper.h` sets `CV_TRY_AVX512_ICL` to 1 in **two** different branches — when ICL is a *dispatch* target, and when ICL is part of the *baseline*:

```c
#if  ... defined CV_CPU_COMPILE_AVX512_ICL            // baseline
#  define CV_TRY_AVX512_ICL 1
#  define CV_CPU_FORCE_AVX512_ICL 1
#elif ... defined CV_CPU_DISPATCH_COMPILE_AVX512_ICL  // dispatch
#  define CV_TRY_AVX512_ICL 1
#  define CV_CPU_FORCE_AVX512_ICL 0
```

Only the dispatch case produces an `opt_AVX512_ICL` namespace. `__ocv_add_dispatched_file` emits it under

```cmake
if(";${CPU_DISPATCH_FINAL};" MATCHES "${OPT}" OR __CPU_DISPATCH_INCLUDE_ALL)
```

and a baseline optimization is deliberately kept out of `CPU_DISPATCH_FINAL` (`OpenCVCompilerOptimizations.cmake`, the `AND NOT __is_from_baseline` condition).

`-march=native` in `CMAKE_CXX_FLAGS` forces `CPU_BASELINE=DETECT`, which promotes every compiler-supported optimization into the baseline. On an ICL-capable CPU that puts AVX512_ICL there, so `#if CV_TRY_AVX512_ICL` is taken while the namespace was never declared.

### Reproduction

Reproduced locally without ICL hardware, by cross-configuring for x86_64 with an ICL-capable `-march`:

```
cmake -S opencv -B build_x86_icl -G Ninja \
  -DCMAKE_SYSTEM_NAME=Darwin -DCMAKE_SYSTEM_PROCESSOR=x86_64 \
  -DCMAKE_OSX_ARCHITECTURES=x86_64 \
  -DCMAKE_CXX_FLAGS="-march=sapphirerapids" -DBUILD_LIST=core,imgproc
```

which yields exactly the reporter's configuration:

```
-- Performing Test HAVE_CPU_AVX512_ICL_SUPPORT - Success
--   CPU/HW features:
--     Baseline: ... AVX512_SKX AVX512_CNL AVX512_CLX AVX512_ICL
--     Dispatched code generation:            <-- empty
```

`modules/core/lut.simd_declarations.hpp` then contains only `CV_CPU_DISPATCH_MODES_ALL BASELINE`, i.e. no `opt_AVX512_ICL`, and the build fails on the same two lines reported:

```
lut.dispatch.cpp:22:16: error: use of undeclared identifier 'opt_AVX512_ICL'
lut.dispatch.cpp:31:16: error: use of undeclared identifier 'opt_AVX512_ICL'
```

(clang wording; GCC says "has not been declared")

With this patch, both files compile and the whole `core,imgproc,dnn,features2d,flann,calib3d,video,photo,ml,objdetect` set builds cleanly in that configuration.

### Fix

Guard on `CV_TRY_AVX512_ICL && !CV_CPU_FORCE_AVX512_ICL`, which is true only in the dispatch case.

Nothing is lost in the baseline case: `cpu_baseline` is then itself compiled with the ICL flags. Disassembling `cpu_baseline::LUT8u_` from the x86_64 ICL build above shows the ICL code path is still selected — 24 `vpermb` (AVX512_VBMI) instructions and `zmm` registers. Falling through to `cpu_baseline` is therefore both correct and optimal, and avoids emitting a second copy of the kernel.

On a target where ICL is not involved the change is a no-op: rebuilding both objects on aarch64 and comparing the `__text` sections against 4.x gives **identical machine code**.

### Why only these two files

Auditing every `opt_<OPT>::` reference in the tree, these are the only two exposed. The others are safe for one of three reasons:

| mechanism | files |
|---|---|
| namespace declared in an always-compiled companion | `resize.cpp`, `imgwarp.cpp`, `fast.cpp`, `int8layers/layers_rvp052` |
| registered with `ocv_add_dispatched_file_force_all` (`__CPU_DISPATCH_INCLUDE_ALL`) | dnn `layers_common`, `conv_block`, `conv_depthwise`, `fast_gemm_kernels` |
| dispatched via the `CV_CPU_DISPATCH` macro, which routes to `cpu_baseline` in the baseline case | `conv_winograd_f63.dispatch.cpp` |

This is confirmed empirically by the build above: with `CPU_DISPATCH_FINAL` empty, `lut.simd_declarations.hpp` emits only `BASELINE`, while dnn's force_all groups still emit every `opt_` namespace.

`ocv_add_dispatched_file_force_all(lut AVX512_ICL)` would be an alternative one-line fix, but it would compile a second copy of the kernel that is dead whenever ICL is already in the baseline.

### Notes

- 5.x carries the same two occurrences and the same CMake logic, so it should follow via the usual backport.
- No CI job builds with `-march=native` / `CPU_BASELINE=DETECT`, which is why this was not caught.
- Documentation/build fix with no functional change on existing configurations; `opencv_test_core --gtest_filter=*LUT*` (320 tests) and `opencv_test_imgproc --gtest_filter=*qualize*` (32 tests) pass unchanged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
