### PR TITLE
fix orientation thresholding in anisotropic_image_segmentation.py

### DIFF
--- a/samples/python/tutorial_code/imgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.py
+++ b/samples/python/tutorial_code/imgProc/anisotropic_image_segmentation/anisotropic_image_segmentation.py
@@ -74,7 +74,7 @@ imgCoherency, imgOrientation = calcGST(imgIn, W)
 
 ## [thresholding]
 _, imgCoherencyBin = cv.threshold(imgCoherency, C_Thr, 255, cv.THRESH_BINARY)
-_, imgOrientationBin = cv.threshold(imgOrientation, LowThr, HighThr, cv.THRESH_BINARY)
+imgOrientationBin = cv.inRange(imgOrientation, LowThr, HighThr)
 ## [thresholding]
 
 ## [combining]


### PR DESCRIPTION
Same as #29757 in 5.x

The Python tutorial sample thresholds the orientation with a single cv.threshold call, passing HighThr as the maxval argument rather than as an upper bound:

```_, imgOrientationBin = cv.threshold(imgOrientation, LowThr, HighThr, cv.THRESH_BINARY)```

That computes imgOrientation > LowThr ? HighThr : 0, so HighThr never restricts the angle. The C++ counterpart uses inRange(imgOrientation, Scalar(LowThr), Scalar(HighThr), imgOrientationBin), and the tutorial text states "LowThr and HighThr define orientation range", so the C++ behaviour is the intended one.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
