### PR TITLE
imgproc: Enable GaussianBlur OpenCL fast paths on non-Intel GPUs.

### DIFF
--- a/modules/imgproc/src/filter.dispatch.cpp
+++ b/modules/imgproc/src/filter.dispatch.cpp
@@ -946,7 +946,6 @@ bool ocl_sepFilter2D(
         double delta, int borderType
 )
 {
-    const ocl::Device & d = ocl::Device::getDefault();
     Size imgSize = _src.size();
 
     int type = _src.type(), sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
@@ -1008,8 +1007,7 @@ bool ocl_sepFilter2D(
             imgSize.width > optimizedSepFilterLocalWidth + anchor.x &&
             imgSize.height > optimizedSepFilterLocalHeight + anchor.y &&
             (!(borderType & BORDER_ISOLATED) || _src.offset() == 0) &&
-            anchor == Point(kernelX.cols >> 1, kernelY.cols >> 1) &&
-            OCL_PERFORMANCE_CHECK(d.isIntel()),  // TODO FIXIT
+            anchor == Point(kernelX.cols >> 1, kernelY.cols >> 1),
             ocl_sepFilter2D_SinglePass(
                     _src, _dst, kernelX, kernelY, delta,
                    borderType & ~BORDER_ISOLATED, ddepth,
@@ -1052,7 +1050,6 @@ bool ocl_sepFilter2D_BitExact(
         int shift_bits
 )
 {
-    const ocl::Device & d = ocl::Device::getDefault();
     Size imgSize = _src.size();
 
     int type = _src.type(), sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
@@ -1082,8 +1079,7 @@ bool ocl_sepFilter2D_BitExact(
             imgSize.width > optimizedSepFilterLocalWidth + anchor.x &&
             imgSize.height > optimizedSepFilterLocalHeight + anchor.y &&
             (!(borderType & BORDER_ISOLATED) || _src.offset() == 0) &&
-            anchor == Point(kernelX.cols >> 1, kernelY.cols >> 1) &&
-            OCL_PERFORMANCE_CHECK(d.isIntel()),  // TODO FIXIT
+            anchor == Point(kernelX.cols >> 1, kernelY.cols >> 1),
             ocl_sepFilter2D_SinglePass(
                     _src, _dst, kernelX, kernelY, delta,
                    borderType & ~BORDER_ISOLATED, ddepth, bdepth,

--- a/modules/imgproc/src/smooth.dispatch.cpp
+++ b/modules/imgproc/src/smooth.dispatch.cpp
@@ -318,10 +318,9 @@ Ptr<FilterEngine> createGaussianFilter( int type, Size ksize,
 static bool ocl_GaussianBlur_8UC1(InputArray _src, OutputArray _dst, Size ksize, int ddepth,
                                   InputArray _kernelX, InputArray _kernelY, int borderType)
 {
-    const ocl::Device & dev = ocl::Device::getDefault();
     int type = _src.type(), sdepth = CV_MAT_DEPTH(type), cn = CV_MAT_CN(type);
 
-    if ( !(dev.isIntel() && (type == CV_8UC1) &&
+    if ( !(type == CV_8UC1 &&
          (_src.offset() == 0) && (_src.step() % 4 == 0) &&
          ((ksize.width == 5 && (_src.cols() % 4 == 0)) ||
          (ksize.width == 3 && (_src.cols() % 16 == 0) && (_src.rows() % 2 == 0)))) )


### PR DESCRIPTION
- Remove Intel-only gates from dedicated 3x3/5x5 GaussianBlur kernels and single-pass separable filter paths 
- enables other OpenCL devices can use the same optimized implementations with existing fallbacks.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

