### PR TITLE
Disable mjpeg_pixel_format_change test on Windows as it requires FFmpeg wrapper rebuild

### DIFF
--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -1189,6 +1189,8 @@ TEST(videoio_ffmpeg, seek_with_negative_dts)
     }
 }
 
+// The test requires FFmpeg wrapper rebuild on Windows
+#ifndef _WIN32
 // MJPEG stream whose chroma subsampling changes mid-stream at constant
 // frame size must not reuse a conversion context built for the previous frame.
 // related issue: https://github.com/opencv/opencv/issues/29699
@@ -1249,5 +1251,6 @@ TEST(videoio_ffmpeg, mjpeg_pixel_format_change)
 
     remove(filename.c_str());
 }
+#endif
 
 }} // namespace


### PR DESCRIPTION
Related to https://github.com/opencv/opencv/pull/29700

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
