### PR TITLE
Fix Python utility compatibility issues

### DIFF
--- a/modules/java/check-tests.py
+++ b/modules/java/check-tests.py
@@ -127,7 +127,6 @@ class JavaParser:
             func = clsname + "--" + func[0].upper() + func[1:]
             args_str = args_str.replace("[]", "Array").replace("...", "Array ")
             args_str = re.sub(r"List<(\w+)>", r"ListOf\g<1>", args_str)
-            args_str = re.sub(r"List<(\w+)>", r"ListOf\g<1>", args_str)
             args = [a.split()[0] for a in args_str.split(",") if a]
             func_ex = func + "".join([a[0].upper() + a[1:] for a in args])
             func_loc = fname + " (line: " + str(linenum)  + ")"

--- a/modules/java/check-tests.py
+++ b/modules/java/check-tests.py
@@ -10,9 +10,9 @@ classes_ignore_list = (
 )
 
 funcs_ignore_list = (
-    '\w+--HashCode',
+    r'\w+--HashCode',
     'Mat--MatLong',
-    '\w+--Equals',
+    r'\w+--Equals',
     'Core--MinMaxLocResult',
 )
 
@@ -26,9 +26,9 @@ class JavaParser:
         self.mwhere = {}
         self.twhere = {}
         self.empty_stubs_cnt = 0
-        self.r1 = re.compile("\s*public\s+(?:static\s+)?(\w+)\(([^)]*)\)") # c-tor
-        self.r2 = re.compile("\s*(?:(?:public|static|final)\s+){1,3}\S+\s+(\w+)\(([^)]*)\)")
-        self.r3 = re.compile('\s*fail\("Not yet implemented"\);') # empty test stub
+        self.r1 = re.compile(r"\s*public\s+(?:static\s+)?(\w+)\(([^)]*)\)") # c-tor
+        self.r2 = re.compile(r"\s*(?:(?:public|static|final)\s+){1,3}\S+\s+(\w+)\(([^)]*)\)")
+        self.r3 = re.compile(r'\s*fail\("Not yet implemented"\);') # empty test stub
 
 
     def dict2set(self, d):
@@ -66,22 +66,24 @@ class JavaParser:
         if ".svn" in path:
             return
         if os.path.isfile(path):
+            if not path.endswith(".java"):
+                return
             if path.endswith("FeatureDetector.java"):
                 for prefix1 in ("", "Grid", "Pyramid", "Dynamic"):
                     for prefix2 in ("FAST", "STAR", "MSER", "ORB", "SIFT", "SURF", "GFTT", "HARRIS", "SIMPLEBLOB", "DENSE", "AKAZE", "KAZE", "BRISK", "AGAST"):
-                        parser.parse_file(path,prefix1+prefix2)
+                        self.parse_file(path,prefix1+prefix2)
             elif path.endswith("DescriptorExtractor.java"):
                 for prefix1 in ("", "Opponent"):
                     for prefix2 in ("BRIEF", "ORB", "SIFT", "SURF", "AKAZE", "KAZE", "BEBLID", "DAISY", "FREAK", "LUCID", "LATCH"):
-                        parser.parse_file(path,prefix1+prefix2)
+                        self.parse_file(path,prefix1+prefix2)
             elif path.endswith("GenericDescriptorMatcher.java"):
                 for prefix in ("OneWay", "Fern"):
-                    parser.parse_file(path,prefix)
+                    self.parse_file(path,prefix)
             elif path.endswith("DescriptorMatcher.java"):
                 for prefix in ("BruteForce", "BruteForceHamming", "BruteForceHammingLUT", "BruteForceL1", "FlannBased", "BruteForceSL2"):
-                    parser.parse_file(path,prefix)
+                    self.parse_file(path,prefix)
             else:
-                parser.parse_file(path)
+                self.parse_file(path)
         elif os.path.isdir(path):
             for x in os.listdir(path):
                 self.parse(path + "/" + x)
@@ -124,8 +126,8 @@ class JavaParser:
             func = re.sub(r"^test", "", func)
             func = clsname + "--" + func[0].upper() + func[1:]
             args_str = args_str.replace("[]", "Array").replace("...", "Array ")
-            args_str = re.sub(r"List<(\w+)>", "ListOf\g<1>", args_str)
-            args_str = re.sub(r"List<(\w+)>", "ListOf\g<1>", args_str)
+            args_str = re.sub(r"List<(\w+)>", r"ListOf\g<1>", args_str)
+            args_str = re.sub(r"List<(\w+)>", r"ListOf\g<1>", args_str)
             args = [a.split()[0] for a in args_str.split(",") if a]
             func_ex = func + "".join([a[0].upper() + a[1:] for a in args])
             func_loc = fname + " (line: " + str(linenum)  + ")"

--- a/modules/ts/misc/chart.py
+++ b/modules/ts/misc/chart.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-r""" OpenCV performance test results charts generator.
+""" OpenCV performance test results charts generator.
 
 This script formats results of a performance test as a table or a series of tables according to test
 parameters.

--- a/modules/ts/misc/chart.py
+++ b/modules/ts/misc/chart.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-""" OpenCV performance test results charts generator.
+r""" OpenCV performance test results charts generator.
 
 This script formats results of a performance test as a table or a series of tables according to test
 parameters.
@@ -46,8 +46,8 @@ import testlog_parser, sys, os, xml, re
 from table_formatter import *
 from optparse import OptionParser
 
-cvsize_re = re.compile("^\d+x\d+$")
-cvtype_re = re.compile("^(CV_)(8U|8S|16U|16S|32S|32F|64F)(C\d{1,3})?$")
+cvsize_re = re.compile(r"^\d+x\d+$")
+cvtype_re = re.compile(r"^(CV_)(8U|8S|16U|16S|32S|32F|64F)(C\d{1,3})?$")
 
 def keyselector(a):
     if cvsize_re.match(a):
@@ -247,7 +247,7 @@ if __name__ == "__main__":
                 stests.append(pair)
 
         tbl = table(metrix_table[options.metric][0] + " for\n" + getTestWideName(sname, indexes, arglists, x, y))
-        tbl.newColumn("x", "X\Y")
+        tbl.newColumn("x", r"X\Y")
         for col in arglists[y]:
             tbl.newColumn(col, col, align="center")
         for row in arglists[x]:

--- a/platforms/apple/cv_build_utils.py
+++ b/platforms/apple/cv_build_utils.py
@@ -46,7 +46,7 @@ def get_xcode_version():
 
 def get_xcode_setting(var, projectdir):
     ret = check_output(["xcodebuild", "-showBuildSettings"], cwd = projectdir).decode('utf-8')
-    m = re.search("\s" + var + " = (.*)", ret)
+    m = re.search(r"\s" + var + r" = (.*)", ret)
     if m:
         return m.group(1)
     else:
@@ -58,7 +58,7 @@ def get_cmake_version():
     command line tools as a tuple of (major, minor, revision)
     """
     ret = check_output(["cmake", "--version"]).decode('utf-8')
-    m = re.match(r'cmake\sversion\s+(\d+)\.(\d+).(\d+)', ret, flags=re.IGNORECASE)
+    m = re.match(r'cmake\s+version\s+(\d+)\.(\d+)\.(\d+)', ret, flags=re.IGNORECASE)
     if m:
         return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
     else:

--- a/samples/dnn/tf_text_graph_efficientdet.py
+++ b/samples/dnn/tf_text_graph_efficientdet.py
@@ -73,10 +73,10 @@ def createGraph(modelPath, outputPath, min_level, aspect_ratios, num_scales,
     nodesToKeep += ['scale_w', 'scale_h']
 
     for node in graph_def.node:
-        if re.match('efficientnet-(.*)/blocks_\d+/se/mul_1', node.name):
+        if re.match(r'efficientnet-(.*)/blocks_\d+/se/mul_1', node.name):
             node.input[0], node.input[1] = node.input[1], node.input[0]
 
-        if re.match('fpn_cells/cell_\d+/fnode\d+/resample(.*)/nearest_upsampling/Reshape_1$', node.name):
+        if re.match(r'fpn_cells/cell_\d+/fnode\d+/resample(.*)/nearest_upsampling/Reshape_1$', node.name):
             node.op = 'ResizeNearestNeighbor'
             node.input[1] = 'scale_w'
             node.input.append('scale_h')
@@ -85,7 +85,7 @@ def createGraph(modelPath, outputPath, min_level, aspect_ratios, num_scales,
                 if inpNode.name == node.name[:node.name.rfind('_')]:
                     node.input[0] = inpNode.input[0]
 
-        if re.match('box_net/box-predict(_\d)*/separable_conv2d$', node.name):
+        if re.match(r'box_net/box-predict(_\d)*/separable_conv2d$', node.name):
             node.addAttr('loc_pred_transposed', True)
 
         # Replace RealDiv to Mul with inversed scale for compatibility

--- a/samples/dnn/tf_text_graph_ssd.py
+++ b/samples/dnn/tf_text_graph_ssd.py
@@ -292,9 +292,9 @@ def createSSDGraph(modelPath, configPath, outputPath):
 
     num_matched_layers = 0
     for node in graph_def.node:
-        if re.match('BoxPredictor_\d/BoxEncodingPredictor/convolution', node.name) or \
-           re.match('BoxPredictor_\d/BoxEncodingPredictor/Conv2D', node.name) or \
-           re.match('WeightSharedConvolutionalBoxPredictor(_\d)*/BoxPredictor/Conv2D', node.name):
+        if re.match(r'BoxPredictor_\d/BoxEncodingPredictor/convolution', node.name) or \
+           re.match(r'BoxPredictor_\d/BoxEncodingPredictor/Conv2D', node.name) or \
+           re.match(r'WeightSharedConvolutionalBoxPredictor(_\d)*/BoxPredictor/Conv2D', node.name):
             node.addAttr('loc_pred_transposed', True)
             num_matched_layers += 1
     assert(num_matched_layers == num_layers)


### PR DESCRIPTION
### Problem

Several repository Python utilities emit invalid escape sequence
SyntaxWarnings under Python 3.13.

The Java test checker also attempts to parse non-Java assets as UTF-8,
causing UnicodeDecodeError, and relies on a global parser instance.

The Apple build utility accepts malformed CMake version strings because
one version separator is an unescaped regex wildcard.

### Changes

- Use raw strings for regular expressions and replacement templates.
- Skip non-Java files in the Java test checker.
- Use the current JavaParser instance instead of global state.
- Require literal dots in parsed CMake versions.

### Verification

- Compiled every tracked Python file with SyntaxWarning treated as an error.
- Ran the Java checker against modules/java/test successfully.
- Verified valid CMake versions are accepted and malformed versions rejected.
- Ran git diff --check.