### PR TITLE
Fix OOB read, silent no-op, and crash in solvePnPRefineLM/VVS for row-vector rvec/tvec

### DIFF
--- a/modules/calib3d/src/solvepnp.cpp
+++ b/modules/calib3d/src/solvepnp.cpp
@@ -750,14 +750,14 @@ static void solvePnPRefine(InputArray _objectPoints, InputArray _imagePoints,
         Mat params(6, 1, CV_64FC1);
         for (int i = 0; i < 3; i++)
         {
-            params.at<double>(i,0) = rvec.at<double>(i,0);
-            params.at<double>(i+3,0) = tvec.at<double>(i,0);
+            params.at<double>(i,0) = rvec.at<double>(i);
+            params.at<double>(i+3,0) = tvec.at<double>(i);
         }
 
         LMSolver::create(makePtr<SolvePnPRefineLMCallback>(opoints, ipoints, cameraMatrix, distCoeffs), _criteria.maxCount, _criteria.epsilon)->run(params);
 
-        params.rowRange(0, 3).convertTo(rvec0, rvec0.depth());
-        params.rowRange(3, 6).convertTo(tvec0, tvec0.depth());
+        params.rowRange(0, 3).reshape(1, rvec0.rows).convertTo(rvec0, rvec0.depth());
+        params.rowRange(3, 6).reshape(1, tvec0.rows).convertTo(tvec0, tvec0.depth());
     }
     else if (_flags == SOLVEPNP_REFINE_VVS)
     {
@@ -765,6 +765,10 @@ static void solvePnPRefine(InputArray _objectPoints, InputArray _imagePoints,
         Mat rvec, tvec;
         rvec0.convertTo(rvec, CV_64F);
         tvec0.convertTo(tvec, CV_64F);
+        // tvec is used in matrix arithmetic below (R1 * tvec) which requires
+        // a Size(3,1) column vector; rvec0/tvec0 (and hence rvec/tvec) may
+        // be Size(1,3) row vectors per this function's own precondition check.
+        tvec = tvec.reshape(1, 3);
 
         std::vector<Point2d> ipoints_normalized;
         undistortPoints(ipoints, ipoints_normalized, cameraMatrix, distCoeffs);
@@ -799,8 +803,8 @@ static void solvePnPRefine(InputArray _objectPoints, InputArray _imagePoints,
         }
 
         Rodrigues(R, rvec);
-        rvec.convertTo(rvec0, rvec0.depth());
-        tvec.convertTo(tvec0, tvec0.depth());
+        rvec.reshape(1, rvec0.rows).convertTo(rvec0, rvec0.depth());
+        tvec.reshape(1, tvec0.rows).convertTo(tvec0, tvec0.depth());
     }
 }
 

--- a/modules/calib3d/test/test_solvepnp_ransac.cpp
+++ b/modules/calib3d/test/test_solvepnp_ransac.cpp
@@ -2110,6 +2110,61 @@ TEST(Calib3d_SolvePnPRansac, inputShape)
     }
 }
 
+TEST(Calib3d_SolvePnP, refine_row_vector)
+{
+    // solvePnPRefineLM()/VVS() explicitly accept rvec/tvec as either
+    // Size(1,3) (row vector) or Size(3,1) (column vector) per their
+    // own precondition check, but historically only the column-vector
+    // shape was exercised. Verify both orientations converge to the
+    // same, correct result.
+    Matx33d intrinsics(605.4, 0.0, 317.35,
+                       0.0, 601.2, 242.63,
+                       0.0, 0.0, 1.0);
+
+    double L = 0.1;
+    vector<Point3d> p3d;
+    p3d.push_back(Point3d(-L, -L, 0.0));
+    p3d.push_back(Point3d(L, -L, 0.0));
+    p3d.push_back(Point3d(L, L, 0.0));
+    p3d.push_back(Point3d(-L, L, L/2));
+    p3d.push_back(Point3d(0, 0, -L/2));
+
+    Mat rvec_ground_truth = (Mat_<double>(3,1) << 0.3, -0.2, 0.75);
+    Mat tvec_ground_truth = (Mat_<double>(3,1) << 0.15, -0.2, 1.5);
+
+    vector<Point2d> p2d;
+    projectPoints(p3d, rvec_ground_truth, tvec_ground_truth, intrinsics, noArray(), p2d);
+
+    for (int method = 0; method < 2; method++)
+    {
+        Mat rvec_col = (Mat_<double>(3,1) << 0.1, -0.1, 0.1);
+        Mat tvec_col = (Mat_<double>(3,1) << 0.0, -0.5, 1.0);
+        Mat rvec_row = rvec_col.reshape(1, 1).clone();
+        Mat tvec_row = tvec_col.reshape(1, 1).clone();
+
+        if (method == 0)
+        {
+            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_col, tvec_col);
+            solvePnPRefineLM(p3d, p2d, intrinsics, noArray(), rvec_row, tvec_row);
+        }
+        else
+        {
+            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_col, tvec_col);
+            solvePnPRefineVVS(p3d, p2d, intrinsics, noArray(), rvec_row, tvec_row);
+        }
+
+        EXPECT_LE(cvtest::norm(rvec_ground_truth, rvec_col, NORM_INF), 1e-6);
+        EXPECT_LE(cvtest::norm(tvec_ground_truth, tvec_col, NORM_INF), 1e-6);
+
+        // the row-vector call must converge to the same result as the
+        // column-vector call, and must actually write back into rvec_row/
+        // tvec_row (a shape mismatch during write-back previously left
+        // these unmodified even after fixing the read-side OOB)
+        EXPECT_LE(cvtest::norm(rvec_col, rvec_row.reshape(1, 3), NORM_INF), 1e-9);
+        EXPECT_LE(cvtest::norm(tvec_col, tvec_row.reshape(1, 3), NORM_INF), 1e-9);
+    }
+}
+
 TEST(Calib3d_SolvePnP, inputShape)
 {
     //https://github.com/opencv/opencv/issues/14423


### PR DESCRIPTION
### Describe

Fixes #29747.

`solvePnPRefine()`'s own precondition (`CV_Assert`) permits `rvec`/`tvec` to be either a 1×3 row vector (`Size(3, 1)`) or a 3×1 column vector(`Size(1, 3)`), but the implementation only correctly supports column vectors. Row vectors hit three bugs, all from the same root cause (see linked issue for full detail and reproduction):

1. **LM path**: `rvec.at<double>(i,0)`/`tvec.at<double>(i,0)` assume column-vector layout -- out-of-bounds read for a row vector (confirmed heap-buffer-overflow with ASan under a Release/NDEBUG build).
2. **LM path**: even after fixing (1), the refined result is silently not written back to the caller for row vectors, because `params.rowRange(...).convertTo(rvec0, ...)` has a shape mismatch that causes `rvec0` to be reallocated (as a local alias) instead of written in place.
3. **VVS path**: `tvec = R1 * tvec + t1` requires a column vector; a row vector throws a `cv::Exception` from `gemm`'s shape assertion.

Fixed all three with shape-agnostic `.at<double>(i)` indexing and `reshape()` before `convertTo()`/matrix arithmetic so orientation always matches, and added `Calib3d_SolvePnP.refine_row_vector` covering both methods and both orientations.

### Expected behavior

Both `solvePnPRefineLM()` and `solvePnPRefineVVS()` should refine correctly in place for either vector orientation their own precondition allows, with identical numerical results regardless of shape.

### Actual behavior

See linked issue for full detail, including an ASan trace for (1) and the exact assertion text for (3). Verified with the full `opencv_test_calib3d` suite (Release build): all 21 `Calib3d_SolvePnP.*` tests pass.

Thanks for reviewing.

---

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`4.x`, per bugfix policy)
- [x] There is a reference to the original bug report and related work (#29747)
- [x] There is an accuracy test (`Calib3d_SolvePnP.refine_row_vector`), self-contained (no `opencv_extra` test data needed); not applicable: performance test (not a perf-sensitive change)
- [x] N/A: this is a bug fix, not a new feature -- no new public API or documentation needed