### PR TITLE
Support batched NHWC input in cv::flip

### DIFF
--- a/modules/core/src/matrix_transform.cpp
+++ b/modules/core/src/matrix_transform.cpp
@@ -1055,6 +1055,19 @@ void flip( InputArray _src, OutputArray _dst, int flip_mode )
 {
     CV_INSTRUMENT_REGION();
 
+    if (_src.dims() == 4)
+    {
+        CV_Assert(flip_mode >= -1 && flip_mode <= 1);
+        if (flip_mode == 0)
+            return flipND(_src, _dst, 1);
+        if (flip_mode == 1)
+            return flipND(_src, _dst, 2);
+
+        Mat tmp;
+        flipND(_src, tmp, 1);
+        return flipND(tmp, _dst, 2);
+    }
+
     CV_Assert( _src.dims() <= 2 );
     Size size = _src.size();
 

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2698,6 +2698,41 @@ INSTANTIATE_TEST_CASE_P(Arithm, FlipND, testing::Combine(
     testing::Values(perf::MatType(CV_8UC1), CV_32FC1)
 ));
 
+TEST(Flip, BatchedNHWC)
+{
+    const int shape[] = {2, 3, 4, 2};
+    Mat src(4, shape, CV_8UC1);
+    randu(src, 0, 255);
+
+    for (int flip_code = -1; flip_code <= 1; ++flip_code)
+    {
+        Mat expected = src.clone();
+        for (int n = 0; n < shape[0]; ++n)
+            for (int h = 0; h < shape[1]; ++h)
+                for (int w = 0; w < shape[2]; ++w)
+                    for (int c = 0; c < shape[3]; ++c)
+                    {
+                        int src_idx[] = {n, h, w, c};
+                        if (flip_code <= 0)
+                            src_idx[1] = shape[1] - h - 1;
+                        if (flip_code != 0)
+                            src_idx[2] = shape[2] - w - 1;
+                        int dst_idx[] = {n, h, w, c};
+                        expected.at<uchar>(dst_idx) = src.at<uchar>(src_idx);
+                    }
+
+        Mat dst;
+        cv::flip(src, dst, flip_code);
+        EXPECT_EQ(dst.dims, 4);
+        EXPECT_EQ(dst.type(), src.type());
+        EXPECT_EQ(cv::norm(dst, expected, NORM_INF), 0);
+
+        Mat inplace = src.clone();
+        cv::flip(inplace, inplace, flip_code);
+        EXPECT_EQ(cv::norm(inplace, expected, NORM_INF), 0);
+    }
+}
+
 TEST(BroadcastTo, basic) {
     std::vector<int> shape_src{2, 1};
     std::vector<int> data_src{1, 2};

--- a/modules/python/test/test_mat.py
+++ b/modules/python/test/test_mat.py
@@ -71,6 +71,17 @@ try:
             res2 = cv.utils.dumpInputArray(mat_data2)
             self.assertEqual(res2, "InputArray: empty()=false kind=0x00010000 flags=0x01010000 total(-1)=500 dims(-1)=3 size(-1)=[5 10 10] type(-1)=CV_64FC3")
 
+        def test_flip_batched_nhwc(self):
+            data = np.arange(2 * 3 * 4 * 2, dtype=np.uint8).reshape(2, 3, 4, 2)
+            expected_axes = {-1: (1, 2), 0: 1, 1: 2}
+
+            for flip_code, axes in expected_axes.items():
+                expected = np.flip(data, axis=axes)
+                result = cv.flip(data, flip_code)
+                np.testing.assert_array_equal(result, expected)
+                self.assertEqual(result.shape, data.shape)
+                self.assertEqual(result.dtype, data.dtype)
+
 
         def test_mat_wrap_channels_fail(self):
             data = np.random.random([2, 3, 4, 520])


### PR DESCRIPTION
## Summary

Fixes #29787.

Extend cv::flip to accept 4D single-channel matrices representing batched NHWC data. The batch and channel dimensions remain unchanged; flip codes map to the H and W dimensions as follows:

- 0: reverse H
- 1: reverse W
- -1: reverse both H and W

The implementation reuses the existing flipND primitive and preserves the existing 2D behavior.

## Testing

- cmake --build build --target opencv_test_core -j2
- build/bin/opencv_test_core --gtest_filter=*Flip* --test_case_count=1 (175 tests passed)
- python3 -m py_compile modules/python/test/test_mat.py
- Added C++ coverage for all flip codes and in-place operation
- Added Python coverage for values, shape, and dtype preservation

The Python runtime test could not be executed in this checkout because Python bindings and NumPy are not available in the local build configuration.