### PR TITLE
videoio: fix FFmpeg VideoCapture ignoring mid-stream pixel format change

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -582,6 +582,7 @@ struct CvCapture_FFMPEG
     AVPacket          packet;
     Image_FFMPEG      frame;
     struct SwsContext *img_convert_ctx;
+    AVPixelFormat     img_convert_ctx_format;
 
     int64_t frame_number, first_frame_number;
 
@@ -648,6 +649,7 @@ void CvCapture_FFMPEG::init()
     memset(&packet, 0, sizeof(packet));
     av_init_packet(&packet);
     img_convert_ctx = 0;
+    img_convert_ctx_format = AV_PIX_FMT_NONE;
 
     avcodec = 0;
     context = 0;
@@ -689,6 +691,7 @@ void CvCapture_FFMPEG::close()
     {
         sws_freeContext(img_convert_ctx);
         img_convert_ctx = 0;
+        img_convert_ctx_format = AV_PIX_FMT_NONE;
     }
 
     if( picture )
@@ -1922,7 +1925,8 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
     if( img_convert_ctx == NULL ||
         frame.width != video_st->CV_FFMPEG_CODEC_FIELD->width ||
         frame.height != video_st->CV_FFMPEG_CODEC_FIELD->height ||
-        frame.data == NULL )
+        frame.data == NULL ||
+        (AVPixelFormat)sw_picture->format != img_convert_ctx_format )
     {
 #if LIBSWSCALE_BUILD >= CALC_FFMPEG_VERSION(6, 4, 100)
         int buffer_width = video_st->CV_FFMPEG_CODEC_FIELD->width;
@@ -1999,6 +2003,8 @@ bool CvCapture_FFMPEG::retrieveFrame(int flag, unsigned char** data, int* step, 
 #endif
             return false;
         }
+
+        img_convert_ctx_format = (AVPixelFormat)sw_picture->format;
 
 #if USE_AV_FRAME_GET_BUFFER
         av_frame_unref(&rgb_picture);

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "test_precomp.hpp"
+#include "opencv2/imgcodecs.hpp"
 
 using namespace std;
 
@@ -1186,6 +1187,67 @@ TEST(videoio_ffmpeg, seek_with_negative_dts)
         ASSERT_FALSE(frame.empty());
         EXPECT_GE(cap.get(CAP_PROP_POS_FRAMES), f);
     }
+}
+
+// MJPEG stream whose chroma subsampling changes mid-stream at constant
+// frame size must not reuse a conversion context built for the previous frame.
+// related issue: https://github.com/opencv/opencv/issues/29699
+TEST(videoio_ffmpeg, mjpeg_pixel_format_change)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    Mat frame0(64, 64, CV_8UC3, Scalar(0, 0, 255));
+    Mat frame1(64, 64, CV_8UC3);
+    for (int y = 0; y < frame1.rows; y++)
+        for (int x = 0; x < frame1.cols; x++)
+            frame1.at<Vec3b>(y, x) = Vec3b((uchar)(x * 4), (uchar)(y * 4), (uchar)((x + y) * 2));
+
+    vector<uchar> buf0, buf1;
+    ASSERT_TRUE(imencode(".jpg", frame0, buf0,
+        {IMWRITE_JPEG_SAMPLING_FACTOR, IMWRITE_JPEG_SAMPLING_FACTOR_422, IMWRITE_JPEG_QUALITY, 100}));
+    ASSERT_TRUE(imencode(".jpg", frame1, buf1,
+        {IMWRITE_JPEG_SAMPLING_FACTOR, IMWRITE_JPEG_SAMPLING_FACTOR_420, IMWRITE_JPEG_QUALITY, 100}));
+
+    const string filename = tempfile("test_pixfmt_change.mjpeg");
+    std::ofstream file(filename.c_str(), ios::out | ios::trunc | std::ios::binary);
+    file.write(reinterpret_cast<char*>(buf0.data()), buf0.size());
+    file.write(reinterpret_cast<char*>(buf1.data()), buf1.size());
+    file.close();
+
+    VideoCapture cap(filename, CAP_FFMPEG);
+    ASSERT_TRUE(cap.isOpened());
+
+    Mat read0, read1;
+    ASSERT_TRUE(cap.read(read0));
+    ASSERT_TRUE(cap.read(read1));
+
+    Mat decodedRef0 = imdecode(buf0, IMREAD_COLOR);
+    Mat decodedRef1 = imdecode(buf1, IMREAD_COLOR);
+    ASSERT_FALSE(decodedRef0.empty());
+    ASSERT_FALSE(decodedRef1.empty());
+    ASSERT_EQ(read0.size(), decodedRef0.size());
+    ASSERT_EQ(read1.size(), decodedRef1.size());
+
+    // JPEG re-encoding is not bit exact, but a correctly decoded frame stays
+    // within a couple of intensity levels per channel; a stale conversion
+    // context (the bug) produces gross corruption of tens of levels.
+    const double maeThreshold = 5.0;
+
+    Mat diff0, diff1;
+    absdiff(read0, decodedRef0, diff0);
+    absdiff(read1, decodedRef1, diff1);
+    Scalar mae0 = mean(diff0);
+    Scalar mae1 = mean(diff1);
+    for (int c = 0; c < 3; c++)
+    {
+        EXPECT_LE(mae0[c], maeThreshold)
+            << "First frame (channel " << c << ") decoded incorrectly";
+        EXPECT_LE(mae1[c], maeThreshold)
+            << "Second frame (channel " << c << ") decoded incorrectly after pixel format change mid-stream";
+    }
+
+    remove(filename.c_str());
 }
 
 }} // namespace


### PR DESCRIPTION
Some MJPEG AVI files change chroma subsampling partway through the stream at a constant frame size. A Bushnell trail camera, for instance, writes its first frame as yuvj422p and every frame after that as yuvj420p. `VideoCapture`'s FFmpeg backend only rebuilds its BGR conversion context when the frame dimensions change, so the stale context keeps the old chroma plane geometry and the conversion reads past the end of the new frame's chroma planes. Since it's an out-of-bounds read, what happens next depends on the platform: a crash on Windows and some Linux builds, or a silently corrupted frame on macOS.

This adds the source pixel format to the rebuild condition in `cap_ffmpeg_impl.hpp`, so a format change forces a fresh context the same way a size change already does. Added a test that builds an in-memory MJPEG stream with a 422-to-420 transition and checks the second frame decodes correctly against an independent reference decode.

Fixes #29699.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake