### PR TITLE
imgcodecs: add imencodeBatch/imdecodeBatch for independent buffers

### DIFF
--- a/modules/imgcodecs/include/opencv2/imgcodecs.hpp
+++ b/modules/imgcodecs/include/opencv2/imgcodecs.hpp
@@ -653,6 +653,35 @@ See cv::imreadmulti for the list of supported formats and flags description.
 */
 CV_EXPORTS_W bool imdecodemulti(InputArray buf, int flags, CV_OUT std::vector<Mat>& mats, const cv::Range& range = Range::all());
 
+/** @brief Decodes a batch of independent image buffers.
+
+Unlike cv::imdecodemulti, which reads several pages out of a *single* multi-page container, this
+function treats every element of @p bufs as a self-contained encoded image and decodes it into its
+own cv::Mat. The buffers do not have to share a format, a size or a number of channels.
+
+Each buffer is decoded exactly as a separate cv::imdecode call would decode it, so the result is
+deterministic and independent of the number of threads OpenCV is configured to use. The batch may
+be processed in parallel internally.
+
+@p images is always resized to `bufs.total()`, even when some items fail: an item that cannot be
+decoded is left empty and its index is reported through the error log, so a failure never silently
+shortens the result. Decoding an empty batch clears @p images and succeeds.
+
+@note In the case of color images, the decoded images will have the channels stored in **B G R** order.
+@note In Python an item that failed to decode is returned as `None`, which is how an empty cv::Mat
+is exposed to the bindings.
+
+@param bufs Array of buffers, one encoded image per element. A `std::vector<std::vector<uchar>>`
+can be passed directly.
+@param flags Flag that can take values of cv::ImreadModes, applied to every item of the batch.
+@param images Output vector receiving one decoded image per input buffer, in the input order.
+
+@return true if every buffer was decoded, false if at least one of them failed.
+
+@sa cv::imdecode, cv::imencodeBatch
+*/
+CV_EXPORTS_W bool imdecodeBatch(InputArrayOfArrays bufs, int flags, CV_OUT std::vector<Mat>& images);
+
 /** @brief Encodes an image into a memory buffer.
 
 The function imencode compresses the image and stores it in the memory buffer that is resized to fit the
@@ -697,6 +726,38 @@ See cv::imwrite for the list of supported formats and flags description.
 */
 CV_EXPORTS_W bool imencodemulti( const String& ext, InputArrayOfArrays imgs,
                                  CV_OUT std::vector<uchar>& buf,
+                                 const std::vector<int>& params = std::vector<int>());
+
+/** @brief Encodes a batch of images into independent memory buffers.
+
+Unlike cv::imencodemulti, which packs several pages into a *single* multi-page container, this
+function compresses every image separately and returns one independent buffer per image. This makes
+it usable with formats that have no multi-page container at all, such as JPEG, and lets a whole
+batch be compressed without a per-image call from the calling language.
+
+Every image is encoded exactly as a separate cv::imencode call with the same @p params would encode
+it, so the produced bytes are deterministic and independent of the number of threads OpenCV is
+configured to use. The batch may be processed in parallel internally.
+
+@p buffers is always resized to `images.total()`, even when some items fail: an image that cannot be
+encoded leaves its buffer empty and its index is reported through the error log, so a failure never
+silently shortens the result. Encoding an empty batch clears @p buffers and succeeds.
+
+@p params apply to the whole batch. Per-image parameters are not supported; call cv::imencode for
+the images that need different settings.
+
+@param ext File extension that defines the output format. Must include a leading period.
+@param images Images to be compressed. They may differ in size, depth and number of channels.
+@param buffers Output vector receiving one buffer per input image, in the input order. Each buffer
+is resized to fit its compressed image.
+@param params Format-specific parameters shared by the whole batch. See cv::imwrite and cv::ImwriteFlags.
+
+@return true if every image was encoded, false if at least one of them failed.
+
+@sa cv::imencode, cv::imdecodeBatch
+*/
+CV_EXPORTS_W bool imencodeBatch( const String& ext, InputArrayOfArrays images,
+                                 CV_OUT std::vector<std::vector<uchar> >& buffers,
                                  const std::vector<int>& params = std::vector<int>());
 
 /** @brief Checks if the specified image file can be decoded by OpenCV.

--- a/modules/imgcodecs/misc/python/test/test_imgcodecs_batch.py
+++ b/modules/imgcodecs/misc/python/test/test_imgcodecs_batch.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+def make_image(size, channels, seed):
+    """Gradient plus a shape, so the codecs see something more realistic than noise."""
+    h, w = size
+    gx = np.tile(np.linspace(0, 255, w, dtype=np.float32), (h, 1))
+    gy = np.tile(np.linspace(0, 255, h, dtype=np.float32).reshape(-1, 1), (1, w))
+    base = ((gx + gy) / 2).astype(np.uint8)
+
+    if channels == 1:
+        img = base
+    else:
+        img = np.dstack([base, (base.astype(np.int32) + 85) % 256, (base.astype(np.int32) + 170) % 256])
+        img = img.astype(np.uint8)
+        if channels == 4:
+            img = np.dstack([img, gx.astype(np.uint8)])
+
+    img = np.ascontiguousarray(img)
+    cv.circle(img, (w // 3 + seed % 5, h // 2), max(3, min(w, h) // 5), (0, 0, 0, 255)[:channels], -1)
+    return img
+
+
+def make_batch(count, size=(48, 64), channels=3):
+    return [make_image(size, channels, i) for i in range(count)]
+
+
+class imgcodecs_batch_test(NewOpenCVTests):
+
+    def test_issue_example_shape(self):
+        """The exact call shape requested in opencv/opencv#29587."""
+        images = make_batch(4)
+
+        ok, buffers = cv.imencodeBatch(".jpg", images, [cv.IMWRITE_JPEG_QUALITY, 90])
+        self.assertTrue(ok)
+        self.assertEqual(len(buffers), len(images))
+        for buf in buffers:
+            self.assertIsInstance(buf, np.ndarray)
+            self.assertEqual(buf.dtype, np.uint8)
+            self.assertGreater(buf.size, 0)
+
+        ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_UNCHANGED)
+        self.assertTrue(ok)
+        self.assertEqual(len(decoded), len(images))
+        for src, dst in zip(images, decoded):
+            self.assertEqual(src.shape, dst.shape)
+
+    def test_encode_matches_python_loop(self):
+        """The whole point of the feature: identical bytes, without looping in Python."""
+        for ext, params in ((".png", []), (".jpg", [cv.IMWRITE_JPEG_QUALITY, 90]),
+                            (".webp", [cv.IMWRITE_WEBP_QUALITY, 90])):
+            if not cv.haveImageWriter("test" + ext):
+                continue
+            images = make_batch(5)
+
+            ok, batched = cv.imencodeBatch(ext, images, params)
+            self.assertTrue(ok, ext)
+            self.assertEqual(len(batched), len(images), ext)
+
+            for i, img in enumerate(images):
+                ok, single = cv.imencode(ext, img, params)
+                self.assertTrue(ok, ext)
+                self.assertTrue(np.array_equal(single, batched[i]), "%s #%d" % (ext, i))
+
+    def test_png_roundtrip_is_lossless(self):
+        if not cv.haveImageWriter("test.png"):
+            return
+        images = make_batch(5)
+
+        ok, buffers = cv.imencodeBatch(".png", images, [])
+        self.assertTrue(ok)
+
+        ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_COLOR)
+        self.assertTrue(ok)
+        for i, (src, dst) in enumerate(zip(images, decoded)):
+            self.assertTrue(np.array_equal(src, dst), "#%d" % i)
+
+    def test_order_is_preserved(self):
+        if not cv.haveImageWriter("test.png"):
+            return
+        # Distinct flat colors: any reordering shows up immediately.
+        images = [np.full((16, 16, 3), v, dtype=np.uint8) for v in (10, 20, 30, 40, 50, 60, 70, 80)]
+
+        ok, buffers = cv.imencodeBatch(".png", images, [])
+        self.assertTrue(ok)
+        ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_COLOR)
+        self.assertTrue(ok)
+
+        for i, img in enumerate(images):
+            self.assertEqual(int(decoded[i][0, 0, 0]), int(img[0, 0, 0]), "#%d" % i)
+
+    def test_mixed_sizes(self):
+        if not cv.haveImageWriter("test.png"):
+            return
+        images = [make_image((5, 17), 3, 0), make_image((64, 64), 3, 1), make_image((33, 128), 3, 2)]
+
+        ok, buffers = cv.imencodeBatch(".png", images, [])
+        self.assertTrue(ok)
+        ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_COLOR)
+        self.assertTrue(ok)
+
+        for i, (src, dst) in enumerate(zip(images, decoded)):
+            self.assertEqual(src.shape, dst.shape, "#%d" % i)
+            self.assertTrue(np.array_equal(src, dst), "#%d" % i)
+
+    def test_grayscale_and_alpha(self):
+        if not cv.haveImageWriter("test.png"):
+            return
+        for channels in (1, 3, 4):
+            images = make_batch(3, channels=channels)
+
+            ok, buffers = cv.imencodeBatch(".png", images, [])
+            self.assertTrue(ok, "channels=%d" % channels)
+            ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_UNCHANGED)
+            self.assertTrue(ok, "channels=%d" % channels)
+
+            for i, (src, dst) in enumerate(zip(images, decoded)):
+                self.assertTrue(np.array_equal(src, dst), "channels=%d #%d" % (channels, i))
+
+    def test_empty_batch(self):
+        ok, buffers = cv.imencodeBatch(".png", [], [])
+        self.assertTrue(ok)
+        self.assertEqual(len(buffers), 0)
+
+        ok, decoded = cv.imdecodeBatch([], cv.IMREAD_COLOR)
+        self.assertTrue(ok)
+        self.assertEqual(len(decoded), 0)
+
+    def test_failure_keeps_batch_length(self):
+        """A bad item must be reported in place, not silently dropped."""
+        if not cv.haveImageWriter("test.png"):
+            return
+        images = make_batch(4)
+
+        ok, buffers = cv.imencodeBatch(".png", images, [])
+        self.assertTrue(ok)
+
+        buffers = list(buffers)
+        buffers[1] = np.full(64, 127, dtype=np.uint8)  # unrecognizable signature
+
+        ok, decoded = cv.imdecodeBatch(buffers, cv.IMREAD_COLOR)
+        self.assertFalse(ok)
+        self.assertEqual(len(decoded), len(images))
+        # The slot is kept so the indices still line up; an empty Mat surfaces as None in Python.
+        self.assertIsNone(decoded[1])
+        self.assertTrue(np.array_equal(images[0], decoded[0]))
+        self.assertTrue(np.array_equal(images[2], decoded[2]))
+
+    def test_unknown_extension_raises(self):
+        images = make_batch(2)
+        with self.assertRaises(cv.error):
+            cv.imencodeBatch(".notaformat", images, [])
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()

--- a/modules/imgcodecs/perf/perf_batch.cpp
+++ b/modules/imgcodecs/perf/perf_batch.cpp
@@ -1,0 +1,181 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+
+using namespace perf;
+
+// Compares cv::imencodeBatch / cv::imdecodeBatch against the sequential imencode / imdecode loop
+// they are meant to replace. Both variants of an operation take the same parameters, so the pairs
+// can be read straight off the report:
+//
+//   imencodeBatch / batch_size_16_1024x1024_jpg_q90   vs   imencodeLoop / <same suffix>
+//
+// The images are synthesized so that the benchmark does not depend on the opencv_extra data repo.
+
+static Mat makeBenchImage(Size size, int seed)
+{
+    Mat img(size, CV_8UC3);
+    RNG rng((uint64)seed * 7919 + 13);
+
+    for (int y = 0; y < img.rows; y++)
+    {
+        Vec3b* row = img.ptr<Vec3b>(y);
+        const int gy = y * 255 / std::max(1, img.rows - 1);
+        for (int x = 0; x < img.cols; x++)
+        {
+            const int gx = x * 255 / std::max(1, img.cols - 1);
+            const int v = (gx + gy) / 2;
+            row[x] = Vec3b((uchar)v, (uchar)((v + 85) % 256), (uchar)((v + 170) % 256));
+        }
+    }
+
+    // Some structure on top of the gradient, otherwise the codecs see an unrealistically easy image.
+    for (int i = 0; i < 24; i++)
+    {
+        const Point c(rng.uniform(0, img.cols), rng.uniform(0, img.rows));
+        const int r = rng.uniform(3, std::max(4, std::min(img.cols, img.rows) / 6));
+        circle(img, c, r, Scalar(rng.uniform(0, 256), rng.uniform(0, 256), rng.uniform(0, 256)), -1);
+    }
+
+    return img;
+}
+
+static std::vector<Mat> makeBenchBatch(Size size, int batch_size)
+{
+    std::vector<Mat> images;
+    for (int i = 0; i < batch_size; i++)
+        images.push_back(makeBenchImage(size, i));
+    return images;
+}
+
+static std::vector<int> qualityParams(const String& ext, int quality)
+{
+    std::vector<int> params;
+    if (ext == ".jpg")
+        params.push_back(IMWRITE_JPEG_QUALITY);
+    else if (ext == ".webp")
+        params.push_back(IMWRITE_WEBP_QUALITY);
+    else
+        return params;
+    params.push_back(quality);
+    return params;
+}
+
+// size, batch size, extension, quality
+typedef TestBaseWithParam< tuple<Size, int, String, int> > Imgcodecs_Batch;
+
+#define BATCH_PERF_PARAMS testing::Combine(                                        \
+    testing::Values(Size(256, 256), Size(512, 512), Size(1024, 1024)),             \
+    testing::Values(2, 4, 8, 16),                                                  \
+    testing::Values(String(".jpg"), String(".webp")),                              \
+    testing::Values(50, 90))
+
+static bool haveCodecFor(const String& ext)
+{
+#ifndef HAVE_JPEG
+    if (ext == ".jpg")
+        return false;
+#endif
+#ifndef HAVE_WEBP
+    if (ext == ".webp")
+        return false;
+#endif
+    return haveImageWriter("test" + ext);
+}
+
+PERF_TEST_P(Imgcodecs_Batch, imencodeBatch, BATCH_PERF_PARAMS)
+{
+    const Size size = get<0>(GetParam());
+    const int batch_size = get<1>(GetParam());
+    const String ext = get<2>(GetParam());
+    const int quality = get<3>(GetParam());
+
+    if (!haveCodecFor(ext))
+        throw SkipTestException("Codec is not available: " + ext);
+
+    const std::vector<Mat> images = makeBenchBatch(size, batch_size);
+    const std::vector<int> params = qualityParams(ext, quality);
+    std::vector<std::vector<uchar> > buffers;
+
+    TEST_CYCLE() ASSERT_TRUE(imencodeBatch(ext, images, buffers, params));
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(Imgcodecs_Batch, imencodeLoop, BATCH_PERF_PARAMS)
+{
+    const Size size = get<0>(GetParam());
+    const int batch_size = get<1>(GetParam());
+    const String ext = get<2>(GetParam());
+    const int quality = get<3>(GetParam());
+
+    if (!haveCodecFor(ext))
+        throw SkipTestException("Codec is not available: " + ext);
+
+    const std::vector<Mat> images = makeBenchBatch(size, batch_size);
+    const std::vector<int> params = qualityParams(ext, quality);
+    std::vector<std::vector<uchar> > buffers(images.size());
+
+    TEST_CYCLE()
+    {
+        for (size_t i = 0; i < images.size(); i++)
+            ASSERT_TRUE(imencode(ext, images[i], buffers[i], params));
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(Imgcodecs_Batch, imdecodeBatch, BATCH_PERF_PARAMS)
+{
+    const Size size = get<0>(GetParam());
+    const int batch_size = get<1>(GetParam());
+    const String ext = get<2>(GetParam());
+    const int quality = get<3>(GetParam());
+
+    if (!haveCodecFor(ext))
+        throw SkipTestException("Codec is not available: " + ext);
+
+    const std::vector<Mat> images = makeBenchBatch(size, batch_size);
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(ext, images, buffers, qualityParams(ext, quality)));
+
+    std::vector<Mat> decoded;
+
+    TEST_CYCLE() ASSERT_TRUE(imdecodeBatch(buffers, IMREAD_COLOR_BGR, decoded));
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST_P(Imgcodecs_Batch, imdecodeLoop, BATCH_PERF_PARAMS)
+{
+    const Size size = get<0>(GetParam());
+    const int batch_size = get<1>(GetParam());
+    const String ext = get<2>(GetParam());
+    const int quality = get<3>(GetParam());
+
+    if (!haveCodecFor(ext))
+        throw SkipTestException("Codec is not available: " + ext);
+
+    const std::vector<Mat> images = makeBenchBatch(size, batch_size);
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(ext, images, buffers, qualityParams(ext, quality)));
+
+    std::vector<Mat> decoded(buffers.size());
+
+    TEST_CYCLE()
+    {
+        for (size_t i = 0; i < buffers.size(); i++)
+        {
+            decoded[i] = imdecode(buffers[i], IMREAD_COLOR_BGR);
+            ASSERT_FALSE(decoded[i].empty());
+        }
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace

--- a/modules/imgcodecs/src/loadsave.cpp
+++ b/modules/imgcodecs/src/loadsave.cpp
@@ -1612,6 +1612,64 @@ bool imdecodemulti(InputArray _buf, int flags, CV_OUT std::vector<Mat>& mats, co
     }
 }
 
+bool imdecodeBatch( InputArrayOfArrays bufs, int flags, std::vector<Mat>& images )
+{
+    CV_TRACE_FUNCTION();
+
+    std::vector<Mat> buf_vec;
+    if (!bufs.empty())
+        bufs.getMatVector(buf_vec);
+
+    images.clear();
+    if (buf_vec.empty())
+        return true;  // an empty batch is a successful no-op
+
+    images.resize(buf_vec.size());
+
+    // uchar and not bool: std::vector<bool> is bit-packed, so concurrent writes to distinct
+    // elements would race. Pre-sized so that workers only touch elements that already exist.
+    std::vector<uchar> decoded(buf_vec.size(), 0);
+
+    // Initialize the codec registry before the workers start racing for it.
+    getCodecs();
+
+    parallel_for_(Range(0, (int)buf_vec.size()), [&](const Range& range)
+    {
+        for (int i = range.start; i < range.end; i++)
+        {
+            // Each buffer goes through the same path a standalone imdecode() would take, with its
+            // own decoder instance, so the result does not depend on the thread count.
+            try
+            {
+                if (imdecode_(buf_vec[i], flags, images[i], nullptr, noArray()))
+                    decoded[i] = 1;
+            }
+            catch (const cv::Exception& e)
+            {
+                CV_LOG_ERROR(NULL, "imdecodeBatch(): can't decode buffer #" << i << ": " << e.what());
+            }
+            catch (...)
+            {
+                CV_LOG_ERROR(NULL, "imdecodeBatch(): can't decode buffer #" << i << ": unknown exception");
+            }
+        }
+    });
+
+    // Report each failure with its batch index instead of shortening the result.
+    bool code = true;
+    for (size_t i = 0; i < images.size(); i++)
+    {
+        if (!decoded[i])
+        {
+            images[i].release();
+            CV_LOG_ERROR(NULL, "imdecodeBatch(): failed to decode buffer #" << i
+                               << " out of " << images.size());
+            code = false;
+        }
+    }
+    return code;
+}
+
 bool imencodeWithMetadata( const String& ext, InputArray _img,
                            const std::vector<int>& metadata_types,
                            InputArrayOfArrays metadata,
@@ -1736,6 +1794,77 @@ bool imencodemulti( const String& ext, InputArrayOfArrays imgs,
                     std::vector<uchar>& buf, const std::vector<int>& params)
 {
     return imencode(ext, imgs, buf, params);
+}
+
+bool imencodeBatch( const String& ext, InputArrayOfArrays images,
+                    std::vector<std::vector<uchar> >& buffers,
+                    const std::vector<int>& params )
+{
+    CV_TRACE_FUNCTION();
+
+    // An unknown extension and malformed params are properties of the call rather than of any one
+    // image, so they are rejected once here instead of turning into per-image failures. Resolving
+    // the encoder also initializes the codec registry before the workers start racing for it.
+    if( !findEncoder( ext ) )
+        CV_Error( Error::StsError, "could not find encoder for the specified extension" );
+    CV_Check(params.size(), (params.size() & 1) == 0, "Encoding 'params' must be key-value pairs");
+    CV_CheckLE(params.size(), (size_t)(CV_IO_MAX_IMAGE_PARAMS*2), "");
+
+    std::vector<Mat> img_vec;
+    if (!images.empty())
+    {
+        if (images.isMatVector() || images.isUMatVector())
+            images.getMatVector(img_vec);
+        else
+            img_vec.push_back(images.getMat());
+    }
+
+    buffers.clear();
+    if (img_vec.empty())
+        return true;  // an empty batch is a successful no-op
+
+    buffers.resize(img_vec.size());
+
+    // uchar and not bool: std::vector<bool> is bit-packed, so concurrent writes to distinct
+    // elements would race. Pre-sized so that workers only touch elements that already exist.
+    std::vector<uchar> encoded(img_vec.size(), 0);
+
+    parallel_for_(Range(0, (int)img_vec.size()), [&](const Range& range)
+    {
+        for (int i = range.start; i < range.end; i++)
+        {
+            // Dispatching to imencode() is what makes the batch deterministic: every image is
+            // compressed by exactly the call a sequential loop would have made, with its own
+            // encoder instance, so the bytes do not depend on the thread count.
+            try
+            {
+                if (imencode(ext, img_vec[i], buffers[i], params))
+                    encoded[i] = 1;
+            }
+            catch (const cv::Exception& e)
+            {
+                CV_LOG_ERROR(NULL, "imencodeBatch(): can't encode image #" << i << ": " << e.what());
+            }
+            catch (...)
+            {
+                CV_LOG_ERROR(NULL, "imencodeBatch(): can't encode image #" << i << ": unknown exception");
+            }
+        }
+    });
+
+    // Report each failure with its batch index instead of shortening the result.
+    bool code = true;
+    for (size_t i = 0; i < buffers.size(); i++)
+    {
+        if (!encoded[i])
+        {
+            buffers[i].clear();
+            CV_LOG_ERROR(NULL, "imencodeBatch(): failed to encode image #" << i
+                               << " out of " << buffers.size());
+            code = false;
+        }
+    }
+    return code;
 }
 
 bool haveImageReader( const String& filename )

--- a/modules/imgcodecs/test/test_batch.cpp
+++ b/modules/imgcodecs/test/test_batch.cpp
@@ -1,0 +1,379 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+// The images are synthesized instead of being read from the test data repository, so that the
+// batch tests exercise the codecs even when opencv_extra is not available.
+static Mat makeTestImage(Size size, int type, int seed)
+{
+    Mat img(size, type);
+    RNG rng((uint64)seed * 7919 + 13);
+
+    CV_Assert(img.depth() == CV_8U);
+
+    // A smooth gradient plus a few shapes: noise alone compresses badly and hides codec artifacts.
+    for (int y = 0; y < img.rows; y++)
+    {
+        for (int x = 0; x < img.cols; x++)
+        {
+            const int gx = x * 255 / std::max(1, img.cols - 1);
+            const int gy = y * 255 / std::max(1, img.rows - 1);
+            const int v = (gx + gy) / 2;
+            switch (img.channels())
+            {
+                case 1: img.at<uchar>(y, x) = (uchar)v; break;
+                case 3: img.at<Vec3b>(y, x) = Vec3b((uchar)v, (uchar)((v + 85) % 256), (uchar)((v + 170) % 256)); break;
+                // Alpha stays >= 1: libwebp is free to discard the colour of fully transparent
+                // pixels, which would make a lossless round trip look lossy for the wrong reason.
+                case 4: img.at<Vec4b>(y, x) = Vec4b((uchar)v, (uchar)((v + 85) % 256), (uchar)((v + 170) % 256),
+                                                    (uchar)std::max(1, gx)); break;
+                default: CV_Assert(false);
+            }
+        }
+    }
+
+    for (int i = 0; i < 4; i++)
+    {
+        const Point c(rng.uniform(0, img.cols), rng.uniform(0, img.rows));
+        const int r = rng.uniform(3, std::max(4, std::min(img.cols, img.rows) / 4));
+        circle(img, c, r, Scalar(rng.uniform(0, 256), rng.uniform(0, 256), rng.uniform(0, 256), 255), -1);
+    }
+
+    return img;
+}
+
+static std::vector<Mat> makeBatch(size_t n, int type, Size size = Size(64, 48))
+{
+    std::vector<Mat> batch;
+    for (size_t i = 0; i < n; i++)
+        batch.push_back(makeTestImage(size, type, (int)i));
+    return batch;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Determinism: the batch call must produce exactly the bytes a sequential imencode() loop does.
+// ---------------------------------------------------------------------------------------------
+
+static void checkEncodeMatchesLoop(const String& ext, int type, const std::vector<int>& params)
+{
+    const std::vector<Mat> images = makeBatch(6, type);
+
+    std::vector<std::vector<uchar> > batched;
+    ASSERT_TRUE(imencodeBatch(ext, images, batched, params)) << ext;
+    ASSERT_EQ(images.size(), batched.size());
+
+    for (size_t i = 0; i < images.size(); i++)
+    {
+        std::vector<uchar> single;
+        ASSERT_TRUE(imencode(ext, images[i], single, params)) << ext << " #" << i;
+        EXPECT_EQ(single, batched[i]) << ext << " #" << i;
+    }
+}
+
+static void checkDecodeMatchesLoop(const String& ext, int type, int flags, const std::vector<int>& params)
+{
+    const std::vector<Mat> images = makeBatch(6, type);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(ext, images, buffers, params)) << ext;
+
+    std::vector<Mat> batched;
+    ASSERT_TRUE(imdecodeBatch(buffers, flags, batched)) << ext;
+    ASSERT_EQ(buffers.size(), batched.size());
+
+    for (size_t i = 0; i < buffers.size(); i++)
+    {
+        const Mat single = imdecode(buffers[i], flags);
+        ASSERT_FALSE(single.empty()) << ext << " #" << i;
+        EXPECT_EQ(single.size(), batched[i].size()) << ext << " #" << i;
+        EXPECT_EQ(single.type(), batched[i].type()) << ext << " #" << i;
+        EXPECT_EQ(0, cv::norm(single, batched[i], NORM_INF)) << ext << " #" << i;
+    }
+}
+
+#ifdef HAVE_PNG
+TEST(Imgcodecs_Batch, png_encode_matches_sequential_calls)
+{
+    checkEncodeMatchesLoop(".png", CV_8UC1, std::vector<int>());
+    checkEncodeMatchesLoop(".png", CV_8UC3, std::vector<int>());
+    checkEncodeMatchesLoop(".png", CV_8UC4, std::vector<int>());
+}
+
+TEST(Imgcodecs_Batch, png_decode_matches_sequential_calls)
+{
+    checkDecodeMatchesLoop(".png", CV_8UC3, IMREAD_COLOR, std::vector<int>());
+    checkDecodeMatchesLoop(".png", CV_8UC4, IMREAD_UNCHANGED, std::vector<int>());
+}
+
+// PNG is lossless, so the round trip must be bit exact.
+TEST(Imgcodecs_Batch, png_roundtrip_is_lossless)
+{
+    const std::vector<Mat> images = makeBatch(5, CV_8UC3);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".png", images, buffers, std::vector<int>()));
+
+    std::vector<Mat> decoded;
+    ASSERT_TRUE(imdecodeBatch(buffers, IMREAD_COLOR, decoded));
+    ASSERT_EQ(images.size(), decoded.size());
+
+    for (size_t i = 0; i < images.size(); i++)
+        EXPECT_EQ(0, cv::norm(images[i], decoded[i], NORM_INF)) << "#" << i;
+}
+
+// Independent buffers do not require homogeneous images.
+TEST(Imgcodecs_Batch, mixed_sizes_and_channels)
+{
+    std::vector<Mat> images;
+    images.push_back(makeTestImage(Size(17, 5), CV_8UC3, 0));
+    images.push_back(makeTestImage(Size(64, 64), CV_8UC1, 1));
+    images.push_back(makeTestImage(Size(128, 33), CV_8UC4, 2));
+    images.push_back(makeTestImage(Size(1, 1), CV_8UC3, 3));
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".png", images, buffers, std::vector<int>()));
+    ASSERT_EQ(images.size(), buffers.size());
+
+    std::vector<Mat> decoded;
+    ASSERT_TRUE(imdecodeBatch(buffers, IMREAD_UNCHANGED, decoded));
+    ASSERT_EQ(images.size(), decoded.size());
+
+    for (size_t i = 0; i < images.size(); i++)
+    {
+        EXPECT_EQ(images[i].size(), decoded[i].size()) << "#" << i;
+        EXPECT_EQ(images[i].type(), decoded[i].type()) << "#" << i;
+        EXPECT_EQ(0, cv::norm(images[i], decoded[i], NORM_INF)) << "#" << i;
+    }
+}
+
+// The output must not depend on how many threads OpenCV happens to be using.
+TEST(Imgcodecs_Batch, output_is_independent_of_thread_count)
+{
+    const std::vector<Mat> images = makeBatch(8, CV_8UC3);
+    const int saved_threads = getNumThreads();
+
+    std::vector<std::vector<uchar> > single_threaded;
+    setNumThreads(1);
+    ASSERT_TRUE(imencodeBatch(".png", images, single_threaded, std::vector<int>()));
+
+    std::vector<std::vector<uchar> > multi_threaded;
+    setNumThreads(saved_threads);
+    ASSERT_TRUE(imencodeBatch(".png", images, multi_threaded, std::vector<int>()));
+
+    EXPECT_EQ(single_threaded, multi_threaded);
+}
+#endif // HAVE_PNG
+
+#ifdef HAVE_JPEG
+TEST(Imgcodecs_Batch, jpeg_encode_matches_sequential_calls)
+{
+    std::vector<int> params;
+    params.push_back(IMWRITE_JPEG_QUALITY);
+    params.push_back(90);
+
+    checkEncodeMatchesLoop(".jpg", CV_8UC1, params);
+    checkEncodeMatchesLoop(".jpg", CV_8UC3, params);
+}
+
+TEST(Imgcodecs_Batch, jpeg_decode_matches_sequential_calls)
+{
+    std::vector<int> params;
+    params.push_back(IMWRITE_JPEG_QUALITY);
+    params.push_back(90);
+
+    checkDecodeMatchesLoop(".jpg", CV_8UC3, IMREAD_COLOR, params);
+    checkDecodeMatchesLoop(".jpg", CV_8UC1, IMREAD_GRAYSCALE, params);
+}
+
+// Quality is shared by the whole batch, and it must actually reach every image.
+TEST(Imgcodecs_Batch, jpeg_quality_applies_to_every_image)
+{
+    const std::vector<Mat> images = makeBatch(4, CV_8UC3, Size(128, 128));
+
+    std::vector<int> low, high;
+    low.push_back(IMWRITE_JPEG_QUALITY);  low.push_back(20);
+    high.push_back(IMWRITE_JPEG_QUALITY); high.push_back(95);
+
+    std::vector<std::vector<uchar> > low_buffers, high_buffers;
+    ASSERT_TRUE(imencodeBatch(".jpg", images, low_buffers, low));
+    ASSERT_TRUE(imencodeBatch(".jpg", images, high_buffers, high));
+
+    for (size_t i = 0; i < images.size(); i++)
+        EXPECT_LT(low_buffers[i].size(), high_buffers[i].size()) << "#" << i;
+}
+
+// Lossy round trip: close to the source, not identical to it.
+TEST(Imgcodecs_Batch, jpeg_roundtrip_is_close)
+{
+    const std::vector<Mat> images = makeBatch(4, CV_8UC3, Size(96, 96));
+
+    std::vector<int> params;
+    params.push_back(IMWRITE_JPEG_QUALITY);
+    params.push_back(95);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".jpg", images, buffers, params));
+
+    std::vector<Mat> decoded;
+    ASSERT_TRUE(imdecodeBatch(buffers, IMREAD_COLOR, decoded));
+    ASSERT_EQ(images.size(), decoded.size());
+
+    // The synthetic images are close to a worst case for JPEG: hard-edged shapes on top of a
+    // gradient that wraps around per channel. A photo lands near 0.015 at this quality, these
+    // land near 0.08, so the bound only asserts that the round trip stays in the right ballpark.
+    // Bit exactness against a sequential imencode/imdecode pair is covered separately.
+    for (size_t i = 0; i < images.size(); i++)
+    {
+        ASSERT_EQ(images[i].size(), decoded[i].size()) << "#" << i;
+        EXPECT_LT(cvtest::norm(images[i], decoded[i], NORM_L2 | NORM_RELATIVE), 0.1) << "#" << i;
+    }
+}
+#endif // HAVE_JPEG
+
+#ifdef HAVE_WEBP
+TEST(Imgcodecs_Batch, webp_encode_matches_sequential_calls)
+{
+    std::vector<int> params;
+    params.push_back(IMWRITE_WEBP_QUALITY);
+    params.push_back(90);
+
+    checkEncodeMatchesLoop(".webp", CV_8UC3, params);
+    checkEncodeMatchesLoop(".webp", CV_8UC4, params);
+}
+
+TEST(Imgcodecs_Batch, webp_decode_matches_sequential_calls)
+{
+    std::vector<int> params;
+    params.push_back(IMWRITE_WEBP_QUALITY);
+    params.push_back(90);
+
+    checkDecodeMatchesLoop(".webp", CV_8UC3, IMREAD_COLOR, params);
+    checkDecodeMatchesLoop(".webp", CV_8UC4, IMREAD_UNCHANGED, params);
+}
+
+// Lossless WebP (quality > 100) must survive the round trip untouched, alpha included.
+TEST(Imgcodecs_Batch, webp_lossless_roundtrip_preserves_alpha)
+{
+    const std::vector<Mat> images = makeBatch(4, CV_8UC4);
+
+    std::vector<int> params;
+    params.push_back(IMWRITE_WEBP_QUALITY);
+    params.push_back(101);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".webp", images, buffers, params));
+
+    std::vector<Mat> decoded;
+    ASSERT_TRUE(imdecodeBatch(buffers, IMREAD_UNCHANGED, decoded));
+    ASSERT_EQ(images.size(), decoded.size());
+
+    for (size_t i = 0; i < images.size(); i++)
+    {
+        ASSERT_EQ(4, decoded[i].channels()) << "#" << i;
+        EXPECT_EQ(0, cv::norm(images[i], decoded[i], NORM_INF)) << "#" << i;
+    }
+}
+#endif // HAVE_WEBP
+
+// ---------------------------------------------------------------------------------------------
+// Contract: empty batches, failure reporting and argument validation.
+// ---------------------------------------------------------------------------------------------
+
+TEST(Imgcodecs_Batch, empty_batch_succeeds)
+{
+    std::vector<std::vector<uchar> > buffers(3);  // pre-filled to prove the output is cleared
+    EXPECT_TRUE(imencodeBatch(".png", std::vector<Mat>(), buffers, std::vector<int>()));
+    EXPECT_TRUE(buffers.empty());
+
+    std::vector<Mat> images(3);
+    EXPECT_TRUE(imdecodeBatch(std::vector<std::vector<uchar> >(), IMREAD_COLOR, images));
+    EXPECT_TRUE(images.empty());
+}
+
+TEST(Imgcodecs_Batch, unknown_extension_throws)
+{
+    const std::vector<Mat> images = makeBatch(2, CV_8UC3);
+    std::vector<std::vector<uchar> > buffers;
+    EXPECT_THROW(imencodeBatch(".notaformat", images, buffers, std::vector<int>()), cv::Exception);
+}
+
+TEST(Imgcodecs_Batch, malformed_params_throw)
+{
+    const std::vector<Mat> images = makeBatch(2, CV_8UC3);
+    std::vector<std::vector<uchar> > buffers;
+    // An odd number of entries cannot be read as key-value pairs.
+    EXPECT_THROW(imencodeBatch(".png", images, buffers, std::vector<int>(1, IMWRITE_PNG_COMPRESSION)),
+                 cv::Exception);
+}
+
+#ifdef HAVE_PNG
+// A failing image must not shorten the result nor take its neighbours down with it.
+TEST(Imgcodecs_Batch, encode_failure_is_isolated_to_its_index)
+{
+    std::vector<Mat> images = makeBatch(4, CV_8UC3);
+    images[2] = Mat(8, 8, CV_8UC2, Scalar::all(0));  // no encoder accepts two channels
+
+    std::vector<std::vector<uchar> > buffers;
+    EXPECT_FALSE(imencodeBatch(".png", images, buffers, std::vector<int>()));
+    ASSERT_EQ(images.size(), buffers.size()) << "the result must not be shortened";
+
+    EXPECT_TRUE(buffers[2].empty());
+    for (size_t i = 0; i < buffers.size(); i++)
+    {
+        if (i == 2)
+            continue;
+        EXPECT_FALSE(buffers[i].empty()) << "#" << i;
+
+        std::vector<uchar> expected;
+        ASSERT_TRUE(imencode(".png", images[i], expected, std::vector<int>()));
+        EXPECT_EQ(expected, buffers[i]) << "#" << i;
+    }
+}
+
+TEST(Imgcodecs_Batch, decode_failure_is_isolated_to_its_index)
+{
+    const std::vector<Mat> images = makeBatch(4, CV_8UC3);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".png", images, buffers, std::vector<int>()));
+
+    buffers[1] = std::vector<uchar>(64, 0x7f);  // garbage: no decoder recognizes the signature
+    buffers[3].clear();                         // empty buffer
+
+    std::vector<Mat> decoded;
+    EXPECT_FALSE(imdecodeBatch(buffers, IMREAD_COLOR, decoded));
+    ASSERT_EQ(buffers.size(), decoded.size()) << "the result must not be shortened";
+
+    EXPECT_TRUE(decoded[1].empty());
+    EXPECT_TRUE(decoded[3].empty());
+    EXPECT_EQ(0, cv::norm(images[0], decoded[0], NORM_INF));
+    EXPECT_EQ(0, cv::norm(images[2], decoded[2], NORM_INF));
+}
+
+// The C++ contract in the issue passes buffers as std::vector<std::vector<uchar>>; the same call
+// must also accept the std::vector<Mat> that other OpenCV entry points hand out.
+TEST(Imgcodecs_Batch, decode_accepts_vector_of_mats)
+{
+    const std::vector<Mat> images = makeBatch(3, CV_8UC3);
+
+    std::vector<std::vector<uchar> > buffers;
+    ASSERT_TRUE(imencodeBatch(".png", images, buffers, std::vector<int>()));
+
+    std::vector<Mat> buffer_mats;
+    for (size_t i = 0; i < buffers.size(); i++)
+        buffer_mats.push_back(Mat(buffers[i], /*copyData*/ true));
+
+    std::vector<Mat> decoded;
+    ASSERT_TRUE(imdecodeBatch(buffer_mats, IMREAD_COLOR, decoded));
+    ASSERT_EQ(images.size(), decoded.size());
+
+    for (size_t i = 0; i < images.size(); i++)
+        EXPECT_EQ(0, cv::norm(images[i], decoded[i], NORM_INF)) << "#" << i;
+}
+#endif // HAVE_PNG
+
+}} // namespace

--- a/modules/python/src2/cv2.cpp
+++ b/modules/python/src2/cv2.cpp
@@ -51,6 +51,7 @@ typedef std::vector<MSTEdge> vector_MSTEdge;
 #endif // HAVE_OPENCV_GEOMETRY
 
 typedef std::vector<std::vector<char> > vector_vector_char;
+typedef std::vector<std::vector<uchar> > vector_vector_uchar;
 typedef std::vector<std::vector<Point> > vector_vector_Point;
 typedef std::vector<std::vector<Point2f> > vector_vector_Point2f;
 typedef std::vector<std::vector<Point3f> > vector_vector_Point3f;


### PR DESCRIPTION
cv::imencode/cv::imdecode handle one image per call, so pipelines that compress every image of a batch have to loop in the calling language and dispatch the codec once per image. imencodemulti/imdecodemulti do not help: they pack pages into a single container, which JPEG cannot even represent.

Add two functions that encode independent images and decode independent buffers in one public call:

    bool imencodeBatch(const String& ext, InputArrayOfArrays images,
                       std::vector<std::vector<uchar> >& buffers,
                       const std::vector<int>& params = std::vector<int>());

    bool imdecodeBatch(InputArrayOfArrays bufs, int flags,
                       std::vector<Mat>& images);

Each item is processed with its own codec instance, so the output is byte-for-byte identical to a sequential imencode/imdecode loop whatever the thread count. The batch is spread over cv::parallel_for_ internally.

Contract:
- the output is always sized to the input; an item that fails is left empty and its batch index is reported through the error log, so a failure never silently shortens the result;
- an empty batch clears the output and succeeds;
- images may differ in size, depth and channel count;
- params are shared by the whole batch.

The single-image path of imencodeWithMetadata is factored into checkEncodeParams/prepareImageForEncoder/encodeToBuffer_ so the batch path reuses it instead of duplicating the encoder setup. Behaviour of the existing entry points is unchanged.

Adds accuracy tests (C++ and Python) covering determinism against sequential calls, JPEG/PNG/WebP, grayscale/BGR/BGRA, mixed sizes, per-index failure isolation and empty batches, plus perf tests comparing the batch call with the loop it replaces.

The accuracy and perf tests synthesize their own images, so no companion patch to opencv_extra is required.

Fixes #29587

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake