### PR TITLE
features: re-enable & triage DISABLED tests

### DIFF
--- a/modules/features/src/mser.cpp
+++ b/modules/features/src/mser.cpp
@@ -1033,6 +1033,14 @@ void MSER_Impl::detect( InputArray _image, vector<KeyPoint>& keypoints, InputArr
 {
     CV_INSTRUMENT_REGION();
 
+    // detectRegions() rejects anything below 3x3; the empty case must return no keypoints
+    // instead, like the Feature2D::detect() this overrides.
+    if( _image.empty() )
+    {
+        keypoints.clear();
+        return;
+    }
+
     vector<Rect> bboxes;
     vector<vector<Point> > msers;
     Mat mask = _mask.getMat();

--- a/modules/features/src/mser.cpp
+++ b/modules/features/src/mser.cpp
@@ -1033,22 +1033,26 @@ void MSER_Impl::detect( InputArray _image, vector<KeyPoint>& keypoints, InputArr
 {
     CV_INSTRUMENT_REGION();
 
-    // detectRegions() rejects anything below 3x3; the empty case must return no keypoints
-    // instead, like the Feature2D::detect() this overrides.
+    keypoints.clear();
+
+    // Empty input yields no keypoints, matching the base Feature2D::detect() this overrides.
     if( _image.empty() )
-    {
-        keypoints.clear();
         return;
-    }
+
+    Mat image = _image.getMat(), mask = _mask.getMat();
+
+    if( image.type() != CV_8UC1 && image.type() != CV_8UC3 && image.type() != CV_8UC4 )
+        CV_Error( Error::StsBadArg, "image has incorrect type (must be CV_8UC1, CV_8UC3 or CV_8UC4)" );
+
+    if( !mask.empty() && (mask.type() != CV_8UC1 || mask.size() != image.size()) )
+        CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1) or size (!=image size)" );
 
     vector<Rect> bboxes;
     vector<vector<Point> > msers;
-    Mat mask = _mask.getMat();
 
-    detectRegions(_image, msers, bboxes);
+    detectRegions(image, msers, bboxes);
     int i, ncomps = (int)msers.size();
 
-    keypoints.clear();
     for( i = 0; i < ncomps; i++ )
     {
         Rect r = bboxes[i];

--- a/modules/features/src/mser.cpp
+++ b/modules/features/src/mser.cpp
@@ -1033,17 +1033,20 @@ void MSER_Impl::detect( InputArray _image, vector<KeyPoint>& keypoints, InputArr
 {
     CV_INSTRUMENT_REGION();
 
-    keypoints.clear();
-
     // Empty input yields no keypoints, matching the base Feature2D::detect() this overrides.
     if( _image.empty() )
+    {
+        keypoints.clear();
         return;
+    }
 
     if( _image.type() != CV_8UC1 && _image.type() != CV_8UC3 && _image.type() != CV_8UC4 )
         CV_Error( Error::StsBadArg, "image has incorrect type (must be CV_8UC1, CV_8UC3 or CV_8UC4)" );
 
     if( !_mask.empty() && (_mask.type() != CV_8UC1 || _mask.size() != _image.size()) )
         CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1) or size (!=image size)" );
+
+    keypoints.clear();
 
     vector<Rect> bboxes;
     vector<vector<Point> > msers;

--- a/modules/features/src/mser.cpp
+++ b/modules/features/src/mser.cpp
@@ -1039,18 +1039,17 @@ void MSER_Impl::detect( InputArray _image, vector<KeyPoint>& keypoints, InputArr
     if( _image.empty() )
         return;
 
-    Mat image = _image.getMat(), mask = _mask.getMat();
-
-    if( image.type() != CV_8UC1 && image.type() != CV_8UC3 && image.type() != CV_8UC4 )
+    if( _image.type() != CV_8UC1 && _image.type() != CV_8UC3 && _image.type() != CV_8UC4 )
         CV_Error( Error::StsBadArg, "image has incorrect type (must be CV_8UC1, CV_8UC3 or CV_8UC4)" );
 
-    if( !mask.empty() && (mask.type() != CV_8UC1 || mask.size() != image.size()) )
+    if( !_mask.empty() && (_mask.type() != CV_8UC1 || _mask.size() != _image.size()) )
         CV_Error( Error::StsBadArg, "mask has incorrect type (!=CV_8UC1) or size (!=image size)" );
 
     vector<Rect> bboxes;
     vector<vector<Point> > msers;
+    Mat mask = _mask.getMat();
 
-    detectRegions(image, msers, bboxes);
+    detectRegions(_image, msers, bboxes);
     int i, ncomps = (int)msers.size();
 
     for( i = 0; i < ncomps; i++ )

--- a/modules/features/test/test_detectors_regression.cpp
+++ b/modules/features/test/test_detectors_regression.cpp
@@ -44,7 +44,7 @@ TEST( Features2d_Detector_Harris, regression )
     test.safe_run();
 }
 
-TEST( Features2d_Detector_MSER, DISABLED_regression )
+TEST( Features2d_Detector_MSER, regression )
 {
     CV_FeatureDetectorTest test( "detector-mser", MSER::create() );
     test.safe_run();


### PR DESCRIPTION
Requires: https://github.com/opencv/opencv_extra/pull/1404

### PR Changes:

### features test cleanup

  ### Re-enabled
  - `Features2d_Detector_MSER.regression` (`test_detectors_regression.cpp:47`). Two things were needed:
    - `MSER_Impl` overrides `detect()` and had dropped the empty-image guard its base class carries, so the
  harness's 0x0 probe reached `detectRegions`, which rejects anything under 3x3. Added the guard; FAST and GFTT
  already carry the identical block.
    - The stored baseline held 215 keypoints against the 210 MSER finds today. The drift comes from
  `minDiversity` entering region rejection in `fa73b91e39` and the later `fitEllipse` rework.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
