### PR TITLE
imgproc: Enable medianBlur OpenCL optimized path on Non-Intel GPUs

### DIFF
--- a/modules/imgproc/src/median_blur.dispatch.cpp
+++ b/modules/imgproc/src/median_blur.dispatch.cpp
@@ -71,8 +71,7 @@ static bool ocl_medianFilter(InputArray _src, OutputArray _dst, int m)
                         (size_t)imgSize.width >= localsize[0] * 8  &&
                         (size_t)imgSize.height >= localsize[1] * 8 &&
                         imgSize.width % 4 == 0 &&
-                        imgSize.height % 4 == 0 &&
-                        (ocl::Device::getDefault().isIntel());
+                        imgSize.height % 4 == 0;
 
     cv::String kname = format( useOptimized ? "medianFilter%d_u" : "medianFilter%d", m) ;
     cv::String kdefs = useOptimized ?


### PR DESCRIPTION
- Remove Intel-only gate for medianFilter3_u/medianFilter5_u.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

