### PR TITLE
calib: fix fisheye::calibrate failing on Nx1 point arrays

### DIFF
--- a/modules/calib/src/fisheye.cpp
+++ b/modules/calib/src/fisheye.cpp
@@ -831,7 +831,7 @@ void cv::internal::ComputeJacobians(InputArrayOfArrays objectPoints, InputArrayO
         objectPoints.getMat(image_idx).convertTo(object, CV_64FC3);
         imagePoints.getMat (image_idx).convertTo(image, CV_64FC2);
 
-        bool imT = image.channels() == 1 && image.rows > image.cols;
+        bool imT = image.rows > image.cols;
         Mat om(omc.getMat().col(image_idx)), T(Tc.getMat().col(image_idx));
 
         std::vector<Point2d> x;
@@ -897,7 +897,7 @@ void cv::internal::EstimateUncertainties(InputArrayOfArrays objectPoints, InputA
         objectPoints.getMat(image_idx).convertTo(object, CV_64FC3);
         imagePoints.getMat (image_idx).convertTo(image, CV_64FC2);
 
-        bool imT = image.channels() == 1 && image.rows > image.cols;
+        bool imT = image.rows > image.cols;
 
         Mat om(omc.getMat().col(image_idx)), T(Tc.getMat().col(image_idx));
 

--- a/modules/calib/test/test_fisheye.cpp
+++ b/modules/calib/test/test_fisheye.cpp
@@ -483,15 +483,15 @@ TEST_F(fisheyeTest, CalibrationWithColumnPoints)
         for (int j = 0; j < boardSize.width; j++)
             corners.push_back(cv::Point3f(j * squareSize, i * squareSize, 0));
 
-    cv::Matx33d K(600, 0, 320,
-                  0, 600, 240,
-                  0, 0, 1);
-    cv::Vec4d D(0.01, -0.005, 0.001, 0.0001);
+    cv::Matx33d theK(600, 0, 320,
+                     0, 600, 240,
+                     0, 0, 1);
+    cv::Vec4d theD(0.01, -0.005, 0.001, 0.0001);
     cv::Vec3d rvec(0.1, 0.2, 0.05);
     cv::Vec3d tvec(0, 0, 500);
 
     std::vector<cv::Point2f> imgPoints;
-    cv::fisheye::projectPoints(corners, imgPoints, rvec, tvec, K, D);
+    cv::fisheye::projectPoints(corners, imgPoints, rvec, tvec, theK, theD);
 
     const int n = (int)corners.size();
 

--- a/modules/calib/test/test_fisheye.cpp
+++ b/modules/calib/test/test_fisheye.cpp
@@ -471,6 +471,57 @@ TEST_F(fisheyeTest, CalibrationWithDifferentPointsNumber)
         cv::noArray(), cv::noArray(), flag, cv::TermCriteria(3, 20, 1e-6));
 }
 
+TEST_F(fisheyeTest, CalibrationWithColumnPoints)
+{
+    // regression test for https://github.com/opencv/opencv/issues/29692
+    // objectPoints/imagePoints given as Nx1 (column) arrays must calibrate
+    // to the same result as the 1xN (row) representation.
+    cv::Size boardSize(9, 6);
+    const float squareSize = 25.f;
+    std::vector<cv::Point3f> corners;
+    for (int i = 0; i < boardSize.height; i++)
+        for (int j = 0; j < boardSize.width; j++)
+            corners.push_back(cv::Point3f(j * squareSize, i * squareSize, 0));
+
+    cv::Matx33d K(600, 0, 320,
+                  0, 600, 240,
+                  0, 0, 1);
+    cv::Vec4d D(0.01, -0.005, 0.001, 0.0001);
+    cv::Vec3d rvec(0.1, 0.2, 0.05);
+    cv::Vec3d tvec(0, 0, 500);
+
+    std::vector<cv::Point2f> imgPoints;
+    cv::fisheye::projectPoints(corners, imgPoints, rvec, tvec, K, D);
+
+    const int n = (int)corners.size();
+
+    cv::Mat objRow(1, n, CV_32FC3), imgRow(1, n, CV_32FC2);
+    cv::Mat objCol(n, 1, CV_32FC3), imgCol(n, 1, CV_32FC2);
+    for (int i = 0; i < n; i++)
+    {
+        cv::Vec3f obj(corners[i].x, corners[i].y, corners[i].z);
+        cv::Vec2f img(imgPoints[i].x, imgPoints[i].y);
+        objRow.at<cv::Vec3f>(0, i) = obj;
+        imgRow.at<cv::Vec2f>(0, i) = img;
+        objCol.at<cv::Vec3f>(i, 0) = obj;
+        imgCol.at<cv::Vec2f>(i, 0) = img;
+    }
+
+    cv::TermCriteria criteria(cv::TermCriteria::COUNT + cv::TermCriteria::EPS, 20, 1e-6);
+
+    cv::Mat Krow, Drow;
+    double rmsRow = cv::fisheye::calibrate(std::vector<cv::Mat>{objRow}, std::vector<cv::Mat>{imgRow},
+        cv::Size(640, 480), Krow, Drow, cv::noArray(), cv::noArray(), 0, criteria);
+
+    cv::Mat Kcol, Dcol;
+    double rmsCol = cv::fisheye::calibrate(std::vector<cv::Mat>{objCol}, std::vector<cv::Mat>{imgCol},
+        cv::Size(640, 480), Kcol, Dcol, cv::noArray(), cv::noArray(), 0, criteria);
+
+    EXPECT_MAT_NEAR(Krow, Kcol, 1e-6);
+    EXPECT_MAT_NEAR(Drow, Dcol, 1e-6);
+    EXPECT_NEAR(rmsRow, rmsCol, 1e-6);
+}
+
 
 TEST_F(fisheyeTest, stereoCalibrateWithPerViewTransformations)
 {


### PR DESCRIPTION
Fixes #29692

`ComputeJacobians` and `EstimateUncertainties` in `modules/calib/src/fisheye.cpp` decided whether to transpose the image points array using:

```cpp
bool imT = image.channels() == 1 && image.rows > image.cols;
```

`image` here is always 2-channel (`CV_64FC2`), so `image.channels() == 1` is never true and the transpose never happens. As a result, calibration only works when points are passed as `1xN` arrays; passing them as `Nx1` (a common shape, e.g. output of `cv::Mat(vector<Point2f>)` reshaped, or numpy `(N,1,C)` arrays from Python) leaves the row/column shapes mismatched between the image points and the projected points, which corrupts the least-squares solve and throws a size-mismatch assertion.

Fix: drop the bogus `channels() == 1` check, matching the transpose logic already used correctly in `CalibrateExtrinsics` a few lines above.

Added a regression test (`fisheyeTest.CalibrationWithColumnPoints`) that calibrates the same synthetic points passed as both `1xN` and `Nx1` arrays and checks the results match. Verified it fails with the old code and passes with the fix.