### PR TITLE
Fixed Clang -Wfloat-conversion warning in public header

### DIFF
--- a/modules/flann/include/opencv2/flann/lsh_index.h
+++ b/modules/flann/include/opencv2/flann/lsh_index.h
@@ -230,7 +230,7 @@ public:
 private:
     /** Defines the comparator on score and index
      */
-    typedef std::pair<float, unsigned int> ScoreIndexPair;
+    typedef std::pair<DistanceType, unsigned int> ScoreIndexPair;
     struct SortScoreIndexPairOnSecond
     {
         bool operator()(const ScoreIndexPair& left, const ScoreIndexPair& right) const
@@ -271,7 +271,7 @@ private:
         static std::vector<ScoreIndexPair> score_index_heap;
 
         if (do_k) {
-            unsigned int worst_score = std::numeric_limits<unsigned int>::max();
+            DistanceType worst_score = std::numeric_limits<DistanceType>::max();
             typename std::vector<lsh::LshTable<ElementType> >::const_iterator table = tables_.begin();
             typename std::vector<lsh::LshTable<ElementType> >::const_iterator table_end = tables_.end();
             for (; table != table_end; ++table) {

--- a/modules/flann/include/opencv2/flann/lsh_table.h
+++ b/modules/flann/include/opencv2/flann/lsh_table.h
@@ -38,6 +38,7 @@
 //! @cond IGNORED
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <iomanip>
 #include <limits.h>
@@ -52,7 +53,6 @@
 #else
 #include <map>
 #endif
-#include <math.h>
 #include <stddef.h>
 
 #include "dynamic_bitset.h"
@@ -205,7 +205,7 @@ public:
     void add(Matrix<ElementType> dataset)
     {
 #if USE_UNORDERED_MAP
-        buckets_space_.rehash((buckets_space_.size() + dataset.rows) * 1.2);
+        buckets_space_.rehash(std::llround((buckets_space_.size() + dataset.rows) * 1.2));
 #endif
         // Add the features to the table
         for (unsigned int i = 0; i < dataset.rows; ++i) add(i, dataset[i]);

--- a/modules/objdetect/src/chessboard.cpp
+++ b/modules/objdetect/src/chessboard.cpp
@@ -332,7 +332,7 @@ inline float calcSubpixel(const float &x_l,const float &x,const float &x_r)
     const float l1 = float(std::log(x+1e-6));
     const float l2 = float(std::log(x_r+1e-6));
     float delta = l2-l1-l1+l0;
-    if(!delta) // this happens if all values are identical
+    if(delta == 0.0f) // this happens if all values are identical
         return 0;
     delta = (l0-l2)/(delta+delta);
     return delta;


### PR DESCRIPTION
It was warning:

Implicit conversion turns floating-point number into integer: 'float' to 'unsigned int'

when assigning to `worst_score`.

Looks to me like `worst_score` is actually being given the wrong type, and that it should have the same type as `hamming_distance`, which is `DistanceType`.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
