### PR TITLE
Fix UMat channel extraction in DNN blobs

### DIFF
--- a/modules/dnn/src/dnn_utils.cpp
+++ b/modules/dnn/src/dnn_utils.cpp
@@ -60,7 +60,7 @@ void getChannelFromBlob(UMat& m, InputArray blob, int i, int j, int rows, int co
 
     const int newShape[1] { length };
     UMat reshaped = ublob.reshape(1, 1, newShape);
-    UMat roi = reshaped(Rect(0, offset, 1, rows * cols));
+    UMat roi = reshaped(Rect(offset, 0, rows * cols, 1));
     m = roi.reshape(CV_MAT_CN(type), rows);
 }
 

--- a/modules/dnn/test/test_misc.cpp
+++ b/modules/dnn/test/test_misc.cpp
@@ -97,6 +97,26 @@ TEST(blobFromImage_4ch, Regression)
     }
 }
 
+TEST(blobFromImage_UMat, Regression)
+{
+    Mat image(10, 10, CV_32FC3);
+    randu(image, 0.0f, 1.0f);
+
+    UMat uimage;
+    image.copyTo(uimage);
+    UMat ublob;
+    dnn::blobFromImage(uimage, ublob, 1.0, Size(), Scalar(), false, false);
+
+    Mat expected = dnn::blobFromImage(image, 1.0, Size(), Scalar(), false, false);
+    Mat actual = ublob.getMat(ACCESS_READ);
+    EXPECT_EQ(actual.dims, expected.dims);
+    EXPECT_EQ(actual.size[0], expected.size[0]);
+    EXPECT_EQ(actual.size[1], expected.size[1]);
+    EXPECT_EQ(actual.size[2], expected.size[2]);
+    EXPECT_EQ(actual.size[3], expected.size[3]);
+    EXPECT_EQ(cvtest::norm(actual, expected, NORM_INF), 0.0);
+}
+
 TEST(blobFromImage, allocated)
 {
     int size[] = { 1, 3, 4, 5 };


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.
- [x] The PR targets the affected `5.x` branch.
- [x] This PR references the original bug report: fixes #29570.
- [x] The change does not require accuracy data, performance data, or opencv_extra updates.
- [x] No documentation or sample changes are required.

### Summary

`getChannelFromBlob(UMat&)` reshapes a blob into a one-dimensional row vector, but the ROI used to extract a channel was constructed with column-vector dimensions. This caused an assertion failure for UMat-backed DNN blob creation on OpenCV 5.x.

The ROI now uses the row-vector dimensions. A regression test compares UMat-backed and Mat-backed `blobFromImage` results, including dimensions and values.

### Validation

Built `opencv_test_dnn` on macOS arm64 with LLVM and ran:

```text
blobFromImage_4ch.Regression
blobFromImage_UMat.Regression
blobFromImage.allocated
imagesFromBlob.Regression
blobFromImageWithParams_4ch.*
blobFromImagesWithParams_4ch.*
```

All 7 focused tests passed.