### PR TITLE
imgproc: add native remap batch API 🤖🤖🤖

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2561,6 +2561,36 @@ CV_EXPORTS_W void remap( InputArray src, OutputArray dst,
                          int interpolation, int borderMode = BORDER_CONSTANT,
                          const Scalar& borderValue = Scalar());
 
+/** @brief Applies a dense geometric transformation to a batch of images.
+
+The input must be a three-dimensional `Mat` with shape `(N, H, W)` (single-channel
+images) or `(N, H, W)` with multiple channels, or a four-dimensional `Mat` with
+shape `(N, H, W, C)` as produced by the Python bindings. The output has the same
+batch and channel layout, with its spatial dimensions taken from the map.
+
+`map1` and `map2` may be shared by every image (the same two-dimensional maps
+accepted by #remap), or supplied per image as three-dimensional maps with shape
+`(N, H, W)` (and a final map-channel dimension for two-channel maps). Per-image
+maps must all have the same spatial size.
+
+Each image is processed with the same interpolation and border semantics as
+#remap. The images are dispatched as one native operation, allowing callers to
+avoid a Python loop while preserving the single-image implementation.
+
+@param src Batch of source images.
+@param dst Batch of destination images. It is created with the same batch and
+       channel layout as `src`.
+@param map1 The first shared or per-image map.
+@param map2 The second shared or per-image map, or an empty array for two-channel maps.
+@param interpolation Interpolation method (see #InterpolationFlags).
+@param borderMode Pixel extrapolation method (see #BorderTypes).
+@param borderValue Value used in case of a constant border.
+ */
+CV_EXPORTS_W void remapBatch( InputArray src, OutputArray dst,
+                              InputArray map1, InputArray map2,
+                              int interpolation, int borderMode = BORDER_CONSTANT,
+                              const Scalar& borderValue = Scalar());
+
 /** @brief Converts image transformation maps from one representation to another.
 
 The function converts a pair of maps for remap from one representation to another. The following

--- a/modules/imgproc/src/imgwarp.cpp
+++ b/modules/imgproc/src/imgwarp.cpp
@@ -1857,6 +1857,100 @@ void cv::remap( InputArray _src, OutputArray _dst,
     parallel_for_(Range(0, dst.rows), invoker, dst.total()/(double)(1<<16));
 }
 
+namespace {
+
+static Mat remapBatchImageView(const Mat& batch, int index)
+{
+    CV_Assert(batch.dims == 3 || batch.dims == 4);
+    const int channels = batch.dims == 4 ? batch.size[3] : batch.channels();
+    CV_Assert(channels > 0 && channels <= CV_CN_MAX);
+    const int type = CV_MAKETYPE(batch.depth(), channels);
+    return Mat(batch.size[1], batch.size[2], type,
+               batch.data + static_cast<size_t>(index) * batch.step[0], batch.step[1]);
+}
+
+static Mat remapBatchMapView(const Mat& maps, int index)
+{
+    CV_Assert(maps.dims == 3 || maps.dims == 4);
+    const int channels = maps.dims == 4 ? maps.size[3] : maps.channels();
+    CV_Assert(channels > 0 && channels <= CV_CN_MAX);
+    const int type = CV_MAKETYPE(maps.depth(), channels);
+    return Mat(maps.size[1], maps.size[2], type,
+               maps.data + static_cast<size_t>(index) * maps.step[0], maps.step[1]);
+}
+
+static Size remapBatchMapSize(const Mat& maps)
+{
+    CV_Assert(maps.dims == 2 || maps.dims == 3 || maps.dims == 4);
+    return maps.dims == 2 ? maps.size() : Size(maps.size[2], maps.size[1]);
+}
+
+static bool remapBatchMapIsPerImage(const Mat& maps)
+{
+    return maps.dims == 3 || maps.dims == 4;
+}
+
+} // namespace
+
+void cv::remapBatch( InputArray _src, OutputArray _dst,
+                     InputArray _map1, InputArray _map2,
+                     int interpolation, int borderType, const Scalar& borderValue )
+{
+    CV_INSTRUMENT_REGION();
+
+    const Mat src = _src.getMat();
+    const Mat map1 = _map1.getMat();
+    const Mat map2 = _map2.getMat();
+
+    CV_Assert(src.dims == 3 || src.dims == 4);
+    CV_Assert(src.size[0] > 0 && src.size[1] > 0 && src.size[2] > 0);
+    CV_Assert(!map1.empty());
+    CV_Assert(map1.dims == 2 || map1.dims == 3 || map1.dims == 4);
+    CV_Assert(map2.empty() || map2.dims == map1.dims);
+
+    const int batchSize = src.size[0];
+    const bool perImageMap = remapBatchMapIsPerImage(map1);
+    if (perImageMap)
+    {
+        CV_Assert(map1.size[0] == batchSize);
+        CV_Assert(map2.empty() || map2.size[0] == batchSize);
+    }
+    else
+    {
+        CV_Assert(map1.dims == 2);
+        CV_Assert(map2.empty() || map2.dims == 2);
+    }
+
+    const Size mapSize = remapBatchMapSize(map1);
+    CV_Assert(mapSize.width > 0 && mapSize.height > 0);
+    CV_Assert(map2.empty() || remapBatchMapSize(map2) == mapSize);
+    if (perImageMap)
+    {
+        CV_Assert(map1.size[1] == mapSize.height && map1.size[2] == mapSize.width);
+        CV_Assert(map2.empty() || (map2.size[1] == mapSize.height && map2.size[2] == mapSize.width));
+    }
+
+    int outputSizes[CV_MAX_DIM];
+    for (int i = 0; i < src.dims; ++i)
+        outputSizes[i] = src.size[i];
+    outputSizes[1] = mapSize.height;
+    outputSizes[2] = mapSize.width;
+    _dst.create(src.dims, outputSizes, src.type());
+    const Mat dst = _dst.getMat();
+
+    parallel_for_(Range(0, batchSize), [&](const Range& range) {
+        for (int i = range.start; i < range.end; ++i)
+        {
+            const Mat srcImage = remapBatchImageView(src, i);
+            Mat dstImage = remapBatchImageView(dst, i);
+            const Mat map1Image = perImageMap ? remapBatchMapView(map1, i) : map1;
+            const Mat map2Image = map2.empty() ? Mat() : (perImageMap ? remapBatchMapView(map2, i) : map2);
+            remap(srcImage, dstImage, map1Image, map2Image,
+                  interpolation, borderType, borderValue);
+        }
+    });
+}
+
 
 void cv::convertMaps( InputArray _map1, InputArray _map2,
                       OutputArray _dstmap1, OutputArray _dstmap2,

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1856,6 +1856,67 @@ TEST(Imgproc_Remap, issue_23562)
     }
 }
 
+TEST(Imgproc_RemapBatch, shared_and_per_image_maps)
+{
+    const int batchSize = 3;
+    const int rows = 4;
+    const int cols = 5;
+
+    int srcSizes[] = {batchSize, rows, cols};
+    Mat src(3, srcSizes, CV_8UC3);
+    randu(src, 0, 256);
+
+    Mat mapx(rows, cols, CV_32FC1), mapy(rows, cols, CV_32FC1);
+    for (int y = 0; y < rows; ++y)
+    {
+        for (int x = 0; x < cols; ++x)
+        {
+            mapx.at<float>(y, x) = static_cast<float>(x);
+            mapy.at<float>(y, x) = static_cast<float>(y);
+        }
+    }
+
+    Mat shared;
+    remapBatch(src, shared, mapx, mapy, INTER_NEAREST);
+    ASSERT_EQ(src.dims, shared.dims);
+    ASSERT_EQ(src.size[0], shared.size[0]);
+    ASSERT_EQ(src.size[1], shared.size[1]);
+    ASSERT_EQ(src.size[2], shared.size[2]);
+    ASSERT_EQ(src.type(), shared.type());
+    for (int i = 0; i < batchSize; ++i)
+    {
+        Mat srcImage(rows, cols, CV_8UC3, src.ptr(i), src.step[1]);
+        Mat dstImage(rows, cols, CV_8UC3, shared.ptr(i), shared.step[1]);
+        Mat expected;
+        remap(srcImage, expected, mapx, mapy, INTER_NEAREST);
+        EXPECT_EQ(0.0, cvtest::norm(expected, dstImage, NORM_INF)) << "batch=" << i;
+    }
+
+    int mapSizes[] = {batchSize, rows, cols};
+    Mat perImageX(3, mapSizes, CV_32FC1), perImageY(3, mapSizes, CV_32FC1);
+    for (int i = 0; i < batchSize; ++i)
+    {
+        Mat mapxImage(rows, cols, CV_32FC1, perImageX.ptr(i), perImageX.step[1]);
+        Mat mapyImage(rows, cols, CV_32FC1, perImageY.ptr(i), perImageY.step[1]);
+        mapx.copyTo(mapxImage);
+        mapy.copyTo(mapyImage);
+        mapxImage.at<float>(0, 0) = static_cast<float>(i);
+    }
+
+    Mat perImage;
+    remapBatch(src, perImage, perImageX, perImageY, INTER_NEAREST);
+    for (int i = 0; i < batchSize; ++i)
+    {
+        Mat srcImage(rows, cols, CV_8UC3, src.ptr(i), src.step[1]);
+        Mat mapxImage(rows, cols, CV_32FC1, perImageX.ptr(i), perImageX.step[1]);
+        Mat mapyImage(rows, cols, CV_32FC1, perImageY.ptr(i), perImageY.step[1]);
+        Mat dstImage(rows, cols, CV_8UC3, perImage.ptr(i), perImage.step[1]);
+        Mat expected;
+        remap(srcImage, expected, mapxImage, mapyImage, INTER_NEAREST);
+        EXPECT_EQ(0.0, cvtest::norm(expected, dstImage, NORM_INF)) << "per-image batch=" << i;
+    }
+}
+
 TEST(Imgproc_getPerspectiveTransform, issue_26916)
 {
     double src_data[] = {320, 512, 960, 512, 0, 1024, 1280, 1024};


### PR DESCRIPTION
## Summary

Adds a native `cv::remapBatch` operation for batched geometric transforms, addressing #29588.

## What changed

- Accepts 3-D `(N, H, W)` batches and 4-D `(N, H, W, C)` batches from the Python bindings.
- Supports shared 2-D maps and per-image 3-D/4-D maps while reusing the existing `cv::remap` validation and interpolation paths.
- Dispatches images through one native parallel operation so callers do not need a Python loop.
- Documents the batch layout and adds shared-map, per-image-map, and multi-channel regression coverage.

## Validation

- Built `opencv_imgproc` and its `opencv_core` dependency with a minimal WSL CMake/Ninja configuration.
- Ran a native C++ harness covering shared maps, per-image maps, three-channel batches, and NHWC 4-D batches; every result matched independent `cv::remap` calls.
- `git diff --check` passes.

## Checklist

- [x] The patch is scoped to the referenced feature.
- [x] The public API is documented.
- [x] Regression coverage exercises the new production path.