### PR TITLE
Fix silent loss of high-channel NumPy dimensions (4.x)

### DIFF
--- a/modules/python/src2/cv2_convert.cpp
+++ b/modules/python/src2/cv2_convert.cpp
@@ -173,7 +173,7 @@ bool pyopencv_to(PyObject* o, Mat& m, const ArgInfo& info)
 
     CV_LOG_DEBUG(NULL, "Incoming ndarray '" << info.name << "': ndims=" << ndims << "  _sizes=" << pycv_dumpArray(_sizes, ndims) << "  _strides=" << pycv_dumpArray(_strides, ndims));
 
-    bool ismultichannel = ndims == 3 && _sizes[2] <= CV_CN_MAX && !info.nd_mat;
+    bool ismultichannel = ndims == 3 && !info.nd_mat;
     if (pyopencv_Mat_TypePtr && PyObject_TypeCheck(o, pyopencv_Mat_TypePtr))
     {
         bool wrapChannels = false;

--- a/modules/python/test/test_mat.py
+++ b/modules/python/test/test_mat.py
@@ -89,6 +89,19 @@ try:
                 print(res1)
 
 
+        def test_ndarray_channel_limit_is_reported(self):
+            map_x, map_y = np.meshgrid(
+                np.arange(8, dtype=np.float32),
+                np.arange(8, dtype=np.float32),
+            )
+            data = np.broadcast_to(
+                np.arange(513, dtype=np.uint8),
+                (8, 8, 513),
+            ).copy()
+
+            with self.assertRaisesRegex(cv.error, "unable to wrap channels"):
+                cv.remap(data, map_x, map_y, cv.INTER_NEAREST)
+
         def test_mat_wrap_channels_zero(self):
             # Passing a 0-channel array must raise cv.error, not segfault.
             data = np.zeros((100, 100, 0), dtype=np.uint8)


### PR DESCRIPTION
Backport of #29686 for the 4.x branch, where CV_CN_MAX is 512.\n\nThis ensures 3-D NumPy arrays with an invalid channel count go through channel validation and raise an OpenCV error rather than silently being interpreted as an N-D single-channel matrix.\n\nIncludes a regression test with 513 channels.