### PR TITLE
Restore match template for newer IPP and ICV packages

### DIFF
--- a/hal/ipp/src/matchtemplate_ipp.cpp
+++ b/hal/ipp/src/matchtemplate_ipp.cpp
@@ -114,10 +114,12 @@ int ipp_hal_matchTemplate(const uchar* src_data, size_t src_step, int src_width,
     if(templ.size().area()*4 > img.size().area())
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
 
+#if IPP_VERSION_X100 < 202610
     // CV_8U SQDIFF/SQDIFF_NORMED suffer from float32 catastrophic cancellation
-    // in IPP's internal accumulators; fall through to the double-precision path instead.
+    // in IPP's internal accumulators (older versions); fall through to the double-precision path instead.
     if(depth == CV_8U && (method == cv::TM_SQDIFF || method == cv::TM_SQDIFF_NORMED))
         return CV_HAL_ERROR_NOT_IMPLEMENTED;
+#endif
 
     if(method == cv::TM_SQDIFF)
     {


### PR DESCRIPTION
Restore match template functionality that was switched off in https://github.com/opencv/opencv/pull/29096.
So, newer IPP packages should contain the fix where the `if`-condition is not needed anymore. It's actual for the current IPP package

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
