### PR TITLE
Optimize fastGEMM1T NEON: extend 4-wide to 8-wide outer loop unrolling

### DIFF
--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -182,6 +182,57 @@ void fastGEMM1T( const float* vec, const float* weights,
     const uint32x4_t tailMaskU = vld1q_u32(tailMaskPtr);
     const float32x4_t tailMask = vreinterpretq_f32_u32(tailMaskU);
 
+    auto hsumq_f32 = [](float32x4_t x) -> float {
+        float32x2_t s2 = vadd_f32(vget_low_f32(x), vget_high_f32(x));
+        s2 = vpadd_f32(s2, s2);
+        return vget_lane_f32(s2, 0);
+    };
+
+    for ( ; i <= nvecs - 8; i += 8 )
+    {
+        const float* wptr = weights + i * wstep;
+        float32x4_t vs0 = vdupq_n_f32(0.0f), vs1 = vdupq_n_f32(0.0f);
+        float32x4_t vs2 = vdupq_n_f32(0.0f), vs3 = vdupq_n_f32(0.0f);
+        float32x4_t vs4 = vdupq_n_f32(0.0f), vs5 = vdupq_n_f32(0.0f);
+        float32x4_t vs6 = vdupq_n_f32(0.0f), vs7 = vdupq_n_f32(0.0f);
+        int k = 0;
+        for ( ; k <= vecsize - 4; k += 4, wptr += 4 )
+        {
+            float32x4_t v = vld1q_f32(vec + k);
+            vs0 = vmlaq_f32(vs0, vld1q_f32(wptr),             v);
+            vs1 = vmlaq_f32(vs1, vld1q_f32(wptr + wstep),     v);
+            vs2 = vmlaq_f32(vs2, vld1q_f32(wptr + wstep * 2), v);
+            vs3 = vmlaq_f32(vs3, vld1q_f32(wptr + wstep * 3), v);
+            vs4 = vmlaq_f32(vs4, vld1q_f32(wptr + wstep * 4), v);
+            vs5 = vmlaq_f32(vs5, vld1q_f32(wptr + wstep * 5), v);
+            vs6 = vmlaq_f32(vs6, vld1q_f32(wptr + wstep * 6), v);
+            vs7 = vmlaq_f32(vs7, vld1q_f32(wptr + wstep * 7), v);
+        }
+        if (k != vecsize)
+        {
+            k    = vecsize - 4;
+            wptr = weights + i * wstep + k;
+            float32x4_t v = vld1q_f32(vec + k);
+            v  = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(v), vreinterpretq_u32_f32(tailMask)));
+            vs0 = vmlaq_f32(vs0, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr)),             vreinterpretq_u32_f32(tailMask))), v);
+            vs1 = vmlaq_f32(vs1, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep)),     vreinterpretq_u32_f32(tailMask))), v);
+            vs2 = vmlaq_f32(vs2, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 2)), vreinterpretq_u32_f32(tailMask))), v);
+            vs3 = vmlaq_f32(vs3, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 3)), vreinterpretq_u32_f32(tailMask))), v);
+            vs4 = vmlaq_f32(vs4, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 4)), vreinterpretq_u32_f32(tailMask))), v);
+            vs5 = vmlaq_f32(vs5, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 5)), vreinterpretq_u32_f32(tailMask))), v);
+            vs6 = vmlaq_f32(vs6, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 6)), vreinterpretq_u32_f32(tailMask))), v);
+            vs7 = vmlaq_f32(vs7, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 7)), vreinterpretq_u32_f32(tailMask))), v);
+        }
+        dst[i + 0] = hsumq_f32(vs0) + bias[i + 0];
+        dst[i + 1] = hsumq_f32(vs1) + bias[i + 1];
+        dst[i + 2] = hsumq_f32(vs2) + bias[i + 2];
+        dst[i + 3] = hsumq_f32(vs3) + bias[i + 3];
+        dst[i + 4] = hsumq_f32(vs4) + bias[i + 4];
+        dst[i + 5] = hsumq_f32(vs5) + bias[i + 5];
+        dst[i + 6] = hsumq_f32(vs6) + bias[i + 6];
+        dst[i + 7] = hsumq_f32(vs7) + bias[i + 7];
+    }
+
     for ( ; i <= nvecs - 4; i += 4 )
     {
         const float* wptr = weights + i * wstep;
@@ -214,12 +265,6 @@ void fastGEMM1T( const float* vec, const float* weights,
             vs2 = vmlaq_f32(vs2, w2, v);
             vs3 = vmlaq_f32(vs3, w3, v);
         }
-
-        auto hsumq_f32 = [](float32x4_t x) -> float {
-            float32x2_t s2 = vadd_f32(vget_low_f32(x), vget_high_f32(x));
-            s2 = vpadd_f32(s2, s2);
-            return vget_lane_f32(s2, 0);
-        };
 
         dst[i + 0] = hsumq_f32(vs0) + bias[i + 0];
         dst[i + 1] = hsumq_f32(vs1) + bias[i + 1];

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -213,15 +213,25 @@ void fastGEMM1T( const float* vec, const float* weights,
             k    = vecsize - 4;
             wptr = weights + i * wstep + k;
             float32x4_t v = vld1q_f32(vec + k);
-            v  = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(v), vreinterpretq_u32_f32(tailMask)));
-            vs0 = vmlaq_f32(vs0, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr)),             vreinterpretq_u32_f32(tailMask))), v);
-            vs1 = vmlaq_f32(vs1, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep)),     vreinterpretq_u32_f32(tailMask))), v);
-            vs2 = vmlaq_f32(vs2, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 2)), vreinterpretq_u32_f32(tailMask))), v);
-            vs3 = vmlaq_f32(vs3, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 3)), vreinterpretq_u32_f32(tailMask))), v);
-            vs4 = vmlaq_f32(vs4, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 4)), vreinterpretq_u32_f32(tailMask))), v);
-            vs5 = vmlaq_f32(vs5, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 5)), vreinterpretq_u32_f32(tailMask))), v);
-            vs6 = vmlaq_f32(vs6, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 6)), vreinterpretq_u32_f32(tailMask))), v);
-            vs7 = vmlaq_f32(vs7, vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 7)), vreinterpretq_u32_f32(tailMask))), v);
+            v = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(v), tailMaskU));
+
+            float32x4_t w0 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr)), tailMaskU));
+            float32x4_t w1 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep)), tailMaskU));
+            float32x4_t w2 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 2)), tailMaskU));
+            float32x4_t w3 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 3)), tailMaskU));
+            float32x4_t w4 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 4)), tailMaskU));
+            float32x4_t w5 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 5)), tailMaskU));
+            float32x4_t w6 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 6)), tailMaskU));
+            float32x4_t w7 = vreinterpretq_f32_u32(vandq_u32(vreinterpretq_u32_f32(vld1q_f32(wptr + wstep * 7)), tailMaskU));
+
+            vs0 = vmlaq_f32(vs0, w0, v);
+            vs1 = vmlaq_f32(vs1, w1, v);
+            vs2 = vmlaq_f32(vs2, w2, v);
+            vs3 = vmlaq_f32(vs3, w3, v);
+            vs4 = vmlaq_f32(vs4, w4, v);
+            vs5 = vmlaq_f32(vs5, w5, v);
+            vs6 = vmlaq_f32(vs6, w6, v);
+            vs7 = vmlaq_f32(vs7, w7, v);
         }
         dst[i + 0] = hsumq_f32(vs0) + bias[i + 0];
         dst[i + 1] = hsumq_f32(vs1) + bias[i + 1];

--- a/modules/dnn/src/layers/layers_common.simd.hpp
+++ b/modules/dnn/src/layers/layers_common.simd.hpp
@@ -182,12 +182,6 @@ void fastGEMM1T( const float* vec, const float* weights,
     const uint32x4_t tailMaskU = vld1q_u32(tailMaskPtr);
     const float32x4_t tailMask = vreinterpretq_f32_u32(tailMaskU);
 
-    auto hsumq_f32 = [](float32x4_t x) -> float {
-        float32x2_t s2 = vadd_f32(vget_low_f32(x), vget_high_f32(x));
-        s2 = vpadd_f32(s2, s2);
-        return vget_lane_f32(s2, 0);
-    };
-
     for ( ; i <= nvecs - 8; i += 8 )
     {
         const float* wptr = weights + i * wstep;
@@ -233,14 +227,10 @@ void fastGEMM1T( const float* vec, const float* weights,
             vs6 = vmlaq_f32(vs6, w6, v);
             vs7 = vmlaq_f32(vs7, w7, v);
         }
-        dst[i + 0] = hsumq_f32(vs0) + bias[i + 0];
-        dst[i + 1] = hsumq_f32(vs1) + bias[i + 1];
-        dst[i + 2] = hsumq_f32(vs2) + bias[i + 2];
-        dst[i + 3] = hsumq_f32(vs3) + bias[i + 3];
-        dst[i + 4] = hsumq_f32(vs4) + bias[i + 4];
-        dst[i + 5] = hsumq_f32(vs5) + bias[i + 5];
-        dst[i + 6] = hsumq_f32(vs6) + bias[i + 6];
-        dst[i + 7] = hsumq_f32(vs7) + bias[i + 7];
+        v_float32x4 sum03 = v_reduce_sum4(v_float32x4(vs0), v_float32x4(vs1), v_float32x4(vs2), v_float32x4(vs3));
+        v_float32x4 sum47 = v_reduce_sum4(v_float32x4(vs4), v_float32x4(vs5), v_float32x4(vs6), v_float32x4(vs7));
+        v_store(dst + i,     v_add(sum03, v_load(bias + i)));
+        v_store(dst + i + 4, v_add(sum47, v_load(bias + i + 4)));
     }
 
     for ( ; i <= nvecs - 4; i += 4 )
@@ -276,10 +266,8 @@ void fastGEMM1T( const float* vec, const float* weights,
             vs3 = vmlaq_f32(vs3, w3, v);
         }
 
-        dst[i + 0] = hsumq_f32(vs0) + bias[i + 0];
-        dst[i + 1] = hsumq_f32(vs1) + bias[i + 1];
-        dst[i + 2] = hsumq_f32(vs2) + bias[i + 2];
-        dst[i + 3] = hsumq_f32(vs3) + bias[i + 3];
+        v_float32x4 sum03 = v_reduce_sum4(v_float32x4(vs0), v_float32x4(vs1), v_float32x4(vs2), v_float32x4(vs3));
+        v_store(dst + i, v_add(sum03, v_load(bias + i)));
     }
 
     for ( ; i < nvecs; i++ )


### PR DESCRIPTION
**PR Description:**

- This PR extends the NEON fastGEMM1T optimization by adding an 8-wide outer loop before the existing 4-wide loop. The 8-wide block processes 8 output neurons per iteration instead of 4, reducing the total number of outer loop iterations by half and sharing the vector load cost across 8 output accumulator registers instead of 4.

- On x86, the AVX2 path processes 8 floats per instruction (256-bit registers) and AVX-512 processes 16 floats per instruction (512-bit registers). On ARM, NEON is 128-bit, only 4 floats per instruction. Intel's wider registers naturally cover more outputs per inner step. This patch brings ARM NEON closer to Intel parity through wider outer loop unrolling.

**Performance results:**
<img width="1236" height="478" alt="image" src="https://github.com/user-attachments/assets/c933e64c-2200-450e-9887-3fd0cbdd5b8e" />


Notes:
- The existing 4-wide loop is retained to handle remainders when nvecs is not a multiple of 8
- No existing tests modified
- Follows the same pattern as the existing 4-wide NEON path.

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch