### PR TITLE
Fix the build when BUILD_opencv_world=ON in 5.x branch

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -69,6 +69,13 @@ foreach(m ${OPENCV_MODULE_${the_module}_DEPS} opencv_world)
   endif()
 endforeach()
 
+# MLAS_OBJECTS (set with PARENT_SCOPE inside 3rdparty/mlas) doesn't
+# survive back to this scope. Pull the OBJECT library objects
+# in directly using the globally-visible target and cache flag.
+if(OPENCV_DNN_MLAS_ENABLED AND TARGET opencv_dnn_mlas)
+  list(APPEND sources_list $<TARGET_OBJECTS:opencv_dnn_mlas>)
+endif()
+
 ocv_glob_module_sources(HEADERS ${headers_list} SOURCES ${sources_list})
 
 ocv_module_include_directories()


### PR DESCRIPTION
When `BUILD_opencv_world=ON` `MLAS_OBJECTS` is set with `PARENT_SCOPE` in `3rdparty/mlas/CMakeLists.txt` (L270), so it propagates to `modules/dnn/CMakeLists.txt`'s scope. However `modules/dnn/CMakeLists.txt` is `include()`d inside `include_one_module()` which is a CMake function (variables set inside functions don't escape to the caller). After `include_one_module(opencv_dnn)` returns, `MLAS_OBJECTS` is gone from the world scope.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
