### PR TITLE
Fix compareHist HISTCMP_CORREL returning -1.0 due to catastrophic cancellation

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -2122,7 +2122,9 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
         size_t total = H1.total();
         double scale = 1./total;
         double num = s12 - s1*s2*scale;
-        double denom2 = (s11 - s1*s1*scale)*(s22 - s2*s2*scale);
+        double var1 = std::max(0., s11 - s1*s1*scale);
+        double var2 = std::max(0., s22 - s2*s2*scale);
+        double denom2 = var1*var2;
         result = std::abs(denom2) > DBL_EPSILON ? num/std::sqrt(denom2) : 1.;
     }
     else if( method == CV_COMP_BHATTACHARYYA )

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2011,22 +2011,21 @@ TEST(Imgproc_Hist_Calc, IPP_ranges_with_equal_exponent_21595)
 }
 TEST(Imgproc_Hist_Calc, self_correlation_regression_29706)
 {
-    // Regression test for #29706: HISTCMP_CORREL could return -1.0
-    // for self-comparison due to catastrophic cancellation.
-    //
-    // Triggered when bin counts are large (~1.68e7, just under 2^24 so
-    // they remain exactly representable as float) and nearly uniform
-    // (differing only by 1 between bins). The true variance is tiny
-    // relative to the magnitude of sq0 and s0*s0/N, so computing
-    // sq0 - s0*s0/N in double precision loses enough precision to go
-    // slightly negative, and sqrt() of that corrupts the result.
+// Regression test for #29706: HISTCMP_CORREL could return -1.0
+// for self-comparison due to catastrophic cancellation.
+// Triggered when bin counts are at 2^24 - 1 (the largest value where
+// base and base+1 are both exactly representable in float32) and only
+// ONE bin differs by 1. The true variance signal is tiny (~1) but the
+// sum-of-squares terms are large enough (~7.2e16) that double-precision
+// subtraction loses the signal entirely, producing a spurious negative
+// "variance" and corrupting the sqrt().
     const int histSize = 256;
     cv::Mat hist(histSize, 1, CV_32F);
 
-    const long long base = 16776954LL;
-    const long long halfBinsPerturbed = 128;
+    const long long base = 16777215LL;  // 2^24 - 1
+    const long long numBinsPerturbed = 1; // only perturb ONE bin
     for (int k = 0; k < histSize; k++)
-        hist.at<float>(k) = (float)(base + (k < halfBinsPerturbed ? 1 : 0));
+        hist.at<float>(k) = (float)(base + (k < numBinsPerturbed ? 1 : 0));
 
     double correl = cv::compareHist(hist, hist, cv::HISTCMP_CORREL);
 

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2013,21 +2013,25 @@ TEST(Imgproc_Hist_Calc, self_correlation_regression_29706)
 {
     // Regression test for #29706: HISTCMP_CORREL could return -1.0
     // for self-comparison due to catastrophic cancellation.
-    cv::Mat img(100, 100, CV_8UC1);
-    cv::randu(img, cv::Scalar(0), cv::Scalar(255));
+    //
+    // Triggered when bin counts are large (~1.68e7, just under 2^24 so
+    // they remain exactly representable as float) and nearly uniform
+    // (differing only by 1 between bins). The true variance is tiny
+    // relative to the magnitude of sq0 and s0*s0/N, so computing
+    // sq0 - s0*s0/N in double precision loses enough precision to go
+    // slightly negative, and sqrt() of that corrupts the result.
+    const int histSize = 256;
+    cv::Mat hist(histSize, 1, CV_32F);
 
-    int histSize = 256;
-    float range[] = { 0, 256 };
-    const float* histRange = { range };
-
-    cv::Mat hist;
-    cv::calcHist(&img, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
+    const long long base = 16776954LL;
+    const long long halfBinsPerturbed = 128;
+    for (int k = 0; k < histSize; k++)
+        hist.at<float>(k) = (float)(base + (k < halfBinsPerturbed ? 1 : 0));
 
     double correl = cv::compareHist(hist, hist, cv::HISTCMP_CORREL);
 
     ASSERT_NEAR(correl, 1.0, 1e-6) << "Self-comparison should be 1.0, got " << correl;
 }
-
 
 
 TEST(Imgproc_Hist_Calc, IPP_ranges_with_nonequal_exponent_21595)

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2009,6 +2009,26 @@ TEST(Imgproc_Hist_Calc, IPP_ranges_with_equal_exponent_21595)
     ASSERT_EQ(histogram_u.at<float>(0), 2.f) << "0 not counts correctly, res: " << histogram_u.at<float>(0);
     ASSERT_EQ(histogram_u.at<float>(1), 4.f) << "1 not counts correctly, res: " << histogram_u.at<float>(0);
 }
+TEST(Imgproc_Hist_Calc, self_correlation_regression_29706)
+{
+    // Regression test for #29706: HISTCMP_CORREL could return -1.0
+    // for self-comparison due to catastrophic cancellation.
+    cv::Mat img(100, 100, CV_8UC1);
+    cv::randu(img, cv::Scalar(0), cv::Scalar(255));
+
+    int histSize = 256;
+    float range[] = { 0, 256 };
+    const float* histRange = { range };
+
+    cv::Mat hist;
+    cv::calcHist(&img, 1, 0, cv::Mat(), hist, 1, &histSize, &histRange);
+
+    double correl = cv::compareHist(hist, hist, cv::HISTCMP_CORREL);
+
+    ASSERT_NEAR(correl, 1.0, 1e-6) << "Self-comparison should be 1.0, got " << correl;
+}
+
+
 
 TEST(Imgproc_Hist_Calc, IPP_ranges_with_nonequal_exponent_21595)
 {


### PR DESCRIPTION
Fixes #29706

compareHist with HISTCMP_CORREL could return -1.0 for self-comparison due to 
catastrophic cancellation when computing the variance terms 
`(s11 - s1*s1*scale and s22 - s2*s2*scale)`. Since variance can never be 
negative, this clamps both terms to 0 before multiplying, preventing 
floating-point rounding noise from flipping the sign of the result.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake