### PR TITLE
gapi(test): narrow down failure condition to GCC 11.0 - 11.1

### DIFF
--- a/modules/gapi/test/gapi_async_test.cpp
+++ b/modules/gapi/test/gapi_async_test.cpp
@@ -359,9 +359,9 @@ TYPED_TEST_CASE_P(cancel);
 
 TYPED_TEST_P(cancel, basic)
 {
-#if defined(__GNUC__) && __GNUC__ == 11
+#if defined(__GNUC__) && __GNUC__ == 11 && __GNUC_MINOR__ < 2
     // std::vector<TypeParam> requests can't handle type with ctor parameter (SelfCanceling)
-    FAIL() << "Test code is not available due to compilation error with GCC 11";
+    FAIL() << "Test code is not available due to compilation error with GCC 11.0 - 11.1";
 #else
     constexpr int num_tasks = 100;
     cancel_struct cancel_struct_ {num_tasks};


### PR DESCRIPTION
* The condition under which the test `AsyncAPICancelation/cancel/0.basic` doesn't compile using GCC 11 is narrowed down to the only GCC versions which are affected: GCC 11.0 and 11.1. The issue was fixed in GCC 11.2 (verified using 11.2.0, 11.3.0, 11.4.0, 11.5.0, 12.1.0 versions of GCC).
* The corresponding issue: opencv/opencv#19678.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
