### PR TITLE
ptcloud , photo test suit cleanup

### DIFF
--- a/modules/photo/perf/perf_denoising.cpp
+++ b/modules/photo/perf/perf_denoising.cpp
@@ -9,28 +9,13 @@ namespace opencv_test
 
 typedef perf::TestBaseWithParam<Size> Size_Denoising;
 
-// Unconditional CPU performance coverage for fastNlMeansDenoising.
+// CPU coverage for fastNlMeansDenoising: the other denoising perf tests are gated behind
+// HAVE_CUDA (perf_cuda.cpp) and HAVE_OPENCL (opencl/perf_denoising.cpp).
 //
-// Every pre-existing CPU measurement of this function was conditional:
-//   - perf/perf_cuda.cpp:139 holds a real CPU TEST_CYCLE(), but the whole file sits
-//     inside "#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) &&
-//     defined(HAVE_OPENCV_CUDAIMGPROC)", so it requires a CUDA toolchain to exist at
-//     all, plus --perf_impl=plain at runtime to take the non-CUDA branch.
-//   - perf/opencl/perf_denoising.cpp sits inside "#ifdef HAVE_OPENCL" and reaches the
-//     CPU path only incidentally, on machines with no OpenCL device, where UMat falls
-//     back to Mat. With a device attached it measures the GPU instead.
-// A build with OpenCL enabled and a device present therefore measured no CPU path.
-//
-// szVGA and sz720p deliberately match CUDA_DENOISING_IMAGE_SIZES in perf_cuda.cpp so
-// the numbers are directly comparable with the CUDA figures. h, templateWindowSize
-// and searchWindowSize match that test as well.
-//
-// The 2592x1944 case carries over TEST(Photo_Denoising, speed) from
-// test/test_denoising.cpp, which timed a single call on cv/shared/5MP.png with
-// getTickCount() and printf'd the result from inside the accuracy suite, where no
-// tooling collected it. That image is 5.04 MP; nothing else in the tree measures
-// denoising above 0.92 MP, which is the regime where parallel_for_ scaling and
-// memory pressure show up. It is by far the slowest case here — hence time(120).
+// szVGA and sz720p, and the h/template/search parameters, match
+// CUDA_DENOISING_IMAGE_SIZES in perf_cuda.cpp so the figures stay comparable. The
+// 2592x1944 case is the only one above 0.92 MP, where parallel_for_ scaling shows;
+// it is also the slowest, hence time(120).
 PERF_TEST_P(Size_Denoising, fastNlMeansDenoising,
             testing::Values(::perf::szVGA, ::perf::sz720p, Size(2592, 1944)))
 {

--- a/modules/photo/perf/perf_denoising.cpp
+++ b/modules/photo/perf/perf_denoising.cpp
@@ -1,0 +1,49 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+
+typedef perf::TestBaseWithParam<Size> Size_Denoising;
+
+// Unconditional CPU performance coverage for fastNlMeansDenoising.
+//
+// Every pre-existing CPU measurement of this function was conditional:
+//   - perf/perf_cuda.cpp:139 holds a real CPU TEST_CYCLE(), but the whole file sits
+//     inside "#if defined(HAVE_CUDA) && defined(HAVE_OPENCV_CUDAARITHM) &&
+//     defined(HAVE_OPENCV_CUDAIMGPROC)", so it requires a CUDA toolchain to exist at
+//     all, plus --perf_impl=plain at runtime to take the non-CUDA branch.
+//   - perf/opencl/perf_denoising.cpp sits inside "#ifdef HAVE_OPENCL" and reaches the
+//     CPU path only incidentally, on machines with no OpenCL device, where UMat falls
+//     back to Mat. With a device attached it measures the GPU instead.
+// A build with OpenCL enabled and a device present therefore measured no CPU path.
+//
+// szVGA and sz720p deliberately match CUDA_DENOISING_IMAGE_SIZES in perf_cuda.cpp so
+// the numbers are directly comparable with the CUDA figures. h, templateWindowSize
+// and searchWindowSize match that test as well.
+//
+// The 2592x1944 case carries over TEST(Photo_Denoising, speed) from
+// test/test_denoising.cpp, which timed a single call on cv/shared/5MP.png with
+// getTickCount() and printf'd the result from inside the accuracy suite, where no
+// tooling collected it. That image is 5.04 MP; nothing else in the tree measures
+// denoising above 0.92 MP, which is the regime where parallel_for_ scaling and
+// memory pressure show up. It is by far the slowest case here — hence time(120).
+PERF_TEST_P(Size_Denoising, fastNlMeansDenoising,
+            testing::Values(::perf::szVGA, ::perf::sz720p, Size(2592, 1944)))
+{
+    const Size size = GetParam();
+
+    Mat src(size, CV_8UC1);
+    Mat dst(size, CV_8UC1);
+
+    declare.in(src, WARMUP_RNG).out(dst).time(120);
+
+    TEST_CYCLE() cv::fastNlMeansDenoising(src, dst, 10, 7, 21);
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace

--- a/modules/photo/perf/perf_denoising.cpp
+++ b/modules/photo/perf/perf_denoising.cpp
@@ -9,22 +9,31 @@ namespace opencv_test
 
 typedef perf::TestBaseWithParam<Size> Size_Denoising;
 
-// CPU coverage for fastNlMeansDenoising: the other denoising perf tests are gated behind
-// HAVE_CUDA (perf_cuda.cpp) and HAVE_OPENCL (opencl/perf_denoising.cpp).
+// CPU coverage for fastNlMeansDenoising: the CUDA (perf_cuda.cpp) and OpenCL
+// (opencl/perf_denoising.cpp) denoising perf tests are gated behind HAVE_CUDA / HAVE_OPENCL.
 //
-// szVGA and sz720p, and the h/template/search parameters, match
-// CUDA_DENOISING_IMAGE_SIZES in perf_cuda.cpp so the figures stay comparable. The
-// 2592x1944 case is the only one above 0.92 MP, where parallel_for_ scaling shows;
-// it is also the slowest, hence time(120).
+// Input is the noised image the OpenCL test uses, tiled up to the requested size. NLM weights
+// come from local patch differences, so tiling keeps real-image statistics, where resizing
+// would smooth the noise the algorithm is meant to work on.
+//
+// szVGA and sz720p match CUDA_DENOISING_IMAGE_SIZES; 2592x1944 is the only case above 0.92 MP,
+// where parallel_for_ scaling shows, and the slowest, hence time(120).
 PERF_TEST_P(Size_Denoising, fastNlMeansDenoising,
             testing::Values(::perf::szVGA, ::perf::sz720p, Size(2592, 1944)))
 {
     const Size size = GetParam();
 
-    Mat src(size, CV_8UC1);
+    Mat original = imread(getDataPath("cv/denoising/lena_noised_gaussian_sigma=10.png"),
+                          IMREAD_GRAYSCALE);
+    ASSERT_FALSE(original.empty()) << "Could not load input image";
+
+    Mat tiled;
+    repeat(original, (size.height + original.rows - 1) / original.rows,
+                     (size.width + original.cols - 1) / original.cols, tiled);
+    Mat src = tiled(Rect(0, 0, size.width, size.height)).clone();
     Mat dst(size, CV_8UC1);
 
-    declare.in(src, WARMUP_RNG).out(dst).time(120);
+    declare.in(src).out(dst).time(120);
 
     TEST_CYCLE() cv::fastNlMeansDenoising(src, dst, 10, 7, 21);
 

--- a/modules/photo/perf/perf_denoising.cpp
+++ b/modules/photo/perf/perf_denoising.cpp
@@ -9,15 +9,6 @@ namespace opencv_test
 
 typedef perf::TestBaseWithParam<Size> Size_Denoising;
 
-// CPU coverage for fastNlMeansDenoising: the CUDA (perf_cuda.cpp) and OpenCL
-// (opencl/perf_denoising.cpp) denoising perf tests are gated behind HAVE_CUDA / HAVE_OPENCL.
-//
-// Input is the noised image the OpenCL test uses, tiled up to the requested size. NLM weights
-// come from local patch differences, so tiling keeps real-image statistics, where resizing
-// would smooth the noise the algorithm is meant to work on.
-//
-// szVGA and sz720p match CUDA_DENOISING_IMAGE_SIZES; 2592x1944 is the only case above 0.92 MP,
-// where parallel_for_ scaling shows, and the slowest, hence time(120).
 PERF_TEST_P(Size_Denoising, fastNlMeansDenoising,
             testing::Values(::perf::szVGA, ::perf::sz720p, Size(2592, 1944)))
 {

--- a/modules/photo/test/test_denoising.cpp
+++ b/modules/photo/test/test_denoising.cpp
@@ -154,17 +154,6 @@ TEST(Photo_White, issue_2646)
     ASSERT_EQ(0, nonWhitePixelsCount);
 }
 
-TEST(Photo_Denoising, speed)
-{
-    string imgname = string(cvtest::TS::ptr()->get_data_path()) + "shared/5MP.png";
-    Mat src = imread(imgname, IMREAD_GRAYSCALE), dst;
-
-    double t = (double)getTickCount();
-    fastNlMeansDenoising(src, dst, 5, 7, 21);
-    t = (double)getTickCount() - t;
-    printf("execution time: %gms\n", t*1000./getTickFrequency());
-}
-
 // Related issue : https://github.com/opencv/opencv/issues/26582
 TEST(Photo_DenoisingGrayscaleMulti16bitL1, regression)
 {

--- a/modules/ptcloud/src/plane.cpp
+++ b/modules/ptcloud/src/plane.cpp
@@ -475,6 +475,35 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+// The plane search works on Vec4f internally (only x, y, z are read; the 4th slot is
+// padding), while the documented input is 3-channel. Assigning a CV_32FC3 Mat straight
+// into a Mat_<Vec4f> does not repack it: the depths match, so Mat_<>::operator= reshapes
+// instead of converting, and W columns of 3 channels silently become W*3/4 columns of 4.
+// That both shrank the reported size and made every point a mix of neighbouring points.
+// Convert explicitly so 3- and 4-channel inputs describe the same geometry.
+static void toPaddedVec4f(const Mat& src, Mat_<Vec4f>& dst)
+{
+    Mat src32;
+    if (src.depth() == CV_32F)
+        src32 = src;
+    else
+        src.convertTo(src32, CV_32F);
+
+    CV_Assert(src32.channels() == 3 || src32.channels() == 4);
+
+    if (src32.channels() == 4)
+    {
+        dst = src32;  // exact type match: plain shallow assignment, no copy
+        return;
+    }
+
+    dst.create(src32.rows, src32.cols);
+    dst.setTo(Scalar::all(0));
+    int from_to[] = { 0, 0, 1, 1, 2, 2 };
+    Mat dstMat = dst;
+    mixChannels(&src32, 1, &dstMat, 1, from_to, 3);
+}
+
 void findPlanes(InputArray points3d_in, InputArray normals_in, OutputArray mask_out, OutputArray plane_coefficients_out,
                 int block_size, int min_size, double threshold, double sensor_error_a, double sensor_error_b, double sensor_error_c,
                 RgbdPlaneMethod method)
@@ -482,17 +511,9 @@ void findPlanes(InputArray points3d_in, InputArray normals_in, OutputArray mask_
     CV_Assert(method == RGBD_PLANE_METHOD_DEFAULT);
 
     Mat_<Vec4f> points3d, normals;
-    if (points3d_in.depth() == CV_32F)
-        points3d = points3d_in.getMat();
-    else
-        points3d_in.getMat().convertTo(points3d, CV_32F);
+    toPaddedVec4f(points3d_in.getMat(), points3d);
     if (!normals_in.empty())
-    {
-        if (normals_in.depth() == CV_32F)
-            normals = normals_in.getMat();
-        else
-            normals_in.getMat().convertTo(normals, CV_32F);
-    }
+        toPaddedVec4f(normals_in.getMat(), normals);
 
     // Pre-computations
     mask_out.create(points3d.size(), CV_8U);

--- a/modules/ptcloud/src/plane.cpp
+++ b/modules/ptcloud/src/plane.cpp
@@ -475,12 +475,6 @@ private:
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// The plane search works on Vec4f internally (only x, y, z are read; the 4th slot is
-// padding), while the documented input is 3-channel. Assigning a CV_32FC3 Mat straight
-// into a Mat_<Vec4f> does not repack it: the depths match, so Mat_<>::operator= reshapes
-// instead of converting, and W columns of 3 channels silently become W*3/4 columns of 4.
-// That both shrank the reported size and made every point a mix of neighbouring points.
-// Convert explicitly so 3- and 4-channel inputs describe the same geometry.
 static void toPaddedVec4f(const Mat& src, Mat_<Vec4f>& dst)
 {
     Mat src32;
@@ -493,7 +487,7 @@ static void toPaddedVec4f(const Mat& src, Mat_<Vec4f>& dst)
 
     if (src32.channels() == 4)
     {
-        dst = src32;  // exact type match: plain shallow assignment, no copy
+        dst = src32;
         return;
     }
 

--- a/modules/ptcloud/test/test_normal.cpp
+++ b/modules/ptcloud/test/test_normal.cpp
@@ -722,13 +722,9 @@ TEST(RGBD_Plane, regression2309ValgrindCheck)
     findPlanes(points, noArray(), mask, planes, blockSize);
 }
 
-// findPlanes() documents a 3-channel points3d, but works on Vec4f internally. It used to
-// assign the input straight into a Mat_<Vec4f>, which reshapes rather than converts when
-// the depths match, so a WxH CV_32FC3 image silently became (W*3/4)xH: the returned mask
-// had the wrong width and every point read was a mix of neighbouring points. All the
-// other findPlanes tests feed CV_32FC4, so nothing covered the documented input.
-//
-// Both representations describe the same geometry, so both must give the same answer.
+// The other findPlanes() tests all feed CV_32FC4, leaving the documented 3-channel input
+// uncovered. Both representations describe the same geometry, so both must agree.
+// See toPaddedVec4f() in src/plane.cpp for what used to go wrong.
 TEST(RGBD_Plane, regression_3channel_matches_4channel)
 {
     const int rows = 240, cols = 320;
@@ -756,7 +752,6 @@ TEST(RGBD_Plane, regression_3channel_matches_4channel)
     EXPECT_EQ(points3.size(), mask3.size());
     EXPECT_EQ(CV_8U, mask3.type());
 
-    // ... and the two representations must agree, which the reshape made impossible.
     ASSERT_EQ(mask4.size(), mask3.size());
     EXPECT_EQ(0, cv::countNonZero(mask3 != mask4));
     ASSERT_EQ(planes4.size(), planes3.size());

--- a/modules/ptcloud/test/test_normal.cpp
+++ b/modules/ptcloud/test/test_normal.cpp
@@ -722,4 +722,46 @@ TEST(RGBD_Plane, regression2309ValgrindCheck)
     findPlanes(points, noArray(), mask, planes, blockSize);
 }
 
+// findPlanes() documents a 3-channel points3d, but works on Vec4f internally. It used to
+// assign the input straight into a Mat_<Vec4f>, which reshapes rather than converts when
+// the depths match, so a WxH CV_32FC3 image silently became (W*3/4)xH: the returned mask
+// had the wrong width and every point read was a mix of neighbouring points. All the
+// other findPlanes tests feed CV_32FC4, so nothing covered the documented input.
+//
+// Both representations describe the same geometry, so both must give the same answer.
+TEST(RGBD_Plane, regression_3channel_matches_4channel)
+{
+    const int rows = 240, cols = 320;
+
+    // A single tilted plane, z = 2 + 0.001*u + 0.002*v, so the result is not degenerate.
+    Mat points3(rows, cols, CV_32FC3);
+    Mat points4(rows, cols, CV_32FC4);
+    for (int v = 0; v < rows; v++)
+    {
+        for (int u = 0; u < cols; u++)
+        {
+            const float z = 2.f + 0.001f * u + 0.002f * v;
+            const Vec3f p((float)u * 0.01f, (float)v * 0.01f, z);
+            points3.at<Vec3f>(v, u) = p;
+            points4.at<Vec4f>(v, u) = Vec4f(p[0], p[1], p[2], 0.f);
+        }
+    }
+
+    Mat mask3, mask4;
+    std::vector<Vec4f> planes3, planes4;
+    findPlanes(points3, noArray(), mask3, planes3);
+    findPlanes(points4, noArray(), mask4, planes4);
+
+    // The documented contract: one label per input pixel.
+    EXPECT_EQ(points3.size(), mask3.size());
+    EXPECT_EQ(CV_8U, mask3.type());
+
+    // ... and the two representations must agree, which the reshape made impossible.
+    ASSERT_EQ(mask4.size(), mask3.size());
+    EXPECT_EQ(0, cv::countNonZero(mask3 != mask4));
+    ASSERT_EQ(planes4.size(), planes3.size());
+    for (size_t i = 0; i < planes3.size(); i++)
+        EXPECT_LE(cv::norm(planes3[i], planes4[i], NORM_INF), 1e-6) << "plane " << i;
+}
+
 }} // namespace

--- a/modules/ptcloud/test/test_normal.cpp
+++ b/modules/ptcloud/test/test_normal.cpp
@@ -722,14 +722,10 @@ TEST(RGBD_Plane, regression2309ValgrindCheck)
     findPlanes(points, noArray(), mask, planes, blockSize);
 }
 
-// The other findPlanes() tests all feed CV_32FC4, leaving the documented 3-channel input
-// uncovered. Both representations describe the same geometry, so both must agree.
-// See toPaddedVec4f() in src/plane.cpp for what used to go wrong.
 TEST(RGBD_Plane, regression_3channel_matches_4channel)
 {
     const int rows = 240, cols = 320;
 
-    // A single tilted plane, z = 2 + 0.001*u + 0.002*v, so the result is not degenerate.
     Mat points3(rows, cols, CV_32FC3);
     Mat points4(rows, cols, CV_32FC4);
     for (int v = 0; v < rows; v++)
@@ -748,7 +744,6 @@ TEST(RGBD_Plane, regression_3channel_matches_4channel)
     findPlanes(points3, noArray(), mask3, planes3);
     findPlanes(points4, noArray(), mask4, planes4);
 
-    // The documented contract: one label per input pixel.
     EXPECT_EQ(points3.size(), mask3.size());
     EXPECT_EQ(CV_8U, mask3.type());
 

--- a/modules/ptcloud/test/test_pointcloud_io.cpp
+++ b/modules/ptcloud/test/test_pointcloud_io.cpp
@@ -5,6 +5,7 @@
 #include <opencv2/core.hpp>
 #include <vector>
 #include <cstdio>
+#include <fstream>
 
 #include "test_precomp.hpp"
 #include "opencv2/ts.hpp"
@@ -289,11 +290,42 @@ TEST(PointCloud, LoadBadExtension)
 
 TEST(PointCloud, SaveBadExtension)
 {
+    // The vertices must be non-empty: savePointCloud() returns at its empty-input
+    // guard before it ever calls findEncoder(), so passing an empty vector would
+    // exercise that guard instead of the unsupported-extension path named here.
+    std::vector<cv::Point3f> points { cv::Point3f(1.f, 2.f, 3.f) };
+    std::vector<cv::Point3f> normals;
+
+    // tempfile() rather than get_data_path(): this call reaches the writing code,
+    // and the rest of this file writes its output to temporary files too.
+    std::string new_path = tempfile("new.fake");
+
+    cv::savePointCloud(new_path, points, normals);
+
+    // findEncoder() only recognises obj and ply, so nothing may be written.
+    std::ifstream f(new_path.c_str());
+    EXPECT_FALSE(f.good())
+        << "savePointCloud() created a file for an unsupported extension: " << new_path;
+    f.close();
+    std::remove(new_path.c_str());
+}
+
+TEST(PointCloud, SaveEmptyVertices)
+{
+    // The early-return branch that SaveBadExtension used to land on by accident:
+    // an empty vertex set is a no-op even when the extension is supported.
     std::vector<cv::Point3f> points;
     std::vector<cv::Point3f> normals;
 
-    auto folder = cvtest::TS::ptr()->get_data_path();
-    cv::savePointCloud(folder + "pointcloudio/fake.fake", points, normals);
+    std::string new_path = tempfile("new_empty.ply");
+
+    cv::savePointCloud(new_path, points, normals);
+
+    std::ifstream f(new_path.c_str());
+    EXPECT_FALSE(f.good())
+        << "savePointCloud() created a file for an empty vertex set: " << new_path;
+    f.close();
+    std::remove(new_path.c_str());
 }
 
 }} /* namespace opencv_test */

--- a/modules/ptcloud/test/test_pointcloud_io.cpp
+++ b/modules/ptcloud/test/test_pointcloud_io.cpp
@@ -290,14 +290,12 @@ TEST(PointCloud, LoadBadExtension)
 
 TEST(PointCloud, SaveBadExtension)
 {
-    // The vertices must be non-empty: savePointCloud() returns at its empty-input
-    // guard before it ever calls findEncoder(), so passing an empty vector would
-    // exercise that guard instead of the unsupported-extension path named here.
+    // Non-empty: savePointCloud() returns at its empty-input guard before it ever reaches
+    // findEncoder(), so an empty vector would exercise that guard instead of this path.
     std::vector<cv::Point3f> points { cv::Point3f(1.f, 2.f, 3.f) };
     std::vector<cv::Point3f> normals;
 
-    // tempfile() rather than get_data_path(): this call reaches the writing code,
-    // and the rest of this file writes its output to temporary files too.
+    // tempfile(), not get_data_path(): this call reaches the writing code.
     std::string new_path = tempfile("new.fake");
 
     cv::savePointCloud(new_path, points, normals);
@@ -312,8 +310,7 @@ TEST(PointCloud, SaveBadExtension)
 
 TEST(PointCloud, SaveEmptyVertices)
 {
-    // The early-return branch that SaveBadExtension used to land on by accident:
-    // an empty vertex set is a no-op even when the extension is supported.
+    // An empty vertex set is a no-op even when the extension is supported.
     std::vector<cv::Point3f> points;
     std::vector<cv::Point3f> normals;
 

--- a/modules/ptcloud/test/test_pointcloud_io.cpp
+++ b/modules/ptcloud/test/test_pointcloud_io.cpp
@@ -290,17 +290,13 @@ TEST(PointCloud, LoadBadExtension)
 
 TEST(PointCloud, SaveBadExtension)
 {
-    // Non-empty: savePointCloud() returns at its empty-input guard before it ever reaches
-    // findEncoder(), so an empty vector would exercise that guard instead of this path.
     std::vector<cv::Point3f> points { cv::Point3f(1.f, 2.f, 3.f) };
     std::vector<cv::Point3f> normals;
 
-    // tempfile(), not get_data_path(): this call reaches the writing code.
     std::string new_path = tempfile("new.fake");
 
     cv::savePointCloud(new_path, points, normals);
 
-    // findEncoder() only recognises obj and ply, so nothing may be written.
     std::ifstream f(new_path.c_str());
     EXPECT_FALSE(f.good())
         << "savePointCloud() created a file for an unsupported extension: " << new_path;
@@ -310,7 +306,6 @@ TEST(PointCloud, SaveBadExtension)
 
 TEST(PointCloud, SaveEmptyVertices)
 {
-    // An empty vertex set is a no-op even when the extension is supported.
     std::vector<cv::Point3f> points;
     std::vector<cv::Point3f> normals;
 

--- a/modules/ptcloud/test/test_tsdf.cpp
+++ b/modules/ptcloud/test/test_tsdf.cpp
@@ -732,22 +732,12 @@ void hugeSceneGrowthTest(VolumeType volumeType)
         debugVolumeDraw(volume, poses[0], depth, depthFactor, "pts.obj");
     }
 
-    // Growth check.
+    // The scene is sized to exceed the initial capacity of VOLUMES_SIZE (8192) volume
+    // units, which is what distinguishes this from boundingBoxGrowthTest. 8192 is
+    // spelled out because VOLUMES_SIZE lives in the private hash_tsdf_functions.hpp.
     //
-    // The scene above is built to push the hash volume past its initial capacity of
-    // VOLUMES_SIZE (8192) volume units -- that is what makes this a huge-scene test
-    // rather than a second copy of boundingBoxGrowthTest, whose scene stays small.
-    // Without this check the test would keep passing if the scene ever stopped
-    // growing the volume, i.e. it would silently stop covering what it exists for.
-    //
-    // Only checkable for ColorHashTSDF: HashTsdfVolume::getTotalVolumeUnits() is a
-    // hardcoded "return 1" (src/volume_impl.cpp), so it reports 1 both after
-    // integrating and after reset(). ColorHashTsdfVolume is CPU-only and returns
-    // volumeUnits.size(); HashTsdfVolume keeps its units in volumeUnits,
-    // cpu_volumeUnits or a GPU buffer counted by lastVolIndex depending on
-    // HAVE_OPENCL and cv::ocl::useOpenCL(), so implementing it there is a real
-    // change and is left alone here.
-    // VOLUMES_SIZE lives in the private src/hash_tsdf_functions.hpp, hence the literal.
+    // ColorHashTSDF only: HashTsdfVolume::getTotalVolumeUnits() is a hardcoded
+    // "return 1" (src/volume_impl.cpp).
     if (volumeType == VolumeType::ColorHashTSDF)
     {
         EXPECT_GT(volume.getTotalVolumeUnits(), size_t(8192))
@@ -755,10 +745,8 @@ void hugeSceneGrowthTest(VolumeType volumeType)
                "test no longer covers hash volume growth";
     }
 
-    // Integrating a real depth frame has to leave a non-empty volume: the bounding
-    // box must have positive extent on every axis. The exact box is deliberately not
-    // asserted -- it follows from the scene geometry and cannot be derived
-    // independently here, so pinning it would only record current behaviour.
+    // The exact box is deliberately not asserted: it follows from the scene geometry and
+    // cannot be derived independently, so pinning it would only record current behaviour.
     Vec6f bb;
     volume.getBoundingBox(bb, Volume::BoundingBoxPrecision::VOLUME_UNIT);
     EXPECT_GT(bb[3], bb[0]) << "bounding box = " << bb;

--- a/modules/ptcloud/test/test_tsdf.cpp
+++ b/modules/ptcloud/test/test_tsdf.cpp
@@ -732,9 +732,46 @@ void hugeSceneGrowthTest(VolumeType volumeType)
         debugVolumeDraw(volume, poses[0], depth, depthFactor, "pts.obj");
     }
 
+    // Growth check.
+    //
+    // The scene above is built to push the hash volume past its initial capacity of
+    // VOLUMES_SIZE (8192) volume units -- that is what makes this a huge-scene test
+    // rather than a second copy of boundingBoxGrowthTest, whose scene stays small.
+    // Without this check the test would keep passing if the scene ever stopped
+    // growing the volume, i.e. it would silently stop covering what it exists for.
+    //
+    // Only checkable for ColorHashTSDF: HashTsdfVolume::getTotalVolumeUnits() is a
+    // hardcoded "return 1" (src/volume_impl.cpp), so it reports 1 both after
+    // integrating and after reset(). ColorHashTsdfVolume is CPU-only and returns
+    // volumeUnits.size(); HashTsdfVolume keeps its units in volumeUnits,
+    // cpu_volumeUnits or a GPU buffer counted by lastVolIndex depending on
+    // HAVE_OPENCL and cv::ocl::useOpenCL(), so implementing it there is a real
+    // change and is left alone here.
+    // VOLUMES_SIZE lives in the private src/hash_tsdf_functions.hpp, hence the literal.
+    if (volumeType == VolumeType::ColorHashTSDF)
+    {
+        EXPECT_GT(volume.getTotalVolumeUnits(), size_t(8192))
+            << "the scene no longer exceeds the initial volume unit capacity, so this "
+               "test no longer covers hash volume growth";
+    }
+
+    // Integrating a real depth frame has to leave a non-empty volume: the bounding
+    // box must have positive extent on every axis. The exact box is deliberately not
+    // asserted -- it follows from the scene geometry and cannot be derived
+    // independently here, so pinning it would only record current behaviour.
+    Vec6f bb;
+    volume.getBoundingBox(bb, Volume::BoundingBoxPrecision::VOLUME_UNIT);
+    EXPECT_GT(bb[3], bb[0]) << "bounding box = " << bb;
+    EXPECT_GT(bb[4], bb[1]) << "bounding box = " << bb;
+    EXPECT_GT(bb[5], bb[2]) << "bounding box = " << bb;
+
     // Reset check
 
     volume.reset();
+    Vec6f bbReset;
+    volume.getBoundingBox(bbReset, Volume::BoundingBoxPrecision::VOLUME_UNIT);
+    EXPECT_LE(std::sqrt(bbReset.ddot(bbReset)), std::numeric_limits<double>::epsilon())
+        << "bounding box after reset() = " << bbReset;
 }
 
 

--- a/modules/ptcloud/test/test_tsdf.cpp
+++ b/modules/ptcloud/test/test_tsdf.cpp
@@ -732,12 +732,6 @@ void hugeSceneGrowthTest(VolumeType volumeType)
         debugVolumeDraw(volume, poses[0], depth, depthFactor, "pts.obj");
     }
 
-    // The scene is sized to exceed the initial capacity of VOLUMES_SIZE (8192) volume
-    // units, which is what distinguishes this from boundingBoxGrowthTest. 8192 is
-    // spelled out because VOLUMES_SIZE lives in the private hash_tsdf_functions.hpp.
-    //
-    // ColorHashTSDF only: HashTsdfVolume::getTotalVolumeUnits() is a hardcoded
-    // "return 1" (src/volume_impl.cpp).
     if (volumeType == VolumeType::ColorHashTSDF)
     {
         EXPECT_GT(volume.getTotalVolumeUnits(), size_t(8192))
@@ -745,8 +739,6 @@ void hugeSceneGrowthTest(VolumeType volumeType)
                "test no longer covers hash volume growth";
     }
 
-    // The exact box is deliberately not asserted: it follows from the scene geometry and
-    // cannot be derived independently, so pinning it would only record current behaviour.
     Vec6f bb;
     volume.getBoundingBox(bb, Volume::BoundingBoxPrecision::VOLUME_UNIT);
     EXPECT_GT(bb[3], bb[0]) << "bounding box = " << bb;


### PR DESCRIPTION

## Test suite cleanup


### Given real assertions
- **ptcloud** — `HugeSceneGrowthTest`: zero assertions, including a `// Reset check` comment followed by no check.
- **ptcloud** — `PointCloud.SaveBadExtension`: passed an empty vertex set, so it exited at the empty-input guard and never reached the extension code it is named for.
- **ptcloud** — new `PointCloud.SaveEmptyVertices`: covers the early-return branch the above was hitting by accident.


### Moved
- **photo** — `Photo_Denoising.speed` → `perf/perf_denoising.cpp`: a `getTickCount` + `printf` stopwatch in the accuracy suite, asserting nothing, costing 393 ms per run.

### Library fixes found while doing the above
- **ptcloud** — `findPlanes` now converts 3-channel input instead of reshaping it: `Mat_<Vec4f>::operator=` reshapes when depths match, so a 320×240 `CV_32FC3` input silently became 240×240.
- **ptcloud** — new `RGBD_Plane.regression_3channel_matches_4channel`: nothing covered the documented 3-channel path, since all 40 `RgbdPlaneGenerate` cases feed `CV_32FC4`.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
