### PR TITLE
Fix min with empty matrices.

### DIFF
--- a/modules/core/src/matrix_wrap.cpp
+++ b/modules/core/src/matrix_wrap.cpp
@@ -1953,8 +1953,7 @@ Mat _OutputArray::reinterpret(int mtype) const
 
 void _OutputArray::createSameSize(const _InputArray& arr, int mtype) const
 {
-    int arrsz[CV_MAX_DIM], d = arr.sizend(arrsz);
-    create(d, arrsz, mtype);
+    create(arr.shape(), mtype);
 }
 
 void _OutputArray::fit(int d, const int* sizes, int mtype, int i,

--- a/modules/core/src/umatrix.cpp
+++ b/modules/core/src/umatrix.cpp
@@ -370,9 +370,7 @@ void UMat::create(Size _sz, int _type, UMatUsageFlags _usageFlags)
 
 void UMat::createSameSize(InputArray arr, int _type, UMatUsageFlags _usageFlags)
 {
-    int arr_size[CV_MAX_DIM];
-    int ndims = arr.sizend(arr_size);
-    create(ndims, arr_size, _type, _usageFlags);
+    create(arr.shape(), _type, _usageFlags);
 }
 
 void UMat::addref()

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -4275,4 +4275,12 @@ TEST(Core_Arithm, DISABLED_mul_overflow_28557)
     }
 }
 
+
+TEST(Core_Arithm, min_empty)
+{
+  cv::Mat A, B, C;
+  cv::max(A,B,C);
+  EXPECT_TRUE(C.empty());
+}
+
 }} // namespace


### PR DESCRIPTION
Fixes https://github.com/opencv/opencv/issues/29739

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
