### PR TITLE
add UTF-8 paths decoding before passing them to ONNX Runtime

### DIFF
--- a/modules/dnn/src/net_impl.cpp
+++ b/modules/dnn/src/net_impl.cpp
@@ -2774,7 +2774,7 @@ void Net::Impl::collectOrtProfileData() const
     }
 
     // Read the JSON entirely into memory, then parse it from the string.
-    std::ifstream in(profile_path.get());
+    std::ifstream in(toOrtPath(profile_path.get()).c_str());
     if (!in.is_open()) {
         CV_LOG_WARNING(NULL, "DNN/ORT: failed to open profile JSON " << profile_path.get());
         return;

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -48,6 +48,13 @@ typedef std::unordered_map<std::string, int64_t> NamesHash;
 
 #ifdef HAVE_ONNXRUNTIME
 struct OrtNamesCache;
+
+#ifdef _WIN32
+typedef std::wstring OrtPathString;
+#else
+typedef std::string OrtPathString;
+#endif
+OrtPathString toOrtPath(const std::string& utf8Path);
 #endif
 
 /** @brief Single entry in a @ref PerfProfile.

--- a/modules/dnn/src/net_impl_backend.cpp
+++ b/modules/dnn/src/net_impl_backend.cpp
@@ -16,6 +16,9 @@
 
 #ifdef HAVE_ONNXRUNTIME
 #include <onnxruntime_cxx_api.h>
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #endif
 
 namespace cv {
@@ -23,6 +26,31 @@ namespace dnn {
 CV__DNN_INLINE_NS_BEGIN
 
 #ifdef HAVE_ONNXRUNTIME
+
+OrtPathString toOrtPath(const std::string& utf8Path)
+{
+#ifdef _WIN32
+    if (utf8Path.empty())
+        return std::wstring();
+
+    const int len = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                                        utf8Path.c_str(), (int)utf8Path.size(), NULL, 0);
+    if (len <= 0)
+    {
+        CV_LOG_WARNING(NULL, "DNN/ONNX/ORT: path is not valid UTF-8, cannot pass it to ONNX Runtime: "
+                             << utf8Path);
+        return std::wstring();
+    }
+
+    std::wstring wide((size_t)len, L'\0');
+    MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS,
+                        utf8Path.c_str(), (int)utf8Path.size(), &wide[0], len);
+    return wide;
+#else
+    return utf8Path;
+#endif
+}
+
 void Net::Impl::refreshOrtMainGraphOutputs()
 {
     CV_Assert(mainGraph && ort_session);
@@ -96,20 +124,12 @@ void Net::Impl::finalizeOrt()
     ort_profile_data.clear();
     if (profilingMode != DNN_PROFILE_NONE) {
         ort_profile_path_prefix = cv::tempfile("opencv_ort_profile_");
-#ifdef _WIN32
-        std::wstring w_profile_path(ort_profile_path_prefix.begin(), ort_profile_path_prefix.end());
-        opts.EnableProfiling(w_profile_path.c_str());
-#else
-        opts.EnableProfiling(ort_profile_path_prefix.c_str());
-#endif
+        const OrtPathString profilePath = toOrtPath(ort_profile_path_prefix);
+        opts.EnableProfiling(profilePath.c_str());
     }
 
-#ifdef _WIN32
-    std::wstring wpath(modelFileName.begin(), modelFileName.end());
-    ort_session = std::make_shared<Ort::Session>(*ort_env, wpath.c_str(), opts);
-#else
-    ort_session = std::make_shared<Ort::Session>(*ort_env, modelFileName.c_str(), opts);
-#endif
+    const OrtPathString modelPath = toOrtPath(modelFileName);
+    ort_session = std::make_shared<Ort::Session>(*ort_env, modelPath.c_str(), opts);
     preferableTarget = target;
     ortNeedsReinit = false;
 


### PR DESCRIPTION
# dnn/ORT: Fix Windows build failure and non-ASCII path handling in ONNX Runtime backend

Fixes #29788

## Problem

`modules/dnn/src/net_impl_backend.cpp` failed to compile on Windows when the DNN module was built with ONNX Runtime enabled (`HAVE_ONNXRUNTIME=1`):


`Ort::SessionOptions::EnableProfiling` takes `const ORTCHAR_T*`, and `ORTCHAR_T` is `wchar_t` on Windows (`char` on Linux/macOS). The profiling call passed a narrow `char*` unconditionally, so it compiled everywhere except Windows. Windows CI does not build the DNN module with ONNX Runtime enabled, which is why this was never caught before release.

## suggested fix from issue #29788

Byte-wise widening copies each UTF-8 byte into its own `wchar_t` instead of decoding the multi-byte sequence, so any non-ASCII path is corrupted and ORT reports that the file doesn't exist.

## Changes

- **New helper `toOrtPath()`** (in `net_impl_backend.cpp`, declared in `net_impl.hpp`): converts an OpenCV UTF-8 path to ORT's `ORTCHAR_T`. On Windows it uses `MultiByteToWideChar(CP_UTF8, ...)` for a proper UTF-8 → UTF-16 conversion; elsewhere it returns the string unchanged. Uses `MB_ERR_INVALID_CHARS` to fail loudly on malformed input rather than silently substituting `U+FFFD` and producing a path that points nowhere.
- **Both ORT call sites now route through the helper** 


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
