### PR TITLE
extend dtype support across engine-new layers

### DIFF
--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -922,9 +922,7 @@ static void fastNormGroupImpl(const Mat &input, const Mat &scale, const Mat &bia
             T var = (T)std::max(0., dmean_sq / norm_size - (double)mean * (double)mean);
             T inv_stdev = (T)1 / std::sqrt(var + epsilon);
 
-            // Loop restructured (channel outer, offset inner) instead of j/step per
-            // element -- avoids a per-element division, cheap win for T=double too and
-            // what lets the T=float instantiation vectorize below.
+            // Channel-outer loop avoids a per-element j/step division and lets T=float vectorize below.
             size_t group_idx = i % num_groups * channels_per_group;
             size_t j = 0;
             for (size_t c_idx = 0; c_idx < channels_per_group; c_idx++) {

--- a/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/fast_norm.cpp
@@ -5,6 +5,7 @@
 #include "../../precomp.hpp"
 #include "fast_norm.hpp"
 #include <opencv2/core/hal/intrin.hpp>
+#include <type_traits>
 
 namespace cv { namespace dnn {
 
@@ -68,6 +69,7 @@ static inline void normAccumSumSqSum64f(const float* x, size_t n, double& sum, d
 }
 #endif
 
+// Unchanged: only mvn_layer.cpp uses this overload, out of scope here.
 void fastNorm(const Mat &input, Mat &output, float epsilon, size_t normalized_axis, bool normalize_variance) {
     const auto input_shape = shape(input);
     CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
@@ -114,11 +116,10 @@ void fastNorm(const Mat &input, Mat &output, float epsilon, size_t normalized_ax
     parallel_for_(Range(0, loops), fn, nstripes);
 }
 
-void fastNormMeanInvStdDev(const Mat& input, Mat& mean, Mat& invStdDev, float epsilon, size_t normalized_axis)
+// Templated on T so CV_64F gets a genuine double accumulator, not a narrowed float one.
+template<typename T>
+static void fastNormMeanInvStdDevImpl(const Mat& input, Mat& mean, Mat& invStdDev, T epsilon, size_t normalized_axis)
 {
-    CV_Assert(input.type() == CV_32F);
-    CV_Assert(mean.type() == CV_32F);
-    CV_Assert(invStdDev.type() == CV_32F);
     CV_Assert(input.isContinuous() && mean.isContinuous() && invStdDev.isContinuous());
 
     const auto input_shape = shape(input);
@@ -126,34 +127,39 @@ void fastNormMeanInvStdDev(const Mat& input, Mat& mean, Mat& invStdDev, float ep
 
     const size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis)));
     const size_t norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
-    const float inv_norm_size = 1.0f / (float)norm_size;
+    const T inv_norm_size = (T)1 / (T)norm_size;
 
     CV_CheckEQ((size_t)mean.total(), loops, "fastNormMeanInvStdDev: mean output size mismatch");
     CV_CheckEQ((size_t)invStdDev.total(), loops, "fastNormMeanInvStdDev: invStdDev output size mismatch");
 
     auto fn = [&](const Range& r) {
-        const float* input_data = input.ptr<float>();
-        float* mean_data = mean.ptr<float>();
-        float* invstd_data = invStdDev.ptr<float>();
+        const T* input_data = input.ptr<T>();
+        T* mean_data = mean.ptr<T>();
+        T* invstd_data = invStdDev.ptr<T>();
         for (int i = r.start; i < r.end; ++i)
         {
-            const float* x = input_data + norm_size * (size_t)i;
-            float m = 0.f, mean_square = 0.f;
+            const T* x = input_data + norm_size * (size_t)i;
+            T m = 0, mean_square = 0;
+            bool simd_done = false;
+            if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            normAccumSumSqSum(x, norm_size, m, mean_square);
-#else
-            for (size_t j = 0; j < norm_size; ++j)
-            {
-                float v = x[j];
-                m += v;
-                mean_square += v * v;
-            }
+                normAccumSumSqSum(x, norm_size, m, mean_square);
+                simd_done = true;
 #endif
+            }
+            if (!simd_done) {
+                for (size_t j = 0; j < norm_size; ++j)
+                {
+                    T v = x[j];
+                    m += v;
+                    mean_square += v * v;
+                }
+            }
             m *= inv_norm_size;
-            const float var = std::max(0.f, mean_square * inv_norm_size - m * m);
-            const float stdev = std::sqrt(var + epsilon);
+            const T var = std::max((T)0, mean_square * inv_norm_size - m * m);
+            const T stdev = std::sqrt(var + epsilon);
             mean_data[i] = m;
-            invstd_data[i] = 1.f / stdev;
+            invstd_data[i] = (T)1 / stdev;
         }
     };
 
@@ -161,49 +167,71 @@ void fastNormMeanInvStdDev(const Mat& input, Mat& mean, Mat& invStdDev, float ep
     parallel_for_(Range(0, (int)loops), fn, nstripes);
 }
 
-void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, size_t normalized_axis, bool recenter) {
+void fastNormMeanInvStdDev(const Mat& input, Mat& mean, Mat& invStdDev, float epsilon, size_t normalized_axis)
+{
+    int type = input.type();
+    CV_CheckType(type, type == CV_32F || type == CV_64F, "fastNormMeanInvStdDev: unsupported type");
+    CV_CheckTypeEQ(type, mean.type(), "fastNormMeanInvStdDev: mean must match input type");
+    CV_CheckTypeEQ(type, invStdDev.type(), "fastNormMeanInvStdDev: invStdDev must match input type");
+
+    if (type == CV_64F)
+        fastNormMeanInvStdDevImpl<double>(input, mean, invStdDev, (double)epsilon, normalized_axis);
+    else
+        fastNormMeanInvStdDevImpl<float>(input, mean, invStdDev, epsilon, normalized_axis);
+}
+
+// RMSNorm (recenter=false) and LayerNorm/LayerNorm2's no-bias path (recenter=true).
+template<typename T>
+static void fastNormImpl(const Mat &input, const Mat &scale, Mat &output, T epsilon, size_t normalized_axis, bool recenter) {
     const auto input_shape = shape(input);
     CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
 
     size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis))),
            norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
-    float inv_norm_size = 1.0 / norm_size;
+    T inv_norm_size = (T)1 / (T)norm_size;
 
     auto fn = [&](const Range &r) {
-        const auto *input_data = input.ptr<const float>();
-        const auto *scale_data = scale.ptr<const float>();
-        auto *output_data = output.ptr<float>();
+        const T *input_data = input.ptr<const T>();
+        const T *scale_data = scale.ptr<const T>();
+        T *output_data = output.ptr<T>();
         for (int i = r.start; i < r.end; i++) {
-            const auto *x = input_data + norm_size * i;
-            auto *y = output_data + norm_size * i;
+            const T *x = input_data + norm_size * i;
+            T *y = output_data + norm_size * i;
 
-            float mean = 0.f, mean_square = 0.f;
+            T mean = 0, mean_square = 0;
+            bool simd_done = false;
+            if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            normAccumSumSqSum(x, norm_size, mean, mean_square);
-            if (!recenter)
-                mean = 0.f;
-#else
-            for (int j = 0; j < norm_size; j++) {
-                float v = x[j];
-                if (recenter)
-                    mean += v;
-                mean_square += v * v;
-            }
+                normAccumSumSqSum(x, norm_size, mean, mean_square);
+                if (!recenter)
+                    mean = 0.f;
+                simd_done = true;
 #endif
+            }
+            if (!simd_done) {
+                for (int j = 0; j < norm_size; j++) {
+                    T v = x[j];
+                    if (recenter)
+                        mean += v;
+                    mean_square += v * v;
+                }
+            }
 
             mean *= inv_norm_size;
-            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
-            float inv_stdev = 1.f / mean_square;
+            mean_square = std::sqrt(std::max((T)0, mean_square * inv_norm_size - mean * mean) + epsilon);
+            T inv_stdev = (T)1 / mean_square;
 
             size_t j = 0;
+            if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
-            v_float32 vmean = vx_setall_f32(mean), vinv_stdev = vx_setall_f32(inv_stdev);
-            for (; j + VEC_SZ <= norm_size; j += VEC_SZ) {
-                v_float32 vs = vx_load(scale_data + j);
-                vx_store(y + j, v_mul(v_mul(vs, v_sub(vx_load(x + j), vmean)), vinv_stdev));
-            }
+                const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
+                v_float32 vmean = vx_setall_f32(mean), vinv_stdev = vx_setall_f32(inv_stdev);
+                for (; j + VEC_SZ <= norm_size; j += VEC_SZ) {
+                    v_float32 vs = vx_load(scale_data + j);
+                    vx_store(y + j, v_mul(v_mul(vs, v_sub(vx_load(x + j), vmean)), vinv_stdev));
+                }
 #endif
+            }
             for (; j < norm_size; j++) {
                 y[j] = scale_data[j] * (x[j] - mean) * inv_stdev;
             }
@@ -213,51 +241,390 @@ void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, si
     parallel_for_(Range(0, loops), fn, nstripes);
 }
 
-void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, size_t normalized_axis) {
+void fastNorm(const Mat &input, const Mat &scale, Mat &output, float epsilon, size_t normalized_axis, bool recenter) {
+    int type = input.type();
+    CV_CheckType(type, type == CV_32F || type == CV_64F, "fastNorm: unsupported type");
+    CV_CheckTypeEQ(type, scale.type(), "fastNorm: scale must match input type");
+    CV_CheckTypeEQ(type, output.type(), "fastNorm: output must match input type");
+
+    if (type == CV_64F)
+        fastNormImpl<double>(input, scale, output, (double)epsilon, normalized_axis, recenter);
+    else
+        fastNormImpl<float>(input, scale, output, epsilon, normalized_axis, recenter);
+}
+
+// Full LayerNorm (scale + bias) -- LayerNorm and LayerNorm2's with-bias path.
+template<typename T>
+static void fastNormImpl(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, T epsilon, size_t normalized_axis) {
     const auto input_shape = shape(input);
     CV_CheckLT(normalized_axis, input_shape.size(), "fastNorm: axis out of range");
     CV_CheckEQ(scale.total(), bias.total(), "fastNorm: scale and bias should have the same shape");
 
     size_t loops = static_cast<size_t>(total(input_shape, 0, static_cast<int>(normalized_axis))),
            norm_size = static_cast<size_t>(total(input_shape, static_cast<int>(normalized_axis)));
-    float inv_norm_size = 1.0 / norm_size;
+    T inv_norm_size = (T)1 / (T)norm_size;
 
     auto fn = [&](const Range &r) {
-        const auto *input_data = input.ptr<const float>();
-        const auto *scale_data = scale.ptr<const float>();
-        const auto *bias_data = bias.ptr<const float>();
-        auto *output_data = output.ptr<float>();
+        const T *input_data = input.ptr<const T>();
+        const T *scale_data = scale.ptr<const T>();
+        const T *bias_data = bias.ptr<const T>();
+        T *output_data = output.ptr<T>();
         for (int i = r.start; i < r.end; i++) {
-            const auto *x = input_data + norm_size * i;
-            auto *y = output_data + norm_size * i;
+            const T *x = input_data + norm_size * i;
+            T *y = output_data + norm_size * i;
 
-            float mean = 0.f, mean_square = 0.f;
+            T mean = 0, mean_square = 0;
+            bool simd_done = false;
+            if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            normAccumSumSqSum(x, norm_size, mean, mean_square);
-#else
-            for (int j = 0; j < norm_size; j++) {
-                float v = x[j];
-                mean += v;
-                mean_square += v * v;
-            }
+                normAccumSumSqSum(x, norm_size, mean, mean_square);
+                simd_done = true;
 #endif
+            }
+            if (!simd_done) {
+                for (int j = 0; j < norm_size; j++) {
+                    T v = x[j];
+                    mean += v;
+                    mean_square += v * v;
+                }
+            }
 
             mean *= inv_norm_size;
-            mean_square = std::sqrt(std::max(0.f, mean_square * inv_norm_size - mean * mean) + epsilon);
-            float inv_stdev = 1.f / mean_square;
+            mean_square = std::sqrt(std::max((T)0, mean_square * inv_norm_size - mean * mean) + epsilon);
+            T inv_stdev = (T)1 / mean_square;
 
             size_t j = 0;
+            if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
-            v_float32 vmean = vx_setall_f32(mean), vinv_stdev = vx_setall_f32(inv_stdev);
-            for (; j + VEC_SZ <= norm_size; j += VEC_SZ) {
-                v_float32 vs = vx_load(scale_data + j);
-                v_float32 vb = vx_load(bias_data + j);
-                vx_store(y + j, v_fma(v_mul(vs, v_sub(vx_load(x + j), vmean)), vinv_stdev, vb));
-            }
+                const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
+                v_float32 vmean = vx_setall_f32(mean), vinv_stdev = vx_setall_f32(inv_stdev);
+                for (; j + VEC_SZ <= norm_size; j += VEC_SZ) {
+                    v_float32 vs = vx_load(scale_data + j);
+                    v_float32 vb = vx_load(bias_data + j);
+                    vx_store(y + j, v_fma(v_mul(vs, v_sub(vx_load(x + j), vmean)), vinv_stdev, vb));
+                }
 #endif
+            }
             for (; j < norm_size; j++) {
                 y[j] = scale_data[j] * (x[j] - mean) * inv_stdev + bias_data[j];
+            }
+        }
+    };
+    double nstripes = loops * norm_size * (1 / 1024.0);
+    parallel_for_(Range(0, loops), fn, nstripes);
+}
+
+void fastNorm(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, size_t normalized_axis) {
+    int type = input.type();
+    CV_CheckType(type, type == CV_32F || type == CV_64F, "fastNorm: unsupported type");
+    CV_CheckTypeEQ(type, scale.type(), "fastNorm: scale must match input type");
+    CV_CheckTypeEQ(type, bias.type(), "fastNorm: bias must match input type");
+    CV_CheckTypeEQ(type, output.type(), "fastNorm: output must match input type");
+
+    if (type == CV_64F)
+        fastNormImpl<double>(input, scale, bias, output, (double)epsilon, normalized_axis);
+    else
+        fastNormImpl<float>(input, scale, bias, output, epsilon, normalized_axis);
+}
+
+// InstanceNorm, BLOCK layout, CV_32F -- extracted verbatim, unchanged.
+static void fastNormChannelBlockF32(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon) {
+    const auto input_shape = shape(input);
+    size_t C = (size_t)input_shape.C;
+
+    CV_Assert(input.dims == 5 && output.dims == 5);
+    CV_Assert(input.isContinuous() && output.isContinuous());
+
+    const int N  = input.size[0];
+    const int C1 = input.size[1];
+    const int H  = input.size[2];
+    const int W  = input.size[3];
+    const int C0 = input.size[4];
+    const int Ci = (int)C;
+
+    const float* scale_data = scale.ptr<float>();
+    const float* bias_data  = bias.ptr<float>();
+
+    const size_t inStep0 = input.step.p[0] / sizeof(float);
+    const size_t inStep1 = input.step.p[1] / sizeof(float);
+    const size_t inStep2 = input.step.p[2] / sizeof(float);
+    const size_t inStep3 = input.step.p[3] / sizeof(float);
+
+    const size_t outStep0 = output.step.p[0] / sizeof(float);
+    const size_t outStep1 = output.step.p[1] / sizeof(float);
+    const size_t outStep2 = output.step.p[2] / sizeof(float);
+    const size_t outStep3 = output.step.p[3] / sizeof(float);
+
+    const size_t norm_size = (size_t)H * (size_t)W;
+
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+    const int VEC_SZ = VTraits<v_float32>::vlanes();
+#endif
+
+    // Accumulators are double-precision
+    const double inv_norm_size_d = 1.0 / (double)norm_size;
+
+    parallel_for_(Range(0, N * C1), [&](const Range& r) {
+        const float* inptr0 = (const float*)input.data;
+        float* outptr0 = (float*)output.data;
+
+        AutoBuffer<double> sumBuf(C0 * 2);
+        double* sum   = sumBuf.data();
+        double* sqsum = sum + C0;
+        AutoBuffer<float> abBuf(C0 * 2);
+        float* alpha = abBuf.data();
+        float* beta  = alpha + C0;
+
+        for (int i = r.start; i < r.end; ++i) {
+            int n  = i / C1;
+            int c1 = i - n * C1;
+            int cbase = c1 * C0;
+            int validC0 = std::min(C0, std::max(0, Ci - cbase));
+
+            const float* inbase  = inptr0  + n * inStep0 + c1 * inStep1;
+            float*       outbase = outptr0 + n * outStep0 + c1 * outStep1;
+
+            int c0 = 0;
+#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
+            const int VEC_SZ_D = VTraits<v_float64>::vlanes();
+            CV_DbgAssert(VEC_SZ == 2 * VEC_SZ_D);
+            for (; c0 <= validC0 - VEC_SZ; c0 += VEC_SZ) {
+                v_float64 vsum_lo = vx_setzero_f64(), vsum_hi = vx_setzero_f64();
+                v_float64 vsqsum_lo = vx_setzero_f64(), vsqsum_hi = vx_setzero_f64();
+                for (int h = 0; h < H; ++h) {
+                    const float* inrow = inbase + h * inStep2;
+                    for (int w = 0; w < W; ++w) {
+                        v_float32 v = vx_load(inrow + w * inStep3 + c0);
+                        v_float64 vlo = v_cvt_f64(v);
+                        v_float64 vhi = v_cvt_f64_high(v);
+                        vsum_lo = v_add(vsum_lo, vlo);
+                        vsum_hi = v_add(vsum_hi, vhi);
+                        vsqsum_lo = v_fma(vlo, vlo, vsqsum_lo);
+                        vsqsum_hi = v_fma(vhi, vhi, vsqsum_hi);
+                    }
+                }
+                vx_store(sum   + c0,             vsum_lo);
+                vx_store(sum   + c0 + VEC_SZ_D, vsum_hi);
+                vx_store(sqsum + c0,             vsqsum_lo);
+                vx_store(sqsum + c0 + VEC_SZ_D, vsqsum_hi);
+            }
+#endif
+            for (; c0 < validC0; ++c0) {
+                double s = 0., sq = 0.;
+                for (int h = 0; h < H; ++h) {
+                    const float* inrow = inbase + h * inStep2;
+                    for (int w = 0; w < W; ++w) {
+                        double v = (double)inrow[w * inStep3 + c0];
+                        s += v;
+                        sq += v * v;
+                    }
+                }
+                sum[c0] = s;
+                sqsum[c0] = sq;
+            }
+
+            for (int c = 0; c < validC0; ++c) {
+                double mean = sum[c] * inv_norm_size_d;
+                double var = std::max(0., sqsum[c] * inv_norm_size_d - mean * mean);
+                float inv_stdev = 1.f / std::sqrt((float)var + epsilon);
+                alpha[c] = scale_data[cbase + c] * inv_stdev;
+                beta[c]  = bias_data[cbase + c] - alpha[c] * (float)mean;
+            }
+
+            c0 = 0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            for (; c0 <= validC0 - VEC_SZ; c0 += VEC_SZ) {
+                v_float32 va = vx_load(alpha + c0);
+                v_float32 vb = vx_load(beta + c0);
+                for (int h = 0; h < H; ++h) {
+                    const float* inrow  = inbase + h * inStep2;
+                    float*       outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w) {
+                        v_float32 vin = vx_load(inrow + w * inStep3 + c0);
+                        vx_store(outrow + w * outStep3 + c0, v_fma(vin, va, vb));
+                    }
+                }
+            }
+#endif
+            for (; c0 < validC0; ++c0) {
+                float a = alpha[c0], b = beta[c0];
+                for (int h = 0; h < H; ++h) {
+                    const float* inrow  = inbase + h * inStep2;
+                    float*       outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w)
+                        outrow[w * outStep3 + c0] = inrow[w * inStep3 + c0] * a + b;
+                }
+            }
+
+            int c0_pad = validC0;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+            for (; c0_pad <= C0 - VEC_SZ; c0_pad += VEC_SZ) {
+                v_float32 vzero = vx_setzero_f32();
+                for (int h = 0; h < H; ++h) {
+                    float* outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w)
+                        vx_store(outrow + w * outStep3 + c0_pad, vzero);
+                }
+            }
+#endif
+            for (; c0_pad < C0; ++c0_pad)
+                for (int h = 0; h < H; ++h) {
+                    float* outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w)
+                        outrow[w * outStep3 + c0_pad] = 0.f;
+                }
+        }
+    });
+}
+
+// InstanceNorm, BLOCK layout, CV_64F -- scalar counterpart to fastNormChannelBlockF32.
+template<typename T>
+static void fastNormChannelBlockT(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, T epsilon) {
+    const auto input_shape = shape(input);
+    size_t C = (size_t)input_shape.C;
+
+    CV_Assert(input.dims == 5 && output.dims == 5);
+    CV_Assert(input.isContinuous() && output.isContinuous());
+
+    const int N  = input.size[0];
+    const int C1 = input.size[1];
+    const int H  = input.size[2];
+    const int W  = input.size[3];
+    const int C0 = input.size[4];
+    const int Ci = (int)C;
+
+    const T* scale_data = scale.ptr<T>();
+    const T* bias_data  = bias.ptr<T>();
+
+    const size_t inStep0 = input.step.p[0] / sizeof(T);
+    const size_t inStep1 = input.step.p[1] / sizeof(T);
+    const size_t inStep2 = input.step.p[2] / sizeof(T);
+    const size_t inStep3 = input.step.p[3] / sizeof(T);
+
+    const size_t outStep0 = output.step.p[0] / sizeof(T);
+    const size_t outStep1 = output.step.p[1] / sizeof(T);
+    const size_t outStep2 = output.step.p[2] / sizeof(T);
+    const size_t outStep3 = output.step.p[3] / sizeof(T);
+
+    const size_t norm_size = (size_t)H * (size_t)W;
+    const T inv_norm_size = (T)1 / (T)norm_size;
+
+    parallel_for_(Range(0, N * C1), [&](const Range& r) {
+        const T* inptr0 = (const T*)input.data;
+        T* outptr0 = (T*)output.data;
+
+        AutoBuffer<T> sumBuf(C0 * 2);
+        T* sum   = sumBuf.data();
+        T* sqsum = sum + C0;
+        AutoBuffer<T> abBuf(C0 * 2);
+        T* alpha = abBuf.data();
+        T* beta  = alpha + C0;
+
+        for (int i = r.start; i < r.end; ++i) {
+            int n  = i / C1;
+            int c1 = i - n * C1;
+            int cbase = c1 * C0;
+            int validC0 = std::min(C0, std::max(0, Ci - cbase));
+
+            const T* inbase  = inptr0  + n * inStep0 + c1 * inStep1;
+            T*       outbase = outptr0 + n * outStep0 + c1 * outStep1;
+
+            for (int c0 = 0; c0 < validC0; ++c0) {
+                T s = 0, sq = 0;
+                for (int h = 0; h < H; ++h) {
+                    const T* inrow = inbase + h * inStep2;
+                    for (int w = 0; w < W; ++w) {
+                        T v = inrow[w * inStep3 + c0];
+                        s += v;
+                        sq += v * v;
+                    }
+                }
+                sum[c0] = s;
+                sqsum[c0] = sq;
+            }
+
+            for (int c = 0; c < validC0; ++c) {
+                T mean = sum[c] * inv_norm_size;
+                T var = std::max((T)0, sqsum[c] * inv_norm_size - mean * mean);
+                T inv_stdev = (T)1 / std::sqrt(var + epsilon);
+                alpha[c] = scale_data[cbase + c] * inv_stdev;
+                beta[c]  = bias_data[cbase + c] - alpha[c] * mean;
+            }
+
+            for (int c0 = 0; c0 < validC0; ++c0) {
+                T a = alpha[c0], b = beta[c0];
+                for (int h = 0; h < H; ++h) {
+                    const T* inrow  = inbase + h * inStep2;
+                    T*       outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w)
+                        outrow[w * outStep3 + c0] = inrow[w * inStep3 + c0] * a + b;
+                }
+            }
+
+            for (int c0_pad = validC0; c0_pad < C0; ++c0_pad)
+                for (int h = 0; h < H; ++h) {
+                    T* outrow = outbase + h * outStep2;
+                    for (int w = 0; w < W; ++w)
+                        outrow[w * outStep3 + c0_pad] = 0;
+                }
+        }
+    });
+}
+
+// InstanceNorm, plain NCHW layout.
+template<typename T>
+static void fastNormChannelImpl(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, T epsilon) {
+    const auto input_shape = shape(input);
+    size_t C = input_shape[1];
+
+    size_t N = input_shape[0];
+    CV_CheckGE(input.dims, 3, "fastNormChannel: input dimension >= 3");
+
+    size_t loops = N * C,
+           norm_size = static_cast<size_t>(total(input_shape, 2));
+
+    auto fn = [&](const Range &r) {
+        const T *input_data = input.ptr<const T>();
+        const T *scale_data = scale.ptr<const T>();
+        const T *bias_data = bias.ptr<const T>();
+        T *output_data = output.ptr<T>();
+        for (int i = r.start; i < r.end; i++) {
+            const T *x = input_data + norm_size * i;
+            T *y = output_data + norm_size * i;
+
+            double dmean = 0., dmean_sq = 0.;
+            bool simd_done = false;
+            if constexpr (std::is_same<T, float>::value) {
+#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
+                normAccumSumSqSum64f(x, norm_size, dmean, dmean_sq);
+                simd_done = true;
+#endif
+            }
+            if (!simd_done) {
+                for (size_t j = 0; j < norm_size; j++) {
+                    double v = (double)x[j];
+                    dmean += v;
+                    dmean_sq += v * v;
+                }
+            }
+
+            T mean = (T)(dmean / norm_size);
+            T var = (T)std::max(0., dmean_sq / norm_size - (double)mean * (double)mean);
+            T inv_stdev = (T)1 / std::sqrt(var + epsilon);
+
+            size_t c = i % C;
+            T s = scale_data[c] * inv_stdev, b = bias_data[c];
+            size_t j = 0;
+            if constexpr (std::is_same<T, float>::value) {
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+                const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
+                v_float32 vmean = vx_setall_f32(mean), vs = vx_setall_f32(s), vb = vx_setall_f32(b);
+                for (; j + VEC_SZ <= norm_size; j += VEC_SZ)
+                    vx_store(y + j, v_fma(v_sub(vx_load(x + j), vmean), vs, vb));
+#endif
+            }
+            for (; j < norm_size; j++) {
+                y[j] = s * (x[j] - mean) + b;
             }
         }
     };
@@ -271,110 +638,112 @@ void fastNormChannel(const Mat &input, const Mat &scale, const Mat &bias, Mat &o
     CV_CheckEQ(scale.total(), C, "fastNormChannel: scale should be a 1d tensor and match the channel of input");
     CV_CheckEQ(bias.total(), C, "fastNormChannel: bias should be a 1d tensor and match the channel of input");
 
+    int type = input.type();
+    CV_CheckType(type, type == CV_32F || type == CV_64F, "fastNormChannel: unsupported type");
+    CV_CheckTypeEQ(type, output.type(), "fastNormChannel: output must match input type");
+    CV_CheckTypeEQ(type, scale.type(), "fastNormChannel: scale must match input type");
+    CV_CheckTypeEQ(type, bias.type(), "fastNormChannel: bias must match input type");
+
     if (input_shape.layout == DATA_LAYOUT_BLOCK) {
-        CV_Assert(input.dims == 5 && output.dims == 5);
-        CV_Assert(input.type() == CV_32F && output.type() == CV_32F);
-        CV_Assert(input.isContinuous() && output.isContinuous());
+        if (type == CV_64F)
+            fastNormChannelBlockT<double>(input, scale, bias, output, (double)epsilon);
+        else
+            fastNormChannelBlockF32(input, scale, bias, output, epsilon);
+        return;
+    }
 
-        const int N  = input.size[0];
-        const int C1 = input.size[1];
-        const int H  = input.size[2];
-        const int W  = input.size[3];
-        const int C0 = input.size[4];
-        const int Ci = (int)C;
+    if (type == CV_64F)
+        fastNormChannelImpl<double>(input, scale, bias, output, (double)epsilon);
+    else
+        fastNormChannelImpl<float>(input, scale, bias, output, epsilon);
+}
 
-        const float* scale_data = scale.ptr<float>();
-        const float* bias_data  = bias.ptr<float>();
+// GroupNorm, BLOCK layout, CV_32F -- extracted verbatim, unchanged.
+static void fastNormGroupBlockF32(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, float epsilon, size_t num_groups) {
+    const auto input_shape = shape(input);
+    size_t C = (size_t)input_shape.C;
 
-        const size_t inStep0 = input.step.p[0] / sizeof(float);
-        const size_t inStep1 = input.step.p[1] / sizeof(float);
-        const size_t inStep2 = input.step.p[2] / sizeof(float);
-        const size_t inStep3 = input.step.p[3] / sizeof(float);
+    CV_Assert(input.dims == 5 && output.dims == 5);
+    CV_Assert(input.isContinuous() && output.isContinuous());
 
-        const size_t outStep0 = output.step.p[0] / sizeof(float);
-        const size_t outStep1 = output.step.p[1] / sizeof(float);
-        const size_t outStep2 = output.step.p[2] / sizeof(float);
-        const size_t outStep3 = output.step.p[3] / sizeof(float);
+    const int N  = input.size[0];
+    const int H  = input.size[2];
+    const int W  = input.size[3];
+    const int C0 = input.size[4];
+    const int Ci = (int)C;
 
-        const size_t norm_size = (size_t)H * (size_t)W;
+    const float* scale_data = scale.ptr<float>();
+    const float* bias_data  = bias.ptr<float>();
+
+    const size_t inStep0 = input.step.p[0] / sizeof(float);
+    const size_t inStep1 = input.step.p[1] / sizeof(float);
+    const size_t inStep2 = input.step.p[2] / sizeof(float);
+    const size_t inStep3 = input.step.p[3] / sizeof(float);
+
+    const size_t outStep0 = output.step.p[0] / sizeof(float);
+    const size_t outStep1 = output.step.p[1] / sizeof(float);
+    const size_t outStep2 = output.step.p[2] / sizeof(float);
+    const size_t outStep3 = output.step.p[3] / sizeof(float);
+
+    const int channels_per_group = Ci / (int)num_groups;
+    const size_t norm_size = (size_t)channels_per_group * (size_t)H * (size_t)W;
+    const double inv_norm_size = 1.0 / (double)norm_size;
 
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-        const int VEC_SZ = VTraits<v_float32>::vlanes();
+    const int VEC_SZ = VTraits<v_float32>::vlanes();
 #endif
 
-        // Accumulators are double-precision
-        const double inv_norm_size_d = 1.0 / (double)norm_size;
+    parallel_for_(Range(0, N * (int)num_groups), [&](const Range& r) {
+        const float* inptr = (const float*)input.data;
+        float* outptr = (float*)output.data;
 
-        parallel_for_(Range(0, N * C1), [&](const Range& r) {
-            const float* inptr0 = (const float*)input.data;
-            float* outptr0 = (float*)output.data;
+        AutoBuffer<float> buf(C0 * 2);
+        float* alpha = buf.data();
+        float* beta  = alpha + C0;
 
-            AutoBuffer<double> sumBuf(C0 * 2);
-            double* sum   = sumBuf.data();
-            double* sqsum = sum + C0;
-            AutoBuffer<float> abBuf(C0 * 2);
-            float* alpha = abBuf.data();
-            float* beta  = alpha + C0;
+        for (int i = r.start; i < r.end; ++i) {
+            int n = i / (int)num_groups;
+            int g = i - n * (int)num_groups;
+            int c_start = g * channels_per_group;
+            int c_end   = c_start + channels_per_group;
 
-            for (int i = r.start; i < r.end; ++i) {
-                int n  = i / C1;
-                int c1 = i - n * C1;
+            double group_sum = 0., group_sqsum = 0.;
+            for (int c = c_start; c < c_end; c++) {
+                int c1 = c / C0;
+                int c0 = c % C0;
+                const float* inbase = inptr + n * inStep0 + c1 * inStep1;
+                for (int h = 0; h < H; ++h) {
+                    const float* inrow = inbase + h * inStep2;
+                    for (int w = 0; w < W; ++w) {
+                        double v = (double)inrow[w * inStep3 + c0];
+                        group_sum += v;
+                        group_sqsum += v * v;
+                    }
+                }
+            }
+
+            float mean = (float)(group_sum * inv_norm_size);
+            float var  = std::max(0.f, (float)(group_sqsum * inv_norm_size - (double)mean * (double)mean));
+            float inv_stdev = 1.f / std::sqrt(var + epsilon);
+
+            for (int c1_start = c_start / C0, c1_end_idx = (c_end - 1) / C0 + 1,
+                     c1 = c1_start; c1 < c1_end_idx; ++c1) {
                 int cbase = c1 * C0;
+                int c0_lo = std::max(0, c_start - cbase);
+                int c0_hi = std::min(C0, c_end - cbase);
                 int validC0 = std::min(C0, std::max(0, Ci - cbase));
 
-                const float* inbase  = inptr0  + n * inStep0 + c1 * inStep1;
-                float*       outbase = outptr0 + n * outStep0 + c1 * outStep1;
-
-                int c0 = 0;
-#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
-                const int VEC_SZ_D = VTraits<v_float64>::vlanes();
-                CV_DbgAssert(VEC_SZ == 2 * VEC_SZ_D);
-                for (; c0 <= validC0 - VEC_SZ; c0 += VEC_SZ) {
-                    v_float64 vsum_lo = vx_setzero_f64(), vsum_hi = vx_setzero_f64();
-                    v_float64 vsqsum_lo = vx_setzero_f64(), vsqsum_hi = vx_setzero_f64();
-                    for (int h = 0; h < H; ++h) {
-                        const float* inrow = inbase + h * inStep2;
-                        for (int w = 0; w < W; ++w) {
-                            v_float32 v = vx_load(inrow + w * inStep3 + c0);
-                            v_float64 vlo = v_cvt_f64(v);
-                            v_float64 vhi = v_cvt_f64_high(v);
-                            vsum_lo = v_add(vsum_lo, vlo);
-                            vsum_hi = v_add(vsum_hi, vhi);
-                            vsqsum_lo = v_fma(vlo, vlo, vsqsum_lo);
-                            vsqsum_hi = v_fma(vhi, vhi, vsqsum_hi);
-                        }
-                    }
-                    vx_store(sum   + c0,             vsum_lo);
-                    vx_store(sum   + c0 + VEC_SZ_D, vsum_hi);
-                    vx_store(sqsum + c0,             vsqsum_lo);
-                    vx_store(sqsum + c0 + VEC_SZ_D, vsqsum_hi);
-                }
-#endif
-                for (; c0 < validC0; ++c0) {
-                    double s = 0., sq = 0.;
-                    for (int h = 0; h < H; ++h) {
-                        const float* inrow = inbase + h * inStep2;
-                        for (int w = 0; w < W; ++w) {
-                            double v = (double)inrow[w * inStep3 + c0];
-                            s += v;
-                            sq += v * v;
-                        }
-                    }
-                    sum[c0] = s;
-                    sqsum[c0] = sq;
+                for (int c0 = c0_lo; c0 < c0_hi; ++c0) {
+                    alpha[c0] = scale_data[cbase + c0] * inv_stdev;
+                    beta[c0]  = bias_data[cbase + c0] - alpha[c0] * mean;
                 }
 
-                for (int c = 0; c < validC0; ++c) {
-                    double mean = sum[c] * inv_norm_size_d;
-                    double var = std::max(0., sqsum[c] * inv_norm_size_d - mean * mean);
-                    float inv_stdev = 1.f / std::sqrt((float)var + epsilon);
-                    alpha[c] = scale_data[cbase + c] * inv_stdev;
-                    beta[c]  = bias_data[cbase + c] - alpha[c] * (float)mean;
-                }
+                const float* inbase  = inptr  + n * inStep0 + c1 * inStep1;
+                float*       outbase = outptr + n * outStep0 + c1 * outStep1;
 
-                c0 = 0;
+                int c0 = c0_lo;
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-                for (; c0 <= validC0 - VEC_SZ; c0 += VEC_SZ) {
+                for (; c0 <= c0_hi - VEC_SZ; c0 += VEC_SZ) {
                     v_float32 va = vx_load(alpha + c0);
                     v_float32 vb = vx_load(beta + c0);
                     for (int h = 0; h < H; ++h) {
@@ -387,7 +756,7 @@ void fastNormChannel(const Mat &input, const Mat &scale, const Mat &bias, Mat &o
                     }
                 }
 #endif
-                for (; c0 < validC0; ++c0) {
+                for (; c0 < c0_hi; ++c0) {
                     float a = alpha[c0], b = beta[c0];
                     for (int h = 0; h < H; ++h) {
                         const float* inrow  = inbase + h * inStep2;
@@ -397,72 +766,185 @@ void fastNormChannel(const Mat &input, const Mat &scale, const Mat &bias, Mat &o
                     }
                 }
 
-                int c0_pad = validC0;
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-                for (; c0_pad <= C0 - VEC_SZ; c0_pad += VEC_SZ) {
-                    v_float32 vzero = vx_setzero_f32();
-                    for (int h = 0; h < H; ++h) {
-                        float* outrow = outbase + h * outStep2;
-                        for (int w = 0; w < W; ++w)
-                            vx_store(outrow + w * outStep3 + c0_pad, vzero);
-                    }
-                }
-#endif
-                for (; c0_pad < C0; ++c0_pad)
+                for (int c0_pad = std::max(c0_hi, validC0); c0_pad < C0; ++c0_pad)
                     for (int h = 0; h < H; ++h) {
                         float* outrow = outbase + h * outStep2;
                         for (int w = 0; w < W; ++w)
                             outrow[w * outStep3 + c0_pad] = 0.f;
                     }
             }
-        });
-        return;
-    }
+        }
+    });
+}
+
+// GroupNorm, BLOCK layout, CV_64F -- scalar counterpart to fastNormGroupBlockF32.
+template<typename T>
+static void fastNormGroupBlockT(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, T epsilon, size_t num_groups) {
+    const auto input_shape = shape(input);
+    size_t C = (size_t)input_shape.C;
+
+    CV_Assert(input.dims == 5 && output.dims == 5);
+    CV_Assert(input.isContinuous() && output.isContinuous());
+
+    const int N  = input.size[0];
+    const int H  = input.size[2];
+    const int W  = input.size[3];
+    const int C0 = input.size[4];
+    const int Ci = (int)C;
+
+    const T* scale_data = scale.ptr<T>();
+    const T* bias_data  = bias.ptr<T>();
+
+    const size_t inStep0 = input.step.p[0] / sizeof(T);
+    const size_t inStep1 = input.step.p[1] / sizeof(T);
+    const size_t inStep2 = input.step.p[2] / sizeof(T);
+    const size_t inStep3 = input.step.p[3] / sizeof(T);
+
+    const size_t outStep0 = output.step.p[0] / sizeof(T);
+    const size_t outStep1 = output.step.p[1] / sizeof(T);
+    const size_t outStep2 = output.step.p[2] / sizeof(T);
+    const size_t outStep3 = output.step.p[3] / sizeof(T);
+
+    const int channels_per_group = Ci / (int)num_groups;
+    const size_t norm_size = (size_t)channels_per_group * (size_t)H * (size_t)W;
+    const T inv_norm_size = (T)1 / (T)norm_size;
+
+    parallel_for_(Range(0, N * (int)num_groups), [&](const Range& r) {
+        const T* inptr = (const T*)input.data;
+        T* outptr = (T*)output.data;
+
+        AutoBuffer<T> buf(C0 * 2);
+        T* alpha = buf.data();
+        T* beta  = alpha + C0;
+
+        for (int i = r.start; i < r.end; ++i) {
+            int n = i / (int)num_groups;
+            int g = i - n * (int)num_groups;
+            int c_start = g * channels_per_group;
+            int c_end   = c_start + channels_per_group;
+
+            T group_sum = 0, group_sqsum = 0;
+            for (int c = c_start; c < c_end; c++) {
+                int c1 = c / C0;
+                int c0 = c % C0;
+                const T* inbase = inptr + n * inStep0 + c1 * inStep1;
+                for (int h = 0; h < H; ++h) {
+                    const T* inrow = inbase + h * inStep2;
+                    for (int w = 0; w < W; ++w) {
+                        T v = inrow[w * inStep3 + c0];
+                        group_sum += v;
+                        group_sqsum += v * v;
+                    }
+                }
+            }
+
+            T mean = group_sum * inv_norm_size;
+            T var  = std::max((T)0, group_sqsum * inv_norm_size - mean * mean);
+            T inv_stdev = (T)1 / std::sqrt(var + epsilon);
+
+            for (int c1_start = c_start / C0, c1_end_idx = (c_end - 1) / C0 + 1,
+                     c1 = c1_start; c1 < c1_end_idx; ++c1) {
+                int cbase = c1 * C0;
+                int c0_lo = std::max(0, c_start - cbase);
+                int c0_hi = std::min(C0, c_end - cbase);
+                int validC0 = std::min(C0, std::max(0, Ci - cbase));
+
+                for (int c0 = c0_lo; c0 < c0_hi; ++c0) {
+                    alpha[c0] = scale_data[cbase + c0] * inv_stdev;
+                    beta[c0]  = bias_data[cbase + c0] - alpha[c0] * mean;
+                }
+
+                const T* inbase  = inptr  + n * inStep0 + c1 * inStep1;
+                T*       outbase = outptr + n * outStep0 + c1 * outStep1;
+
+                for (int c0 = c0_lo; c0 < c0_hi; ++c0) {
+                    T a = alpha[c0], b = beta[c0];
+                    for (int h = 0; h < H; ++h) {
+                        const T* inrow  = inbase + h * inStep2;
+                        T*       outrow = outbase + h * outStep2;
+                        for (int w = 0; w < W; ++w)
+                            outrow[w * outStep3 + c0] = inrow[w * inStep3 + c0] * a + b;
+                    }
+                }
+
+                for (int c0_pad = std::max(c0_hi, validC0); c0_pad < C0; ++c0_pad)
+                    for (int h = 0; h < H; ++h) {
+                        T* outrow = outbase + h * outStep2;
+                        for (int w = 0; w < W; ++w)
+                            outrow[w * outStep3 + c0_pad] = 0;
+                    }
+            }
+        }
+    });
+}
+
+// GroupNorm, plain NCHW layout.
+template<typename T>
+static void fastNormGroupImpl(const Mat &input, const Mat &scale, const Mat &bias, Mat &output, T epsilon, size_t num_groups) {
+    const auto input_shape = shape(input);
+    size_t C = input_shape[1];
 
     size_t N = input_shape[0];
-    CV_CheckGE(input.dims, 3, "fastNormChannel: input dimension >= 3");
+    CV_CheckGE(input.dims, 3, "fastNormGroup: input dimension >= 3");
 
-    size_t loops = N * C,
-           norm_size = static_cast<size_t>(total(input_shape, 2));
+    size_t channels_per_group = C / num_groups;
+    size_t loops = N * num_groups;
+    size_t norm_size = static_cast<size_t>(total(input_shape, 2) * channels_per_group);
+    size_t step = norm_size / channels_per_group;
 
     auto fn = [&](const Range &r) {
-        const auto *input_data = input.ptr<const float>();
-        const auto *scale_data = scale.ptr<const float>();
-        const auto *bias_data = bias.ptr<const float>();
-        auto *output_data = output.ptr<float>();
+        const T *input_data = input.ptr<const T>();
+        const T *scale_data = scale.ptr<const T>();
+        const T *bias_data = bias.ptr<const T>();
+        T *output_data = output.ptr<T>();
+
         for (int i = r.start; i < r.end; i++) {
-            const auto *x = input_data + norm_size * i;
-            auto *y = output_data + norm_size * i;
+            const T *x = input_data + norm_size * i;
+            T *y = output_data + norm_size * i;
 
             double dmean = 0., dmean_sq = 0.;
+            bool simd_done = false;
+            if constexpr (std::is_same<T, float>::value) {
 #if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
-            normAccumSumSqSum64f(x, norm_size, dmean, dmean_sq);
-#else
-            for (size_t j = 0; j < norm_size; j++) {
-                double v = (double)x[j];
-                dmean += v;
-                dmean_sq += v * v;
+                normAccumSumSqSum64f(x, norm_size, dmean, dmean_sq);
+                simd_done = true;
+#endif
             }
-#endif
+            if (!simd_done) {
+                for (size_t j = 0; j < norm_size; j++) {
+                    double v = (double)x[j];
+                    dmean += v;
+                    dmean_sq += v * v;
+                }
+            }
 
-            float mean = (float)(dmean / norm_size);
-            float var = (float)std::max(0., dmean_sq / norm_size - (double)mean * (double)mean);
-            float inv_stdev = 1.f / std::sqrt(var + epsilon);
+            T mean = (T)(dmean / norm_size);
+            T var = (T)std::max(0., dmean_sq / norm_size - (double)mean * (double)mean);
+            T inv_stdev = (T)1 / std::sqrt(var + epsilon);
 
-            size_t c = i % C;
-            float s = scale_data[c] * inv_stdev, b = bias_data[c];
+            // Loop restructured (channel outer, offset inner) instead of j/step per
+            // element -- avoids a per-element division, cheap win for T=double too and
+            // what lets the T=float instantiation vectorize below.
+            size_t group_idx = i % num_groups * channels_per_group;
             size_t j = 0;
+            for (size_t c_idx = 0; c_idx < channels_per_group; c_idx++) {
+                size_t c = group_idx + c_idx;
+                T s = scale_data[c] * inv_stdev, b = bias_data[c];
+                const size_t j_end = j + step;
+                if constexpr (std::is_same<T, float>::value) {
 #if (CV_SIMD || CV_SIMD_SCALABLE)
-            const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
-            v_float32 vmean = vx_setall_f32(mean), vs = vx_setall_f32(s), vb = vx_setall_f32(b);
-            for (; j + VEC_SZ <= norm_size; j += VEC_SZ)
-                vx_store(y + j, v_fma(v_sub(vx_load(x + j), vmean), vs, vb));
+                    const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
+                    v_float32 vmean = vx_setall_f32(mean), vs = vx_setall_f32(s), vb = vx_setall_f32(b);
+                    for (; j + VEC_SZ <= j_end; j += VEC_SZ)
+                        vx_store(y + j, v_fma(v_sub(vx_load(x + j), vmean), vs, vb));
 #endif
-            for (; j < norm_size; j++) {
-                y[j] = s * (x[j] - mean) + b;
+                }
+                for (; j < j_end; j++)
+                    y[j] = s * (x[j] - mean) + b;
             }
         }
     };
+
     double nstripes = loops * norm_size * (1 / 1024.0);
     parallel_for_(Range(0, loops), fn, nstripes);
 }
@@ -473,181 +955,24 @@ void fastNormGroup(const Mat &input, const Mat &scale, const Mat &bias, Mat &out
     CV_CheckEQ(scale.total(), bias.total(), "fastNormGroup: scale and bias should have the same shape");
     CV_CheckEQ(scale.total(), C, "fastNormGroup: scale should be a 1d tensor and match the channel of input");
 
-    // Block layout path: [N, C1, H, W, C0]
+    int type = input.type();
+    CV_CheckType(type, type == CV_32F || type == CV_64F, "fastNormGroup: unsupported type");
+    CV_CheckTypeEQ(type, output.type(), "fastNormGroup: output must match input type");
+    CV_CheckTypeEQ(type, scale.type(), "fastNormGroup: scale must match input type");
+    CV_CheckTypeEQ(type, bias.type(), "fastNormGroup: bias must match input type");
+
     if (input_shape.layout == DATA_LAYOUT_BLOCK) {
-        CV_Assert(input.dims == 5 && output.dims == 5);
-        CV_Assert(input.type() == CV_32F && output.type() == CV_32F);
-        CV_Assert(input.isContinuous() && output.isContinuous());
-
-        const int N  = input.size[0];
-        const int H  = input.size[2];
-        const int W  = input.size[3];
-        const int C0 = input.size[4];
-        const int Ci = (int)C;
-
-        const float* scale_data = scale.ptr<float>();
-        const float* bias_data  = bias.ptr<float>();
-
-        const size_t inStep0 = input.step.p[0] / sizeof(float);
-        const size_t inStep1 = input.step.p[1] / sizeof(float);
-        const size_t inStep2 = input.step.p[2] / sizeof(float);
-        const size_t inStep3 = input.step.p[3] / sizeof(float);
-
-        const size_t outStep0 = output.step.p[0] / sizeof(float);
-        const size_t outStep1 = output.step.p[1] / sizeof(float);
-        const size_t outStep2 = output.step.p[2] / sizeof(float);
-        const size_t outStep3 = output.step.p[3] / sizeof(float);
-
-        const int channels_per_group = Ci / (int)num_groups;
-        const size_t norm_size = (size_t)channels_per_group * (size_t)H * (size_t)W;
-        const double inv_norm_size = 1.0 / (double)norm_size;
-
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-        const int VEC_SZ = VTraits<v_float32>::vlanes();
-#endif
-
-        parallel_for_(Range(0, N * (int)num_groups), [&](const Range& r) {
-            const float* inptr = (const float*)input.data;
-            float* outptr = (float*)output.data;
-
-            AutoBuffer<float> buf(C0 * 2);
-            float* alpha = buf.data();
-            float* beta  = alpha + C0;
-
-            for (int i = r.start; i < r.end; ++i) {
-                int n = i / (int)num_groups;
-                int g = i - n * (int)num_groups;
-                int c_start = g * channels_per_group;
-                int c_end   = c_start + channels_per_group;
-
-                double group_sum = 0., group_sqsum = 0.;
-                for (int c = c_start; c < c_end; c++) {
-                    int c1 = c / C0;
-                    int c0 = c % C0;
-                    const float* inbase = inptr + n * inStep0 + c1 * inStep1;
-                    for (int h = 0; h < H; ++h) {
-                        const float* inrow = inbase + h * inStep2;
-                        for (int w = 0; w < W; ++w) {
-                            double v = (double)inrow[w * inStep3 + c0];
-                            group_sum += v;
-                            group_sqsum += v * v;
-                        }
-                    }
-                }
-
-                float mean = (float)(group_sum * inv_norm_size);
-                float var  = std::max(0.f, (float)(group_sqsum * inv_norm_size - (double)mean * (double)mean));
-                float inv_stdev = 1.f / std::sqrt(var + epsilon);
-
-                for (int c1_start = c_start / C0, c1_end_idx = (c_end - 1) / C0 + 1,
-                         c1 = c1_start; c1 < c1_end_idx; ++c1) {
-                    int cbase = c1 * C0;
-                    int c0_lo = std::max(0, c_start - cbase);
-                    int c0_hi = std::min(C0, c_end - cbase);
-                    int validC0 = std::min(C0, std::max(0, Ci - cbase));
-
-                    for (int c0 = c0_lo; c0 < c0_hi; ++c0) {
-                        alpha[c0] = scale_data[cbase + c0] * inv_stdev;
-                        beta[c0]  = bias_data[cbase + c0] - alpha[c0] * mean;
-                    }
-
-                    const float* inbase  = inptr  + n * inStep0 + c1 * inStep1;
-                    float*       outbase = outptr + n * outStep0 + c1 * outStep1;
-
-                    int c0 = c0_lo;
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-                    for (; c0 <= c0_hi - VEC_SZ; c0 += VEC_SZ) {
-                        v_float32 va = vx_load(alpha + c0);
-                        v_float32 vb = vx_load(beta + c0);
-                        for (int h = 0; h < H; ++h) {
-                            const float* inrow  = inbase + h * inStep2;
-                            float*       outrow = outbase + h * outStep2;
-                            for (int w = 0; w < W; ++w) {
-                                v_float32 vin = vx_load(inrow + w * inStep3 + c0);
-                                vx_store(outrow + w * outStep3 + c0, v_fma(vin, va, vb));
-                            }
-                        }
-                    }
-#endif
-                    for (; c0 < c0_hi; ++c0) {
-                        float a = alpha[c0], b = beta[c0];
-                        for (int h = 0; h < H; ++h) {
-                            const float* inrow  = inbase + h * inStep2;
-                            float*       outrow = outbase + h * outStep2;
-                            for (int w = 0; w < W; ++w)
-                                outrow[w * outStep3 + c0] = inrow[w * inStep3 + c0] * a + b;
-                        }
-                    }
-
-                    for (int c0_pad = std::max(c0_hi, validC0); c0_pad < C0; ++c0_pad)
-                        for (int h = 0; h < H; ++h) {
-                            float* outrow = outbase + h * outStep2;
-                            for (int w = 0; w < W; ++w)
-                                outrow[w * outStep3 + c0_pad] = 0.f;
-                        }
-                }
-            }
-        });
+        if (type == CV_64F)
+            fastNormGroupBlockT<double>(input, scale, bias, output, (double)epsilon, num_groups);
+        else
+            fastNormGroupBlockF32(input, scale, bias, output, epsilon, num_groups);
         return;
     }
 
-    // NCHW path
-    size_t N = input_shape[0];
-    CV_CheckGE(input.dims, 3, "fastNormGroup: input dimension >= 3");
-
-    size_t channels_per_group = C / num_groups;
-    size_t loops = N * num_groups;
-    size_t norm_size = static_cast<size_t>(total(input_shape, 2) * channels_per_group);
-    size_t step = norm_size / channels_per_group;
-
-    auto fn = [&](const Range &r) {
-        const auto *input_data = input.ptr<const float>();
-        const auto *scale_data = scale.ptr<const float>();
-        const auto *bias_data = bias.ptr<const float>();
-        auto *output_data = output.ptr<float>();
-
-        for (int i = r.start; i < r.end; i++) {
-            const auto *x = input_data + norm_size * i;
-            auto *y = output_data + norm_size * i;
-
-            double dmean = 0., dmean_sq = 0.;
-#if CV_SIMD_64F || CV_SIMD_SCALABLE_64F
-            normAccumSumSqSum64f(x, norm_size, dmean, dmean_sq);
-#else
-            for (size_t j = 0; j < norm_size; j++) {
-                double v = (double)x[j];
-                dmean += v;
-                dmean_sq += v * v;
-            }
-#endif
-
-            float mean = (float)(dmean / norm_size);
-            float var = (float)std::max(0., dmean_sq / norm_size - (double)mean * (double)mean);
-            float inv_stdev = 1.f / std::sqrt(var + epsilon);
-
-            size_t group_idx = i % num_groups * channels_per_group;
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-            const size_t VEC_SZ = (size_t)VTraits<v_float32>::vlanes();
-            v_float32 vmean = vx_setall_f32(mean);
-#endif
-            size_t j = 0;
-            for (size_t c_idx = 0; c_idx < channels_per_group; c_idx++) {
-                size_t c = group_idx + c_idx;
-                float s = scale_data[c] * inv_stdev, b = bias_data[c];
-                const size_t j_end = j + step;
-#if (CV_SIMD || CV_SIMD_SCALABLE)
-                v_float32 vs = vx_setall_f32(s), vb = vx_setall_f32(b);
-                for (; j + VEC_SZ <= j_end; j += VEC_SZ)
-                    vx_store(y + j, v_fma(v_sub(vx_load(x + j), vmean), vs, vb));
-#endif
-                for (; j < j_end; j++)
-                    y[j] = s * (x[j] - mean) + b;
-            }
-        }
-    };
-
-    double nstripes = loops * norm_size * (1 / 1024.0);
-    parallel_for_(Range(0, loops), fn, nstripes);
+    if (type == CV_64F)
+        fastNormGroupImpl<double>(input, scale, bias, output, (double)epsilon, num_groups);
+    else
+        fastNormGroupImpl<float>(input, scale, bias, output, epsilon, num_groups);
 }
 
 }} // cv::dnn

--- a/modules/dnn/src/layers/cumprod_layer.cpp
+++ b/modules/dnn/src/layers/cumprod_layer.cpp
@@ -42,7 +42,8 @@ public:
                   std::vector<MatType>& outputs, std::vector<MatType>&) const CV_OVERRIDE
     {
         CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_64F ||
-                     inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_16F, "");
+                     inputs[0] == CV_32S || inputs[0] == CV_64S ||
+                     inputs[0] == CV_32U || inputs[0] == CV_64U || inputs[0] == CV_16F, "");
         outputs.assign(1, inputs[0]);
     }
 
@@ -64,6 +65,8 @@ public:
             case CV_32S: forwardImpl<int32_t>(inputs, outputs); break;
             case CV_64S: forwardImpl<int64_t>(inputs, outputs); break;
             case CV_64F: forwardImpl<double>(inputs, outputs); break;
+            case CV_32U: forwardImpl<uint32_t>(inputs, outputs); break;
+            case CV_64U: forwardImpl<uint64_t>(inputs, outputs); break;
             default: CV_Error(Error::BadDepth, "");
         }
     }

--- a/modules/dnn/src/layers/cumsum_layer.cpp
+++ b/modules/dnn/src/layers/cumsum_layer.cpp
@@ -46,7 +46,8 @@ public:
         std::vector<MatType>& outputs,
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
-        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_64F || inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_16F, "");
+        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_64F || inputs[0] == CV_32S || inputs[0] == CV_64S ||
+                                inputs[0] == CV_32U || inputs[0] == CV_64U || inputs[0] == CV_16F, "");
         outputs.assign(1, inputs[0]);
     }
 
@@ -80,6 +81,12 @@ public:
                 break;
             case CV_64F:
                 forwardImpl<double>(inputs, outputs);
+                break;
+            case CV_32U:
+                forwardImpl<uint32_t>(inputs, outputs);
+                break;
+            case CV_64U:
+                forwardImpl<uint64_t>(inputs, outputs);
                 break;
             default:
                 CV_Error(Error::BadDepth, "");

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -52,6 +52,8 @@ bool constC(LayerGemmOpMode mode){
 // Y = alpha * A’ * B’ + beta * C
 class GemmLayerImpl CV_FINAL : public GemmLayer {
 public:
+    mutable int inpType = -1;
+
     GemmLayerImpl(const LayerParams& params) {
         setParamsFrom(params);
 
@@ -71,10 +73,25 @@ public:
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE {
         return backendId == DNN_BACKEND_OPENCV ||
-               (backendId == DNN_BACKEND_CUDA && const_B && !trans_a) ||
+               (backendId == DNN_BACKEND_CUDA && const_B && !trans_a && inpType == CV_32F) ||
                backendId == DNN_BACKEND_CANN ||
                backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ||
                (backendId == DNN_BACKEND_VKCOM && haveVulkan() && !have_bias && !trans_a);
+    }
+
+    virtual void getTypes(const std::vector<MatType>& inputs,
+                          const int requiredOutputs,
+                          const int requiredInternals,
+                          std::vector<MatType>& outputs,
+                          std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F, "");
+
+        inpType = inputs[0];
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
     }
 
 

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -252,6 +252,13 @@ public:
         opt.init();
         std::vector<Mat> inputs;
         inputs_arr.getMatVector(inputs);
+
+        // CV_64F runs entirely through forward()'s separate cv::gemm-based path
+        // (forwardDouble), recomputed fresh every call. None of the packed-B /
+        // MLAS fast-path caching below is float-only-safe, so skip it here.
+        if (inputs[0].depth() == CV_64F)
+            return;
+
         LayerGemmOpMode mode = getOpMode(inputs.size(), blobs.size());
 
         // pack B if it is const
@@ -351,6 +358,11 @@ public:
         outputs_arr.getMatVector(outputs);
 
         LayerGemmOpMode mode = getOpMode(inputs.size(), blobs.size());
+
+        if (inputs[0].depth() == CV_64F) {
+            forwardDouble(inputs, outputs, mode);
+            return;
+        }
 
         const auto &A = inputs[0];
         auto &Y = outputs[0];
@@ -470,6 +482,91 @@ public:
             }
         } else {
             fastGemmBatch(trans_a, trans_b, alpha, A, inputs[1], 1.f, Y, opt);
+        }
+    }
+
+    // Writes beta*C, broadcast to (M, N), into dst. Double-precision analogue of
+    // broadcastCWtihBeta() above, recomputed on every call instead of cached -- this
+    // path skips finalize()'s packed-B/broadcast caching entirely for CV_64F (see
+    // finalize() and forwardDouble()), so there is no cache to keep in sync here.
+    static void fillBroadcastCDouble(int M, int N, const Mat& C, double beta, Mat& dst)
+    {
+        CV_Assert(dst.rows == M && dst.cols == N);
+        double* out = dst.ptr<double>();
+        size_t total = (size_t)M * (size_t)N;
+
+        if (beta == 0 || C.empty()) {
+            std::fill_n(out, total, 0.0);
+            return;
+        }
+
+        const double* c = C.ptr<const double>();
+        const auto shape_C = shape(C);
+        int ndims_C = (int)shape_C.size();
+
+        if (ndims_C == 0 || (ndims_C == 1 && shape_C[0] == 1) ||
+            (ndims_C == 2 && shape_C[0] == 1 && shape_C[1] == 1)) {
+            // (), (1,), (1, 1): single scalar broadcast to every element.
+            std::fill_n(out, total, beta * c[0]);
+        } else if ((ndims_C == 1 && shape_C[0] == N) ||
+                   (ndims_C == 2 && shape_C[0] == 1 && shape_C[1] == N)) {
+            // (N,), (1, N): one row broadcast down every row.
+            for (int i = 0; i < M; i++)
+                for (int j = 0; j < N; j++)
+                    out[(size_t)i * N + j] = beta * c[j];
+        } else if (ndims_C == 2 && shape_C[0] == M && shape_C[1] == 1) {
+            // (M, 1): one value per row broadcast across every column.
+            for (int i = 0; i < M; i++)
+                std::fill_n(out + (size_t)i * N, N, beta * c[i]);
+        } else {
+            // (M, N): no broadcast, just scale.
+            CV_CheckEQ(shape_C[0], M, "DNN/Gemm: C is not broadcast properly");
+            CV_CheckEQ(shape_C[1], N, "DNN/Gemm: C is not broadcast properly");
+            for (size_t i = 0; i < total; i++)
+                out[i] = beta * c[i];
+        }
+    }
+
+    // Y = alpha * A' * B' + beta * C for CV_64F, via cv::gemm's HAL-backed CV_64FC1
+    // path. Deliberately not reusing fastGemm/fastGemmBatch/MLAS above: those are
+    // float-only fast kernels (SIMD/packed), and extending them to double would mean
+    // writing a new SIMD double GEMM from scratch -- disproportionate for one dtype.
+    // ORT takes the same posture: its fast/packed kernels are float (and fp16) only,
+    // with MatMul<double>/GemmEx<double> going through the plain, unfused path.
+    // No B-packing or bias-broadcast caching here either (see finalize()) -- this is
+    // the correctness-first, unoptimized double path, not a fused fast path.
+    void forwardDouble(const std::vector<Mat>& inputs, std::vector<Mat>& outputs, LayerGemmOpMode mode)
+    {
+        const Mat &A = inputs[0];
+        Mat &Y = outputs[0];
+        const Mat &B = constB(mode) ? blobs[0] : inputs[1];
+
+        CV_CheckTypeEQ(B.depth(), CV_64F, "DNN/Gemm: B must be CV_64F to match A");
+        CV_Assert(A.isContinuous() && Y.isContinuous());
+
+        const auto shape_A = shape(A), shape_Y = shape(Y);
+        size_t dims_A = shape_A.size();
+        int na = shape_A[dims_A - 1];
+        size_t dims_Y = shape_Y.size();
+        int N = shape_Y[dims_Y - 1];
+        const int rows = (int)(Y.total() / (size_t)N);
+
+        // A/Y reshaped to plain 2D views onto their own (contiguous) data -- no copy.
+        // B is already exactly 2D per the CV_CheckEQ in getMemoryShapes(). trans_a/
+        // trans_b are expressed via cv::gemm's own transpose flags rather than a
+        // pre-transposed/packed buffer, matching the "no packing" scope above.
+        Mat Aview = A.reshape(1, (int)(A.total() / (size_t)na));
+        Mat Yview = Y.reshape(1, rows);
+        const int flags = (trans_a ? GEMM_1_T : 0) | (trans_b ? GEMM_2_T : 0);
+
+        const bool haveC = constC(mode) || inputs.size() >= 3;
+        if (haveC) {
+            const Mat& C = (inputs.size() >= 3) ? inputs.back() : blobs.back();
+            CV_CheckTypeEQ(C.depth(), CV_64F, "DNN/Gemm: C must be CV_64F to match A");
+            fillBroadcastCDouble(rows, N, C, (double)beta, Yview);
+            cv::gemm(Aview, B, (double)alpha, Yview, 1.0, Yview, flags);
+        } else {
+            cv::gemm(Aview, B, (double)alpha, Mat(), 0.0, Yview, flags);
         }
     }
 

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -253,9 +253,7 @@ public:
         std::vector<Mat> inputs;
         inputs_arr.getMatVector(inputs);
 
-        // CV_64F runs entirely through forward()'s separate cv::gemm-based path
-        // (forwardDouble), recomputed fresh every call. None of the packed-B /
-        // MLAS fast-path caching below is float-only-safe, so skip it here.
+        // CV_64F skips the float-only packed-B/MLAS caching below; see forwardDouble().
         if (inputs[0].depth() == CV_64F)
             return;
 
@@ -485,10 +483,7 @@ public:
         }
     }
 
-    // Writes beta*C, broadcast to (M, N), into dst. Double-precision analogue of
-    // broadcastCWtihBeta() above, recomputed on every call instead of cached -- this
-    // path skips finalize()'s packed-B/broadcast caching entirely for CV_64F (see
-    // finalize() and forwardDouble()), so there is no cache to keep in sync here.
+    // Double-precision analogue of broadcastCWtihBeta() above; not cached (see finalize()).
     static void fillBroadcastCDouble(int M, int N, const Mat& C, double beta, Mat& dst)
     {
         CV_Assert(dst.rows == M && dst.cols == N);
@@ -527,14 +522,7 @@ public:
         }
     }
 
-    // Y = alpha * A' * B' + beta * C for CV_64F, via cv::gemm's HAL-backed CV_64FC1
-    // path. Deliberately not reusing fastGemm/fastGemmBatch/MLAS above: those are
-    // float-only fast kernels (SIMD/packed), and extending them to double would mean
-    // writing a new SIMD double GEMM from scratch -- disproportionate for one dtype.
-    // ORT takes the same posture: its fast/packed kernels are float (and fp16) only,
-    // with MatMul<double>/GemmEx<double> going through the plain, unfused path.
-    // No B-packing or bias-broadcast caching here either (see finalize()) -- this is
-    // the correctness-first, unoptimized double path, not a fused fast path.
+    // CV_64F via cv::gemm, not the float-only fastGemm/MLAS kernels above.
     void forwardDouble(const std::vector<Mat>& inputs, std::vector<Mat>& outputs, LayerGemmOpMode mode)
     {
         const Mat &A = inputs[0];
@@ -551,10 +539,7 @@ public:
         int N = shape_Y[dims_Y - 1];
         const int rows = (int)(Y.total() / (size_t)N);
 
-        // A/Y reshaped to plain 2D views onto their own (contiguous) data -- no copy.
-        // B is already exactly 2D per the CV_CheckEQ in getMemoryShapes(). trans_a/
-        // trans_b are expressed via cv::gemm's own transpose flags rather than a
-        // pre-transposed/packed buffer, matching the "no packing" scope above.
+        // 2D views onto existing data, no copy; trans_a/trans_b via cv::gemm's own flags.
         Mat Aview = A.reshape(1, (int)(A.total() / (size_t)na));
         Mat Yview = Y.reshape(1, rows);
         const int flags = (trans_a ? GEMM_1_T : 0) | (trans_b ? GEMM_2_T : 0);

--- a/modules/dnn/src/layers/hardmax.cpp
+++ b/modules/dnn/src/layers/hardmax.cpp
@@ -31,7 +31,7 @@ public:
         CV_Assert(inputs.size());
         for (auto input : inputs)
         {
-            CV_CheckType(input, input == CV_32F || input == CV_8S || input == CV_8U || input == CV_32S || input == CV_64S || input == CV_Bool, "");
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U || input == CV_32S || input == CV_64S || input == CV_Bool, "");
         }
 
         outputs.assign(requiredOutputs, inputs[0]);

--- a/modules/dnn/src/layers/if_layer.cpp
+++ b/modules/dnn/src/layers/if_layer.cpp
@@ -29,6 +29,27 @@ public:
         return false;
     }
 
+    // Control flow forwards subgraph tensors rather than computing on them, so
+    // it's native for any type; only cond (read in branch() below) needs a
+    // depth this layer itself understands, and that switch already covers
+    // every non-fp16/bf16 depth.
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8U || input == CV_8S ||
+                                input == CV_16U || input == CV_16S || input == CV_32U || input == CV_32S ||
+                                input == CV_64U || input == CV_64S || input == CV_Bool,
+                         "If: unsupported input type");
+
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
+    }
+
     bool dynamicOutputShapes() const CV_OVERRIDE { return true; }
 
     int branch(InputArray arr) const CV_OVERRIDE

--- a/modules/dnn/src/layers/if_layer.cpp
+++ b/modules/dnn/src/layers/if_layer.cpp
@@ -29,10 +29,7 @@ public:
         return false;
     }
 
-    // Control flow forwards subgraph tensors rather than computing on them, so
-    // it's native for any type; only cond (read in branch() below) needs a
-    // depth this layer itself understands, and that switch already covers
-    // every non-fp16/bf16 depth.
+    // Control flow just forwards tensors; branch() below already handles every depth.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,

--- a/modules/dnn/src/layers/loop_layer.cpp
+++ b/modules/dnn/src/layers/loop_layer.cpp
@@ -29,10 +29,7 @@ public:
         return false;
     }
 
-    // Control flow forwards subgraph tensors rather than computing on them, so
-    // it's native for any type; only cond (read below) needs a depth this
-    // layer itself understands, and that switch already covers every
-    // non-fp16/bf16 depth.
+    // Control flow just forwards tensors; cond() below already handles every depth.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,

--- a/modules/dnn/src/layers/loop_layer.cpp
+++ b/modules/dnn/src/layers/loop_layer.cpp
@@ -29,6 +29,27 @@ public:
         return false;
     }
 
+    // Control flow forwards subgraph tensors rather than computing on them, so
+    // it's native for any type; only cond (read below) needs a depth this
+    // layer itself understands, and that switch already covers every
+    // non-fp16/bf16 depth.
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8U || input == CV_8S ||
+                                input == CV_16U || input == CV_16S || input == CV_32U || input == CV_32S ||
+                                input == CV_64U || input == CV_64S || input == CV_Bool,
+                         "Loop: unsupported input type");
+
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
+    }
+
     bool dynamicOutputShapes() const CV_OVERRIDE { return true; }
 
     // OPTIMIZATION: Reduced to a simple numeric check via double

--- a/modules/dnn/src/layers/matmul_layer.cpp
+++ b/modules/dnn/src/layers/matmul_layer.cpp
@@ -120,7 +120,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         return false;
     }
 
-    // 64F/64S were already admitted by the default gate; 32S/32U/64U are new here.
+    // Only types forward() actually dispatches; the default gate's CV_8S/CV_8U had no kernel and corrupted memory.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,
@@ -129,7 +129,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
     {
         CV_Assert(inputs.size());
         for (auto input : inputs)
-            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U ||
+            CV_CheckType(input, input == CV_32F || input == CV_64F ||
                                 input == CV_32S || input == CV_64S || input == CV_32U || input == CV_64U, "");
 
         outputs.assign(requiredOutputs, inputs[0]);
@@ -411,11 +411,17 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         const T* bptr0 = B.ptr<T>();
         T* yptr0 = Y.ptr<T>();
 
-        // Real ONNX MatMul never sets alpha/beta; round rather than reject if fusion does.
-        const Acc alphaScale = (Acc)std::llround((double)alpha);
-        const Acc betaScale  = (Acc)std::llround((double)beta);
-
+        // Real ONNX MatMul never sets alpha/beta; only some internal fusion could.
+        // A non-integer scale has no exact meaning for an integer accumulator, so
+        // reject it here rather than round it away -- rounding 0.4 or 0.2 to 0 would
+        // silently zero out the product/bias instead of erroring.
         const bool haveBias = (inputs.size() + blobs.size()) >= 3;
+        double alpha_d = (double)alpha, beta_d = haveBias ? (double)beta : 0.0;
+        CV_CheckTrue(std::floor(alpha_d) == alpha_d, "DNN/MatMul: alpha must be an integer value for integer types");
+        CV_CheckTrue(std::floor(beta_d) == beta_d, "DNN/MatMul: beta must be an integer value for integer types");
+        const Acc alphaScale = (Acc)alpha_d;
+        const Acc betaScale  = (Acc)beta_d;
+
         Mat biasBroadcast;
         if (haveBias) {
             const Mat& bias_mat = blobs.size() >= 2 ? blobs.back() : inputs.back();

--- a/modules/dnn/src/layers/matmul_layer.cpp
+++ b/modules/dnn/src/layers/matmul_layer.cpp
@@ -120,8 +120,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         return false;
     }
 
-    // No override existed before -- inherited the default gate (32F/64F/8S/8U/64S).
-    // 64F/64S were already admitted; 32S/32U/64U are the new ones here.
+    // 64F/64S were already admitted by the default gate; 32S/32U/64U are new here.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,
@@ -172,9 +171,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
                    C_shape = shape(outputs[0]);
         helper.compute(trans_a, trans_b, A_shape, B_shape, C_shape);
 
-        // CV_64F/32S/64S/32U/64U run entirely through forward()'s dedicated cv::gemm /
-        // integer-accumulation paths (forwardDouble/forwardInt), recomputed fresh every
-        // call -- none of the float-only packed-B/MLAS caching below applies to them.
+        // These five types skip the float-only packed-B/MLAS caching below.
         {
             int depth0 = inputs[0].depth();
             if (depth0 == CV_64F || depth0 == CV_32S || depth0 == CV_64S || depth0 == CV_32U || depth0 == CV_64U)
@@ -345,19 +342,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         }
     }
 
-    // Y = alpha * A' * B' + beta * C for CV_64F, one cv::gemm call per batch slice.
-    // Unlike Gemm's single monolithic 2D multiply, MatMul's batches are genuinely
-    // independent matrix products (helper.batch may be > 1), so this loops over them
-    // rather than collapsing into one call. Deliberately not using fastGemmBatch/MLAS
-    // (float-only fast kernels) or the packed-B cache in finalize() (skipped for these
-    // types there) -- same posture as Gemm's forwardDouble: correctness-first, matching
-    // ORT's own plain (unfused) double path.
-    //
-    // Bias here uses the mathematically correct alpha*A@B + beta*bias formula, not
-    // necessarily bit-identical to the float path's beta handling for non-scalar bias
-    // with beta != 1: genuine ONNX MatMul never carries alpha/beta at all (those are
-    // Gemm-only attributes, reachable here only through internal fusion), so that
-    // combination is practically unreachable from any real imported graph.
+    // CV_64F: one cv::gemm call per batch slice (batches don't collapse like Gemm's).
     void forwardDouble(const std::vector<Mat>& inputs, std::vector<Mat>& outputs)
     {
         const Mat &A = inputs[0];
@@ -403,14 +388,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         }
     }
 
-    // Y = alpha * A' * B' + beta * C for CV_32S/64S/32U/64U -- no BLAS-like routine
-    // handles integer types, so this is a direct accumulation loop using helper's own
-    // lda0/lda1/ldb0/ldb1 strides (already account for trans_a/trans_b). Accumulator
-    // is always 64-bit: a genuine widen for the 32-bit types, matching width (not
-    // narrower) for the 64-bit types -- same choice already made for CumSum/CumProd
-    // and PowerFunctor's integer Neg/Power path elsewhere in this codebase. The final
-    // narrowing cast wraps rather than saturates, matching that same precedent
-    // (ONNX integer overflow is wraparound, not clamped).
+    // No BLAS routine handles integers; accumulates in 64-bit Acc and wraps on cast.
     template<typename T>
     void forwardInt(const std::vector<Mat>& inputs, std::vector<Mat>& outputs)
     {
@@ -433,9 +411,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         const T* bptr0 = B.ptr<T>();
         T* yptr0 = Y.ptr<T>();
 
-        // Real ONNX MatMul never carries alpha/beta; only relevant if internal fusion
-        // sets them, so round to the nearest integer scale rather than reject --
-        // mirrors PowerFunctor's integerScale() gate for elementwise Neg/Power.
+        // Real ONNX MatMul never sets alpha/beta; round rather than reject if fusion does.
         const Acc alphaScale = (Acc)std::llround((double)alpha);
         const Acc betaScale  = (Acc)std::llround((double)beta);
 

--- a/modules/dnn/src/layers/matmul_layer.cpp
+++ b/modules/dnn/src/layers/matmul_layer.cpp
@@ -411,10 +411,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         const T* bptr0 = B.ptr<T>();
         T* yptr0 = Y.ptr<T>();
 
-        // Real ONNX MatMul never sets alpha/beta; only some internal fusion could.
-        // A non-integer scale has no exact meaning for an integer accumulator, so
-        // reject it here rather than round it away -- rounding 0.4 or 0.2 to 0 would
-        // silently zero out the product/bias instead of erroring.
+        // Reject non-integer alpha/beta rather than round: rounding 0.4/0.2 to 0 would silently zero the result.
         const bool haveBias = (inputs.size() + blobs.size()) >= 3;
         double alpha_d = (double)alpha, beta_d = haveBias ? (double)beta : 0.0;
         CV_CheckTrue(std::floor(alpha_d) == alpha_d, "DNN/MatMul: alpha must be an integer value for integer types");

--- a/modules/dnn/src/layers/matmul_layer.cpp
+++ b/modules/dnn/src/layers/matmul_layer.cpp
@@ -4,6 +4,7 @@
 
 #include "../precomp.hpp"
 
+#include <type_traits>
 #include <opencv2/dnn/shape_utils.hpp>
 #include "cpu_kernels/fast_gemm.hpp"
 #include "cpu_kernels/mlas_gemm.hpp"
@@ -119,6 +120,23 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         return false;
     }
 
+    // No override existed before -- inherited the default gate (32F/64F/8S/8U/64S).
+    // 64F/64S were already admitted; 32S/32U/64U are the new ones here.
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U ||
+                                input == CV_32S || input == CV_64S || input == CV_32U || input == CV_64U, "");
+
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
+    }
+
     virtual int64 getFLOPS(const std::vector<MatShape> &inputs,
                            const std::vector<MatShape> &outputs) const CV_OVERRIDE
     {
@@ -153,6 +171,15 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
                    B_shape = blobs.empty() ? shape(inputs[1]) : shape(blobs[0]),
                    C_shape = shape(outputs[0]);
         helper.compute(trans_a, trans_b, A_shape, B_shape, C_shape);
+
+        // CV_64F/32S/64S/32U/64U run entirely through forward()'s dedicated cv::gemm /
+        // integer-accumulation paths (forwardDouble/forwardInt), recomputed fresh every
+        // call -- none of the float-only packed-B/MLAS caching below applies to them.
+        {
+            int depth0 = inputs[0].depth();
+            if (depth0 == CV_64F || depth0 == CV_32S || depth0 == CV_64S || depth0 == CV_32U || depth0 == CV_64U)
+                return;
+        }
 
         // Pack only 2D weight matrices; skip higher-dim tensors (e.g. Q@K^T in attention).
         const Mat* B_mat = !blobs.empty() ? &blobs[0] :
@@ -233,6 +260,15 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);
 
+        switch (inputs[0].depth()) {
+            case CV_64F: forwardDouble(inputs, outputs); return;
+            case CV_32S: forwardInt<int32_t>(inputs, outputs); return;
+            case CV_64S: forwardInt<int64_t>(inputs, outputs); return;
+            case CV_32U: forwardInt<uint32_t>(inputs, outputs); return;
+            case CV_64U: forwardInt<uint64_t>(inputs, outputs); return;
+            default: break;
+        }
+
         const auto &A = inputs[0];
         auto &Y = outputs[0];
 
@@ -307,6 +343,139 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
                           helper.M, helper.N, helper.K, alpha, a, helper.lda0, helper.lda1,
                           b, helper.ldb0, helper.ldb1, beta, y, helper.ldc, opt);
         }
+    }
+
+    // Y = alpha * A' * B' + beta * C for CV_64F, one cv::gemm call per batch slice.
+    // Unlike Gemm's single monolithic 2D multiply, MatMul's batches are genuinely
+    // independent matrix products (helper.batch may be > 1), so this loops over them
+    // rather than collapsing into one call. Deliberately not using fastGemmBatch/MLAS
+    // (float-only fast kernels) or the packed-B cache in finalize() (skipped for these
+    // types there) -- same posture as Gemm's forwardDouble: correctness-first, matching
+    // ORT's own plain (unfused) double path.
+    //
+    // Bias here uses the mathematically correct alpha*A@B + beta*bias formula, not
+    // necessarily bit-identical to the float path's beta handling for non-scalar bias
+    // with beta != 1: genuine ONNX MatMul never carries alpha/beta at all (those are
+    // Gemm-only attributes, reachable here only through internal fusion), so that
+    // combination is practically unreachable from any real imported graph.
+    void forwardDouble(const std::vector<Mat>& inputs, std::vector<Mat>& outputs)
+    {
+        const Mat &A = inputs[0];
+        Mat &Y = outputs[0];
+        const Mat &B = blobs.empty() ? inputs[1] : blobs[0];
+
+        CV_CheckTypeEQ(B.depth(), CV_64F, "DNN/MatMul: B must be CV_64F to match A");
+        CV_Assert(A.isContinuous() && B.isContinuous() && Y.isContinuous());
+
+        const auto shape_A = shape(A), shape_B = shape(B), shape_Y = shape(Y);
+        const int ma = shape_A[shape_A.size() - 2], na = shape_A.back();
+        const int mb = shape_B[shape_B.size() - 2], nb = shape_B.back();
+        const int M = helper.M, N = helper.N;
+
+        double* yptr0 = Y.ptr<double>();
+        const bool haveBias = (inputs.size() + blobs.size()) >= 3;
+        if (haveBias) {
+            const Mat& bias_mat = blobs.size() >= 2 ? blobs.back() : inputs.back();
+            CV_CheckTypeEQ(bias_mat.depth(), CV_64F, "DNN/MatMul: bias must be CV_64F to match A");
+            if (bias_mat.total() == 1) {
+                std::fill_n(yptr0, Y.total(), (double)beta * bias_mat.ptr<double>()[0]);
+            } else {
+                Mat biasBroadcast(shape_Y, CV_64F);
+                cv::broadcast(bias_mat, shape_Y, biasBroadcast);
+                const double* bb = biasBroadcast.ptr<double>();
+                double b = (double)beta;
+                for (size_t i = 0; i < Y.total(); i++)
+                    yptr0[i] = b * bb[i];
+            }
+        } else {
+            std::fill_n(yptr0, Y.total(), 0.0);
+        }
+
+        const int flags = (trans_a ? GEMM_1_T : 0) | (trans_b ? GEMM_2_T : 0);
+        const double* aptr0 = A.ptr<double>();
+        const double* bptr0 = B.ptr<double>();
+
+        for (size_t i = 0; i < helper.batch; i++) {
+            Mat Aview(ma, na, CV_64F, (void*)(aptr0 + helper.A_offsets[i]));
+            Mat Bview(mb, nb, CV_64F, (void*)(bptr0 + helper.B_offsets[i]));
+            Mat Yview(M, N, CV_64F, (void*)(yptr0 + helper.C_offsets[i]));
+            cv::gemm(Aview, Bview, (double)alpha, Yview, 1.0, Yview, flags);
+        }
+    }
+
+    // Y = alpha * A' * B' + beta * C for CV_32S/64S/32U/64U -- no BLAS-like routine
+    // handles integer types, so this is a direct accumulation loop using helper's own
+    // lda0/lda1/ldb0/ldb1 strides (already account for trans_a/trans_b). Accumulator
+    // is always 64-bit: a genuine widen for the 32-bit types, matching width (not
+    // narrower) for the 64-bit types -- same choice already made for CumSum/CumProd
+    // and PowerFunctor's integer Neg/Power path elsewhere in this codebase. The final
+    // narrowing cast wraps rather than saturates, matching that same precedent
+    // (ONNX integer overflow is wraparound, not clamped).
+    template<typename T>
+    void forwardInt(const std::vector<Mat>& inputs, std::vector<Mat>& outputs)
+    {
+        typedef typename std::conditional<std::is_unsigned<T>::value, uint64_t, int64_t>::type Acc;
+
+        const Mat &A = inputs[0];
+        Mat &Y = outputs[0];
+        const Mat &B = blobs.empty() ? inputs[1] : blobs[0];
+
+        CV_CheckTypeEQ(B.depth(), A.depth(), "DNN/MatMul: B must match A's type");
+        CV_Assert(A.isContinuous() && B.isContinuous() && Y.isContinuous());
+
+        const auto shape_Y = shape(Y);
+        const int M = helper.M, N = helper.N, K = helper.K;
+        const int lda0 = helper.lda0, lda1 = helper.lda1;
+        const int ldb0 = helper.ldb0, ldb1 = helper.ldb1;
+        const int ldc = helper.ldc;
+
+        const T* aptr0 = A.ptr<T>();
+        const T* bptr0 = B.ptr<T>();
+        T* yptr0 = Y.ptr<T>();
+
+        // Real ONNX MatMul never carries alpha/beta; only relevant if internal fusion
+        // sets them, so round to the nearest integer scale rather than reject --
+        // mirrors PowerFunctor's integerScale() gate for elementwise Neg/Power.
+        const Acc alphaScale = (Acc)std::llround((double)alpha);
+        const Acc betaScale  = (Acc)std::llround((double)beta);
+
+        const bool haveBias = (inputs.size() + blobs.size()) >= 3;
+        Mat biasBroadcast;
+        if (haveBias) {
+            const Mat& bias_mat = blobs.size() >= 2 ? blobs.back() : inputs.back();
+            CV_CheckTypeEQ(bias_mat.depth(), A.depth(), "DNN/MatMul: bias must match A's type");
+            if ((size_t)bias_mat.total() != Y.total() || shape(bias_mat).size() != shape_Y.size()) {
+                biasBroadcast = Mat(shape_Y, A.depth());
+                cv::broadcast(bias_mat, shape_Y, biasBroadcast);
+            } else {
+                biasBroadcast = bias_mat;
+            }
+        }
+        const T* biasPtr0 = haveBias ? biasBroadcast.ptr<T>() : nullptr;
+
+        parallel_for_(Range(0, (int)(helper.batch * (size_t)M)), [&](const Range& r) {
+            for (int idx = r.start; idx < r.end; idx++) {
+                int bi = idx / M;
+                int m  = idx % M;
+                const T* aBase = aptr0 + helper.A_offsets[bi];
+                const T* bBase = bptr0 + helper.B_offsets[bi];
+                T* yRow = yptr0 + helper.C_offsets[bi] + (size_t)m * ldc;
+                const T* biasRow = haveBias ? biasPtr0 + helper.C_offsets[bi] + (size_t)m * ldc : nullptr;
+
+                for (int n = 0; n < N; n++) {
+                    Acc sum = 0;
+                    for (int k = 0; k < K; k++) {
+                        Acc av = (Acc)aBase[(size_t)m * lda0 + (size_t)k * lda1];
+                        Acc bv = (Acc)bBase[(size_t)k * ldb0 + (size_t)n * ldb1];
+                        sum += av * bv;
+                    }
+                    Acc result = sum * alphaScale;
+                    if (haveBias)
+                        result += betaScale * (Acc)biasRow[n];
+                    yRow[n] = (T)result;
+                }
+            }
+        }, (double)helper.batch * M * N * (1 / 1024.0));
     }
 
 #ifdef HAVE_OPENCL

--- a/modules/dnn/src/layers/max_unpooling_layer.cpp
+++ b/modules/dnn/src/layers/max_unpooling_layer.cpp
@@ -75,7 +75,7 @@ public:
         std::vector<MatType>& internals) const CV_OVERRIDE
     {
         CV_CheckGE(inputs.size(), (size_t)2, "");
-        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_16F || inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_8S || inputs[0] == CV_8U, "");
+        CV_CheckType(inputs[0], inputs[0] == CV_32F || inputs[0] == CV_64F || inputs[0] == CV_16F || inputs[0] == CV_32S || inputs[0] == CV_64S || inputs[0] == CV_8S || inputs[0] == CV_8U, "");
         CV_CheckType(inputs[1], inputs[1] == CV_64S || inputs[1] == CV_32S, "");
         outputs.assign(1, inputs[0]);
     }
@@ -121,6 +121,9 @@ public:
                 break;
             case CV_32F:
                 run<float, T_INDEX>(std::forward<Args>(args)...);
+                break;
+            case CV_64F:
+                run<double, T_INDEX>(std::forward<Args>(args)...);
                 break;
             case CV_16F:
                 run<int16_t, T_INDEX>(std::forward<Args>(args)...);

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -229,9 +229,7 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
     });
 }
 
-// Scalar (non-SIMD) BLOCK-layout kernel for the types maxPool32f's SIMD path
-// doesn't cover. Max needs no accumulator and is exact in every type, so a
-// plain std::max reduction is already the correct, native answer here.
+// Scalar counterpart to maxPool32f's SIMD path, for the types it doesn't cover.
 template<typename _Tp>
 static void maxPoolScalarT(const void* inp_, void* out_, const ConvState& cs)
 {

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -229,6 +229,111 @@ static void maxPool32f(const void* inp_, void* out_, const ConvState& cs)
     });
 }
 
+// Scalar (non-SIMD) BLOCK-layout kernel for the types maxPool32f's SIMD path
+// doesn't cover. Max needs no accumulator and is exact in every type, so a
+// plain std::max reduction is already the correct, native answer here.
+template<typename _Tp>
+static void maxPoolScalarT(const void* inp_, void* out_, const ConvState& cs)
+{
+    int NC1 = cs.inpshape[0]*cs.inpshape[1];
+
+    CV_Assert(cs.inpshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.outshape.layout == DATA_LAYOUT_BLOCK);
+    CV_Assert(cs.inpshape.dims == cs.outshape.dims);
+
+    parallel_for_(Range(0, NC1), [&](const Range& r) {
+        constexpr int MAX_POOL_DIMS = ConvState::MAX_CONV_DIMS;
+
+        CV_Assert(cs.nspatialdims <= MAX_POOL_DIMS && MAX_POOL_DIMS == 3);
+
+        int sdims = cs.nspatialdims;
+        int nc0 = r.start, nc1 = r.end;
+        int C0 = cs.inpshape.back();
+        int Di = sdims > 2 ? cs.inpshape[sdims - 1] : 1;
+        int Hi = sdims > 1 ? cs.inpshape[sdims] : 1;
+        int Wi = cs.inpshape[sdims + 1];
+        int D = sdims > 2 ? cs.outshape[sdims - 1] : 1;
+        int H = sdims > 1 ? cs.outshape[sdims] : 1;
+        int W = cs.outshape[sdims + 1];
+        int iplanesize = Di*Hi*Wi*C0;
+        int planesize = D*H*W*C0;
+        int SZ = cs.strides[0], SY = cs.strides[1], SX = cs.strides[2];
+        int padZ0 = cs.pads[0], padY0 = cs.pads[1], padX0 = cs.pads[2];
+        int inner_z0 = cs.inner[0], inner_z1 = cs.inner[MAX_POOL_DIMS];
+        int inner_y0 = cs.inner[1], inner_y1 = cs.inner[MAX_POOL_DIMS + 1];
+        int inner_x0 = cs.inner[2], inner_x1 = cs.inner[MAX_POOL_DIMS + 2];
+        int ksize = (int)cs.ofstab.size();
+        const int* zyxtab = cs.coordtab.data();
+        const int* ofstab = cs.ofstab.data();
+
+        const _Tp* inp = (const _Tp*)inp_ + nc0*iplanesize;
+        _Tp* out = (_Tp*)out_ + nc0*planesize;
+        const _Tp INITVAL = std::numeric_limits<_Tp>::lowest();
+
+        for (int nc = nc0; nc < nc1; nc++, inp += iplanesize) {
+            for (int z0 = 0; z0 < D; z0++) {
+                int zi_ = z0*SZ - padZ0;
+                for (int y0 = 0; y0 < H; y0++, out += W*C0) {
+                    int x0 = 0;
+                    int x1 = z0 >= inner_z0 && z0 < inner_z1 &&
+                        y0 >= inner_y0 && y0 < inner_y1 ? inner_x0 : W;
+                    int yi_ = y0*SY - padY0;
+
+                    for (int c = 0; c < C0*W; c++)
+                        out[c] = INITVAL;
+
+                    for(;;) {
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            for (int k = 0; k < ksize; k++) {
+                                int zi = zi_ + zyxtab[k*MAX_POOL_DIMS];
+                                int yi = yi_ + zyxtab[k*MAX_POOL_DIMS+1];
+                                int xi = xi_ + zyxtab[k*MAX_POOL_DIMS+2];
+                                if ((unsigned)zi >= (unsigned)Di ||
+                                    (unsigned)yi >= (unsigned)Hi ||
+                                    (unsigned)xi >= (unsigned)Wi)
+                                    continue;
+                                const _Tp* inptr = inp + ((zi*Hi + yi)*Wi + xi)*C0;
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] = std::max(out[x0*C0 + c], inptr[c]);
+                            }
+                        }
+                        if (x0 == W)
+                            break;
+                        x1 = inner_x1;
+
+                        for (; x0 < x1; x0++) {
+                            int xi_ = x0*SX - padX0;
+                            const _Tp* inp_xi = inp + ((Hi*zi_ + yi_)*Wi + xi_)*C0;
+                            for (int k = 0; k < ksize; k++) {
+                                const _Tp* inptr = inp_xi + ofstab[k];
+                                for (int c = 0; c < C0; c++)
+                                    out[x0*C0 + c] = std::max(out[x0*C0 + c], inptr[c]);
+                            }
+                        }
+                        x1 = W;
+                    }
+                }
+            }
+        }
+    });
+}
+
+static void maxPool8s(const void* inp_, void* out_, const ConvState& cs)
+{
+    maxPoolScalarT<int8_t>(inp_, out_, cs);
+}
+
+static void maxPool8u(const void* inp_, void* out_, const ConvState& cs)
+{
+    maxPoolScalarT<uint8_t>(inp_, out_, cs);
+}
+
+static void maxPool64f(const void* inp_, void* out_, const ConvState& cs)
+{
+    maxPoolScalarT<double>(inp_, out_, cs);
+}
+
 // temporarily exclude fp16/bf16 versions,
 // since convolution and other layers don't support those types yet
 #if 0
@@ -399,10 +504,11 @@ static void maxPool16bf(const void* inp_, void* out_, const ConvState& cs)
 typedef void (*MaxPoolFunc)(const void* inp, void* out, const ConvState& cs);
 
 // 2-output (values + ONNX-style int64 indices) NCHW scalar implementation.
-static void maxPool32f_nchw_with_indices(const float* inp, float* out, int64_t* outIdx,
-                                         int N, int C, int Hi, int Wi, int H, int W,
-                                         int kH, int kW, int sH, int sW,
-                                         int padH, int padW, int dilH, int dilW)
+template<typename _Tp>
+static void maxPoolNchwWithIndices(const _Tp* inp, _Tp* out, int64_t* outIdx,
+                                   int N, int C, int Hi, int Wi, int H, int W,
+                                   int kH, int kW, int sH, int sW,
+                                   int padH, int padW, int dilH, int dilW)
 {
     int NC = N * C;
     int inHW = Hi * Wi;
@@ -410,12 +516,12 @@ static void maxPool32f_nchw_with_indices(const float* inp, float* out, int64_t* 
     parallel_for_(Range(0, NC), [&](const Range& r) {
         for (int nc = r.start; nc < r.end; nc++) {
             int c = nc % C;
-            const float* inp_nc = inp + nc * inHW;
-            float*       out_nc = out + nc * outHW;
-            int64_t*     idx_nc = outIdx + nc * outHW;
+            const _Tp* inp_nc = inp + nc * inHW;
+            _Tp*       out_nc = out + nc * outHW;
+            int64_t*   idx_nc = outIdx + nc * outHW;
             for (int yo = 0; yo < H; yo++) {
                 for (int xo = 0; xo < W; xo++) {
-                    float vmax = -FLT_MAX;
+                    _Tp vmax = std::numeric_limits<_Tp>::lowest();
                     int64_t idxmax = -1;
                     for (int ky = 0; ky < kH; ky++) {
                         int yi = yo * sH - padH + ky * dilH;
@@ -425,7 +531,7 @@ static void maxPool32f_nchw_with_indices(const float* inp, float* out, int64_t* 
                             int xi = xo * sW - padW + kx * dilW;
                             if ((unsigned)xi >= (unsigned)Wi)
                                 continue;
-                            float v = inp_nc[yi * Wi + xi];
+                            _Tp v = inp_nc[yi * Wi + xi];
                             if (v > vmax) {
                                 vmax = v;
                                 // ONNX storage_order=0: index = (c*Hi + yi)*Wi + xi
@@ -434,7 +540,7 @@ static void maxPool32f_nchw_with_indices(const float* inp, float* out, int64_t* 
                         }
                     }
                     if (idxmax < 0) {
-                        vmax = 0.f;
+                        vmax = (_Tp)0;
                         idxmax = (int64_t)(c * Hi + 0) * Wi + 0;
                     }
                     out_nc[yo * W + xo] = vmax;
@@ -622,7 +728,8 @@ public:
         const bool wantsIndices = (noutputs == 2u);
 
         if (wantsIndices) {
-            CV_Assert(inptype == CV_32F && "MaxPool with indices currently supports CV_32F only");
+            CV_CheckType(inptype, inptype == CV_32F || inptype == CV_8S || inptype == CV_8U || inptype == CV_64F,
+                         "MaxPool with indices: unsupported data type");
             CV_Assert(inpshape.dims == 4 && "MaxPool with indices: only 4D (N,C,H,W) inputs supported");
             CV_Assert(inpshape.layout != DATA_LAYOUT_BLOCK &&
                       "MaxPool with indices does not run on a BLOCK-layout input");
@@ -683,9 +790,31 @@ public:
         const int dilW = dilations.size() > 1 ? (int)dilations[1] : dilH;
         const int padH = pads.size() > 0 ? (int)pads[0] : 0;
         const int padW = pads.size() > 1 ? (int)pads[1] : padH;
-        maxPool32f_nchw_with_indices(
-            inp.ptr<float>(), outVal.ptr<float>(), outIdx.ptr<int64_t>(),
-            N, C, Hi, Wi, H, W, kH, kW, sH, sW, padH, padW, dilH, dilW);
+
+        switch (inp.depth()) {
+            case CV_32F:
+                maxPoolNchwWithIndices<float>(
+                    inp.ptr<float>(), outVal.ptr<float>(), outIdx.ptr<int64_t>(),
+                    N, C, Hi, Wi, H, W, kH, kW, sH, sW, padH, padW, dilH, dilW);
+                break;
+            case CV_8S:
+                maxPoolNchwWithIndices<int8_t>(
+                    inp.ptr<int8_t>(), outVal.ptr<int8_t>(), outIdx.ptr<int64_t>(),
+                    N, C, Hi, Wi, H, W, kH, kW, sH, sW, padH, padW, dilH, dilW);
+                break;
+            case CV_8U:
+                maxPoolNchwWithIndices<uint8_t>(
+                    inp.ptr<uint8_t>(), outVal.ptr<uint8_t>(), outIdx.ptr<int64_t>(),
+                    N, C, Hi, Wi, H, W, kH, kW, sH, sW, padH, padW, dilH, dilW);
+                break;
+            case CV_64F:
+                maxPoolNchwWithIndices<double>(
+                    inp.ptr<double>(), outVal.ptr<double>(), outIdx.ptr<int64_t>(),
+                    N, C, Hi, Wi, H, W, kH, kW, sH, sW, padH, padW, dilH, dilW);
+                break;
+            default:
+                CV_Error(Error::BadDepth, "MaxPool with indices: unsupported data type");
+        }
     }
 
     void runOp(const Mat& inp, Mat& out, const ConvState& cs)
@@ -693,6 +822,9 @@ public:
         int inptype = inp.type();
         MaxPoolFunc func =
             inptype == CV_32F ? maxPool32f :
+            inptype == CV_8S  ? maxPool8s :
+            inptype == CV_8U  ? maxPool8u :
+            inptype == CV_64F ? maxPool64f :
             /*inptype == CV_16F ? maxPool16f :
             inptype == CV_16BF ? maxPool16bf :*/
             nullptr;

--- a/modules/dnn/src/layers/maxpool_layer.cpp
+++ b/modules/dnn/src/layers/maxpool_layer.cpp
@@ -552,6 +552,8 @@ static void maxPoolNchwWithIndices(const _Tp* inp, _Tp* out, int64_t* outIdx,
 class MaxPoolLayerImpl : public MaxPoolLayer
 {
 public:
+    mutable int inpType = -1;
+
     MaxPoolLayerImpl(const LayerParams& params)
     {
         setParamsFrom(params);
@@ -601,6 +603,8 @@ public:
     {
 #ifdef HAVE_CUDA
         if (backendId == DNN_BACKEND_CUDA) {
+            if (inpType != CV_32F)
+                return false;
             if (kernel_shape.size() != 2 || outputs.size() != 1)
                 return false;
             for (int d : dilations) if (d != 1) return false;
@@ -665,6 +669,7 @@ public:
         int ninputs = (int)inptypes.size();
         CV_Assert(ninputs == 1);
 
+        inpType = inptypes[0];
         outtypes.clear();
         outtypes.push_back(inferType(inptypes[0]));
         if (outputs.size() == 2u)

--- a/modules/dnn/src/layers/range_layer.cpp
+++ b/modules/dnn/src/layers/range_layer.cpp
@@ -55,6 +55,8 @@ static void makeRange(_Tp start, _Tp limit, _Tp delta, Mat& out)
         IMPL_RANGE(int32_t);
     } else if (type == CV_64S) {
         IMPL_RANGE(int64_t);
+    } else if (type == CV_16S) {
+        IMPL_RANGE(int16_t);
     } else {
         CV_Error_(Error::StsNotImplemented, ("invalid/unsupported tensor type: %s", typeToString(out.type()).c_str()));
     }

--- a/modules/dnn/src/layers/resize2_layer.cpp
+++ b/modules/dnn/src/layers/resize2_layer.cpp
@@ -1097,6 +1097,25 @@ public:
         return (outputs[0][2] == inputs[0][2]) && (outputs[0][3] == inputs[0][3]);
     }
 
+    // CV_32S added to the default gate; only resizeNearest is a genuine int32
+    // path today (pure gather), so forward() rejects CV_32S for bilinear/cubic/
+    // antialias rather than silently routing it through the CV_32F conversion
+    // that would lose precision above float32's 24-bit mantissa.
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U ||
+                                input == CV_64S || input == CV_32S, "");
+
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
+    }
+
     virtual bool supportBackend(int backendId) CV_OVERRIDE
     {
         if (backendId == DNN_BACKEND_CUDA)
@@ -1268,8 +1287,20 @@ public:
 
         int depth = inp_.type(), orig_depth = depth;
 
+        // Nearest is a pure gather, so CV_32S is exact there; bilinear/cubic/antialias
+        // would need a fixed-point (non-float) accumulator to be genuine for CV_32S,
+        // which doesn't exist yet -- reject explicitly rather than silently falling
+        // through to the CV_32F conversion below and losing precision.
+        if (depth == CV_32S && interpolation != "nearest") {
+            CV_Error(Error::StsNotImplemented,
+                     "Resize2: CV_32S is currently only supported with nearest-neighbor "
+                     "interpolation; bilinear/cubic/antialias would need a fixed-point "
+                     "implementation to preserve int32 precision");
+        }
+
         Mat inp, out;
-        if (depth != CV_32F && depth != CV_8S && depth != CV_8U && depth != CV_16F && depth != CV_16BF) {
+        if (depth != CV_32F && depth != CV_8S && depth != CV_8U && depth != CV_16F && depth != CV_16BF &&
+            depth != CV_32S) {
             inp_.convertTo(inp, CV_32F);
             out.fit(outShape, CV_32F);
             depth = CV_32F;
@@ -1316,6 +1347,9 @@ public:
                 break;
             case CV_32F:
                 resizeNearest<float>(inp,out,scaleHeight,scaleWidth,length_resized_y,length_resized_x,nearestModeE,coordTransMode,halfPixelCenters,roi_start_y,roi_end_y,roi_start_x,roi_end_x,extrapolation_value);
+                break;
+            case CV_32S:
+                resizeNearest<int32_t>(inp,out,scaleHeight,scaleWidth,length_resized_y,length_resized_x,nearestModeE,coordTransMode,halfPixelCenters,roi_start_y,roi_end_y,roi_start_x,roi_end_x,extrapolation_value);
                 break;
             default: CV_Error(Error::StsUnsupportedFormat,"Unsupported depth");
             }

--- a/modules/dnn/src/layers/resize2_layer.cpp
+++ b/modules/dnn/src/layers/resize2_layer.cpp
@@ -1097,10 +1097,7 @@ public:
         return (outputs[0][2] == inputs[0][2]) && (outputs[0][3] == inputs[0][3]);
     }
 
-    // CV_32S added to the default gate; only resizeNearest is a genuine int32
-    // path today (pure gather), so forward() rejects CV_32S for bilinear/cubic/
-    // antialias rather than silently routing it through the CV_32F conversion
-    // that would lose precision above float32's 24-bit mantissa.
+    // Only resizeNearest has a genuine CV_32S path; other modes reject it below.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,
@@ -1287,10 +1284,7 @@ public:
 
         int depth = inp_.type(), orig_depth = depth;
 
-        // Nearest is a pure gather, so CV_32S is exact there; bilinear/cubic/antialias
-        // would need a fixed-point (non-float) accumulator to be genuine for CV_32S,
-        // which doesn't exist yet -- reject explicitly rather than silently falling
-        // through to the CV_32F conversion below and losing precision.
+        // Bilinear/cubic/antialias have no fixed-point CV_32S path yet.
         if (depth == CV_32S && interpolation != "nearest") {
             CV_Error(Error::StsNotImplemented,
                      "Resize2: CV_32S is currently only supported with nearest-neighbor "

--- a/modules/dnn/src/layers/scan_layer.cpp
+++ b/modules/dnn/src/layers/scan_layer.cpp
@@ -46,6 +46,26 @@ public:
         return false;
     }
 
+    // Scan iterates by shape/axis alone and never inspects an element value, so
+    // it's native for any type; unlike If/Loop there's no condition tensor to
+    // read either.
+    void getTypes(const std::vector<MatType>& inputs,
+                  const int requiredOutputs,
+                  const int requiredInternals,
+                  std::vector<MatType>& outputs,
+                  std::vector<MatType>& internals) const CV_OVERRIDE
+    {
+        CV_Assert(inputs.size());
+        for (auto input : inputs)
+            CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8U || input == CV_8S ||
+                                input == CV_16U || input == CV_16S || input == CV_32U || input == CV_32S ||
+                                input == CV_64U || input == CV_64S || input == CV_Bool,
+                         "Scan: unsupported input type");
+
+        outputs.assign(requiredOutputs, inputs[0]);
+        internals.assign(requiredInternals, inputs[0]);
+    }
+
     int numScanInputs() const CV_OVERRIDE { return num_scan_inputs; }
     const std::vector<int>& scanInputAxes() const CV_OVERRIDE { return input_axes; }
     const std::vector<int>& scanOutputAxes() const CV_OVERRIDE { return output_axes; }

--- a/modules/dnn/src/layers/scan_layer.cpp
+++ b/modules/dnn/src/layers/scan_layer.cpp
@@ -46,9 +46,7 @@ public:
         return false;
     }
 
-    // Scan iterates by shape/axis alone and never inspects an element value, so
-    // it's native for any type; unlike If/Loop there's no condition tensor to
-    // read either.
+    // Scan iterates by shape/axis alone; there's no value to gate on.
     void getTypes(const std::vector<MatType>& inputs,
                   const int requiredOutputs,
                   const int requiredInternals,

--- a/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
+++ b/modules/dnn/src/onnx/onnx_graph_simplifier.cpp
@@ -1965,7 +1965,7 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToI
 {
     if (tensor_proto.raw_data().empty() && tensor_proto.float_data().empty() &&
         tensor_proto.double_data().empty() && tensor_proto.int64_data().empty() &&
-        tensor_proto.int32_data().empty() &&
+        tensor_proto.int32_data().empty() && tensor_proto.uint64_data().empty() &&
         (!tensor_proto.has_data_location() || tensor_proto.data_location() != opencv_onnx::TensorProto::EXTERNAL)
     )
     {
@@ -2088,7 +2088,7 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToI
         if (!tensor_proto.double_data().empty())
         {
             checkPayloadSize(tensor_proto.double_data().size());
-            Mat(sizes, CV_64FC1, (void*)tensor_proto.double_data().data()).convertTo(blob, CV_32FC1);
+            Mat(sizes, CV_64FC1, (void*)tensor_proto.double_data().data()).copyTo(blob);
         }
         else
         {
@@ -2172,10 +2172,11 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToI
     }
     else if (datatype == opencv_onnx::TensorProto_DataType_UINT32)
     {
-        if (!tensor_proto.int32_data().empty())
+        // ONNX packs both UINT32 and UINT64 values into uint64_data, per spec.
+        if (!tensor_proto.uint64_data().empty())
         {
-            checkPayloadSize(tensor_proto.int32_data().size());
-            Mat(sizes, CV_32SC1, (void*)tensor_proto.int32_data().data()).convertTo(blob, CV_32UC1);
+            checkPayloadSize(tensor_proto.uint64_data().size());
+            Mat(sizes, CV_64UC1, (void*)tensor_proto.uint64_data().data()).convertTo(blob, CV_32UC1);
         }
         else
         {
@@ -2185,10 +2186,10 @@ Mat getMatFromTensor(const opencv_onnx::TensorProto& tensor_proto, bool uint8ToI
     }
     else if (datatype == opencv_onnx::TensorProto_DataType_UINT64)
     {
-        if (!tensor_proto.int64_data().empty())
+        if (!tensor_proto.uint64_data().empty())
         {
-            checkPayloadSize(tensor_proto.int64_data().size());
-            Mat(sizes, CV_64SC1, (void*)tensor_proto.int64_data().data()).convertTo(blob, CV_64UC1);
+            checkPayloadSize(tensor_proto.uint64_data().size());
+            Mat(sizes, CV_64UC1, (void*)tensor_proto.uint64_data().data()).copyTo(blob);
         }
         else
         {

--- a/modules/dnn/test/npy_blob.cpp
+++ b/modules/dnn/test/npy_blob.cpp
@@ -81,12 +81,23 @@ Mat blobFromNPY(const std::string& path)
 
     // Extract data type.
     int matType;
-    if (getType(header) == "<f4")
+    std::string npyType = getType(header);
+    if (npyType == "<f4")
         matType = CV_32F;
-    else if (getType(header) == "<i4")
+    else if (npyType == "<f8")
+        matType = CV_64F;
+    else if (npyType == "<i4")
         matType = CV_32S;
-    else if (getType(header) == "<i8")
+    else if (npyType == "<i8")
         matType = CV_64S;
+    else if (npyType == "<u4")
+        matType = CV_32U;
+    else if (npyType == "<u8")
+        matType = CV_64U;
+    else if (npyType == "|i1")
+        matType = CV_8S;
+    else if (npyType == "|u1")
+        matType = CV_8U;
     else
         CV_Error(Error::BadDepth, "Unsupported numpy type");
 

--- a/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
+++ b/modules/dnn/test/test_onnx_conformance_layer_filter_opencv_all_denylist.inl.hpp
@@ -8,7 +8,6 @@
 "test_castlike_STRING_to_FLOAT_expanded", // unexception during net.forward() call
 "test_maxpool_2d_dilations", // output size mismatch in NORMASSERT
 "test_maxpool_2d_same_lower", // wrong output
-"test_maxpool_2d_uint8",  // output type mismatch
 "test_maxpool_with_argmax_2d_precomputed_strides", // wrong output
 "test_maxunpool_export_with_output_shape",  // unexception during net.forward() call
 "test_upsample_nearest", // Dimension mismatch of input

--- a/modules/dnn/test/test_onnx_importer.cpp
+++ b/modules/dnn/test/test_onnx_importer.cpp
@@ -261,6 +261,17 @@ TEST_P(Test_ONNX_layers, MaxPooling_2)
     testONNXModels("two_maxpooling", npy, 0, 0, false, false);
 }
 
+// maxPool8s scalar kernel path.
+TEST_P(Test_ONNX_layers, MaxPooling_int8)
+{
+    testONNXModels("maxpool_2d_int8", npy, 0, 0, false, false);
+}
+// maxPool64f scalar kernel path.
+TEST_P(Test_ONNX_layers, MaxPooling_double)
+{
+    testONNXModels("maxpool_2d_double", npy, 0, 0, false, false);
+}
+
 TEST_P(Test_ONNX_layers, Convolution)
 {
     testONNXModels("convolution");
@@ -1151,6 +1162,29 @@ TEST_P(Test_ONNX_layers, MatMul_init_bcast)
 
 TEST_P(Test_ONNX_layers, MatMul_bcast_3dx2d) {
     testONNXModels("matmul_bcast");
+}
+
+// forwardInt<T> integer-accumulation path.
+TEST_P(Test_ONNX_layers, MatMul_int32)
+{
+    testONNXModels("matmul_int32_init");
+}
+TEST_P(Test_ONNX_layers, MatMul_int64)
+{
+    testONNXModels("matmul_int64_init");
+}
+TEST_P(Test_ONNX_layers, MatMul_uint32)
+{
+    testONNXModels("matmul_uint32_init");
+}
+TEST_P(Test_ONNX_layers, MatMul_uint64)
+{
+    testONNXModels("matmul_uint64_init");
+}
+// forwardDouble cv::gemm delegation path.
+TEST_P(Test_ONNX_layers, MatMul_double)
+{
+    testONNXModels("matmul_double_init");
 }
 
 TEST_P(Test_ONNX_layers, MatMulAdd)
@@ -2262,6 +2296,12 @@ TEST_P(Test_ONNX_layers, Gemm)
 TEST_P(Test_ONNX_layers, Gemm_bias)
 {
     testONNXModels("gemm_vector_bias");
+}
+
+// forwardDouble cv::gemm delegation path.
+TEST_P(Test_ONNX_layers, Gemm_double)
+{
+    testONNXModels("gemm_double");
 }
 
 TEST_P(Test_ONNX_layers, Quantized_Convolution)


### PR DESCRIPTION
## dnn: extend engine-new layer dtype coverage (control flow, Range, Hardmax, MaxUnpool, CumSum/CumProd, MaxPool, Resize2, normalization, Gemm, MatMul)

ONNX permits these dtypes on these ops, but the engine-new layers refused them at graph-construction time, so :
- valid models either failed to load outright or 
- a layer quietly converted to float32 instead (Resize2)
- ran but silently lost precision above float32's 24-bit mantissa.

Companion PR (test data) : [1406](https://github.com/opencv/opencv_extra/pull/1406)

### Support added, per layer

| Layer | Types added | Gate / kernel |
|---|---|---|
| If | Bool, 16U, 16S, 32U, 32S, 64U | Gate only — the condition-reading switch already handled every depth |
| Loop | Bool, 16U, 16S, 32U, 32S, 64U | Gate only — same as If |
| Scan | Bool, 16U, 16S, 32U, 32S, 64U | Gate only — Scan never inspects element values at all |
| Range | 16S | Kernel only — gate was already an unconditional passthrough |
| Hardmax | 64F | Gate only — the `double` kernel has existed since 2024, just unreachable |
| MaxUnpool | 64F | Gate + a genuine `double` instantiation of the value-scatter routine |
| CumSum | 32U, 64U | Gate + two instantiations of the existing running-sum template (wraparound on overflow) |
| CumProd | 32U, 64U | Gate + two instantiations of the existing running-product template |
| MaxPool | 8S, 8U, 64F | Kernel only (gate was already open) — new scalar kernel for the blocked values-only path **and** the separate values+indices path, which had its own float32-only assert |
| Resize2 | 32S (nearest-neighbor only) | Gate + native `int32` gather; bilinear/cubic now reject 32S explicitly instead of silently converting to `float` |
| RMSNorm | 64F | Kernel — `fast_norm.cpp` templated on `T`, genuine `double` accumulator |
| LayerNorm | 64F | Kernel — same shared `fast_norm.cpp` path |
| LayerNorm2 | 64F | Kernel — same shared `fast_norm.cpp` path |
| InstanceNorm | 64F | Kernel — existing SIMD float32 blocked path left untouched, new scalar `double` path added beside it |
| GroupNorm | 64F | Kernel — same treatment as InstanceNorm |
| Gemm | 64F | Kernel — dedicated `cv::gemm` path, bypassing the float-only fastGemm/MLAS kernels |
| MatMul | 64F, 32S, 64S, 32U, 64U | Gate + two new paths: per-batch `cv::gemm` for 64F, and a direct 64-bit-accumulated loop for the four integer types |

Removed `test_maxpool_2d_uint8` from `opencv_all_denylist` : with 8U now supported, the test passes NORMASSERT on all backend/target combinations .



### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
