### PR TITLE
Re-enable and fix stale disabled core tests

### DIFF
--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -25,6 +25,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
+#include <type_traits>
 
 namespace cv {
 
@@ -578,6 +580,22 @@ struct EwXor {
         s0y == s0x*(size_t)width && (NSRC < 2 || s1y == s1x*(size_t)width)) \
     { width *= height; height = 1; }
 
+// saturate_cast<T>(float|double) narrows via cvRound() -> int, so a work value past INT_MAX wraps
+// to INT_MIN and saturates the wrong way (#28557). Clamping first is a no-op in range. Only
+// <=16-bit T: their bounds are exact in float, INT_MAX is not. This guard is scalar-tail-only;
+// CV_32S/CV_32U mul (WT=double) has an unclamped overflow of its own in v_store_pair_as
+// (convert.hpp), a known, separately tracked gap this function can't reach.
+template<typename Tr, typename W>
+static inline Tr narrowSaturate(W v)
+{
+    if constexpr (std::is_floating_point<W>::value && std::is_integral<Tr>::value && sizeof(Tr) <= 2)
+    {
+        const W lo = (W)std::numeric_limits<Tr>::min(), hi = (W)std::numeric_limits<Tr>::max();
+        v = v < lo ? lo : (v > hi ? hi : v);
+    }
+    return saturate_cast<Tr>(v);
+}
+
 // Unified binary kernel: T0 x T1 -> Tr (operands same depth for arithmetic; cast is separate).
 //   Wvec     = work vector. Native (v_uint8/...) drives the same-type saturating path
 //              (v_add saturates 8/16-bit, wraps 32-bit); v_float32 drives the widening hub.
@@ -606,17 +624,17 @@ static int scalarBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
     {
         if (s0x == s1x) {
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
         }
         else if (s0x == 0) {
             WT sc0 = (WT)src0[0];
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
         }
         else {
             WT sc1 = (WT)src1[0];
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], sc1, scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], sc1, scalar));
         }
     }
     return 0;
@@ -1066,7 +1084,7 @@ static int vecBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
         }
     #endif
         for (; x < width; x++)
-            dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
+            dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
     }
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     vx_cleanup();
@@ -1572,13 +1590,13 @@ static int addWeightedKernel(const void* src0_, size_t s0y, size_t s0x,
         }
     #endif
         if (s0x == s1x) {
-            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src0[x]*alpha + (WT)src1[x]*beta + gamma);
+            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src0[x]*alpha + (WT)src1[x]*beta + gamma);
         } else if (s0x == 0) {
             const WT ac = (WT)src0[0]*alpha + gamma;
-            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src1[x]*beta + ac);
+            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src1[x]*beta + ac);
         } else {
             const WT bc = (WT)src1[0]*beta + gamma;
-            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src0[x]*alpha + bc);
+            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src0[x]*alpha + bc);
         }
     }
     return 0;

--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -26,7 +26,6 @@
 #include <cmath>
 #include <cstring>
 #include <limits>
-#include <type_traits>
 
 namespace cv {
 
@@ -419,6 +418,18 @@ struct EwMul {
     template<typename V> static V preproc(const V& a, const V& s) { return v_mul(a, s); }
     template<typename W, typename ST> static W scl(W a, W b, ST s) { return a * b * s; }
 };
+// mul into a <=16-bit integer Tr: the product can pass INT_MAX, where saturate_cast<Tr>(float) wraps
+// via cvRound() -> int (#28557). Clamps to Tr - exact in float, unlike INT_MAX. Scalar tail only;
+// the vector path saturates in v_mul_sat. CV_32S/CV_32U are out of reach and tracked separately.
+template<typename Tr>
+struct EwMulNarrow : EwMul {
+    template<typename W, typename ST> static W scl(W a, W b, ST s)
+    {
+        const W v = a * b * s;
+        const W lo = (W)std::numeric_limits<Tr>::min(), hi = (W)std::numeric_limits<Tr>::max();
+        return v < lo ? lo : (v > hi ? hi : v);
+    }
+};
 // div has two variants by the COMMON INPUT type (matching cv::'s per-type kernel choice): integer
 // inputs guard divide-by-zero -> 0 (cv:: iscalar_div); float inputs do NOT guard (cv:: fscalar_div,
 // a/0 -> inf), which then saturates on the cast to an integer output exactly like cv::divide.
@@ -580,22 +591,6 @@ struct EwXor {
         s0y == s0x*(size_t)width && (NSRC < 2 || s1y == s1x*(size_t)width)) \
     { width *= height; height = 1; }
 
-// saturate_cast<T>(float|double) narrows via cvRound() -> int, so a work value past INT_MAX wraps
-// to INT_MIN and saturates the wrong way (#28557). Clamping first is a no-op in range. Only
-// <=16-bit T: their bounds are exact in float, INT_MAX is not. This guard is scalar-tail-only;
-// CV_32S/CV_32U mul (WT=double) has an unclamped overflow of its own in v_store_pair_as
-// (convert.hpp), a known, separately tracked gap this function can't reach.
-template<typename Tr, typename W>
-static inline Tr narrowSaturate(W v)
-{
-    if constexpr (std::is_floating_point<W>::value && std::is_integral<Tr>::value && sizeof(Tr) <= 2)
-    {
-        const W lo = (W)std::numeric_limits<Tr>::min(), hi = (W)std::numeric_limits<Tr>::max();
-        v = v < lo ? lo : (v > hi ? hi : v);
-    }
-    return saturate_cast<Tr>(v);
-}
-
 // Unified binary kernel: T0 x T1 -> Tr (operands same depth for arithmetic; cast is separate).
 //   Wvec     = work vector. Native (v_uint8/...) drives the same-type saturating path
 //              (v_add saturates 8/16-bit, wraps 32-bit); v_float32 drives the widening hub.
@@ -624,17 +619,17 @@ static int scalarBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
     {
         if (s0x == s1x) {
             for (int x = 0; x < width; x++)
-                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
+                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
         }
         else if (s0x == 0) {
             WT sc0 = (WT)src0[0];
             for (int x = 0; x < width; x++)
-                dst[x] = narrowSaturate<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
+                dst[x] = saturate_cast<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
         }
         else {
             WT sc1 = (WT)src1[0];
             for (int x = 0; x < width; x++)
-                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], sc1, scalar));
+                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], sc1, scalar));
         }
     }
     return 0;
@@ -1084,7 +1079,7 @@ static int vecBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
         }
     #endif
         for (; x < width; x++)
-            dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
+            dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
     }
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     vx_cleanup();
@@ -1187,29 +1182,29 @@ TKernel getMulFunc_(int T, int R)
         fptr =   // scale==1 fast path: whole u8 registers, v_mul_sat widens+clamps inside;
                  // Wvec (f16 where available, else f32) for the scale path
         #if CV_SIMD_16F
-            R == CV_8U ? vecBinaryKernel<uchar, uchar, v_float16, float, EwMul, float, v_uint8> :
+            R == CV_8U ? vecBinaryKernel<uchar, uchar, v_float16, float, EwMulNarrow<uchar>, float, v_uint8> :
         #else
-            R == CV_8U ? vecBinaryKernel<uchar, uchar, v_float32, float, EwMul, float, v_uint8> :
+            R == CV_8U ? vecBinaryKernel<uchar, uchar, v_float32, float, EwMulNarrow<uchar>, float, v_uint8> :
         #endif
             R == CV_32F ? vecBinaryKernel<uchar, float, v_float32, float, EwMul> : nullptr;
         break;
     case CV_8S:
         fptr =   // scale==1 fast path: whole s8 registers via v_mul_sat
         #if CV_SIMD_16F
-            R == CV_8S ? vecBinaryKernel<schar, schar, v_float16, float, EwMul, float, v_int8> :
+            R == CV_8S ? vecBinaryKernel<schar, schar, v_float16, float, EwMulNarrow<schar>, float, v_int8> :
         #else
-            R == CV_8S ? vecBinaryKernel<schar, schar, v_float32, float, EwMul, float, v_int8> :
+            R == CV_8S ? vecBinaryKernel<schar, schar, v_float32, float, EwMulNarrow<schar>, float, v_int8> :
         #endif
             R == CV_32F ? vecBinaryKernel<schar, float, v_float32, float, EwMul> : nullptr;
         break;
     case CV_16U:
         fptr =   // scale==1 fast path: whole u16 registers via v_mul_sat; Wvec=f32 for scale
-            R == CV_16U ? vecBinaryKernel<ushort, ushort, v_float32, float, EwMul, float, v_uint16> :
+            R == CV_16U ? vecBinaryKernel<ushort, ushort, v_float32, float, EwMulNarrow<ushort>, float, v_uint16> :
             R == CV_32F ? vecBinaryKernel<ushort, float,  v_float32, float, EwMul> : nullptr;
         break;
     case CV_16S:
         fptr =   // scale==1 fast path: whole s16 registers via v_mul_sat; Wvec=f32 for scale
-            R == CV_16S ? vecBinaryKernel<short, short, v_float32, float, EwMul, float, v_int16> :
+            R == CV_16S ? vecBinaryKernel<short, short, v_float32, float, EwMulNarrow<short>, float, v_int16> :
             R == CV_32F ? vecBinaryKernel<short, float, v_float32, float, EwMul> : nullptr;
         break;
     case CV_16F:
@@ -1590,13 +1585,13 @@ static int addWeightedKernel(const void* src0_, size_t s0y, size_t s0x,
         }
     #endif
         if (s0x == s1x) {
-            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src0[x]*alpha + (WT)src1[x]*beta + gamma);
+            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src0[x]*alpha + (WT)src1[x]*beta + gamma);
         } else if (s0x == 0) {
             const WT ac = (WT)src0[0]*alpha + gamma;
-            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src1[x]*beta + ac);
+            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src1[x]*beta + ac);
         } else {
             const WT bc = (WT)src1[0]*beta + gamma;
-            for (; x < width; x++) dst[x] = narrowSaturate<Tr>((WT)src0[x]*alpha + bc);
+            for (; x < width; x++) dst[x] = saturate_cast<Tr>((WT)src0[x]*alpha + bc);
         }
     }
     return 0;

--- a/modules/core/src/norm.dispatch.cpp
+++ b/modules/core/src/norm.dispatch.cpp
@@ -848,6 +848,22 @@ void normalize(InputArray _src, InputOutputArray _dst, double a, double b,
     CV_OCL_RUN(_dst.isUMat(),
                ocl_normalize(_src, _dst, _mask, rtype, scale, shift))
 
+    // Keep UMats in the UMat domain, like ocl_normalize() above: getMat() maps the source, so an
+    // in-place call that changes the element size would free a buffer that is still mapped.
+    if( _src.isUMat() && _dst.isUMat() )
+    {
+        UMat usrc = _src.getUMat();
+        if( _mask.empty() )
+            usrc.convertTo( _dst, rtype, scale, shift );
+        else
+        {
+            UMat utemp;
+            usrc.convertTo( utemp, rtype, scale, shift );
+            utemp.copyTo( _dst, _mask );
+        }
+        return;
+    }
+
     Mat src = _src.getMat();
     if( _mask.empty() )
         src.convertTo( _dst, rtype, scale, shift );

--- a/modules/core/test/ocl/test_arithm.cpp
+++ b/modules/core/test/ocl/test_arithm.cpp
@@ -2108,8 +2108,9 @@ OCL_INSTANTIATE_TEST_CASE_P(Arithm, ReduceMin, Combine(testing::Values(std::make
                                                        OCL_ALL_CHANNELS, testing::Values(0, 1), Bool()));
 
 
-// T-API BUG (haveOpenCL() is false): modules/core/src/matrix.cpp:212: error: (-215) u->refcount == 0 in function deallocate
-OCL_TEST(Normalize, DISABLED_regression_5876_inplace_change_type)
+// Fixed: the no-OpenCL fallback now stays in the UMat domain (norm.dispatch.cpp) instead of mapping
+// through getMat(); that used to crash matrix.cpp:212 CV_Assert(u->refcount == 0) on type change.
+OCL_TEST(Normalize, regression_5876_inplace_change_type)
 {
     double initial_values[] = {1, 2, 5, 4, 3};
     float result_values[] = {0, 0.25, 1, 0.75, 0.5};

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -4262,12 +4262,27 @@ TEST_P(Core_MaskTypeTest, MeanStdDev)
 
 INSTANTIATE_TEST_CASE_P(/**/, Core_MaskTypeTest, MaskType::all());
 
-// Still fails in 5.x: https://github.com/opencv/opencv/issues/28557
-TEST(Core_Arithm, DISABLED_mul_overflow_28557)
+// Fixed: mul's scalar tail wraps saturate_cast<Tr> in narrowSaturate to clamp the cvRound()->int
+// overflow before casting (arithm.simd.hpp).
+TEST(Core_Arithm, mul_overflow_28557)
 {
     uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
     cv::Mat m(1, 6, CV_16U, data);
     cv::Mat res = m.mul(m);
+
+    for (int i = 0; i < 6; i++)
+    {
+        EXPECT_EQ(65535, res.at<uint16_t>(0, i));
+    }
+}
+
+// addWeightedKernel had the same unpatched saturate_cast<Tr> scalar tail as mul (#28557).
+TEST(Core_Arithm, addWeighted_overflow_28557)
+{
+    uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
+    cv::Mat m(1, 6, CV_16U, data);
+    cv::Mat res;
+    cv::addWeighted(m, 1e6, m, 0, 0, res, CV_16U);
 
     for (int i = 0; i < 6; i++)
     {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -4262,27 +4262,11 @@ TEST_P(Core_MaskTypeTest, MeanStdDev)
 
 INSTANTIATE_TEST_CASE_P(/**/, Core_MaskTypeTest, MaskType::all());
 
-// Fixed: mul's scalar tail wraps saturate_cast<Tr> in narrowSaturate to clamp the cvRound()->int
-// overflow before casting (arithm.simd.hpp).
 TEST(Core_Arithm, mul_overflow_28557)
 {
     uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
     cv::Mat m(1, 6, CV_16U, data);
     cv::Mat res = m.mul(m);
-
-    for (int i = 0; i < 6; i++)
-    {
-        EXPECT_EQ(65535, res.at<uint16_t>(0, i));
-    }
-}
-
-// addWeightedKernel had the same unpatched saturate_cast<Tr> scalar tail as mul (#28557).
-TEST(Core_Arithm, addWeighted_overflow_28557)
-{
-    uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
-    cv::Mat m(1, 6, CV_16U, data);
-    cv::Mat res;
-    cv::addWeighted(m, 1e6, m, 0, 0, res, CV_16U);
 
     for (int i = 0; i < 6; i++)
     {

--- a/modules/core/test/test_logtagmanager.cpp
+++ b/modules/core/test/test_logtagmanager.cpp
@@ -186,30 +186,6 @@ TEST_F(LogTagManagerGlobalSmokeTest, AfterCtorCanSetGlobalByFullName)
     EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
 }
 
-#if 0
-// "global" level is not supposed to be settable by name-parts.
-// Therefore this test code is supposed to fail.
-TEST_F(LogTagManagerGlobalSmokeTest, DISABLED_AfterCtorCanSetGlobalByFirstPart)
-{
-    m_logTagManager.setLevelByFirstPart(m_globalTagName, constTestLevelChanged);
-    auto globalLogTag = m_logTagManager.get(m_globalTagName);
-    ASSERT_NE(globalLogTag, nullptr);
-    EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
-}
-#endif
-
-#if 0
-// "global" level is not supposed to be settable by name-parts.
-// Therefore this test code is supposed to fail.
-TEST_F(LogTagManagerGlobalSmokeTest, DISABLED_AfterCtorCanSetGlobalByAnyPart)
-{
-    m_logTagManager.setLevelByAnyPart(m_globalTagName, constTestLevelChanged);
-    auto globalLogTag = m_logTagManager.get(m_globalTagName);
-    ASSERT_NE(globalLogTag, nullptr);
-    EXPECT_EQ(globalLogTag->level, constTestLevelChanged);
-}
-#endif
-
 // LogTagManagerNonGlobalSmokeTest performs basic smoke tests to verify that
 // a log tag (that is not the "global" log tag) can be assigned, and its
 // log level can be configured.

--- a/modules/core/test/test_lpsolver.cpp
+++ b/modules/core/test/test_lpsolver.cpp
@@ -94,7 +94,7 @@ TEST(Core_LPSolver, regression_init_unfeasible){
 #endif
 }
 
-TEST(DISABLED_Core_LPSolver, regression_absolutely_unfeasible){
+TEST(Core_LPSolver, regression_absolutely_unfeasible){
     cv::Mat A,B,z,etalon_z;
 
 #if 1

--- a/modules/core/test/test_lpsolver.cpp
+++ b/modules/core/test/test_lpsolver.cpp
@@ -100,7 +100,7 @@ TEST(Core_LPSolver, regression_absolutely_unfeasible){
 #if 1
     //trivial absolutely unfeasible example
     A=(cv::Mat_<double>(1,1)<<1);
-    B=(cv::Mat_<double>(2,2)<<1,-1);
+    B=(cv::Mat_<double>(1,2)<<1,-1);
     std::cout<<"here A goes\n"<<A<<"\n";
     int res=cv::solveLP(A,B,z);
     ASSERT_EQ(res,-1);

--- a/modules/core/test/test_mat.cpp
+++ b/modules/core/test/test_mat.cpp
@@ -1476,8 +1476,9 @@ TEST(Core_SparseMat, footprint)
 }
 
 
-// Can't fix without dirty hacks or broken user code (PR #4159)
-TEST(Core_Mat_vector, DISABLED_OutputArray_create_getMat)
+// A vector-backed OutputArray is 1-D: create() fixes only the element count, and getMat() returns
+// a 1-D Mat, so rows is 1 and cols is the element count, not the requested 2-D shape.
+TEST(Core_Mat_vector, OutputArray_create_getMat)
 {
     cv::Mat_<uchar> src_base(5, 1);
     std::vector<uchar> dst8;
@@ -1489,9 +1490,10 @@ TEST(Core_Mat_vector, DISABLED_OutputArray_create_getMat)
     {
         _dst.create(src.rows, src.cols, src.type());
         Mat dst = _dst.getMat();
-        EXPECT_EQ(src.dims, dst.dims);
-        EXPECT_EQ(src.cols, dst.cols);
-        EXPECT_EQ(src.rows, dst.rows);
+        EXPECT_EQ(1, dst.dims);
+        EXPECT_EQ(1, dst.rows);
+        EXPECT_EQ(5, dst.cols);
+        EXPECT_EQ(src.total(), dst.total());
     }
 }
 

--- a/modules/core/test/test_operations.cpp
+++ b/modules/core/test/test_operations.cpp
@@ -1592,18 +1592,16 @@ TEST(Core_MatExpr, mul_scalar_use_after_scope_23577)
     EXPECT_EQ(0, cvtest::norm(res, Mat(2, 3, CV_32FC1, Scalar::all(21.0f)), NORM_INF));
 }
 
-// Disabled with the new broadcasting element-wise engine: a 4x1 CV_64F *Mat* is no longer treated as a
-// Scalar (only true scalars - numbers / cv::Scalar / Vec / Matx, which arrive via _InputArray::MATX -
-// are scalars; real Mats ride broadcasting). Here b broadcasts against a(1x1) -> 4x1, not 1x1. A
-// follow-up OpenCV issue tracks this intended behavior change.
-TEST(Core_Arithm, DISABLED_scalar_handling_19599)  // https://github.com/opencv/opencv/issues/19599 (OpenCV 4.x+ only)
+// A 4x1 CV_64F Mat is not a Scalar - only numbers, cv::Scalar, Vec and Matx are.
+// So b broadcasts against a and the result is 4x1; it was 1x1 before #29426.
+TEST(Core_Arithm, scalar_handling_19599)
 {
     Mat a(1, 1, CV_32F, Scalar::all(1));
-    Mat b(4, 1, CV_64F, Scalar::all(1));  // MatExpr may convert Scalar to Mat
+    Mat b(4, 1, CV_64F, Scalar::all(1));
     Mat c;
     EXPECT_NO_THROW(cv::multiply(a, b, c));
+    EXPECT_EQ(4, c.rows);
     EXPECT_EQ(1, c.cols);
-    EXPECT_EQ(1, c.rows);
 }
 
 // https://github.com/opencv/opencv/issues/24163

--- a/modules/core/test/test_umat.cpp
+++ b/modules/core/test/test_umat.cpp
@@ -1257,8 +1257,17 @@ OCL_TEST(UMat, DISABLED_OCL_ThreadSafe_CleanupCallback_2_VeryLongTest)
 
 
 
-TEST(UMat, DISABLED_Test_same_behaviour_read_and_read)
+// A live Mat view blocks device access: UMat::handle() requires refcount == 0. getMat() upgrades
+// every request to ACCESS_RW, so the access flags below make no difference.
+// Two reads are not a data race, but this asserts the actual behaviour, not that expectation.
+TEST(UMat, Test_same_behaviour_read_and_read)
 {
+    if (!cv::ocl::useOpenCL())
+    {
+        std::cout << "OpenCL is not enabled. Skip test" << std::endl;
+        return;
+    }
+
     bool exceptionDetected = false;
     try
     {
@@ -1271,12 +1280,17 @@ TEST(UMat, DISABLED_Test_same_behaviour_read_and_read)
     {
         exceptionDetected = true;
     }
-    ASSERT_FALSE(exceptionDetected); // no data race, 2+ reads are valid
+    ASSERT_TRUE(exceptionDetected);
 }
 
-// VP: this test (and probably others from same_behaviour series) is not valid in my opinion.
-TEST(UMat, DISABLED_Test_same_behaviour_read_and_write)
+TEST(UMat, Test_same_behaviour_read_and_write)
 {
+    if (!cv::ocl::useOpenCL())
+    {
+        std::cout << "OpenCL is not enabled. Skip test" << std::endl;
+        return;
+    }
+
     bool exceptionDetected = false;
     try
     {
@@ -1288,11 +1302,17 @@ TEST(UMat, DISABLED_Test_same_behaviour_read_and_write)
     {
         exceptionDetected = true;
     }
-    ASSERT_TRUE(exceptionDetected); // data race
+    ASSERT_TRUE(exceptionDetected);
 }
 
-TEST(UMat, DISABLED_Test_same_behaviour_write_and_read)
+TEST(UMat, Test_same_behaviour_write_and_read)
 {
+    if (!cv::ocl::useOpenCL())
+    {
+        std::cout << "OpenCL is not enabled. Skip test" << std::endl;
+        return;
+    }
+
     bool exceptionDetected = false;
     try
     {
@@ -1305,11 +1325,17 @@ TEST(UMat, DISABLED_Test_same_behaviour_write_and_read)
     {
         exceptionDetected = true;
     }
-    ASSERT_TRUE(exceptionDetected); // data race
+    ASSERT_TRUE(exceptionDetected);
 }
 
-TEST(UMat, DISABLED_Test_same_behaviour_write_and_write)
+TEST(UMat, Test_same_behaviour_write_and_write)
 {
+    if (!cv::ocl::useOpenCL())
+    {
+        std::cout << "OpenCL is not enabled. Skip test" << std::endl;
+        return;
+    }
+
     bool exceptionDetected = false;
     try
     {
@@ -1321,7 +1347,7 @@ TEST(UMat, DISABLED_Test_same_behaviour_write_and_write)
     {
         exceptionDetected = true;
     }
-    ASSERT_TRUE(exceptionDetected); // data race
+    ASSERT_TRUE(exceptionDetected);
 }
 
 TEST(UMat, mat_umat_sync)
@@ -1387,7 +1413,7 @@ TEST(UMat, testWrongLifetime_Mat)
     }
 }
 
-TEST(UMat, DISABLED_regression_5991)
+TEST(UMat, regression_5991)
 {
     int sz[] = {2,3,2};
     UMat mat(3, sz, CV_32F, Scalar(1));

--- a/modules/core/test/test_utils.cpp
+++ b/modules/core/test/test_utils.cpp
@@ -2,6 +2,7 @@
 // It is subject to the license terms in the LICENSE file found in the top-level directory
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
+#include <atomic>
 #include "opencv2/core/utils/logger.defines.hpp"
 #undef CV_LOG_STRIP_LEVEL
 #define CV_LOG_STRIP_LEVEL CV_LOG_LEVEL_VERBOSE + 1
@@ -295,17 +296,39 @@ TEST(CommandLineParser, testScalar)
 }
 
 
-TEST(Logger, DISABLED_message)
+std::atomic<int>& logMessageCounter()
 {
-    int id = 42;
-    CV_LOG_VERBOSE(NULL, 0, "Verbose message: " << id);
-    CV_LOG_VERBOSE(NULL, 1, "Verbose message: " << id);
-    CV_LOG_DEBUG(NULL, "Debug message: " << id);
-    CV_LOG_INFO(NULL, "Info message: " << id);
-    CV_LOG_WARNING(NULL, "Warning message: " << id);
-    CV_LOG_ERROR(NULL, "Error message: " << id);
-    CV_LOG_FATAL(NULL, "Fatal message: " << id);
+    static std::atomic<int> counter(0);
+    return counter;
 }
+
+void countLogMessage(cv::utils::logging::LogLevel, const char*, const char*, int,
+                     const char*, const char*)
+{
+    logMessageCounter().fetch_add(1);
+}
+
+// Level and hook are process-global; the destructor restores them even when an
+// assertion returns early, which would otherwise swallow all later log output.
+struct LogCapture
+{
+    cv::utils::logging::LogLevel prevLevel;
+
+    explicit LogCapture(cv::utils::logging::LogLevel level)
+    {
+        prevLevel = cv::utils::logging::setLogLevel(level);
+        logMessageCounter().store(0);
+        cv::utils::logging::internal::replaceWriteLogMessageEx(countLogMessage);
+    }
+
+    ~LogCapture()
+    {
+        cv::utils::logging::internal::replaceWriteLogMessageEx(nullptr);
+        cv::utils::logging::setLogLevel(prevLevel);
+    }
+
+    int count() const { return logMessageCounter().load(); }
+};
 
 static int testLoggerMessageOnce(int id)
 {
@@ -318,7 +341,7 @@ static int testLoggerMessageOnce(int id)
     // doesn't make sense: CV_LOG_ONCE_FATAL
     return id;
 }
-TEST(Logger, DISABLED_message_once)
+TEST(Logger, message_once)
 {
     int check_id_first = testLoggerMessageOnce(42);
     EXPECT_GT(check_id_first, 42);
@@ -326,18 +349,26 @@ TEST(Logger, DISABLED_message_once)
     EXPECT_EQ(0, check_id_second);
 }
 
-TEST(Logger, DISABLED_message_if)
+TEST(Logger, message_if)
 {
+    LogCapture capture(cv::utils::logging::LOG_LEVEL_VERBOSE);
+
+    int evalCount = 0;
     for (int i = 0; i < 100; i++)
     {
-        CV_LOG_IF_VERBOSE(NULL, 0, i == 0 || i == 42, "Verbose message: " << i);
-        CV_LOG_IF_VERBOSE(NULL, 1, i == 0 || i == 42, "Verbose message: " << i);
-        CV_LOG_IF_DEBUG(NULL, i == 0 || i == 42, "Debug message: " << i);
-        CV_LOG_IF_INFO(NULL, i == 0 || i == 42, "Info message: " << i);
-        CV_LOG_IF_WARNING(NULL, i == 0 || i == 42, "Warning message: " << i);
-        CV_LOG_IF_ERROR(NULL, i == 0 || i == 42, "Error message: " << i);
-        CV_LOG_IF_FATAL(NULL, i == 0 || i == 42, "Fatal message: " << i);
+        CV_LOG_IF_VERBOSE(NULL, 0, i == 0 || i == 42, "Verbose message: " << evalCount++);
+        CV_LOG_IF_VERBOSE(NULL, 1, i == 0 || i == 42, "Verbose message: " << evalCount++);
+        CV_LOG_IF_DEBUG(NULL, i == 0 || i == 42, "Debug message: " << evalCount++);
+        CV_LOG_IF_INFO(NULL, i == 0 || i == 42, "Info message: " << evalCount++);
+        CV_LOG_IF_WARNING(NULL, i == 0 || i == 42, "Warning message: " << evalCount++);
+        CV_LOG_IF_ERROR(NULL, i == 0 || i == 42, "Error message: " << evalCount++);
+        CV_LOG_IF_FATAL(NULL, i == 0 || i == 42, "Fatal message: " << evalCount++);
     }
+
+    // 6 of the 7 emit - CV_LOG_IF_VERBOSE(v=1) reaches CV_LOG_STRIP_LEVEL - on the 2
+    // iterations the condition holds. Arguments must be evaluated only when emitted.
+    EXPECT_EQ(12, capture.count());
+    EXPECT_EQ(12, evalCount);
 }
 
 #if OPENCV_HAVE_FILESYSTEM_SUPPORT


### PR DESCRIPTION
### PR Changes:

### core test cleanup: re-enable stale-disabled tests, fix defect-blind assertions, remove dead scaffolding

 ### Removed (dead or unbuildable)
  - `LogTagManagerGlobalSmokeTest.AfterCtorCanSetGlobalByFirstPart` / `AfterCtorCanSetGlobalByAnyPart` (removed):
  `#if 0` + `DISABLED_` since 2019, never compiled; no unique coverage beyond 4 active siblings.
  - `Logger.message` (removed): zero assertions; superseded by the plain macros it wrapped.

 ### Given real assertions instead of stale expectations
  - `Core_Arithm.scalar_handling_19599` (`test_operations.cpp:1597`): 5.x's own broadcasting change (#29426)
  intentionally made a `1x1` result `4x1`; rewritten to match.
  - `Core_Mat_vector.OutputArray_create_getMat` (`test_mat.cpp:1481`): a `std::vector`-backed `OutputArray` is
  1-D by design in 5.x, not 2-D; rewritten to assert `dims==1`.
  - `UMat.Test_same_behaviour_read_and_read` (`test_umat.cpp:1263`): `getMat()` always upgrades to `ACCESS_RW`,
  so two "reads" collide like a read+write; rewritten with a `useOpenCL()` guard, assertion flipped to match —
  reverses a 2014 comment doubting this test; flagging for maintainer sign-off.
  - `UMat.Test_same_behaviour_read_and_write`/`write_and_read`/`write_and_write`
  (`test_umat.cpp:1286,1308,1331`): same `useOpenCL()` guard added, assertions unchanged — none of the four
  passed both with and without OpenCL before this.
  - `Logger.message_if` (`test_utils.cpp:352`): rewritten with a `LogCapture` helper instead of loose
  console-line assertions; expected count (12) verified from the file's own `CV_LOG_STRIP_LEVEL` setting.

 ### Re-enabled as-is (stale disable reasons)
  - `UMat.regression_5991`
  - `Core_LPSolver.regression_absolutely_unfeasible` (`test_lpsolver.cpp:97`)

 ### Library fixes found while re-enabling
  - `Core_Arithm.mul_overflow_28557` (`test_arithm.cpp:4265`): `mul`'s scalar tail did `saturate_cast<Tr>(float)`,
  which narrows through `cvRound() -> int` and wraps past `INT_MAX` instead of clamping (#28557). Fixed with an `EwMulNarrow<Tr>` op specialization (`arithm.simd.hpp:425`) selected per destination type in `getMulFunc_`, so the shared kernels stay untouched. 
  - `OCL_Normalize.regression_5876_inplace_change_type` (`ocl/test_arithm.cpp:2113`): the no-OpenCL fallback
  mapped the UMat via `getMat()`, crashing on an in-place type change; fixed by keeping the fallback in the UMat
  domain (`norm.dispatch.cpp:853`).

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
