### PR TITLE
ptcloud: fix NaN bypass in TSDF volume integration bounds check

### DIFF
--- a/modules/ptcloud/src/tsdf_functions.cpp
+++ b/modules/ptcloud/src/tsdf_functions.cpp
@@ -160,9 +160,11 @@ void integrateTsdfVolumeUnit(const VolumeSettings& settings, const Matx44f& volu
                     // bilinearly interpolate depth at projected
                     {
                         const v_float32x4& pt = projected;
-                        // check coords >= 0 and < imgSize
+                        // check coords >= 0 and < imgSize; NaN (e.g. from an unstable pose)
+                        // compares false against both bounds and must be rejected explicitly
                         v_uint32x4 limits = v_or(v_reinterpret_as_u32(v_lt(pt, v_setzero_f32())),
                             v_reinterpret_as_u32(v_ge(pt, upLimits)));
+                        limits = v_or(limits, v_reinterpret_as_u32(v_ne(pt, pt)));
                         limits = v_or(limits, v_rotate_right<1>(limits));
                         if (v_get0(limits))
                             continue;

--- a/modules/ptcloud/src/tsdf_functions.cpp
+++ b/modules/ptcloud/src/tsdf_functions.cpp
@@ -160,11 +160,10 @@ void integrateTsdfVolumeUnit(const VolumeSettings& settings, const Matx44f& volu
                     // bilinearly interpolate depth at projected
                     {
                         const v_float32x4& pt = projected;
-                        // check coords >= 0 and < imgSize; NaN (e.g. from an unstable pose)
-                        // compares false against both bounds and must be rejected explicitly
+                        // check coords >= 0 and < imgSize; NaN passes both, so reject it explicitly
                         v_uint32x4 limits = v_or(v_reinterpret_as_u32(v_lt(pt, v_setzero_f32())),
                             v_reinterpret_as_u32(v_ge(pt, upLimits)));
-                        limits = v_or(limits, v_reinterpret_as_u32(v_ne(pt, pt)));
+                        limits = v_or(limits, v_not(v_reinterpret_as_u32(v_not_nan(pt))));
                         limits = v_or(limits, v_rotate_right<1>(limits));
                         if (v_get0(limits))
                             continue;

--- a/modules/ptcloud/src/tsdf_functions.hpp
+++ b/modules/ptcloud/src/tsdf_functions.hpp
@@ -85,7 +85,9 @@ inline depthType bilinearDepth(const Depth& m, cv::Point2f pt)
 {
     const bool fixMissingData = false;
     const depthType defaultValue = qnan;
-    if (pt.x < 0 || pt.x >= m.cols - 1 ||
+    // NaN passes both bounds checks below, so reject it explicitly
+    if (cvIsNaN(pt.x) || cvIsNaN(pt.y) ||
+        pt.x < 0 || pt.x >= m.cols - 1 ||
         pt.y < 0 || pt.y >= m.rows - 1)
         return defaultValue;
 

--- a/modules/ptcloud/test/test_tsdf.cpp
+++ b/modules/ptcloud/test/test_tsdf.cpp
@@ -1410,10 +1410,9 @@ INSTANTIATE_TEST_CASE_P(Volume, HugeSceneGrowthTest,
                           VolumeTypeEnum(VolumeType::ColorHashTSDF))));
 
 
-// A near-singular cameraPose makes Matx44f::inv() produce NaN entries. Those NaNs used to
-// bypass the SIMD bounds check in integrateTsdfVolumeUnit() (NaN compares false against both
-// bounds), reaching v_load_low() with an out-of-range index.
-TEST(Volume_TSDF, integrateSingularPoseNoOOBRead)
+// cameraPose/K below are the singular-pose reproducer from issue 29763 verbatim: Matx44f::inv()
+// turns them into NaN, which used to slip past the bounds check in integrateTsdfVolumeUnit().
+TEST(Volume, issue_29763)
 {
     OpenCLStatusRevert oclStatus;
     oclStatus.off();
@@ -1424,8 +1423,8 @@ TEST(Volume_TSDF, integrateSingularPoseNoOOBRead)
     vs.setTsdfTruncateDistance(0.001f);
     vs.setDepthFactor(1.0f);
     vs.setCameraIntegrateIntrinsics(Matx33f(2.0793828200968182e-21f, 0.0f, 0.0f,
-                                             0.0f, 2.0793828200968182e-21f, 2.079376761645066e-21f,
-                                             0.0f, 0.0f, 1.0f));
+        0.0f, 2.0793828200968182e-21f, 2.079376761645066e-21f,
+        0.0f, 0.0f, 1.0f));
     vs.setIntegrateWidth(256);
     vs.setIntegrateHeight(256);
 
@@ -1438,13 +1437,12 @@ TEST(Volume_TSDF, integrateSingularPoseNoOOBRead)
         2.3573155059146355e-21f, 48.23234939575195f, 4.336825233554269e-19f, -2.3078916742541476e+18f,
         2.3510601678662556e-38f, -3.040599552058244e+27f, -9.17830472262132e+27f, 0.0f);
 
-    ASSERT_NO_FATAL_FAILURE(volume.integrate(depth, cameraPose));
+    // The crash is a wild read, not a gtest failure, so surviving this call is the actual check.
+    volume.integrate(depth, cameraPose);
 
-    // Every projected pixel here is NaN, so none should be treated as a valid depth sample;
-    // the volume must come out of integrate() with no voxels touched.
     Mat points, normals;
     volume.fetchPointsNormals(points, normals);
-    ASSERT_EQ(points.total(), 0u);
+    ASSERT_EQ(points.total(), 0u) << "NaN projections must not touch any voxel";
 }
 
 }

--- a/modules/ptcloud/test/test_tsdf.cpp
+++ b/modules/ptcloud/test/test_tsdf.cpp
@@ -1409,5 +1409,43 @@ INSTANTIATE_TEST_CASE_P(Volume, HugeSceneGrowthTest,
         ::testing::Values(VolumeTypeEnum(VolumeType::HashTSDF),
                           VolumeTypeEnum(VolumeType::ColorHashTSDF))));
 
+
+// A near-singular cameraPose makes Matx44f::inv() produce NaN entries. Those NaNs used to
+// bypass the SIMD bounds check in integrateTsdfVolumeUnit() (NaN compares false against both
+// bounds), reaching v_load_low() with an out-of-range index.
+TEST(Volume_TSDF, integrateSingularPoseNoOOBRead)
+{
+    OpenCLStatusRevert oclStatus;
+    oclStatus.off();
+
+    VolumeSettings vs(VolumeType::TSDF);
+    vs.setVolumeResolution(Vec3i(128, 128, 128));
+    vs.setVoxelSize(0.5f);
+    vs.setTsdfTruncateDistance(0.001f);
+    vs.setDepthFactor(1.0f);
+    vs.setCameraIntegrateIntrinsics(Matx33f(2.0793828200968182e-21f, 0.0f, 0.0f,
+                                             0.0f, 2.0793828200968182e-21f, 2.079376761645066e-21f,
+                                             0.0f, 0.0f, 1.0f));
+    vs.setIntegrateWidth(256);
+    vs.setIntegrateHeight(256);
+
+    Volume volume(VolumeType::TSDF, vs);
+
+    Mat depth(256, 256, CV_32F, Scalar(2.0f));
+    Matx44f cameraPose(
+        2.370550395715484e-21f, 0.0f, 2.0793955428454976e-21f, 2.0793828200968182e-21f,
+        -2.3058509806729953e+18f, 2.079376761645066e-21f, 2.673673266036358e-39f, 2.0778708324878865e-21f,
+        2.3573155059146355e-21f, 48.23234939575195f, 4.336825233554269e-19f, -2.3078916742541476e+18f,
+        2.3510601678662556e-38f, -3.040599552058244e+27f, -9.17830472262132e+27f, 0.0f);
+
+    ASSERT_NO_FATAL_FAILURE(volume.integrate(depth, cameraPose));
+
+    // Every projected pixel here is NaN, so none should be treated as a valid depth sample;
+    // the volume must come out of integrate() with no voxels touched.
+    Mat points, normals;
+    volume.fetchPointsNormals(points, normals);
+    ASSERT_EQ(points.total(), 0u);
+}
+
 }
 }  // namespace


### PR DESCRIPTION
Fixes #29763.

A singular or near-singular `cameraPose` makes `Matx44f::inv()` return NaN. That NaN reaches the SIMD bounds check in `integrateTsdfVolumeUnit()`, which rejects out-of-range pixels by ORing `v_lt(pt, 0)` with `v_ge(pt, upLimits)`. Under IEEE 754 both comparisons return false for NaN, so the check lets it through silently. `v_floor(NaN)` then produces an indefinite integer value (`INT_MIN` on x86), and the resulting row/column index reads out of bounds in `v_load_low()`.

Added `v_not_nan()` to the mask so a NaN lane is always treated as out of range, matching the NaN-guard idiom already used elsewhere in OpenCV (e.g. `bilateral_filter.simd.hpp`). The scalar fallback of the same function goes through `bilinearDepth()` in `tsdf_functions.hpp`, which had the identical gap (`pt.x < 0 || pt.x >= ...` also can't catch NaN), so that's covered too. Added a regression test using the singular pose from the issue's reproducer; note it can only confirm no voxel gets corrupted, not the crash itself, since that needs ASan on x86 to reproduce reliably.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`5.x`, `ptcloud` doesn't exist on `4.x`)
- [x] There is a reference to the original bug report and related work (#29763)
- [x] There is an accuracy test (`Volume.issue_29763`), self-contained (no `opencv_extra` test data needed); not applicable: performance test (not a perf-sensitive change)
- [x] N/A: this is a bug fix, not a new feature -- no new public API or documentation needed
