### PR TITLE
cmake: check every hb_raster_* symbol used before selecting system HarfBuzz

### DIFF
--- a/cmake/OpenCVFindHarfBuzz.cmake
+++ b/cmake/OpenCVFindHarfBuzz.cmake
@@ -37,8 +37,15 @@ if(WITH_HARFBUZZ)
         set(_hb_libs "${HARFBUZZ_LIBRARIES}")
       endif()
 
-      # Verify the header and symbol actually compile and link with the chosen
+      # Verify the header and symbols actually compile and link with the chosen
       # libraries; otherwise fall back to the bundled copy.
+      # Reference every hb_raster_* entry point used by
+      # modules/imgproc/src/drawing_text.cpp: a system HarfBuzz may declare the
+      # whole hb-raster API in its header while exporting only part of it, which
+      # passes a narrower probe and then fails at link time. The array is
+      # volatile so the initializers are not optimized away at -O3 (a function
+      # address is never null, so the compiler would otherwise fold the test
+      # away and emit no relocations, letting a partial library pass).
       ocv_clear_vars(HAVE_HARFBUZZ)
       set(CMAKE_REQUIRED_INCLUDES "${_hb_inc}")
       set(CMAKE_REQUIRED_LIBRARIES "${_hb_libs}")
@@ -46,9 +53,19 @@ if(WITH_HARFBUZZ)
         #include <hb.h>
         #include <hb-raster.h>
         int main() {
-          hb_raster_draw_t* rd = hb_raster_draw_create_or_fail();
-          hb_raster_draw_render(rd);
-          return rd ? 0 : 1;
+          void (*volatile fns[])() = {
+            (void(*)())&hb_raster_draw_create_or_fail,
+            (void(*)())&hb_raster_draw_destroy,
+            (void(*)())&hb_raster_draw_set_scale_factor,
+            (void(*)())&hb_raster_draw_set_extents,
+            (void(*)())&hb_raster_draw_set_glyph_extents,
+            (void(*)())&hb_raster_draw_glyph,
+            (void(*)())&hb_raster_draw_render,
+            (void(*)())&hb_raster_draw_recycle_image,
+            (void(*)())&hb_raster_image_get_extents,
+            (void(*)())&hb_raster_image_get_buffer,
+          };
+          return fns[0] ? 0 : 1;
         }" HARFBUZZ_HAS_RASTER)
       unset(CMAKE_REQUIRED_INCLUDES)
       unset(CMAKE_REQUIRED_LIBRARIES)


### PR DESCRIPTION
### Problem

Building against a system HarfBuzz that exports only part of the hb-raster API fails at link time:

```
undefined reference to `hb_raster_draw_destroy'
```

Reported in #29458, still present after #29534.

### Root cause

`modules/imgproc/src/drawing_text.cpp` calls ten `hb_raster_*` entry points. The `HARFBUZZ_HAS_RASTER` probe added in #29300 references only two of them:

```cpp
hb_raster_draw_t* rd = hb_raster_draw_create_or_fail();
hb_raster_draw_render(rd);
```

hb-raster is recent enough that distributions ship partial or differently split builds. Such a HarfBuzz declares the full API in `hb-raster.h` (so the probe compiles) and exports the two probed symbols (so it links), which sets `HARFBUZZ_HAS_RASTER=1`. OpenCV then selects the system library rather than falling back to the bundled copy, and `drawing_text.cpp` fails on the eight symbols that are missing.

### Fix

Reference all ten symbols the module actually uses.

Two details worth noting:

- The array is `volatile` deliberately. `check_cxx_source_compiles` builds with `-O3`, and a function address is never null, so with a plain array the compiler folds `fns[0] ? 0 : 1` to a constant, discards the initializers and emits no relocations — a partial library still passes. I confirmed this: the non-volatile version of this patch does **not** fix the problem.
- It is an array of function pointers rather than `void*`, so no function-pointer-to-object-pointer cast is needed (that conversion is only conditionally supported in C++).

### Validation

I had no system HarfBuzz available, so I built two stub libraries against the hb-raster API — one exporting all ten symbols, one exporting only the two previously probed — and ran OpenCV's CMake against each via `PKG_CONFIG_PATH`:

| scenario | `HARFBUZZ_HAS_RASTER` | HarfBuzz selected |
|---|---|---|
| before, partial system lib | 1 | system → link failure |
| after, partial system lib | empty | bundled |
| after, complete system lib | 1 | system (unchanged) |

With the patch and the partial library, configure reports:

```
-- Performing Test HARFBUZZ_HAS_RASTER - Failed
-- HarfBuzz: found system version 14.2.1 but it lacks the hb-raster API; building the bundled copy instead
--     HarfBuzz:                    build (14.2.1)
```

`opencv_imgproc` then builds and links via the bundled copy: 275/275 targets, `libopencv_imgproc.so.5.1.0` produced, no undefined references.

The complete-library case confirms this does not push working setups onto the bundled build.

### Risk

CMake only, no library code changed. A system HarfBuzz that genuinely provides the full API is unaffected. The change can only move a build from "selects a partial system HarfBuzz and fails to link" to "uses the bundled copy".

I have asked the reporter of #29458 to confirm which `hb_raster_*` symbols their HarfBuzz actually exports; if it turns out to export all ten, then their failure has a different cause and this patch is hardening rather than the fix for that specific report.
