### PR TITLE
gapi: fix typo in GStreamer initialization error message

### DIFF
--- a/modules/gapi/src/streaming/gstreamer/gstreamerenv.cpp
+++ b/modules/gapi/src/streaming/gstreamer/gstreamerenv.cpp
@@ -36,7 +36,7 @@ GStreamerEnv::GStreamerEnv()
         if (err)
         {
             cv::util::throw_error(
-                std::runtime_error(std::string("GStreamer initializaton error! Details: ") +
+                std::runtime_error(std::string("GStreamer initialization error! Details: ") +
                                    err->message));
         }
     }


### PR DESCRIPTION
Fix a typo in the GStreamer initialization error message:

`initializaton` -> `initialization`

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
