### PR TITLE
docs: fix typos in tutorials and core.hpp reference

### DIFF
--- a/doc/tutorials/dnn/dnn_yolo/dnn_yolo.markdown
+++ b/doc/tutorials/dnn/dnn_yolo/dnn_yolo.markdown
@@ -54,7 +54,7 @@ sizes contingent upon the model's scale.
 
 This table provides a quick reference to understand the different input dimensions commonly used in
 various YOLO models inputs. These are standard input shapes. Make sure you use input size that you
-trained model with, if it is differed from from the size mentioned in the table.
+trained model with, if it is differed from the size mentioned in the table.
 
 The next critical element in the process involves understanding the specifics of image pre-processing
 for YOLO detectors. While the fundamental pre-processing approach remains consistent across the YOLO
@@ -78,7 +78,7 @@ the ONNX graph, a process that we will detail further in the subsequent sections
 
 ### PyTorch Model Export
 
-Now that we know know the parameters of the pre-precessing we can go on and export the model from
+Now that we know the parameters of the pre-processing we can go on and export the model from
 Pytorch to ONNX graph. Since in this tutorial we are using YOLOX as our sample model, lets use its
 export for demonstration purposes (the process is  identical for the rest of the YOLO detectors except `YOLOv10` model, see details on how to export it later in the post).
 To exporting YOLOX we can just use [export script](https://github.com/Megvii-BaseDetection/YOLOX/blob/ac58e0a5e68e57454b7b9ac822aced493b553c53/tools/export_onnx.py). Particularly we need following commands:

--- a/doc/tutorials/introduction/android_binary_package/android_ocl_intro.markdown
+++ b/doc/tutorials/introduction/android_binary_package/android_ocl_intro.markdown
@@ -49,7 +49,7 @@ libOpenCL.so may be provided with BSP or just downloaded from any OpenCL-cabaple
 cd your_path/ANDROID_OPENCL_SDK && mkdir lib && cd lib
 adb pull /system/vendor/lib64/libOpenCL.so
 @endcode
-System verison of libOpenCL.so may have a lot of platform specific dependencies. `-Wl,--allow-shlib-undefined` flag allows
+System version of libOpenCL.so may have a lot of platform specific dependencies. `-Wl,--allow-shlib-undefined` flag allows
 to ignore 3rdparty symbols if they are not used during the build.
 The following CMake line allows to link the JNI part against standard OpenCL, but not include the loadLibrary into
 application package. System OpenCL API is used in run-time.

--- a/doc/tutorials/introduction/crosscompilation/crosscompile_with_multiarch.markdown
+++ b/doc/tutorials/introduction/crosscompilation/crosscompile_with_multiarch.markdown
@@ -370,7 +370,7 @@ If enabling Python 3 wrapper is succeeded, `Python 3:` section shows more.
 
 ### Step 3. Build and archive OpenCV libraries and headers
 
-This step in in host.
+This step in host.
 
 Build and install.
 (This `install` means only that copying artifacts to `install` folder.)

--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -1689,7 +1689,7 @@ CV_EXPORTS_W void patchNaNs(InputOutputArray a, double val = 0);
 
 /** @brief Generates a mask of finite float values, i.e. not NaNs nor Infs.
 
-An element is set to to 255 (all 1-bits) if all channels are finite.
+An element is set to 255 (all 1-bits) if all channels are finite.
 @param src Input matrix, should contain float or double elements of 1 to 4 channels
 @param mask Output matrix of the same size as input of type CV_8UC1
 */


### PR DESCRIPTION
Small documentation cleanup found while reading the docs:

**doc/tutorials/dnn/dnn_yolo/dnn_yolo.markdown**
- "if it is differed from from the size mentioned" → "differed from the size"
- "we know know the parameters of the pre-precessing" → "we know the parameters of the pre-processing" (also fixes misspelled *precessing*)

**doc/tutorials/introduction/crosscompilation/crosscompile_with_multiarch.markdown**
- "This step in in host." → "This step in host."

**doc/tutorials/introduction/android_binary_package/android_ocl_intro.markdown**
- "System verison of libOpenCL.so" → "System version"

**modules/core/include/opencv2/core.hpp**
- checkFinite() reference: "An element is set to to 255" → "set to 255"