### PR TITLE
stitching: re-enable & triage DISABLED tests

### DIFF
--- a/modules/stitching/test/test_matchers.cpp
+++ b/modules/stitching/test/test_matchers.cpp
@@ -104,13 +104,11 @@ TEST(ParallelFeaturesFinder, IsSameWithSerial)
     {
         SCOPED_TRACE(cv::format("i=%zu", i));
         EXPECT_EQ(serial_descriptors.size(), para_features[i].descriptors.size());
-#if 0 // FIXIT ORB descriptors are not bit-exact (perhaps due internal parallel_for usage)
-        ASSERT_EQ(0, cv::norm(u_serial_descriptors, para_features[i].descriptors, NORM_L1))
-            << "serial_size=" << u_serial_descriptors.size()
+        ASSERT_EQ(0, cv::norm(serial_descriptors, para_features[i].descriptors, NORM_L1))
+            << "serial_size=" << serial_descriptors.size()
             << " par_size=" << para_features[i].descriptors.size()
-            << endl << u_serial_descriptors.getMat(ACCESS_READ)
+            << endl << serial_descriptors
             << endl << endl << para_features[i].descriptors.getMat(ACCESS_READ);
-#endif
         EXPECT_EQ(serial_features.img_size, para_features[i].img_size);
         EXPECT_EQ(serial_features.keypoints.size(), para_features[i].keypoints.size());
     }


### PR DESCRIPTION
### PR changes:

### stitching test cleanup: re-enable a stale-disabled assertion

 ### Re-enabled (stale disable reason)
  - `ParallelFeaturesFinder.IsSameWithSerial` (`test_matchers.cpp:87`): the descriptor comparison sat behind `#if
  0` with a FIXIT saying ORB descriptors are not bit-exact under `parallel_for_`. They are now, so the guard is
  removed and the assertion runs.

    The block referenced `u_serial_descriptors`, which no longer exists in that function (it is
  `serial_descriptors`, a `Mat`), so removing the guard alone does not compile. The identifier was corrected and
  `.getMat(ACCESS_READ)` dropped, that being `UMat`-only. The assertion itself, `cv::norm(..., NORM_L1) == 0`, is
  unchanged.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
