### PR TITLE
video: make BackgroundSubtractorKNN honor zero learning rate 🤖🤖🤖

### DIFF
--- a/modules/video/src/bgfg_KNN.cpp
+++ b/modules/video/src/bgfg_KNN.cpp
@@ -529,6 +529,7 @@ public:
                float _fTau,
                bool _bShadowDetection,
                uchar _nShadowDetection,
+               bool _updateModel,
                const Mat& _knownForegroundMask)
             :  knownForegroundMask(_knownForegroundMask)
     {
@@ -550,6 +551,7 @@ public:
         m_nkNN = _nkNN;
         m_bShadowDetection = _bShadowDetection;
         m_nShadowDetection = _nShadowDetection;
+        m_updateModel = _updateModel;
     }
 
     void operator()(const Range& range) const CV_OVERRIDE
@@ -578,19 +580,22 @@ public:
                 int result= _cvCheckPixelBackgroundNP(data, nchannels,
                         m_nN, m_aModel, m_fTb,m_nkNN, m_fTau,m_bShadowDetection,include);
 
-                _cvUpdatePixelBackgroundNP(x,data,nchannels,
-                        m_nN, m_aModel,
-                        m_nNextLongUpdate,
-                        m_nNextMidUpdate,
-                        m_nNextShortUpdate,
-                        m_aModelIndexLong,
-                        m_aModelIndexMid,
-                        m_aModelIndexShort,
-                        m_nLongCounter,
-                        m_nMidCounter,
-                        m_nShortCounter,
-                        include
-                        );
+                if (m_updateModel)
+                {
+                    _cvUpdatePixelBackgroundNP(x,data,nchannels,
+                            m_nN, m_aModel,
+                            m_nNextLongUpdate,
+                            m_nNextMidUpdate,
+                            m_nNextShortUpdate,
+                            m_aModelIndexLong,
+                            m_aModelIndexMid,
+                            m_aModelIndexShort,
+                            m_nLongCounter,
+                            m_nMidCounter,
+                            m_nShortCounter,
+                            include
+                            );
+                }
                 // Check that foreground mask exists
                 if (!knownForegroundMask.empty()) {
                     // If input mask states pixel is foreground
@@ -641,6 +646,7 @@ public:
     int m_nkNN;
     bool m_bShadowDetection;
     uchar m_nShadowDetection;
+    bool m_updateModel;
     const Mat& knownForegroundMask;
 };
 
@@ -655,6 +661,7 @@ bool BackgroundSubtractorKNNImpl::ocl_apply(InputArray _image, OutputArray _fgma
     ++nframes;
     learningRate = learningRate >= 0 && nframes > 1 ? learningRate : 1./std::min( 2*nframes, history );
     CV_Assert(learningRate >= 0);
+    const bool updateModel = learningRate > 0;
 
     _fgmask.create(_image.size(), CV_8U);
     UMat fgmask = _fgmask.getUMat();
@@ -663,16 +670,20 @@ bool BackgroundSubtractorKNNImpl::ocl_apply(InputArray _image, OutputArray _fgma
 
     //recalculate update rates - in case alpha is changed
     // calculate update parameters (using alpha)
-    int Kshort,Kmid,Klong;
-    //approximate exponential learning curve
-    Kshort=(int)(log(0.7)/log(1-learningRate))+1;//Kshort
-    Kmid=(int)(log(0.4)/log(1-learningRate))-Kshort+1;//Kmid
-    Klong=(int)(log(0.1)/log(1-learningRate))-Kshort-Kmid+1;//Klong
+    int nShortUpdate = 0, nMidUpdate = 0, nLongUpdate = 0;
+    if (updateModel)
+    {
+        int Kshort,Kmid,Klong;
+        //approximate exponential learning curve
+        Kshort=(int)(log(0.7)/log(1-learningRate))+1;//Kshort
+        Kmid=(int)(log(0.4)/log(1-learningRate))-Kshort+1;//Kmid
+        Klong=(int)(log(0.1)/log(1-learningRate))-Kshort-Kmid+1;//Klong
 
-    //refresh rates
-    int nShortUpdate = (Kshort/nN)+1;
-    int nMidUpdate = (Kmid/nN)+1;
-    int nLongUpdate = (Klong/nN)+1;
+        //refresh rates
+        nShortUpdate = (Kshort/nN)+1;
+        nMidUpdate = (Kmid/nN)+1;
+        nLongUpdate = (Klong/nN)+1;
+    }
 
     int idxArg = 0;
     idxArg = kernel_apply.set(idxArg, ocl::KernelArg::ReadOnly(frame));
@@ -692,6 +703,7 @@ bool BackgroundSubtractorKNNImpl::ocl_apply(InputArray _image, OutputArray _fgma
     idxArg = kernel_apply.set(idxArg, fTb);
     idxArg = kernel_apply.set(idxArg, nkNN);
     idxArg = kernel_apply.set(idxArg, fTau);
+    idxArg = kernel_apply.set(idxArg, (uchar)updateModel);
     if (bShadowDetection)
         kernel_apply.set(idxArg, nShadowDetection);
 
@@ -699,23 +711,26 @@ bool BackgroundSubtractorKNNImpl::ocl_apply(InputArray _image, OutputArray _fgma
     if(!kernel_apply.run(2, globalsize, NULL, true))
         return false;
 
-    nShortCounter++;//0,1,...,nShortUpdate-1
-    nMidCounter++;
-    nLongCounter++;
-    if (nShortCounter >= nShortUpdate)
+    if (updateModel)
     {
-        nShortCounter = 0;
-        randu(u_nNextShortUpdate, Scalar::all(0),  Scalar::all(nShortUpdate));
-    }
-    if (nMidCounter >= nMidUpdate)
-    {
-        nMidCounter = 0;
-        randu(u_nNextMidUpdate, Scalar::all(0),  Scalar::all(nMidUpdate));
-    }
-    if (nLongCounter >= nLongUpdate)
-    {
-        nLongCounter = 0;
-        randu(u_nNextLongUpdate, Scalar::all(0),  Scalar::all(nLongUpdate));
+        nShortCounter++;//0,1,...,nShortUpdate-1
+        nMidCounter++;
+        nLongCounter++;
+        if (nShortCounter >= nShortUpdate)
+        {
+            nShortCounter = 0;
+            randu(u_nNextShortUpdate, Scalar::all(0),  Scalar::all(nShortUpdate));
+        }
+        if (nMidCounter >= nMidUpdate)
+        {
+            nMidCounter = 0;
+            randu(u_nNextMidUpdate, Scalar::all(0),  Scalar::all(nMidUpdate));
+        }
+        if (nLongCounter >= nLongUpdate)
+        {
+            nLongCounter = 0;
+            randu(u_nNextLongUpdate, Scalar::all(0),  Scalar::all(nLongUpdate));
+        }
     }
     return true;
 }
@@ -789,19 +804,24 @@ void BackgroundSubtractorKNNImpl::apply(InputArray _image, InputArray _knownFore
     ++nframes;
     learningRate = learningRate >= 0 && nframes > 1 ? learningRate : 1./std::min( 2*nframes, history );
     CV_Assert(learningRate >= 0);
+    const bool updateModel = learningRate > 0;
 
     //recalculate update rates - in case alpha is changed
     // calculate update parameters (using alpha)
-    int Kshort,Kmid,Klong;
-    //approximate exponential learning curve
-    Kshort=(int)(log(0.7)/log(1-learningRate))+1;//Kshort
-    Kmid=(int)(log(0.4)/log(1-learningRate))-Kshort+1;//Kmid
-    Klong=(int)(log(0.1)/log(1-learningRate))-Kshort-Kmid+1;//Klong
+    int nShortUpdate = 0, nMidUpdate = 0, nLongUpdate = 0;
+    if (updateModel)
+    {
+        int Kshort,Kmid,Klong;
+        //approximate exponential learning curve
+        Kshort=(int)(log(0.7)/log(1-learningRate))+1;//Kshort
+        Kmid=(int)(log(0.4)/log(1-learningRate))-Kshort+1;//Kmid
+        Klong=(int)(log(0.1)/log(1-learningRate))-Kshort-Kmid+1;//Klong
 
-    //refresh rates
-    int nShortUpdate = (Kshort/nN)+1;
-    int nMidUpdate = (Kmid/nN)+1;
-    int nLongUpdate = (Klong/nN)+1;
+        //refresh rates
+        nShortUpdate = (Kshort/nN)+1;
+        nMidUpdate = (Kmid/nN)+1;
+        nLongUpdate = (Klong/nN)+1;
+    }
 
     parallel_for_(Range(0, image.rows),
                   KNNInvoker(image, fgmask,
@@ -821,26 +841,30 @@ void BackgroundSubtractorKNNImpl::apply(InputArray _image, InputArray _knownFore
                              fTau,
                              bShadowDetection,
                              nShadowDetection,
+                             updateModel,
                              knownForegroundMask),
                              image.total()/(double)(1 << 16));
 
-    nShortCounter++;//0,1,...,nShortUpdate-1
-    nMidCounter++;
-    nLongCounter++;
-    if (nShortCounter >= nShortUpdate)
+    if (updateModel)
     {
-        nShortCounter = 0;
-        randu(nNextShortUpdate, Scalar::all(0),  Scalar::all(nShortUpdate));
-    }
-    if (nMidCounter >= nMidUpdate)
-    {
-        nMidCounter = 0;
-        randu(nNextMidUpdate, Scalar::all(0),  Scalar::all(nMidUpdate));
-    }
-    if (nLongCounter >= nLongUpdate)
-    {
-        nLongCounter = 0;
-        randu(nNextLongUpdate, Scalar::all(0),  Scalar::all(nLongUpdate));
+        nShortCounter++;//0,1,...,nShortUpdate-1
+        nMidCounter++;
+        nLongCounter++;
+        if (nShortCounter >= nShortUpdate)
+        {
+            nShortCounter = 0;
+            randu(nNextShortUpdate, Scalar::all(0),  Scalar::all(nShortUpdate));
+        }
+        if (nMidCounter >= nMidUpdate)
+        {
+            nMidCounter = 0;
+            randu(nNextMidUpdate, Scalar::all(0),  Scalar::all(nMidUpdate));
+        }
+        if (nLongCounter >= nLongUpdate)
+        {
+            nLongCounter = 0;
+            randu(nNextLongUpdate, Scalar::all(0),  Scalar::all(nLongUpdate));
+        }
     }
 }
 

--- a/modules/video/src/opencl/bgfg_knn.cl
+++ b/modules/video/src/opencl/bgfg_knn.cl
@@ -79,7 +79,7 @@ __kernel void knn_kernel(__global const uchar* frame, int frame_step, int frame_
                          __global uchar* sample,
                          __global uchar* fgmask, int fgmask_step, int fgmask_offset,
                          int nLongCounter, int nMidCounter, int nShortCounter,
-                         float c_Tb, int c_nkNN, float c_tau
+                         float c_Tb, int c_nkNN, float c_tau, uchar updateModel
 #ifdef SHADOW_DETECT
                          , uchar c_shadowVal
 #endif
@@ -177,6 +177,9 @@ __kernel void knn_kernel(__global const uchar* frame, int frame_step, int frame_
 #endif
         __global uchar* _fgmask = fgmask + mad24(y, fgmask_step, x + fgmask_offset);
         *_fgmask = (uchar)foreground;
+
+        if (!updateModel)
+            return;
 
         __global const uchar* _nNextLongUpdate = nNextLongUpdate + pt_idx;
         __global const uchar* _nNextMidUpdate = nNextMidUpdate + pt_idx;

--- a/modules/video/test/ocl/test_bgfg_knn.cpp
+++ b/modules/video/test/ocl/test_bgfg_knn.cpp
@@ -1,0 +1,52 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "../test_precomp.hpp"
+#include "opencv2/ts/ocl_test.hpp"
+
+#ifdef HAVE_OPENCL
+
+namespace opencv_test {
+namespace ocl {
+
+OCL_TEST(BackgroundSubtractorKNN, ZeroLearningRateFreezesModel)
+{
+    const int imageTypes[] = { CV_8UC1, CV_8UC3 };
+    for (int imageType : imageTypes)
+    {
+        SCOPED_TRACE(cv::typeToString(imageType));
+
+        Ptr<BackgroundSubtractorKNN> knn =
+                createBackgroundSubtractorKNN(50, 400.0, false);
+        UMat background(Size(16, 16), imageType, Scalar::all(0));
+        UMat foreground(background.size(), background.type(), Scalar::all(255));
+        UMat fgmask;
+
+        for (int i = 0; i < 30; ++i)
+        {
+            OCL_ON(knn->apply(background, fgmask, 0.2));
+        }
+        ASSERT_EQ(0, countNonZero(fgmask));
+
+        for (int i = 0; i < 30; ++i)
+        {
+            OCL_ON(knn->apply(foreground, fgmask, 0.0));
+            EXPECT_EQ((int)fgmask.total(), countNonZero(fgmask)) << "iteration " << i;
+        }
+
+        UMat model;
+        OCL_ON(knn->getBackgroundImage(model));
+        EXPECT_EQ(0.0, cv::norm(background, model, NORM_INF));
+
+        for (int i = 0; i < 30; ++i)
+        {
+            OCL_ON(knn->apply(foreground, fgmask, 0.2));
+        }
+        EXPECT_EQ(0, countNonZero(fgmask));
+    }
+}
+
+}} // namespace opencv_test::ocl
+
+#endif

--- a/modules/video/test/test_bgfg2.cpp
+++ b/modules/video/test/test_bgfg2.cpp
@@ -104,5 +104,38 @@ TEST(BackgroundSubtractorKNN, KnownForegroundMaskShadowsFalse)
     }
 }
 
+TEST(BackgroundSubtractorKNN, ZeroLearningRateFreezesModel)
+{
+    const int imageTypes[] = { CV_8UC1, CV_8UC3 };
+    for (int imageType : imageTypes)
+    {
+        SCOPED_TRACE(cv::typeToString(imageType));
+
+        Ptr<BackgroundSubtractorKNN> knn =
+                createBackgroundSubtractorKNN(50, 400.0, false);
+        Mat background(Size(16, 16), imageType, Scalar::all(0));
+        Mat foreground(background.size(), background.type(), Scalar::all(255));
+        Mat fgmask;
+
+        for (int i = 0; i < 30; ++i)
+            knn->apply(background, fgmask, 0.2);
+        ASSERT_EQ(0, countNonZero(fgmask));
+
+        for (int i = 0; i < 30; ++i)
+        {
+            knn->apply(foreground, fgmask, 0.0);
+            EXPECT_EQ((int)fgmask.total(), countNonZero(fgmask)) << "iteration " << i;
+        }
+
+        Mat model;
+        knn->getBackgroundImage(model);
+        EXPECT_EQ(0.0, cv::norm(background, model, NORM_INF));
+
+        for (int i = 0; i < 30; ++i)
+            knn->apply(foreground, fgmask, 0.2);
+        EXPECT_EQ(0, countNonZero(fgmask));
+    }
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
### Pull Request Readiness Checklist

- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x` for a bug fix applicable to OpenCV 4.x)
- [x] There is a reference to the original bug report and related work
- [x] There is an accuracy test, performance test and test data in `opencv_extra`, if applicable (the regression uses generated frames and needs no external data)
- [x] The feature is well documented and sample code can be built with the project CMake (no public API, documentation, or sample change is needed)

Addresses the `BackgroundSubtractorKNN` part of #24226.

### Problem

`BackgroundSubtractorKNN::apply(..., learningRate=0)` continued to update its background model. Besides violating the documented zero-learning-rate semantics, the update-rate calculation evaluated divisions by `log(1 - learningRate)`, which is zero at that value.

On the unmodified `4.x` base, a model trained on a black frame absorbs a stationary white foreground after four calls with `learningRate=0`; the reconstructed background changes by 255 in infinity norm.

### Implementation

- Keep foreground/background/shadow classification active when the learning rate is zero.
- Skip sample, flag, model-index, counter, and randomized update-schedule mutations while the model is frozen.
- Apply the same behavior to the CPU and OpenCL implementations.
- Preserve the scheduler phase while frozen so learning resumes predictably when a positive rate is supplied.
- Keep existing initialization and automatic-learning-rate behavior unchanged.

### Tests

Added matching CPU and OpenCL regression coverage for `CV_8UC1` and `CV_8UC3` frames. Each test verifies that:

1. repeated zero-rate calls continue to classify changed pixels as foreground;
2. the reconstructed background remains unchanged;
3. a later positive learning rate resumes model updates.

Local verification on Windows with MSVC, Ninja, and OpenCL enabled:

```text
opencv_test_video.exe --gtest_filter=*ZeroLearningRate*
[  PASSED  ] 2 tests.
```

The OpenCL regression passed on both an NVIDIA GeForce RTX 3050 Laptop GPU (OpenCL 3.0) and Intel UHD Graphics (OpenCL 3.0). OpenCL build/runtime error propagation was enabled during these runs to prevent a silent CPU fallback.
