### PR TITLE
Document BORDER_TRANSPARENT for warpPerspective 🤖🤖🤖

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2151,7 +2151,9 @@ and then put in the formula above instead of M. The function cannot operate in-p
 @param flags combination of interpolation methods (#INTER_LINEAR or #INTER_NEAREST) and the
 optional flag #WARP_INVERSE_MAP, that sets M as the inverse transformation (
 \f$\texttt{dst}\rightarrow\texttt{src}\f$ ).
-@param borderMode pixel extrapolation method (#BORDER_CONSTANT or #BORDER_REPLICATE).
+@param borderMode pixel extrapolation method (see #BorderTypes); when
+borderMode=#BORDER_TRANSPARENT, it means that the pixels in the destination image corresponding to
+the "outliers" in the source image are not modified by the function.
 @param borderValue value used in case of a constant border; by default, it equals 0.
 @param hint Implementation modification flags. Set #ALGO_HINT_APPROX to use FP16 precision (if available)
 for linear calculation for faster speed. See #AlgorithmHint.

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -898,6 +898,20 @@ TEST(Imgproc_Warp, multichannel)
 }
 
 
+TEST(Imgproc_Warp, perspective_transparent_border)
+{
+    const Mat src(3, 3, CV_8UC1, Scalar::all(7));
+    Mat dst(5, 5, CV_8UC1, Scalar::all(42));
+    const Mat transform = Mat::eye(3, 3, CV_64F);
+
+    warpPerspective(src, dst, transform, dst.size(), INTER_NEAREST, BORDER_TRANSPARENT);
+
+    Mat expected(5, 5, CV_8UC1, Scalar::all(42));
+    src.copyTo(expected(Rect(0, 0, src.cols, src.rows)));
+    EXPECT_EQ(0.0, cvtest::norm(dst, expected, NORM_INF));
+}
+
+
 TEST(Imgproc_Warp, regression_19566)  // valgrind should detect problem if any
 {
     const Size imgSize(8192, 8);


### PR DESCRIPTION
### Summary

`warpPerspective` accepts `BORDER_TRANSPARENT`, but its public documentation currently lists only `BORDER_CONSTANT` and `BORDER_REPLICATE`.

This change:
- documents that destination pixels mapped outside the source remain unchanged with `BORDER_TRANSPARENT`;
- adds a focused regression test covering that behavior with an identity perspective transform.

Fixes #17522.

### Validation

A focused C++ regression test was added to `test_imgwarp.cpp`. Tests were not run locally.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (`5.x`).
- [x] There is a reference to the original bug report and related work.
- [x] There is an accuracy test, where applicable.
- [x] The behavior is documented.

### AI-assisted authorship

This patch and PR description were prepared with OpenAI Codex. The contributor reviewed and submitted the resulting change.
