### PR TITLE
expose per-instance cv::RNG objects

### DIFF
--- a/modules/core/include/opencv2/core.hpp
+++ b/modules/core/include/opencv2/core.hpp
@@ -2878,7 +2878,7 @@ Gaussian-distribution random numbers are generated using the Ziggurat
 algorithm ( <http://en.wikipedia.org/wiki/Ziggurat_algorithm> ),
 introduced by G. Marsaglia and W. W. Tsang.
 */
-class CV_EXPORTS RNG
+class CV_EXPORTS_W_SIMPLE RNG
 {
 public:
     enum { UNIFORM = 0,
@@ -2893,14 +2893,14 @@ public:
     , the constructor uses the above default value instead to avoid the
     singular random number sequence, consisting of all zeros.
     */
-    RNG();
+    CV_WRAP RNG();
     /** @overload
     @param state 64-bit value used to initialize the RNG.
     */
-    RNG(uint64 state);
+    CV_WRAP RNG(uint64 state);
     /**The method updates the state using the MWC algorithm and returns the
     next 32-bit random number.*/
-    unsigned next();
+    CV_WRAP unsigned next();
 
     /**Each of the methods updates the state using the MWC algorithm and
     returns the next random number of the specified type. In case of integer
@@ -2973,11 +2973,11 @@ public:
     @param a lower inclusive boundary of the returned random number.
     @param b upper non-inclusive boundary of the returned random number.
     */
-    int uniform(int a, int b);
+    CV_WRAP int uniform(int a, int b);
     /** @overload */
     float uniform(float a, float b);
     /** @overload */
-    double uniform(double a, double b);
+    CV_WRAP double uniform(double a, double b);
 
     /** @brief Fills arrays with random numbers.
 
@@ -3013,7 +3013,7 @@ public:
     with zero mean and identity covariation matrix, and then transforms them
     using transform to get samples from the specified Gaussian distribution.
     */
-    void fill( InputOutputArray mat, int distType, InputArray a, InputArray b, bool saturateRange = false );
+    CV_WRAP void fill( InputOutputArray mat, int distType, InputArray a, InputArray b, bool saturateRange = false );
 
     /** @brief Returns the next random number sampled from the Gaussian distribution
     @param sigma standard deviation of the distribution.
@@ -3023,9 +3023,9 @@ public:
     the mean value of the returned random numbers is zero and the standard
     deviation is the specified sigma .
     */
-    double gaussian(double sigma);
+    CV_WRAP double gaussian(double sigma);
 
-    uint64 state;
+    CV_PROP_RW uint64 state;
 
     bool operator ==(const RNG& other) const;
 };

--- a/modules/core/misc/java/gen_dict.json
+++ b/modules/core/misc/java/gen_dict.json
@@ -6,7 +6,8 @@
         "FileStorage",
         "KDTree",
         "KeyPoint",
-        "DMatch"
+        "DMatch",
+        "RNG"
     ],
     "missing_consts" : {
         "Core" : {

--- a/modules/core/misc/objc/gen_dict.json
+++ b/modules/core/misc/objc/gen_dict.json
@@ -5,7 +5,8 @@
         "FileStorage",
         "KDTree",
         "KeyPoint",
-        "DMatch"
+        "DMatch",
+        "RNG"
     ],
     "missing_consts" : {
         "Core" : {

--- a/modules/core/misc/python/pyopencv_core.hpp
+++ b/modules/core/misc/python/pyopencv_core.hpp
@@ -5,6 +5,23 @@
 
 #include "dlpack/dlpack.h"
 
+// cv::RNG is a "simple" wrapped type, so its C++ instance is stored by value inside
+// the Python object. Functions like cv::randShuffle() accept an optional RNG*, which
+// must alias that very instance (and not a copy of it) to advance the caller's state.
+// The pointer stays valid for the duration of the call because the Python object is
+// kept alive by the argument tuple. A missing argument (or None) is left as the
+// default null pointer, which means "use cv::theRNG()".
+template<>
+bool pyopencv_to(PyObject* obj, cv::RNG*& value, const ArgInfo& info)
+{
+    if (!obj || obj == Py_None)
+        return true;
+    if (pyopencv_RNG_getp(obj, value))
+        return true;
+    failmsg("Expected cv::RNG for argument '%s'", info.name);
+    return false;
+}
+
 static PyObject* pycvMakeType(PyObject* , PyObject* args, PyObject* kw) {
     const char *keywords[] = { "depth", "channels", NULL };
 

--- a/modules/python/src2/gen2.py
+++ b/modules/python/src2/gen2.py
@@ -33,7 +33,7 @@ else:
 
 forbidden_arg_types = ["void*"]
 
-ignored_arg_types = ["RNG*"]
+ignored_arg_types = []
 
 pass_by_val_types = ["Point*", "Point2f*", "Rect*", "String*", "double*", "float*", "int*"]
 
@@ -229,6 +229,7 @@ ArgTypeInfo.__new__.__defaults__ = (False,)
 simple_argtype_mapping = {
     "bool": ArgTypeInfo("bool", FormatStrings.unsigned_char, "0", True),
     "size_t": ArgTypeInfo("size_t", FormatStrings.unsigned_long_long, "0", True),
+    "uint64": ArgTypeInfo("uint64", FormatStrings.unsigned_long_long, "0", True),
     "int": ArgTypeInfo("int", FormatStrings.int, "0", True),
     "float": ArgTypeInfo("float", FormatStrings.float, "0.f", True),
     "double": ArgTypeInfo("double", FormatStrings.double, "0", True),

--- a/modules/python/src2/typing_stubs_generation/predefined_types.py
+++ b/modules/python/src2/typing_stubs_generation/predefined_types.py
@@ -27,6 +27,7 @@ _PREDEFINED_TYPES = (
     PrimitiveTypeNode.int_("int32_t"),
     PrimitiveTypeNode.int_("uint32_t"),
     PrimitiveTypeNode.int_("size_t"),
+    PrimitiveTypeNode.int_("uint64"),
     PrimitiveTypeNode.int_("int64_t"),
     PrimitiveTypeNode.int_("long long"),
     PrimitiveTypeNode.float_("float"),

--- a/modules/python/test/test_rng.py
+++ b/modules/python/test/test_rng.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python
+
+'''
+Tests for the per-instance cv.RNG bindings.
+
+They check that a cv.RNG object owns and advances its own C++ cv::RNG state and
+that this state is fully isolated from the default (global) OpenCV generator.
+'''
+
+from __future__ import print_function
+
+import numpy as np
+import cv2 as cv
+
+from tests_common import NewOpenCVTests
+
+
+# Deliberately larger than 32 bits so that a truncated uint64 seed is detectable.
+BIG_SEED = (1 << 40) + 137
+
+
+class rng_test(NewOpenCVTests):
+
+    def global_uniform_bytes(self, shape=(8, 8)):
+        """Draws from the default (global) generator via the module level API."""
+        return cv.randu(np.zeros(shape, np.uint8), 0, 256).copy()
+
+    def test_rng_is_exposed_and_constructible(self):
+        self.assertTrue(hasattr(cv, 'RNG'))
+
+        default_rng = cv.RNG()
+        self.assertIsInstance(default_rng, cv.RNG)
+        # cv::RNG() uses 2**32-1 as the pre-defined initial state.
+        self.assertEqual(default_rng.state, 0xffffffff)
+
+        seeded_rng = cv.RNG(137)
+        self.assertIsInstance(seeded_rng, cv.RNG)
+        self.assertEqual(seeded_rng.state, 137)
+
+        # The distribution identifiers needed by fill() are available.
+        self.assertEqual(cv.RNG_UNIFORM, 0)
+        self.assertEqual(cv.RNG_NORMAL, 1)
+
+    def test_state_is_readable_and_writable(self):
+        rng = cv.RNG()
+        rng.state = 137
+        self.assertEqual(rng.state, 137)
+
+        seeded = cv.RNG(137)
+        self.assertEqual([rng.next() for _ in range(4)],
+                         [seeded.next() for _ in range(4)])
+
+    def test_seed_is_not_truncated_to_32_bits(self):
+        self.assertEqual(cv.RNG(BIG_SEED).state, BIG_SEED)
+
+        full, truncated = cv.RNG(BIG_SEED), cv.RNG(BIG_SEED & 0xffffffff)
+        self.assertNotEqual([full.next() for _ in range(4)],
+                            [truncated.next() for _ in range(4)])
+
+    def test_same_seed_gives_identical_sequences(self):
+        rng_a = cv.RNG(137)
+        rng_b = cv.RNG(137)
+
+        self.assertEqual([rng_a.next() for _ in range(16)],
+                         [rng_b.next() for _ in range(16)])
+        self.assertEqual([rng_a.uniform(0, 1000) for _ in range(16)],
+                         [rng_b.uniform(0, 1000) for _ in range(16)])
+        self.assertEqual([rng_a.uniform(-1.5, 2.5) for _ in range(16)],
+                         [rng_b.uniform(-1.5, 2.5) for _ in range(16)])
+        self.assertEqual([rng_a.gaussian(2.0) for _ in range(16)],
+                         [rng_b.gaussian(2.0) for _ in range(16)])
+        self.assertEqual(rng_a.state, rng_b.state)
+
+    def test_instances_advance_independently(self):
+        rng_a = cv.RNG(BIG_SEED)
+        rng_b = cv.RNG(BIG_SEED)
+
+        # Advancing rng_a must leave rng_b exactly where it was.
+        head_a = [rng_a.next() for _ in range(5)]
+        self.assertNotEqual(rng_a.state, rng_b.state)
+        self.assertEqual(rng_b.state, BIG_SEED)
+
+        head_b = [rng_b.next() for _ in range(5)]
+        self.assertEqual(head_a, head_b)
+        self.assertEqual(rng_a.state, rng_b.state)
+
+        # Draws 5..9 of the sequence differ from draws 0..4, so a generator that
+        # is ahead really does yield different values than a freshly seeded one.
+        tail = [rng_a.next() for _ in range(5)]
+        fresh = cv.RNG(BIG_SEED)
+        self.assertNotEqual(tail, [fresh.next() for _ in range(5)])
+
+    def test_fill_uniform(self):
+        low, high = 10, 20
+        shape = (4, 5)
+
+        dst_a = np.zeros(shape, np.uint8)
+        dst_b = np.zeros(shape, np.uint8)
+        out_a = cv.RNG(137).fill(dst_a, cv.RNG_UNIFORM, low, high)
+        out_b = cv.RNG(137).fill(dst_b, cv.RNG_UNIFORM, low, high)
+
+        self.assertEqual(out_a.dtype, np.uint8)
+        self.assertEqual(out_a.shape, shape)
+        self.assertTrue(np.array_equal(out_a, out_b))
+        self.assertTrue(np.all(out_a >= low))
+        self.assertTrue(np.all(out_a < high))
+
+        # Filling advances the instance, so a second fill differs from the first.
+        rng = cv.RNG(137)
+        first = rng.fill(np.zeros(shape, np.uint8), cv.RNG_UNIFORM, low, high).copy()
+        state_after_first = rng.state
+        second = rng.fill(np.zeros(shape, np.uint8), cv.RNG_UNIFORM, low, high).copy()
+        self.assertTrue(np.array_equal(first, out_a))
+        self.assertNotEqual(rng.state, state_after_first)
+        self.assertFalse(np.array_equal(first, second))
+
+    def test_fill_normal(self):
+        shape = (3, 7)
+
+        out_a = cv.RNG(137).fill(np.zeros(shape, np.float32), cv.RNG_NORMAL, 0.0, 1.0)
+        out_b = cv.RNG(137).fill(np.zeros(shape, np.float32), cv.RNG_NORMAL, 0.0, 1.0)
+
+        self.assertEqual(out_a.dtype, np.float32)
+        self.assertEqual(out_a.shape, shape)
+        self.assertTrue(np.array_equal(out_a, out_b))
+        self.assertTrue(np.all(np.isfinite(out_a)))
+
+        # A different seed drives a different sequence.
+        out_c = cv.RNG(138).fill(np.zeros(shape, np.float32), cv.RNG_NORMAL, 0.0, 1.0)
+        self.assertFalse(np.array_equal(out_a, out_c))
+
+    def test_scalar_operations_mutate_only_the_instance(self):
+        rng = cv.RNG(137)
+        other = cv.RNG(137)
+
+        state = rng.state
+        value = rng.next()
+        self.assertIsInstance(value, int)
+        self.assertTrue(0 <= value <= 0xffffffff)
+        self.assertNotEqual(rng.state, state)
+        self.assertEqual(other.state, 137)
+
+        state = rng.state
+        value = rng.uniform(3, 9)
+        self.assertIsInstance(value, int)
+        self.assertTrue(3 <= value < 9)
+        self.assertNotEqual(rng.state, state)
+
+        state = rng.state
+        value = rng.uniform(-2.0, 2.0)
+        self.assertIsInstance(value, float)
+        self.assertTrue(-2.0 <= value < 2.0)
+        self.assertNotEqual(rng.state, state)
+
+        state = rng.state
+        value = rng.gaussian(1.5)
+        self.assertIsInstance(value, float)
+        self.assertNotEqual(rng.state, state)
+
+        # None of the above touched the second instance.
+        self.assertEqual(other.state, 137)
+
+    def test_instance_does_not_disturb_global_rng(self):
+        cv.setRNGSeed(12345)
+        expected = self.global_uniform_bytes()
+
+        cv.setRNGSeed(12345)
+        rng = cv.RNG(999)
+        rng.next()
+        rng.uniform(0, 100)
+        rng.uniform(0.0, 1.0)
+        rng.gaussian(1.0)
+        rng.fill(np.zeros((6, 6), np.uint8), cv.RNG_UNIFORM, 0, 256)
+        rng.fill(np.zeros((6, 6), np.float32), cv.RNG_NORMAL, 0.0, 1.0)
+        cv.randShuffle(np.arange(32, dtype=np.int32).reshape(1, -1), 1.0, rng)
+        actual = self.global_uniform_bytes()
+
+        self.assertTrue(np.array_equal(expected, actual))
+
+    def test_global_rng_does_not_disturb_instances(self):
+        rng_a = cv.RNG(137)
+        rng_b = cv.RNG(137)
+
+        seq_a = [rng_a.next() for _ in range(8)]
+
+        cv.setRNGSeed(4242)
+        cv.randu(np.zeros((16, 16), np.uint8), 0, 256)
+        cv.randn(np.zeros((16, 16), np.float32), 0.0, 1.0)
+        cv.setRNGSeed(7)
+        cv.randShuffle(np.arange(64, dtype=np.int32).reshape(1, -1))
+
+        seq_b = [rng_b.next() for _ in range(8)]
+
+        self.assertEqual(seq_a, seq_b)
+        self.assertEqual(rng_a.state, rng_b.state)
+
+    def test_rand_shuffle_with_instance_rng(self):
+        values = np.arange(64, dtype=np.int32).reshape(1, -1)
+
+        shuffled_a = cv.randShuffle(values.copy(), 1.0, cv.RNG(137))
+        shuffled_b = cv.randShuffle(values.copy(), 1.0, cv.RNG(137))
+
+        self.assertTrue(np.array_equal(shuffled_a, shuffled_b))
+        self.assertTrue(np.array_equal(np.sort(shuffled_a, axis=1), values))
+
+        # The rng argument is really used: a different seed shuffles differently.
+        shuffled_c = cv.randShuffle(values.copy(), 1.0, cv.RNG(555))
+        self.assertFalse(np.array_equal(shuffled_a, shuffled_c))
+
+        # ... and the global seed is irrelevant when an instance is supplied.
+        cv.setRNGSeed(1)
+        shuffled_d = cv.randShuffle(values.copy(), 1.0, cv.RNG(137))
+        cv.setRNGSeed(2)
+        shuffled_e = cv.randShuffle(values.copy(), 1.0, cv.RNG(137))
+        self.assertTrue(np.array_equal(shuffled_a, shuffled_d))
+        self.assertTrue(np.array_equal(shuffled_a, shuffled_e))
+
+    def test_rand_shuffle_advances_the_supplied_instance(self):
+        values = np.arange(64, dtype=np.int32).reshape(1, -1)
+
+        rng = cv.RNG(137)
+        state = rng.state
+        first = cv.randShuffle(values.copy(), 1.0, rng).copy()
+        # A copy of the RNG would have left the caller's state untouched.
+        self.assertNotEqual(rng.state, state)
+
+        second = cv.randShuffle(values.copy(), 1.0, rng).copy()
+        self.assertFalse(np.array_equal(first, second))
+
+        # Two independent instances stay in lockstep with each other.
+        rng_a, rng_b = cv.RNG(137), cv.RNG(137)
+        cv.randShuffle(values.copy(), 1.0, rng_a)
+        self.assertNotEqual(rng_a.state, rng_b.state)
+        cv.randShuffle(values.copy(), 1.0, rng_b)
+        self.assertEqual(rng_a.state, rng_b.state)
+
+    def test_rand_shuffle_without_instance_uses_global_rng(self):
+        values = np.arange(64, dtype=np.int32).reshape(1, -1)
+
+        cv.setRNGSeed(7)
+        expected = cv.randShuffle(values.copy()).copy()
+        cv.setRNGSeed(7)
+        self.assertTrue(np.array_equal(cv.randShuffle(values.copy(), 1.0), expected))
+        cv.setRNGSeed(7)
+        self.assertTrue(np.array_equal(cv.randShuffle(values.copy(), 1.0, None), expected))
+
+        # An interleaved instance based shuffle leaves the global sequence intact.
+        cv.setRNGSeed(7)
+        cv.randShuffle(values.copy(), 1.0, cv.RNG(137))
+        self.assertTrue(np.array_equal(cv.randShuffle(values.copy()), expected))
+
+    def test_rand_shuffle_rejects_non_rng_argument(self):
+        values = np.arange(8, dtype=np.int32).reshape(1, -1)
+        with self.assertRaises(cv.error):
+            cv.randShuffle(values, 1.0, 137)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Resolves #29591.

### Problem

`cv::RNG` was never annotated for the bindings, so Python could only reach the
process-wide generator through `randu`, `randn`, `randShuffle` and
`setRNGSeed`. Any call that reseeds it changes the sequence observed by every
other OpenCV user in the same process, which forces downstream libraries to
serialize around `setRNGSeed()` instead of giving each pipeline its own
generator.

### What this does

Wraps `cv::RNG` as `CV_EXPORTS_W_SIMPLE` and makes the existing C++ object
constructible and usable from Python:

```python
rng_a = cv2.RNG(137)
rng_b = cv2.RNG(137)

rng_a.next()
rng_a.uniform(0, 10)          # int overload
rng_a.uniform(0.0, 1.0)       # double overload
rng_a.gaussian(1.0)
rng_a.fill(img, cv2.RNG_UNIFORM, 0, 256)

cv2.randShuffle(values, 1.0, rng_b)
```

No new random-number code: this exposes the existing implementation. The
header change is annotations only — preprocessed output of `opencv2/core.hpp`
is byte-identical before and after, so there is no C++ API or ABI change.

The `float uniform(float, float)` overload is intentionally left unwrapped,
since no Python scalar type selects it and its presence would make
`rng.uniform(0.0, 1.0)` return single precision.

### Design notes

Three changes go beyond header annotations. Each is there because the existing
machinery could not express the API:

**`ignored_arg_types`.** `randShuffle()` already accepts an optional `RNG*`,
but `gen2.py` listed `"RNG*"` in `ignored_arg_types` and substituted `0` for
it, so the argument never reached Python. The C++ declaration and
implementation are untouched; only the block-list entry is dropped.

**`pyopencv_to()` for `cv::RNG*`.** Once the parameter is visible the generator
needs a converter. `CV_PY_TO_CLASS_PTR()` is not usable here: it routes through
a local `Ptr<>`, which for a by-value ("simple") class both copies the
generator — so the caller's state would never advance — and leaves the pointer
dangling. The specialization instead aliases the `cv::RNG` stored inside the
Python object via the generated `pyopencv_RNG_getp()`. A missing argument or
`None` keeps the null default, so `theRNG()` is still used exactly as before.

**`uint64`.** The seeding constructor takes `uint64`, so the type is registered
in `simple_argtype_mapping` and in the typing-stub predefined types. Without
the latter, stub generation cannot resolve the constructor and silently drops
*every* stub.

`RNG` is added to the Java and Objective-C `class_ignore_list` so those
bindings are unchanged by this PR. `gen_objc.py` has no `uint64` mapping and
aborts with `KeyError: 'uint64'` on the `state` property, and `gen_java.py`
would emit an `RNG` class with `RNG(uint64)`, `next()` and `state` all skipped,
i.e. one that cannot be seeded. Happy to expose it there instead if preferred —
that needs `uint64` added to both `type_dict`s.

### Testing

New `modules/python/test/test_rng.py`, 14 tests, picked up by the existing glob
discovery. Coverage: construction and both constructors; seeds wider than 32
bits; same-seed determinism across `next`/`uniform`/`gaussian`; independent
advancement of two instances; uniform fill on `uint8` with bounds; normal fill
on `float32`; isolation from the global RNG in **both** directions; and
`randShuffle` with an instance RNG, including that the caller's instance is
advanced rather than copied and that the global sequence is untouched. All
comparisons are exact, no statistical assertions.

Verified locally:

- 14/14 new Python tests pass; full Python suite shows no new failures
- `opencv_test_core` passes in full (12408 tests)
- Generated-bindings diff against `4.x` across all main-repo headers including
  gapi is limited to the `rng` parameter on `randShuffle` and the new `RNG`
  type — nothing else changes
- Java and Objective-C generator output is byte-identical to `4.x`

Java/ObjC bindings were verified at the generator-output level; they were not
compile-tested locally (no JDK/Xcode), so CI is the check there.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake