### PR TITLE
video: exclude the Gaussian pre-filter's extrapolated border ring from the ECC template mask 🤖🤖🤖

### DIFF
--- a/modules/video/src/ecc.cpp
+++ b/modules/video/src/ecc.cpp
@@ -471,6 +471,20 @@ double cv::findTransformECCWithMask( InputArray templateImage,
         templtMask.convertTo(templtMask, CV_8U);
     }
 
+    // The Gaussian pre-filter above extrapolates the template border
+    // (BORDER_REFLECT_101), so a ring of gaussFiltSize/2 px of templateFloat is
+    // fabricated rather than measured.  Used at full weight it biases the
+    // estimated linear part, so drop it.  (The blur+threshold erosion above
+    // cannot do this: blurring an all-ones mask returns all ones.)
+    const int blurRing = gaussFiltSize / 2;
+    if (blurRing > 0 && templtMask.rows > 2*blurRing && templtMask.cols > 2*blurRing)
+    {
+        templtMask.rowRange(0, blurRing).setTo(0);
+        templtMask.rowRange(templtMask.rows - blurRing, templtMask.rows).setTo(0);
+        templtMask.colRange(0, blurRing).setTo(0);
+        templtMask.colRange(templtMask.cols - blurRing, templtMask.cols).setTo(0);
+    }
+
     //to use it for mask warping
     Mat preMask;
     if(inputMask.empty())
@@ -531,7 +545,7 @@ double cv::findTransformECCWithMask( InputArray templateImage,
             warpPerspective(preMask, imageMask, map, imageMask.size(), maskFlags);
         }
 
-        if (!templateMask.empty())
+        if (!templateMask.empty() || blurRing > 0)
         {
             cv::bitwise_and(imageMask, templtMask, imageMask);
 

--- a/modules/video/test/test_ecc.cpp
+++ b/modules/video/test/test_ecc.cpp
@@ -459,6 +459,104 @@ TEST(Video_ECC_Test_Compute, bug_14657) {
     EXPECT_NEAR(computeECC(img, img), 1.0f, 1e-5f);
 }
 
+// A band-limited analytic scene.  Both images rendered from it below are direct
+// samples of the same continuous function, related by a known warp, so nothing
+// resamples the data before the estimator sees it: the only interpolation in the
+// experiment is the one findTransformECC performs itself.  That makes a drift
+// away from the known warp attributable to the estimator.
+class EccAnalyticScene {
+   public:
+    EccAnalyticScene() {
+        RNG rng(7);
+        for (int i = 0; i < components; i++) {
+            const double frequency = 0.22 * std::sqrt(rng.uniform(0.02, 1.0));  // below Nyquist
+            const double direction = rng.uniform(0.0, CV_PI);
+            frequencyX.push_back(frequency * std::cos(direction));
+            frequencyY.push_back(frequency * std::sin(direction));
+            phase.push_back(rng.uniform(0.0, 2 * CV_PI));
+        }
+    }
+
+    // image(x, y) = scene(imageToScene * (x, y, 1))
+    void render(Mat& image, Size size, const Matx33d& imageToScene) const {
+        image.create(size, CV_32F);
+        for (int y = 0; y < size.height; y++)
+            for (int x = 0; x < size.width; x++) {
+                const double sceneX = imageToScene(0, 0) * x + imageToScene(0, 1) * y + imageToScene(0, 2);
+                const double sceneY = imageToScene(1, 0) * x + imageToScene(1, 1) * y + imageToScene(1, 2);
+                double sum = 0;
+                for (int i = 0; i < components; i++)
+                    sum += std::cos(2 * CV_PI * (frequencyX[i] * sceneX + frequencyY[i] * sceneY) +
+                                    phase[i]);
+                image.at<float>(y, x) = (float)(128.0 + 120.0 / components * sum);
+            }
+    }
+
+   private:
+    static const int components = 16;
+    std::vector<double> frequencyX, frequencyY, phase;
+};
+
+// The Gaussian pre-filter extrapolates the template border (BORDER_REFLECT_101),
+// so a ring of gaussFiltSize/2 px of the smoothed template is fabricated rather
+// than measured.  Weighting that ring like real data biases the estimated linear
+// part, because the Jacobian columns of the linear parameters carry the window
+// coordinate and the opposite rings therefore do not cancel.  The translation
+// columns carry no such weight, so a check on the recovered shift stays blind to
+// it; this test starts at the known warp and watches the linear part instead.
+// The bias grows as the template shrinks, so a small window is both the cheaper
+// and the more sensitive choice here.
+TEST(Video_ECC_Affine, prefilter_border_does_not_bias_scale) {
+    const EccAnalyticScene scene;
+    const int templateSize = 128, margin = 8, inputSize = templateSize + 2 * margin, trials = 20;
+    const TermCriteria criteria(TermCriteria::COUNT + TermCriteria::EPS, 50, 1e-6);
+    const std::vector<Point2f> templateCorners = {
+        Point2f(0, 0), Point2f((float)templateSize, 0),
+        Point2f(0, (float)templateSize), Point2f((float)templateSize, (float)templateSize)};
+
+    RNG rng(12345);
+    double scaleErrorSum = 0, cornerErrorSum = 0;
+
+    for (int k = 0; k < trials; k++) {
+        const double angle = rng.uniform(-2.0, 2.0) * CV_PI / 180;
+        const double scale = rng.uniform(-0.02, 0.02);
+        const double shear = rng.uniform(-0.01, 0.01);
+        const Matx22d rotation(std::cos(angle), -std::sin(angle), std::sin(angle), std::cos(angle));
+        const Matx22d linearPart = rotation * Matx22d(1 + scale, shear, shear, 1 - scale);
+        const Matx33d groundMap(linearPart(0, 0), linearPart(0, 1), margin + rng.uniform(-3.0, 3.0),
+                                linearPart(1, 0), linearPart(1, 1), margin + rng.uniform(-3.0, 3.0),
+                                0, 0, 1);
+        const Matx33d sceneOffset(1, 0, rng.uniform(0.0, 997.0),
+                                  0, 1, rng.uniform(0.0, 991.0), 0, 0, 1);
+
+        // templateImage(x) and inputImage(groundMap * x) sample the same scene point
+        Mat templateImage, inputImage;
+        scene.render(templateImage, Size(templateSize, templateSize), sceneOffset);
+        scene.render(inputImage, Size(inputSize, inputSize), sceneOffset * groundMap.inv());
+
+        // start at the known warp, so any movement is the estimator's own doing
+        const Mat groundMatrix = (Mat_<float>(2, 3) << groundMap(0, 0), groundMap(0, 1), groundMap(0, 2),
+                                                       groundMap(1, 0), groundMap(1, 1), groundMap(1, 2));
+        Mat foundMatrix = groundMatrix.clone();
+        findTransformECC(templateImage, inputImage, foundMatrix, MOTION_AFFINE, criteria);
+
+        const Matx22d foundLinearPart(foundMatrix.at<float>(0, 0), foundMatrix.at<float>(0, 1),
+                                      foundMatrix.at<float>(1, 0), foundMatrix.at<float>(1, 1));
+        scaleErrorSum += std::sqrt(std::abs(determinant(foundLinearPart * linearPart.inv()))) - 1.0;
+
+        std::vector<Point2f> expectedCorners, foundCorners;
+        cv::transform(templateCorners, expectedCorners, groundMatrix);
+        cv::transform(templateCorners, foundCorners, foundMatrix);
+        // NORM_L2 over four points, so dividing by sqrt(4) gives the RMS displacement
+        cornerErrorSum += cv::norm(foundCorners, expectedCorners, NORM_L2) / 2;
+    }
+
+    // the recovered scale must carry no systematic offset ...
+    EXPECT_LT(std::abs(scaleErrorSum / trials), 1e-4);
+    // ... and the window must land well inside a tenth of a pixel
+    EXPECT_LT(cornerErrorSum / trials, 0.02);
+}
+
 TEST(Video_ECC_Mask, accuracy) {
     CV_ECC_Test_Mask test;
     test.safe_run();


### PR DESCRIPTION
Fixes #29774

`findTransformECC` smooths the template with `GaussianBlur(..., gaussFiltSize, ...)`, which extrapolates the border with `BORDER_REFLECT_101`. A ring of `gaussFiltSize/2` px of `templateFloat` is therefore not measured data, yet it is used at full weight in the correlation and in the Jacobian. The Jacobian columns of the linear parameters carry the window coordinate, so the opposite rings do not cancel and the recovered scale comes out systematically too small; translation carries no such weight and is unaffected.

This marks that ring invalid in `templtMask` and lets the existing per-iteration block apply it (`bitwise_and` into `imageMask`, then zero the warped gradients). Two notes for review:

- the blur+threshold erosion used for a caller-supplied mask cannot mark the image border, because blurring an all-ones mask with a normalized kernel returns all ones;
- zeroing the warped gradients is required rather than incidental. ECC assumes "outside the mask ⇒ warped image and gradients are zero", which holds because those pixels come from `BORDER_CONSTANT`. Narrowing `imageMask` alone leaves the un-zero-meaned ring feeding `project_onto_jacobian_ECC` and makes the affine error 3.5× worse instead of better.

Measured on 4.15.0-dev against an exact analytic ground truth, 200 trials, 200×200 template, estimator started at the known warp (corner RMS over the template window):

| motion | before | after |
|---|---:|---:|
| translation | 0.0167 px | 0.0176 px |
| euclidean | 0.0043 px | **0.0018 px** |
| affine | 0.0408 px | **0.0017 px** |
| homography | 0.0428 px | **0.0026 px** |
| affine scale bias | −2.8e−4 | **+5.8e−7** |

Convergence is unchanged — 200/197/136/49/8 trials out of 200 reach the optimum from a no-motion start across five motion magnitudes, against 200/197/135/48/10 before. The fix also wins at every noise level tested (σ = 1, 3, 10 grey levels), gains more on smaller templates, and is a no-op when `gaussFiltSize == 1`.

The first commit adds a self-contained regression test (201 ms, no new test data) that fails before the second commit and passes after it. `opencv_test_video --gtest_filter=*ECC*` passes 15/15 with the patch applied, including `Video_ECC_BigMS` and `Video_ECC_BigMS_Mask`, whose hard-coded `expectedRes` baselines need no update.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable *(accuracy test added in the first commit; self-contained, no new test data)*
- [ ] The feature is well documented and sample code can be built with the project CMake *(not applicable: bug fix, no API or documented behaviour change)*

---

*Disclosure: the patch, the added test and the text of this description were drafted with AI assistance (Claude). I built 4.15.0-dev, reproduced every number quoted above on that build, confirmed the new test fails before the second commit and passes after it, and reviewed the change before submitting.*
