### PR TITLE
Add FPS based subsampling for video

### DIFF
--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -806,20 +806,16 @@ public:
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.
     @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
-    at this rate instead of the source's native rate. 0 (default) leaves the source rate
-    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
-    to have any effect); it does not duplicate frames to increase it.
-
-    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
-    cannot currently be combined with the `params` vector overloads below (e.g. to also set
-    CAP_PROP_HW_ACCELERATION in the same open() call).
-
-    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
-    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
-    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
-    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
-    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
-    multi-head note on grab() below).
+    at this rate instead of the source's native rate; 0 (default) leaves the source untouched.
+    Frames are never duplicated, so a target_fps above the native rate has no effect. Supported on
+    cv::CAP_FFMPEG, cv::CAP_GSTREAMER, cv::CAP_V4L2 and cv::CAP_OPENCV_MJPEG; ignored with a warning
+    on any other backend. While enabled, VideoCapture::get() describes the emitted stream:
+    CAP_PROP_FPS is the emitted rate, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)` tags output
+    correctly, and the CAP_PROP_POS_* properties refer to the frame the last read() returned as the
+    backend reported it (cv::CAP_OPENCV_MJPEG derives CAP_PROP_POS_MSEC from the next frame's index,
+    so on that backend it reads one source frame ahead). grab() decodes every source frame in order
+    to inspect its timestamp, and only channel 0 is supported. Not available on the `params` vector
+    overloads below.
 
     @sa cv::VideoCaptureAPIs
     */
@@ -841,20 +837,16 @@ public:
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.
     @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
-    at this rate instead of the source's native rate. 0 (default) leaves the source rate
-    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
-    to have any effect); it does not duplicate frames to increase it.
-
-    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
-    cannot currently be combined with the `params` vector overloads below (e.g. to also set
-    CAP_PROP_HW_ACCELERATION in the same open() call).
-
-    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
-    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
-    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
-    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
-    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
-    multi-head note on grab() below).
+    at this rate instead of the source's native rate; 0 (default) leaves the source untouched.
+    Frames are never duplicated, so a target_fps above the native rate has no effect. Supported on
+    cv::CAP_FFMPEG, cv::CAP_GSTREAMER, cv::CAP_V4L2 and cv::CAP_OPENCV_MJPEG; ignored with a warning
+    on any other backend. While enabled, VideoCapture::get() describes the emitted stream:
+    CAP_PROP_FPS is the emitted rate, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)` tags output
+    correctly, and the CAP_PROP_POS_* properties refer to the frame the last read() returned as the
+    backend reported it (cv::CAP_OPENCV_MJPEG derives CAP_PROP_POS_MSEC from the next frame's index,
+    so on that backend it reads one source frame ahead). grab() decodes every source frame in order
+    to inspect its timestamp, and only channel 0 is supported. Not available on the `params` vector
+    overloads below.
 
     @sa cv::VideoCaptureAPIs
     */
@@ -894,7 +886,8 @@ public:
     @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
     they are emitted at this rate instead of the source's native rate. Only supports reducing
     the rate; see the target_fps documentation on the matching VideoCapture constructor for the
-    grab() cost, multi-head/channel, and params-overload limitations.
+    supported backends, what VideoCapture::get() reports while it is enabled, and the grab()
+    cost, multi-head/channel, and params-overload limitations.
      */
     CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
 
@@ -923,7 +916,8 @@ public:
     @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
     they are emitted at this rate instead of the source's native rate. Only supports reducing
     the rate; see the target_fps documentation on the matching VideoCapture constructor for the
-    grab() cost, multi-head/channel, and params-overload limitations.
+    supported backends, what VideoCapture::get() reports while it is enabled, and the grab()
+    cost, multi-head/channel, and params-overload limitations.
     */
     CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY, double target_fps = 0);
 
@@ -1096,33 +1090,41 @@ protected:
     Ptr<IVideoCapture> icap;
     bool throwOnFail;
 
-    // Backend-agnostic, drop-only frame-rate control set via the target_fps constructor/open()
-    // parameter. See cap.cpp for the algorithm, which mirrors the selection rule of FFmpeg's
-    // `fps` filter: a 2-frame lookahead buffer compared against a steadily advancing output
-    // clock decides whether a buffered frame is stale and should be dropped.
-    //
-    // kFpsControlEpsMs absorbs floating-point rounding noise in backend-reported timestamps
-    // (observed on the order of 1e-13 ms) so an exact schedule boundary in fpsControlGrab()
-    // doesn't get flipped by it; see cap.cpp for where it's used.
+    // Drop-only frame-rate control set via the target_fps constructor/open() parameter; see
+    // fpsControlGrab() in cap.cpp for the algorithm.
+
+    // Tolerance for backend timestamp rounding noise at an exact schedule boundary.
     static const double kFpsControlEpsMs;
+
+    // A frame plus the position properties the backend reported for it, captured together at
+    // retrieve time so get() can report them consistently for the frame actually emitted.
+    struct FpsControlFrame
+    {
+        Mat frame;
+        double posMsec = -1.0;
+        double posFrames = -1.0;
+        double posAviRatio = -1.0;
+
+        void reset() { frame.release(); posMsec = posFrames = posAviRatio = -1.0; }
+    };
 
     struct FpsControlState
     {
         bool enabled = false;
+        double targetFps = 0.0;            // requested output fps, for get(CAP_PROP_FPS)
         double outFrameDurationMs = 0.0;   // 1000 / requested output fps
         double nextOutPts = -1.0;          // output clock; unset (<0) until first frame anchors it
 
-        Mat bufFrame[2];
-        double bufPts[2] = { -1.0, -1.0 };
+        FpsControlFrame buf[2];            // lookahead buffer
         int bufCount = 0;
 
-        Mat pendingFrame;                  // frame fpsControlGrab() picked for retrieve() to return
-        double pendingPts = -1.0;          // pendingFrame's timestamp, for get(CAP_PROP_POS_MSEC)
+        FpsControlFrame pending;           // frame fpsControlGrab() picked for retrieve() to return
     } fpsCtl;
 
     void enableFpsControl(double target_fps);
     bool fpsControlReadOne();
     bool fpsControlGrab();
+    void fpsControlResetClock();
 
     friend class internal::VideoCapturePrivateAccessor;
 };

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -205,6 +205,7 @@ enum VideoCaptureProperties {
        CAP_PROP_PTS = 71, //!<  (read-only) FFmpeg back-end only - presentation timestamp of the most recently read frame using the FPS time base.  e.g. fps = 25, VideoCapture::get(\ref CAP_PROP_PTS) = 3, presentation time = 3/25 seconds.
        CAP_PROP_DTS_DELAY = 72, //!<  (read-only) FFmpeg back-end only - maximum difference between presentation (pts) and decompression timestamps (dts) using FPS time base.  e.g. delay is maximum when frame_num = 0, if true, VideoCapture::get(\ref CAP_PROP_PTS) = 0 and VideoCapture::get(\ref CAP_PROP_DTS_DELAY) = 2, dts = -2.  Non zero values usually imply the stream is encoded using B-frames which are not decoded in presentation order.
        CAP_PROP_IMAGE_SEQ_START = 73, //!< (**open-only**) Start number for image sequences opened with a printf-style pattern (e.g. `frame_%05d.dpx`). Sets the initial frame number and disables automatic first-frame detection. Applicable to \ref CAP_FFMPEG (passed as the image2 demuxer `start_number`) and \ref CAP_IMAGES backends. Default: not set (automatic detection).
+       CAP_PROP_TARGET_FPS = 74, //!< (**open-only**, via `params`) Drops frames so VideoCapture::read() emits at this rate instead of the source's native rate; supported on \ref CAP_FFMPEG, \ref CAP_GSTREAMER, \ref CAP_V4L2 and \ref CAP_OPENCV_MJPEG, ignored (with a warning) elsewhere.
 #ifndef CV_DOXYGEN
        CV__CAP_PROP_LATEST
 #endif
@@ -805,27 +806,16 @@ public:
       documentation of source stream to know the right URL.
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.
-    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
-    at this rate instead of the source's native rate; 0 (default) leaves the source untouched.
-    Frames are never duplicated, so a target_fps above the native rate has no effect. Supported on
-    cv::CAP_FFMPEG, cv::CAP_GSTREAMER, cv::CAP_V4L2 and cv::CAP_OPENCV_MJPEG; ignored with a warning
-    on any other backend. While enabled, VideoCapture::get() describes the emitted stream:
-    CAP_PROP_FPS is the emitted rate, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)` tags output
-    correctly, and the CAP_PROP_POS_* properties refer to the frame the last read() returned as the
-    backend reported it (cv::CAP_OPENCV_MJPEG derives CAP_PROP_POS_MSEC from the next frame's index,
-    so on that backend it reads one source frame ahead). grab() decodes every source frame in order
-    to inspect its timestamp, and only channel 0 is supported. Not available on the `params` vector
-    overloads below.
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
+    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY);
 
     /** @overload
     @brief Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
 
     The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`.
-    See cv::VideoCaptureProperties
+    See cv::VideoCaptureProperties (this includes \ref CAP_PROP_TARGET_FPS for drop-only frame-rate control)
     */
     CV_WRAP explicit VideoCapture(const String& filename, int apiPreference, const std::vector<int>& params);
 
@@ -836,27 +826,16 @@ public:
     (to backward compatibility usage of camera_id + domain_offset (CAP_*) is valid when apiPreference is CAP_ANY)
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.
-    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
-    at this rate instead of the source's native rate; 0 (default) leaves the source untouched.
-    Frames are never duplicated, so a target_fps above the native rate has no effect. Supported on
-    cv::CAP_FFMPEG, cv::CAP_GSTREAMER, cv::CAP_V4L2 and cv::CAP_OPENCV_MJPEG; ignored with a warning
-    on any other backend. While enabled, VideoCapture::get() describes the emitted stream:
-    CAP_PROP_FPS is the emitted rate, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)` tags output
-    correctly, and the CAP_PROP_POS_* properties refer to the frame the last read() returned as the
-    backend reported it (cv::CAP_OPENCV_MJPEG derives CAP_PROP_POS_MSEC from the next frame's index,
-    so on that backend it reads one source frame ahead). grab() decodes every source frame in order
-    to inspect its timestamp, and only channel 0 is supported. Not available on the `params` vector
-    overloads below.
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY, double target_fps = 0);
+    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY);
 
     /** @overload
     @brief Opens a camera for video capturing with API Preference and parameters
 
     The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`.
-    See cv::VideoCaptureProperties
+    See cv::VideoCaptureProperties (this includes \ref CAP_PROP_TARGET_FPS for drop-only frame-rate control)
     */
     CV_WRAP explicit VideoCapture(int index, int apiPreference, const std::vector<int>& params);
 
@@ -882,21 +861,15 @@ public:
     @return `true` if the file has been successfully opened
 
     The method first calls VideoCapture::release to close the already opened file or camera.
-
-    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
-    they are emitted at this rate instead of the source's native rate. Only supports reducing
-    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
-    supported backends, what VideoCapture::get() reports while it is enabled, and the grab()
-    cost, multi-head/channel, and params-overload limitations.
      */
-    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
+    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY);
 
     /** @brief  Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
 
     @overload
 
     The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`.
-    See cv::VideoCaptureProperties
+    See cv::VideoCaptureProperties (this includes \ref CAP_PROP_TARGET_FPS for drop-only frame-rate control)
 
     @return `true` if the file has been successfully opened
 
@@ -912,21 +885,15 @@ public:
     @return `true` if the camera has been successfully opened.
 
     The method first calls VideoCapture::release to close the already opened file or camera.
-
-    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
-    they are emitted at this rate instead of the source's native rate. Only supports reducing
-    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
-    supported backends, what VideoCapture::get() reports while it is enabled, and the grab()
-    cost, multi-head/channel, and params-overload limitations.
     */
-    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY, double target_fps = 0);
+    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY);
 
     /** @brief  Opens a camera for video capturing with API Preference and parameters
 
     @overload
 
     The `params` parameter allows to specify extra parameters encoded as pairs `(paramId_1, paramValue_1, paramId_2, paramValue_2, ...)`.
-    See cv::VideoCaptureProperties
+    See cv::VideoCaptureProperties (this includes \ref CAP_PROP_TARGET_FPS for drop-only frame-rate control)
 
     @return `true` if the camera has been successfully opened.
 
@@ -1090,23 +1057,11 @@ protected:
     Ptr<IVideoCapture> icap;
     bool throwOnFail;
 
-    // Drop-only frame-rate control set via the target_fps constructor/open() parameter; see
-    // fpsControlGrab() in cap.cpp for the algorithm.
+    // Drop-only frame-rate control set via CAP_PROP_TARGET_FPS in the `params` vector passed to a
+    // constructor/open() call; see fpsControlGrab() in cap.cpp for the algorithm.
 
     // Tolerance for backend timestamp rounding noise at an exact schedule boundary.
     static const double kFpsControlEpsMs;
-
-    // A frame plus the position properties the backend reported for it, captured together at
-    // retrieve time so get() can report them consistently for the frame actually emitted.
-    struct FpsControlFrame
-    {
-        Mat frame;
-        double posMsec = -1.0;
-        double posFrames = -1.0;
-        double posAviRatio = -1.0;
-
-        void reset() { frame.release(); posMsec = posFrames = posAviRatio = -1.0; }
-    };
 
     struct FpsControlState
     {
@@ -1115,14 +1070,17 @@ protected:
         double outFrameDurationMs = 0.0;   // 1000 / requested output fps
         double nextOutPts = -1.0;          // output clock; unset (<0) until first frame anchors it
 
-        FpsControlFrame buf[2];            // lookahead buffer
-        int bufCount = 0;
-
-        FpsControlFrame pending;           // frame fpsControlGrab() picked for retrieve() to return
+        // Set by fpsControlGrab() when it finds the frame due for the current tick. Its pixel data
+        // is deliberately left un-retrieved in the backend's own internal buffer -- retrieve()
+        // fetches it directly from there, exactly like the disabled path, so a dropped frame is
+        // never decoded/copied and the kept frame is never copied more than once.
+        bool pendingValid = false;
+        double pendingPosMsec = -1.0;
+        double pendingPosFrames = -1.0;
+        double pendingPosAviRatio = -1.0;
     } fpsCtl;
 
     void enableFpsControl(double target_fps);
-    bool fpsControlReadOne();
     bool fpsControlGrab();
     void fpsControlResetClock();
 

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -805,10 +805,25 @@ public:
       documentation of source stream to know the right URL.
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_FFMPEG or cv::CAP_IMAGES or cv::CAP_DSHOW.
+    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
+    at this rate instead of the source's native rate. 0 (default) leaves the source rate
+    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
+    to have any effect); it does not duplicate frames to increase it.
+
+    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
+    cannot currently be combined with the `params` vector overloads below (e.g. to also set
+    CAP_PROP_HW_ACCELERATION in the same open() call).
+
+    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
+    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
+    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
+    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
+    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
+    multi-head note on grab() below).
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY);
+    CV_WRAP explicit VideoCapture(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @overload
     @brief Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
@@ -825,10 +840,25 @@ public:
     (to backward compatibility usage of camera_id + domain_offset (CAP_*) is valid when apiPreference is CAP_ANY)
     @param apiPreference preferred Capture API backends to use. Can be used to enforce a specific reader
     implementation if multiple are available: e.g. cv::CAP_DSHOW or cv::CAP_MSMF or cv::CAP_V4L.
+    @param target_fps if greater than 0, VideoCapture::read() drops frames so they are emitted
+    at this rate instead of the source's native rate. 0 (default) leaves the source rate
+    untouched. Only supports reducing the rate (target_fps must be <= the source's native rate
+    to have any effect); it does not duplicate frames to increase it.
+
+    Only this overload and the matching open(..., target_fps) overload support target_fps -- it
+    cannot currently be combined with the `params` vector overloads below (e.g. to also set
+    CAP_PROP_HW_ACCELERATION in the same open() call).
+
+    While enabled, grab() fully decodes every source frame (not just the ones actually kept) in
+    order to inspect its timestamp, so it no longer has the fast, decode-free cost multi-camera
+    callers rely on -- see the multi-camera-sync note on grab() below. Only channel 0 is
+    supported: VideoCapture::retrieve() with any other channel fails while target_fps is set, so
+    this is not compatible with multi-head sources (stereo camera, Kinect, etc; see the
+    multi-head note on grab() below).
 
     @sa cv::VideoCaptureAPIs
     */
-    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY);
+    CV_WRAP explicit VideoCapture(int index, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @overload
     @brief Opens a camera for video capturing with API Preference and parameters
@@ -860,8 +890,13 @@ public:
     @return `true` if the file has been successfully opened
 
     The method first calls VideoCapture::release to close the already opened file or camera.
+
+    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
+    they are emitted at this rate instead of the source's native rate. Only supports reducing
+    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
+    grab() cost, multi-head/channel, and params-overload limitations.
      */
-    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY);
+    CV_WRAP virtual bool open(const String& filename, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @brief  Opens a video file or a capturing device or an IP video stream for video capturing with API Preference and parameters
 
@@ -884,8 +919,13 @@ public:
     @return `true` if the camera has been successfully opened.
 
     The method first calls VideoCapture::release to close the already opened file or camera.
+
+    @param target_fps if greater than 0, subsequent VideoCapture::read() calls drop frames so
+    they are emitted at this rate instead of the source's native rate. Only supports reducing
+    the rate; see the target_fps documentation on the matching VideoCapture constructor for the
+    grab() cost, multi-head/channel, and params-overload limitations.
     */
-    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY);
+    CV_WRAP virtual bool open(int index, int apiPreference = CAP_ANY, double target_fps = 0);
 
     /** @brief  Opens a camera for video capturing with API Preference and parameters
 
@@ -1055,6 +1095,34 @@ public:
 protected:
     Ptr<IVideoCapture> icap;
     bool throwOnFail;
+
+    // Backend-agnostic, drop-only frame-rate control set via the target_fps constructor/open()
+    // parameter. See cap.cpp for the algorithm, which mirrors the selection rule of FFmpeg's
+    // `fps` filter: a 2-frame lookahead buffer compared against a steadily advancing output
+    // clock decides whether a buffered frame is stale and should be dropped.
+    //
+    // kFpsControlEpsMs absorbs floating-point rounding noise in backend-reported timestamps
+    // (observed on the order of 1e-13 ms) so an exact schedule boundary in fpsControlGrab()
+    // doesn't get flipped by it; see cap.cpp for where it's used.
+    static const double kFpsControlEpsMs;
+
+    struct FpsControlState
+    {
+        bool enabled = false;
+        double outFrameDurationMs = 0.0;   // 1000 / requested output fps
+        double nextOutPts = -1.0;          // output clock; unset (<0) until first frame anchors it
+
+        Mat bufFrame[2];
+        double bufPts[2] = { -1.0, -1.0 };
+        int bufCount = 0;
+
+        Mat pendingFrame;                  // frame fpsControlGrab() picked for retrieve() to return
+        double pendingPts = -1.0;          // pendingFrame's timestamp, for get(CAP_PROP_POS_MSEC)
+    } fpsCtl;
+
+    void enableFpsControl(double target_fps);
+    bool fpsControlReadOne();
+    bool fpsControlGrab();
 
     friend class internal::VideoCapturePrivateAccessor;
 };

--- a/modules/videoio/include/opencv2/videoio.hpp
+++ b/modules/videoio/include/opencv2/videoio.hpp
@@ -1057,8 +1057,7 @@ protected:
     Ptr<IVideoCapture> icap;
     bool throwOnFail;
 
-    // Drop-only frame-rate control set via CAP_PROP_TARGET_FPS in the `params` vector passed to a
-    // constructor/open() call; see fpsControlGrab() in cap.cpp for the algorithm.
+    // Drop-only frame-rate control set via CAP_PROP_TARGET_FPS; see fpsControlGrab() in cap.cpp.
 
     // Tolerance for backend timestamp rounding noise at an exact schedule boundary.
     static const double kFpsControlEpsMs;
@@ -1070,10 +1069,7 @@ protected:
         double outFrameDurationMs = 0.0;   // 1000 / requested output fps
         double nextOutPts = -1.0;          // output clock; unset (<0) until first frame anchors it
 
-        // Set by fpsControlGrab() when it finds the frame due for the current tick. Its pixel data
-        // is deliberately left un-retrieved in the backend's own internal buffer -- retrieve()
-        // fetches it directly from there, exactly like the disabled path, so a dropped frame is
-        // never decoded/copied and the kept frame is never copied more than once.
+        // Set by fpsControlGrab(); pixel data stays un-retrieved until retrieve() fetches it.
         bool pendingValid = false;
         double pendingPosMsec = -1.0;
         double pendingPosFrames = -1.0;

--- a/modules/videoio/perf/perf_target_fps.cpp
+++ b/modules/videoio/perf/perf_target_fps.cpp
@@ -1,0 +1,39 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test
+{
+using namespace perf;
+
+// target_fps <= 0 must show zero measurable overhead vs. not passing the parameter at all --
+// that path bypasses fpsControlGrab() entirely (see VideoCapture::grab()). Enabling it, by
+// contrast, makes grab() fully decode (and Mat::clone()) every source frame rather than just
+// the ones actually returned, so throughput is expected to be measurably worse than disabled
+// even though fewer frames come back to the caller -- this perf test exists to catch a
+// regression in either direction (disabled path picking up overhead it shouldn't, or the
+// enabled path's overhead growing unexpectedly), not to demonstrate a speedup.
+
+typedef tuple<string, double> VideoCapture_TargetFpsParams;
+typedef perf::TestBaseWithParam<VideoCapture_TargetFpsParams> VideoCapture_TargetFps;
+
+PERF_TEST_P(VideoCapture_TargetFps, ReadThroughput,
+            testing::Combine(testing::Values(string("highgui/video/big_buck_bunny.mp4")),
+                              testing::Values(0.0, 12.0))) // 0 = disabled; 12 = half native 24fps
+{
+    const string filename = getDataPath(get<0>(GetParam()));
+    const double target_fps = get<1>(GetParam());
+
+    TEST_CYCLE()
+    {
+        VideoCapture cap(filename, CAP_ANY, target_fps);
+        Mat frame;
+        while (cap.read(frame)) {}
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace

--- a/modules/videoio/perf/perf_target_fps.cpp
+++ b/modules/videoio/perf/perf_target_fps.cpp
@@ -8,13 +8,15 @@ namespace opencv_test
 {
 using namespace perf;
 
-// target_fps <= 0 must show zero measurable overhead vs. not passing the parameter at all --
-// that path bypasses fpsControlGrab() entirely (see VideoCapture::grab()). Enabling it, by
-// contrast, makes grab() fully decode (and Mat::clone()) every source frame rather than just
-// the ones actually returned, so throughput is expected to be measurably worse than disabled
-// even though fewer frames come back to the caller -- this perf test exists to catch a
-// regression in either direction (disabled path picking up overhead it shouldn't, or the
-// enabled path's overhead growing unexpectedly), not to demonstrate a speedup.
+// target_fps <= 0 must show zero measurable overhead vs. not requesting CAP_PROP_TARGET_FPS at
+// all -- that path bypasses fpsControlGrab() entirely (see VideoCapture::grab()). Enabling it, by
+// contrast, still decodes every source frame via grabFrame(), but a dropped frame is never handed
+// to retrieveFrame() (see fpsControlGrab()'s comment), so it never pays for color conversion or
+// the output Mat's allocation/copy -- only the frame actually kept each tick does. Throughput is
+// therefore expected to be at or below the disabled path's, improving as target_fps drops further
+// below the source's native rate -- this perf test exists to catch a regression in either
+// direction (disabled path picking up overhead it shouldn't, or the enabled path's saving eroding
+// or reversing unexpectedly).
 
 typedef tuple<string, double> VideoCapture_TargetFpsParams;
 typedef perf::TestBaseWithParam<VideoCapture_TargetFpsParams> VideoCapture_TargetFps;
@@ -28,7 +30,7 @@ PERF_TEST_P(VideoCapture_TargetFps, ReadThroughput,
 
     TEST_CYCLE()
     {
-        VideoCapture cap(filename, CAP_ANY, target_fps);
+        VideoCapture cap(filename, CAP_ANY, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
         Mat frame;
         while (cap.read(frame)) {}
     }

--- a/modules/videoio/perf/perf_target_fps.cpp
+++ b/modules/videoio/perf/perf_target_fps.cpp
@@ -8,15 +8,7 @@ namespace opencv_test
 {
 using namespace perf;
 
-// target_fps <= 0 must show zero measurable overhead vs. not requesting CAP_PROP_TARGET_FPS at
-// all -- that path bypasses fpsControlGrab() entirely (see VideoCapture::grab()). Enabling it, by
-// contrast, still decodes every source frame via grabFrame(), but a dropped frame is never handed
-// to retrieveFrame() (see fpsControlGrab()'s comment), so it never pays for color conversion or
-// the output Mat's allocation/copy -- only the frame actually kept each tick does. Throughput is
-// therefore expected to be at or below the disabled path's, improving as target_fps drops further
-// below the source's native rate -- this perf test exists to catch a regression in either
-// direction (disabled path picking up overhead it shouldn't, or the enabled path's saving eroding
-// or reversing unexpectedly).
+// Catches a regression in either direction: disabled-path overhead, or enabled-path savings eroding.
 
 typedef tuple<string, double> VideoCapture_TargetFpsParams;
 typedef perf::TestBaseWithParam<VideoCapture_TargetFpsParams> VideoCapture_TargetFps;

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -70,10 +70,10 @@ IStreamReader::~IStreamReader()
 VideoCapture::VideoCapture() : throwOnFail(false)
 {}
 
-VideoCapture::VideoCapture(const String& filename, int apiPreference) : throwOnFail(false)
+VideoCapture::VideoCapture(const String& filename, int apiPreference, double target_fps) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(filename, apiPreference);
+    open(filename, apiPreference, target_fps);
 }
 
 VideoCapture::VideoCapture(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -90,10 +90,10 @@ VideoCapture::VideoCapture(const Ptr<IStreamReader>& source, int apiPreference, 
     open(source, apiPreference, params);
 }
 
-VideoCapture::VideoCapture(int index, int apiPreference) : throwOnFail(false)
+VideoCapture::VideoCapture(int index, int apiPreference, double target_fps) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(index, apiPreference);
+    open(index, apiPreference, target_fps);
 }
 
 VideoCapture::VideoCapture(int index, int apiPreference, const std::vector<int>& params)
@@ -109,9 +109,13 @@ VideoCapture::~VideoCapture()
     icap.release();
 }
 
-bool VideoCapture::open(const String& filename, int apiPreference)
+bool VideoCapture::open(const String& filename, int apiPreference, double target_fps)
 {
-    return open(filename, apiPreference, std::vector<int>());
+    CV_INSTRUMENT_REGION();
+    bool ok = open(filename, apiPreference, std::vector<int>());
+    if (ok)
+        enableFpsControl(target_fps);
+    return ok;
 }
 
 bool VideoCapture::open(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -361,9 +365,13 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     return false;
 }
 
-bool VideoCapture::open(int cameraNum, int apiPreference)
+bool VideoCapture::open(int cameraNum, int apiPreference, double target_fps)
 {
-    return open(cameraNum, apiPreference, std::vector<int>());
+    CV_INSTRUMENT_REGION();
+    bool ok = open(cameraNum, apiPreference, std::vector<int>());
+    if (ok)
+        enableFpsControl(target_fps);
+    return ok;
 }
 
 bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>& params)
@@ -519,12 +527,160 @@ void VideoCapture::release()
 {
     CV_TRACE_FUNCTION();
     icap.release();
+    fpsCtl = FpsControlState(); // don't leak fps-control state (clock/buffers) across reopen
+}
+
+// target_fps <= 0 disables frame-rate control entirely (plain passthrough).
+//
+// Only enabled for backends confirmed (by reading each one's getProperty(CAP_PROP_POS_MSEC)
+// implementation) to report a real, per-frame timestamp:
+//   - FFmpeg          -- decoded AVFrame/AVPacket pts
+//   - GStreamer        -- pipeline buffer timestamp
+//   - V4L2             -- kernel capture buffer timestamp
+//   - OpenCV MJPEG     -- derived frame-index * 1000/fps; not a decoded PTS, but genuinely monotonic
+//   - MSMF (Windows)   -- real per-sample presentation timestamp (usedVideoSampleTime); used for
+//                         both file playback and live cameras on Windows -- NOT the same backend
+//                         as the older CAP_DSHOW, which has no CAP_PROP_POS_MSEC case at all
+//   - Aravis           -- derived frameID/fps, same genuinely-monotonic pattern as OpenCV MJPEG
+//   - OpenNI2 / ASUS   -- real per-frame SDK timestamp (streamFrames[...].getTimestamp())
+//   - Xine             -- real xine_get_pos_length() position; NOTE falls back to
+//                         CAP_PROP_UNKNOWN on an individual query failure, not bulletproof
+//   - gPhoto2          -- real elapsed time since first frame, but only whole-second (time_t)
+//                         resolution -- coarser than the others, fine only if frames arrive
+//                         >1s apart (true for its tethered-DSLR use case, not a general guarantee)
+// Every other backend either never implements CAP_PROP_POS_MSEC at all (falls through to the
+// interface's own CAP_PROP_UNKNOWN default, e.g. Intel MFX/UEYE/OBSENSOR/DShow/Android/DC1394/
+// PvAPI/WinRT/RealSense/XIMEA) or explicitly returns a constant unrelated to real time
+// (CV_IMAGES) -- silently trusting one of those would either drop every frame but the last one
+// (bounded sources, confirmed empirically on CV_IMAGES) or hang grab() forever (live sources that
+// never reach EOF), since the drop-selection algorithm has no way to detect a stale/constant
+// timestamp on its own. Falling back to plain, unrestricted passthrough is always safe; silently
+// mis-selecting frames or hanging is not.
+void VideoCapture::enableFpsControl(double target_fps)
+{
+    fpsCtl = FpsControlState();
+    if (target_fps > 0 && !icap.empty())
+    {
+        int domain = icap->isOpened() ? icap->getCaptureDomain() : 0;
+        if (domain != CAP_FFMPEG && domain != CAP_GSTREAMER && domain != CAP_V4L2 &&
+            domain != CAP_OPENCV_MJPEG)
+        {
+            CV_LOG_WARNING(NULL, "VIDEOIO: target_fps is not supported for backend "
+                << (domain != 0 ? cv::videoio_registry::getBackendName(static_cast<VideoCaptureAPIs>(domain)) : cv::String("<unknown>"))
+                << " -- frame-rate control not enabled, using plain passthrough instead");
+            return; // fpsCtl.enabled stays false from the reset above
+        }
+        fpsCtl.enabled = true;
+        fpsCtl.outFrameDurationMs = 1000.0 / target_fps;
+    }
+}
+
+// Pull exactly one real frame from the backend into the next free lookahead-buffer slot.
+// Always clones: some backends reuse a single internal decode buffer across grabFrame() calls,
+// and we need two buffered frames to stay valid and independent at the same time.
+bool VideoCapture::fpsControlReadOne()
+{
+    CV_Assert(fpsCtl.bufCount < 2);
+    if (!icap->grabFrame())
+        return false;
+    Mat frame;
+    if (!icap->retrieveFrame(0, frame) || frame.empty())
+        return false;
+    fpsCtl.bufFrame[fpsCtl.bufCount] = frame.clone();
+    fpsCtl.bufPts[fpsCtl.bufCount] = icap->getProperty(CAP_PROP_POS_MSEC);
+    fpsCtl.bufCount++;
+    return true;
+}
+
+// Drop-only version of FFmpeg's vf_fps.c decision rule: keep 2 frames buffered and compare the
+// *next* frame's timestamp against the output clock (nextOutPts). If the next frame has already
+// reached or passed the current tick, the buffered frame is stale -- drop it and re-check.
+// Otherwise it's the answer for this tick -- consume it and advance the clock by one output-frame
+// duration. Since target_fps is always <= the source rate here, a buffered frame is never held
+// over for a second tick, so there is no duplicate case to handle.
+//
+// At end of stream, only one frame may be left buffered with no lookahead to compare it against --
+// in that case its own timestamp is checked directly against the clock instead: still due -> emit
+// it (the last available data is the best answer for this tick); not yet due -> the schedule never
+// caught up before the source ran out, so there's nothing to emit for this tick.
+//
+// kFpsControlEpsMs (see videoio.hpp, next to FpsControlState) absorbs floating-point rounding
+// noise in backend-reported timestamps so an exact schedule boundary doesn't get flipped by it.
+const double VideoCapture::kFpsControlEpsMs = 1e-6;
+
+bool VideoCapture::fpsControlGrab()
+{
+    FpsControlState& s = fpsCtl;
+
+    for (;;)
+    {
+        while (s.bufCount < 2)
+        {
+            if (fpsControlReadOne())
+                continue;
+            break; // source exhausted -- bufCount may now be 0 or 1
+        }
+
+        if (s.bufCount == 0)
+        {
+            // Nothing buffered and nothing left to emit -- invalidate the previous answer so a
+            // retrieve() call made without checking this grab()'s return value can't silently
+            // re-serve a stale frame instead of failing.
+            s.pendingFrame.release();
+            s.pendingPts = -1.0;
+            return false;
+        }
+
+        if (s.nextOutPts < 0)
+            s.nextOutPts = s.bufPts[0]; // anchor the output clock to the first real frame's timestamp
+
+        if (s.bufCount == 2)
+        {
+            if (s.bufPts[1] <= s.nextOutPts + kFpsControlEpsMs)
+            {
+                // buf[0] is stale -- drop it, shift, and re-check against the new pair.
+                s.bufFrame[0] = s.bufFrame[1];
+                s.bufPts[0] = s.bufPts[1];
+                s.bufCount = 1;
+                continue;
+            }
+        }
+        else // bufCount == 1: source is exhausted, no lookahead frame left to compare against
+        {
+            if (s.bufPts[0] < s.nextOutPts - kFpsControlEpsMs)
+            {
+                s.pendingFrame.release(); // same reasoning as the bufCount==0 case above
+                s.pendingPts = -1.0;
+                return false; // schedule never caught up before the source ran out
+            }
+        }
+
+        // buf[0] is the answer for this tick.
+        s.pendingFrame = s.bufFrame[0];
+        s.pendingPts = s.bufPts[0];
+        s.nextOutPts += s.outFrameDurationMs;
+        if (s.bufCount == 2)
+        {
+            s.bufFrame[0] = s.bufFrame[1];
+            s.bufPts[0] = s.bufPts[1];
+            s.bufCount = 1;
+        }
+        else
+        {
+            s.bufCount = 0;
+        }
+        return true;
+    }
 }
 
 bool VideoCapture::grab()
 {
     CV_INSTRUMENT_REGION();
-    bool ret = !icap.empty() ? icap->grabFrame() : false;
+    bool ret = false;
+    if (!icap.empty())
+    {
+        ret = fpsCtl.enabled ? fpsControlGrab() : icap->grabFrame();
+    }
     if (!ret && throwOnFail)
     {
         CV_Error(Error::StsError, "");
@@ -539,7 +695,28 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
     bool ret = false;
     if (!icap.empty())
     {
-        ret = icap->retrieveFrame(channel, image);
+        if (fpsCtl.enabled)
+        {
+            // target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
+            // retrieveFrame(0, ...)) -- it does not support multi-head sources (stereo camera,
+            // Kinect, etc: see the multi-head note on grab() above). Fail loudly rather than
+            // silently handing back channel 0's data for a different requested channel.
+            if (channel != 0)
+            {
+                CV_LOG_WARNING(NULL, "VIDEOIO: target_fps does not support multi-head capture "
+                                      "(channel != 0); use target_fps <= 0 for multi-head sources");
+            }
+            else if (!fpsCtl.pendingFrame.empty())
+            {
+                // grab() already fully decoded this frame via fpsControlGrab() -- hand back a copy.
+                fpsCtl.pendingFrame.copyTo(image);
+                ret = true;
+            }
+        }
+        else
+        {
+            ret = icap->retrieveFrame(channel, image);
+        }
     }
     if (!ret && throwOnFail)
     {
@@ -622,6 +799,15 @@ double VideoCapture::get(int propId) const
             return CAP_PROP_UNKNOWN;
         }
         return static_cast<double>(api);
+    }
+    if (propId == CAP_PROP_POS_MSEC && fpsCtl.enabled && fpsCtl.pendingPts >= 0)
+    {
+        // Report the timestamp of the frame actually handed back by read()/retrieve(), not the
+        // backend's own internal position -- which, under fps control, sits on whichever
+        // lookahead frame the algorithm most recently had to pull to make its drop/keep decision
+        // (one frame ahead of the emitted one in steady state, or an inconsistent
+        // backend-specific value right at end-of-stream).
+        return fpsCtl.pendingPts;
     }
     return !icap.empty() ? icap->getProperty(propId) : static_cast<double>(CAP_PROP_UNKNOWN);
 }

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -530,54 +530,32 @@ void VideoCapture::release()
     fpsCtl = FpsControlState(); // don't leak fps-control state (clock/buffers) across reopen
 }
 
-// target_fps <= 0 disables frame-rate control entirely (plain passthrough).
-//
-// Only enabled for backends confirmed (by reading each one's getProperty(CAP_PROP_POS_MSEC)
-// implementation) to report a real, per-frame timestamp:
-//   - FFmpeg          -- decoded AVFrame/AVPacket pts
-//   - GStreamer        -- pipeline buffer timestamp
-//   - V4L2             -- kernel capture buffer timestamp
-//   - OpenCV MJPEG     -- derived frame-index * 1000/fps; not a decoded PTS, but genuinely monotonic
-//   - MSMF (Windows)   -- real per-sample presentation timestamp (usedVideoSampleTime); used for
-//                         both file playback and live cameras on Windows -- NOT the same backend
-//                         as the older CAP_DSHOW, which has no CAP_PROP_POS_MSEC case at all
-//   - Aravis           -- derived frameID/fps, same genuinely-monotonic pattern as OpenCV MJPEG
-//   - OpenNI2 / ASUS   -- real per-frame SDK timestamp (streamFrames[...].getTimestamp())
-//   - Xine             -- real xine_get_pos_length() position; NOTE falls back to
-//                         CAP_PROP_UNKNOWN on an individual query failure, not bulletproof
-//   - gPhoto2          -- real elapsed time since first frame, but only whole-second (time_t)
-//                         resolution -- coarser than the others, fine only if frames arrive
-//                         >1s apart (true for its tethered-DSLR use case, not a general guarantee)
-// Every other backend either never implements CAP_PROP_POS_MSEC at all (falls through to the
-// interface's own CAP_PROP_UNKNOWN default, e.g. Intel MFX/UEYE/OBSENSOR/DShow/Android/DC1394/
-// PvAPI/WinRT/RealSense/XIMEA) or explicitly returns a constant unrelated to real time
-// (CV_IMAGES) -- silently trusting one of those would either drop every frame but the last one
-// (bounded sources, confirmed empirically on CV_IMAGES) or hang grab() forever (live sources that
-// never reach EOF), since the drop-selection algorithm has no way to detect a stale/constant
-// timestamp on its own. Falling back to plain, unrestricted passthrough is always safe; silently
-// mis-selecting frames or hanging is not.
+// Enable drop-only frame-rate control; target_fps <= 0 leaves the capture as plain passthrough.
+// Restricted to backends whose CAP_PROP_POS_MSEC is a real per-frame timestamp -- the rest either
+// never implement it or return a constant, which would make every drop comparison read as stale.
 void VideoCapture::enableFpsControl(double target_fps)
 {
     fpsCtl = FpsControlState();
-    if (target_fps > 0 && !icap.empty())
+    if (target_fps <= 0 || icap.empty())
+        return;
+
+    const int domain = icap->isOpened() ? icap->getCaptureDomain() : 0;
+    if (domain != CAP_FFMPEG && domain != CAP_GSTREAMER && domain != CAP_V4L2 &&
+        domain != CAP_OPENCV_MJPEG)
     {
-        int domain = icap->isOpened() ? icap->getCaptureDomain() : 0;
-        if (domain != CAP_FFMPEG && domain != CAP_GSTREAMER && domain != CAP_V4L2 &&
-            domain != CAP_OPENCV_MJPEG)
-        {
-            CV_LOG_WARNING(NULL, "VIDEOIO: target_fps is not supported for backend "
-                << (domain != 0 ? cv::videoio_registry::getBackendName(static_cast<VideoCaptureAPIs>(domain)) : cv::String("<unknown>"))
-                << " -- frame-rate control not enabled, using plain passthrough instead");
-            return; // fpsCtl.enabled stays false from the reset above
-        }
-        fpsCtl.enabled = true;
-        fpsCtl.outFrameDurationMs = 1000.0 / target_fps;
+        CV_LOG_WARNING(NULL, "VIDEOIO: target_fps is not supported for backend "
+            << (domain != 0 ? cv::videoio_registry::getBackendName(static_cast<VideoCaptureAPIs>(domain)) : cv::String("<unknown>"))
+            << " -- frame-rate control not enabled, using plain passthrough instead");
+        return; // fpsCtl.enabled stays false from the reset above
     }
+
+    fpsCtl.enabled = true;
+    fpsCtl.targetFps = target_fps;
+    fpsCtl.outFrameDurationMs = 1000.0 / target_fps;
 }
 
-// Pull exactly one real frame from the backend into the next free lookahead-buffer slot.
-// Always clones: some backends reuse a single internal decode buffer across grabFrame() calls,
-// and we need two buffered frames to stay valid and independent at the same time.
+// Pull one frame into the next free lookahead slot, cloned because some backends reuse a single
+// internal decode buffer across grabFrame() calls.
 bool VideoCapture::fpsControlReadOne()
 {
     CV_Assert(fpsCtl.bufCount < 2);
@@ -586,27 +564,35 @@ bool VideoCapture::fpsControlReadOne()
     Mat frame;
     if (!icap->retrieveFrame(0, frame) || frame.empty())
         return false;
-    fpsCtl.bufFrame[fpsCtl.bufCount] = frame.clone();
-    fpsCtl.bufPts[fpsCtl.bufCount] = icap->getProperty(CAP_PROP_POS_MSEC);
+    FpsControlFrame& slot = fpsCtl.buf[fpsCtl.bufCount];
+    slot.frame = frame.clone();
+    // Read the positions now, while the backend is still on this frame; by get() time it has
+    // advanced to the lookahead frame.
+    slot.posMsec = icap->getProperty(CAP_PROP_POS_MSEC);
+    slot.posFrames = icap->getProperty(CAP_PROP_POS_FRAMES);
+    slot.posAviRatio = icap->getProperty(CAP_PROP_POS_AVI_RATIO);
     fpsCtl.bufCount++;
     return true;
 }
 
-// Drop-only version of FFmpeg's vf_fps.c decision rule: keep 2 frames buffered and compare the
-// *next* frame's timestamp against the output clock (nextOutPts). If the next frame has already
-// reached or passed the current tick, the buffered frame is stale -- drop it and re-check.
-// Otherwise it's the answer for this tick -- consume it and advance the clock by one output-frame
-// duration. Since target_fps is always <= the source rate here, a buffered frame is never held
-// over for a second tick, so there is no duplicate case to handle.
-//
-// At end of stream, only one frame may be left buffered with no lookahead to compare it against --
-// in that case its own timestamp is checked directly against the clock instead: still due -> emit
-// it (the last available data is the best answer for this tick); not yet due -> the schedule never
-// caught up before the source ran out, so there's nothing to emit for this tick.
-//
-// kFpsControlEpsMs (see videoio.hpp, next to FpsControlState) absorbs floating-point rounding
-// noise in backend-reported timestamps so an exact schedule boundary doesn't get flipped by it.
+// Drop the output clock and buffers on a seek, leaving the feature enabled and its rate intact.
+void VideoCapture::fpsControlResetClock()
+{
+    fpsCtl.nextOutPts = -1.0;
+    fpsCtl.buf[0].reset();
+    fpsCtl.buf[1].reset();
+    fpsCtl.bufCount = 0;
+    fpsCtl.pending.reset();
+}
+
+// Absorbs floating-point rounding noise in backend timestamps so an exact schedule boundary in
+// fpsControlGrab() doesn't get flipped by it.
 const double VideoCapture::kFpsControlEpsMs = 1e-6;
+
+// Drop-only port of FFmpeg's vf_fps.c rule: with 2 frames buffered, if the *next* frame has already
+// reached the output clock then the buffered one is stale, so drop it and re-check; otherwise emit
+// it and advance the clock by one output-frame duration. At end of stream only one frame may remain,
+// with no lookahead to compare against, so its own timestamp is checked against the clock instead.
 
 bool VideoCapture::fpsControlGrab()
 {
@@ -623,46 +609,40 @@ bool VideoCapture::fpsControlGrab()
 
         if (s.bufCount == 0)
         {
-            // Nothing buffered and nothing left to emit -- invalidate the previous answer so a
-            // retrieve() call made without checking this grab()'s return value can't silently
-            // re-serve a stale frame instead of failing.
-            s.pendingFrame.release();
-            s.pendingPts = -1.0;
+            // Invalidate the previous answer, so a retrieve() after a failed grab() can't re-serve
+            // a stale frame instead of failing.
+            s.pending.reset();
             return false;
         }
 
         if (s.nextOutPts < 0)
-            s.nextOutPts = s.bufPts[0]; // anchor the output clock to the first real frame's timestamp
+            s.nextOutPts = s.buf[0].posMsec; // anchor the output clock to the first real frame's timestamp
 
         if (s.bufCount == 2)
         {
-            if (s.bufPts[1] <= s.nextOutPts + kFpsControlEpsMs)
+            if (s.buf[1].posMsec <= s.nextOutPts + kFpsControlEpsMs)
             {
                 // buf[0] is stale -- drop it, shift, and re-check against the new pair.
-                s.bufFrame[0] = s.bufFrame[1];
-                s.bufPts[0] = s.bufPts[1];
+                s.buf[0] = s.buf[1];
                 s.bufCount = 1;
                 continue;
             }
         }
         else // bufCount == 1: source is exhausted, no lookahead frame left to compare against
         {
-            if (s.bufPts[0] < s.nextOutPts - kFpsControlEpsMs)
+            if (s.buf[0].posMsec < s.nextOutPts - kFpsControlEpsMs)
             {
-                s.pendingFrame.release(); // same reasoning as the bufCount==0 case above
-                s.pendingPts = -1.0;
+                s.pending.reset(); // same reasoning as the bufCount==0 case above
                 return false; // schedule never caught up before the source ran out
             }
         }
 
         // buf[0] is the answer for this tick.
-        s.pendingFrame = s.bufFrame[0];
-        s.pendingPts = s.bufPts[0];
+        s.pending = s.buf[0];
         s.nextOutPts += s.outFrameDurationMs;
         if (s.bufCount == 2)
         {
-            s.bufFrame[0] = s.bufFrame[1];
-            s.bufPts[0] = s.bufPts[1];
+            s.buf[0] = s.buf[1];
             s.bufCount = 1;
         }
         else
@@ -697,19 +677,18 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
     {
         if (fpsCtl.enabled)
         {
-            // target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
-            // retrieveFrame(0, ...)) -- it does not support multi-head sources (stereo camera,
-            // Kinect, etc: see the multi-head note on grab() above). Fail loudly rather than
-            // silently handing back channel 0's data for a different requested channel.
+            // fpsControlReadOne() only ever buffers channel 0, so multi-head sources (stereo
+            // camera, Kinect) are unsupported. Fail loudly rather than silently returning
+            // channel 0's data for a different requested channel.
             if (channel != 0)
             {
                 CV_LOG_WARNING(NULL, "VIDEOIO: target_fps does not support multi-head capture "
                                       "(channel != 0); use target_fps <= 0 for multi-head sources");
             }
-            else if (!fpsCtl.pendingFrame.empty())
+            else if (!fpsCtl.pending.frame.empty())
             {
                 // grab() already fully decoded this frame via fpsControlGrab() -- hand back a copy.
-                fpsCtl.pendingFrame.copyTo(image);
+                fpsCtl.pending.frame.copyTo(image);
                 ret = true;
             }
         }
@@ -778,6 +757,13 @@ bool VideoCapture::set(int propId, double value)
 {
     CV_CheckNE(propId, (int)CAP_PROP_BACKEND, "Can't set read-only property");
     bool ret = !icap.empty() ? icap->setProperty(propId, value) : false;
+    if (ret && fpsCtl.enabled &&
+        (propId == CAP_PROP_POS_MSEC || propId == CAP_PROP_POS_FRAMES || propId == CAP_PROP_POS_AVI_RATIO))
+    {
+        // Pre-seek frames would otherwise be emitted, and the stale clock would drop frames until
+        // the source caught up to it (fpsControlGrab() only re-anchors when the clock is unset).
+        fpsControlResetClock();
+    }
     if (!ret && throwOnFail)
     {
         CV_Error_(Error::StsError, ("could not set prop %d = %f", propId, value));
@@ -800,14 +786,38 @@ double VideoCapture::get(int propId) const
         }
         return static_cast<double>(api);
     }
-    if (propId == CAP_PROP_POS_MSEC && fpsCtl.enabled && fpsCtl.pendingPts >= 0)
+    if (fpsCtl.enabled)
     {
-        // Report the timestamp of the frame actually handed back by read()/retrieve(), not the
-        // backend's own internal position -- which, under fps control, sits on whichever
-        // lookahead frame the algorithm most recently had to pull to make its drop/keep decision
-        // (one frame ahead of the emitted one in steady state, or an inconsistent
-        // backend-specific value right at end-of-stream).
-        return fpsCtl.pendingPts;
+        // Report the stream the caller sees, not the backend's own position, which sits on the
+        // lookahead frame. All three positions come from the same captured frame so they cannot
+        // contradict each other, and each falls through to the backend until one has been emitted.
+        switch (propId)
+        {
+        case CAP_PROP_POS_MSEC:
+            if (fpsCtl.pending.posMsec >= 0)
+                return fpsCtl.pending.posMsec;
+            break;
+        case CAP_PROP_POS_FRAMES:
+            if (fpsCtl.pending.posFrames >= 0)
+                return fpsCtl.pending.posFrames;
+            break;
+        case CAP_PROP_POS_AVI_RATIO:
+            if (fpsCtl.pending.posAviRatio >= 0)
+                return fpsCtl.pending.posAviRatio;
+            break;
+        case CAP_PROP_FPS:
+        {
+            // The rate read() actually emits at, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)`
+            // tags the output correctly. Clamped to the native rate because this only ever drops
+            // frames: above it, target_fps degrades to plain passthrough.
+            const double nativeFps = !icap.empty() ? icap->getProperty(CAP_PROP_FPS) : 0.0;
+            if (nativeFps > 0 && nativeFps < fpsCtl.targetFps)
+                return nativeFps;
+            return fpsCtl.targetFps;
+        }
+        default:
+            break;
+        }
     }
     return !icap.empty() ? icap->getProperty(propId) : static_cast<double>(CAP_PROP_UNKNOWN);
 }

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -70,10 +70,10 @@ IStreamReader::~IStreamReader()
 VideoCapture::VideoCapture() : throwOnFail(false)
 {}
 
-VideoCapture::VideoCapture(const String& filename, int apiPreference, double target_fps) : throwOnFail(false)
+VideoCapture::VideoCapture(const String& filename, int apiPreference) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(filename, apiPreference, target_fps);
+    open(filename, apiPreference);
 }
 
 VideoCapture::VideoCapture(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -90,10 +90,10 @@ VideoCapture::VideoCapture(const Ptr<IStreamReader>& source, int apiPreference, 
     open(source, apiPreference, params);
 }
 
-VideoCapture::VideoCapture(int index, int apiPreference, double target_fps) : throwOnFail(false)
+VideoCapture::VideoCapture(int index, int apiPreference) : throwOnFail(false)
 {
     CV_TRACE_FUNCTION();
-    open(index, apiPreference, target_fps);
+    open(index, apiPreference);
 }
 
 VideoCapture::VideoCapture(int index, int apiPreference, const std::vector<int>& params)
@@ -109,13 +109,10 @@ VideoCapture::~VideoCapture()
     icap.release();
 }
 
-bool VideoCapture::open(const String& filename, int apiPreference, double target_fps)
+bool VideoCapture::open(const String& filename, int apiPreference)
 {
     CV_INSTRUMENT_REGION();
-    bool ok = open(filename, apiPreference, std::vector<int>());
-    if (ok)
-        enableFpsControl(target_fps);
-    return ok;
+    return open(filename, apiPreference, std::vector<int>());
 }
 
 bool VideoCapture::open(const String& filename, int apiPreference, const std::vector<int>& params)
@@ -128,6 +125,11 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
     }
 
     const VideoCaptureParameters parameters(params);
+    // Consumed here, before any backend's open() runs its own warnUnusedParameters() check --
+    // otherwise a backend that bails out on unrecognized params (e.g. FFmpeg, CAP_IMAGES) would
+    // reject this one, even though it's meant to be handled generically below regardless of
+    // whether the chosen backend knows about it.
+    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByFilename();
     for (size_t i = 0; i < backends.size(); i++)
     {
@@ -156,6 +158,8 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
                                                         info.name, icap->isOpened()));
                         if (icap->isOpened())
                         {
+                            if (target_fps > 0)
+                                enableFpsControl(target_fps);
                             return true;
                         }
                         icap.release();
@@ -256,6 +260,9 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     }
 
     const VideoCaptureParameters parameters(params);
+    // See the filename-based open() overload above for why this must be consumed before any
+    // backend's createCapture() runs its own unused-parameter validation.
+    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByStream();
     for (size_t i = 0; i < backends.size(); i++)
     {
@@ -285,6 +292,8 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
                                                     info.name, icap->isOpened()));
                     if (icap->isOpened())
                     {
+                        if (target_fps > 0)
+                            enableFpsControl(target_fps);
                         return true;
                     }
                     icap.release();
@@ -365,13 +374,10 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     return false;
 }
 
-bool VideoCapture::open(int cameraNum, int apiPreference, double target_fps)
+bool VideoCapture::open(int cameraNum, int apiPreference)
 {
     CV_INSTRUMENT_REGION();
-    bool ok = open(cameraNum, apiPreference, std::vector<int>());
-    if (ok)
-        enableFpsControl(target_fps);
-    return ok;
+    return open(cameraNum, apiPreference, std::vector<int>());
 }
 
 bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>& params)
@@ -395,6 +401,9 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
     }
 
     const VideoCaptureParameters parameters(params);
+    // See the filename-based open() overload above for why this must be consumed before any
+    // backend's createCapture() runs its own unused-parameter validation.
+    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByIndex();
     for (size_t i = 0; i < backends.size(); i++)
     {
@@ -423,6 +432,8 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
                                                         info.name, icap->isOpened()));
                         if (icap->isOpened())
                         {
+                            if (target_fps > 0)
+                                enableFpsControl(target_fps);
                             return true;
                         }
                         icap.release();
@@ -554,101 +565,65 @@ void VideoCapture::enableFpsControl(double target_fps)
     fpsCtl.outFrameDurationMs = 1000.0 / target_fps;
 }
 
-// Pull one frame into the next free lookahead slot, cloned because some backends reuse a single
-// internal decode buffer across grabFrame() calls.
-bool VideoCapture::fpsControlReadOne()
-{
-    CV_Assert(fpsCtl.bufCount < 2);
-    if (!icap->grabFrame())
-        return false;
-    Mat frame;
-    if (!icap->retrieveFrame(0, frame) || frame.empty())
-        return false;
-    FpsControlFrame& slot = fpsCtl.buf[fpsCtl.bufCount];
-    slot.frame = frame.clone();
-    // Read the positions now, while the backend is still on this frame; by get() time it has
-    // advanced to the lookahead frame.
-    slot.posMsec = icap->getProperty(CAP_PROP_POS_MSEC);
-    slot.posFrames = icap->getProperty(CAP_PROP_POS_FRAMES);
-    slot.posAviRatio = icap->getProperty(CAP_PROP_POS_AVI_RATIO);
-    fpsCtl.bufCount++;
-    return true;
-}
-
-// Drop the output clock and buffers on a seek, leaving the feature enabled and its rate intact.
+// Drop the output clock on a seek, leaving the feature enabled and its rate intact.
 void VideoCapture::fpsControlResetClock()
 {
     fpsCtl.nextOutPts = -1.0;
-    fpsCtl.buf[0].reset();
-    fpsCtl.buf[1].reset();
-    fpsCtl.bufCount = 0;
-    fpsCtl.pending.reset();
+    fpsCtl.pendingValid = false;
+    fpsCtl.pendingPosMsec = fpsCtl.pendingPosFrames = fpsCtl.pendingPosAviRatio = -1.0;
 }
 
 // Absorbs floating-point rounding noise in backend timestamps so an exact schedule boundary in
 // fpsControlGrab() doesn't get flipped by it.
 const double VideoCapture::kFpsControlEpsMs = 1e-6;
 
-// Drop-only port of FFmpeg's vf_fps.c rule: with 2 frames buffered, if the *next* frame has already
-// reached the output clock then the buffered one is stale, so drop it and re-check; otherwise emit
-// it and advance the clock by one output-frame duration. At end of stream only one frame may remain,
-// with no lookahead to compare against, so its own timestamp is checked against the clock instead.
-
+// Drop-only frame-rate control: grab one source frame at a time and compare its own timestamp
+// against the output clock (nextOutPts). Not yet due -- drop it (never retrieved, so a backend
+// whose retrieveFrame() does real decode/color-conversion work never pays that cost for it) and
+// grab the next one. Due (or past due) -- stop right there, leave it un-retrieved in the backend's
+// own internal buffer, and let retrieve() fetch it directly, exactly like the disabled path: no
+// intermediate clone, no extra copy.
+//
+// This deliberately does not reproduce FFmpeg's vf_fps.c 2-frame-lookahead selection rule (which
+// picks the *last* frame at-or-before each tick, using the next frame to detect when a buffered
+// one has been superseded). It instead picks the *first* frame at-or-after each tick, using only
+// that frame's own timestamp. The two rules select the same frames on evenly-spaced/constant-rate
+// timestamps (the only case this feature is validated against -- see the file-based-only note on
+// the target_fps parameter docs); they can diverge on irregular/jittery timestamps, where a
+// lookahead-free check has no way to tell that a later frame would have been a closer match.
 bool VideoCapture::fpsControlGrab()
 {
     FpsControlState& s = fpsCtl;
 
     for (;;)
     {
-        while (s.bufCount < 2)
-        {
-            if (fpsControlReadOne())
-                continue;
-            break; // source exhausted -- bufCount may now be 0 or 1
-        }
-
-        if (s.bufCount == 0)
+        if (!icap->grabFrame())
         {
             // Invalidate the previous answer, so a retrieve() after a failed grab() can't re-serve
             // a stale frame instead of failing.
-            s.pending.reset();
+            s.pendingValid = false;
             return false;
         }
 
+        const double posMsec = icap->getProperty(CAP_PROP_POS_MSEC);
+
         if (s.nextOutPts < 0)
-            s.nextOutPts = s.buf[0].posMsec; // anchor the output clock to the first real frame's timestamp
+            s.nextOutPts = posMsec; // anchor the output clock to the first real frame's timestamp
 
-        if (s.bufCount == 2)
+        if (posMsec < s.nextOutPts - kFpsControlEpsMs)
         {
-            if (s.buf[1].posMsec <= s.nextOutPts + kFpsControlEpsMs)
-            {
-                // buf[0] is stale -- drop it, shift, and re-check against the new pair.
-                s.buf[0] = s.buf[1];
-                s.bufCount = 1;
-                continue;
-            }
-        }
-        else // bufCount == 1: source is exhausted, no lookahead frame left to compare against
-        {
-            if (s.buf[0].posMsec < s.nextOutPts - kFpsControlEpsMs)
-            {
-                s.pending.reset(); // same reasoning as the bufCount==0 case above
-                return false; // schedule never caught up before the source ran out
-            }
+            // Not yet due -- drop and try the next frame, without ever calling retrieveFrame().
+            continue;
         }
 
-        // buf[0] is the answer for this tick.
-        s.pending = s.buf[0];
+        // This frame is the answer for this tick. Read the other position properties now, while
+        // the backend is still on this frame; by retrieve() time it would still be, but get() may
+        // be called several times before/instead of retrieve() and must keep answering correctly.
+        s.pendingValid = true;
+        s.pendingPosMsec = posMsec;
+        s.pendingPosFrames = icap->getProperty(CAP_PROP_POS_FRAMES);
+        s.pendingPosAviRatio = icap->getProperty(CAP_PROP_POS_AVI_RATIO);
         s.nextOutPts += s.outFrameDurationMs;
-        if (s.bufCount == 2)
-        {
-            s.buf[0] = s.buf[1];
-            s.bufCount = 1;
-        }
-        else
-        {
-            s.bufCount = 0;
-        }
         return true;
     }
 }
@@ -677,19 +652,20 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
     {
         if (fpsCtl.enabled)
         {
-            // fpsControlReadOne() only ever buffers channel 0, so multi-head sources (stereo
-            // camera, Kinect) are unsupported. Fail loudly rather than silently returning
-            // channel 0's data for a different requested channel.
+            // fpsControlGrab() only ever decides based on channel 0's timestamp, so multi-head
+            // sources (stereo camera, Kinect) are unsupported. Fail loudly rather than silently
+            // returning channel 0's data for a different requested channel.
             if (channel != 0)
             {
                 CV_LOG_WARNING(NULL, "VIDEOIO: target_fps does not support multi-head capture "
                                       "(channel != 0); use target_fps <= 0 for multi-head sources");
             }
-            else if (!fpsCtl.pending.frame.empty())
+            else if (fpsCtl.pendingValid)
             {
-                // grab() already fully decoded this frame via fpsControlGrab() -- hand back a copy.
-                fpsCtl.pending.frame.copyTo(image);
-                ret = true;
+                // fpsControlGrab() left the kept frame un-retrieved in the backend's own internal
+                // buffer -- fetch it now, directly into the caller's image, exactly like the
+                // disabled path (no intermediate clone/copy).
+                ret = icap->retrieveFrame(0, image);
             }
         }
         else
@@ -788,22 +764,22 @@ double VideoCapture::get(int propId) const
     }
     if (fpsCtl.enabled)
     {
-        // Report the stream the caller sees, not the backend's own position, which sits on the
-        // lookahead frame. All three positions come from the same captured frame so they cannot
-        // contradict each other, and each falls through to the backend until one has been emitted.
+        // Report the stream the caller sees. All three positions were captured together, straight
+        // off the emitted frame, inside fpsControlGrab() -- they cannot contradict each other, and
+        // each falls through to the backend until a frame has actually been emitted.
         switch (propId)
         {
         case CAP_PROP_POS_MSEC:
-            if (fpsCtl.pending.posMsec >= 0)
-                return fpsCtl.pending.posMsec;
+            if (fpsCtl.pendingPosMsec >= 0)
+                return fpsCtl.pendingPosMsec;
             break;
         case CAP_PROP_POS_FRAMES:
-            if (fpsCtl.pending.posFrames >= 0)
-                return fpsCtl.pending.posFrames;
+            if (fpsCtl.pendingPosFrames >= 0)
+                return fpsCtl.pendingPosFrames;
             break;
         case CAP_PROP_POS_AVI_RATIO:
-            if (fpsCtl.pending.posAviRatio >= 0)
-                return fpsCtl.pending.posAviRatio;
+            if (fpsCtl.pendingPosAviRatio >= 0)
+                return fpsCtl.pendingPosAviRatio;
             break;
         case CAP_PROP_FPS:
         {

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -125,10 +125,7 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
     }
 
     const VideoCaptureParameters parameters(params);
-    // Consumed here, before any backend's open() runs its own warnUnusedParameters() check --
-    // otherwise a backend that bails out on unrecognized params (e.g. FFmpeg, CAP_IMAGES) would
-    // reject this one, even though it's meant to be handled generically below regardless of
-    // whether the chosen backend knows about it.
+    // Consumed here, before backend open() can reject it as an unrecognized parameter.
     const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByFilename();
     for (size_t i = 0; i < backends.size(); i++)
@@ -260,8 +257,7 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
     }
 
     const VideoCaptureParameters parameters(params);
-    // See the filename-based open() overload above for why this must be consumed before any
-    // backend's createCapture() runs its own unused-parameter validation.
+    // See the filename-based open() overload above for why this is consumed before createCapture().
     const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByStream();
     for (size_t i = 0; i < backends.size(); i++)
@@ -401,8 +397,7 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
     }
 
     const VideoCaptureParameters parameters(params);
-    // See the filename-based open() overload above for why this must be consumed before any
-    // backend's createCapture() runs its own unused-parameter validation.
+    // See the filename-based open() overload above for why this is consumed before createCapture().
     const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByIndex();
     for (size_t i = 0; i < backends.size(); i++)
@@ -541,9 +536,7 @@ void VideoCapture::release()
     fpsCtl = FpsControlState(); // don't leak fps-control state (clock/buffers) across reopen
 }
 
-// Enable drop-only frame-rate control; target_fps <= 0 leaves the capture as plain passthrough.
-// Restricted to backends whose CAP_PROP_POS_MSEC is a real per-frame timestamp -- the rest either
-// never implement it or return a constant, which would make every drop comparison read as stale.
+// target_fps <= 0 disables; restricted to backends with a real per-frame CAP_PROP_POS_MSEC.
 void VideoCapture::enableFpsControl(double target_fps)
 {
     fpsCtl = FpsControlState();
@@ -573,24 +566,10 @@ void VideoCapture::fpsControlResetClock()
     fpsCtl.pendingPosMsec = fpsCtl.pendingPosFrames = fpsCtl.pendingPosAviRatio = -1.0;
 }
 
-// Absorbs floating-point rounding noise in backend timestamps so an exact schedule boundary in
-// fpsControlGrab() doesn't get flipped by it.
+// Absorbs floating-point rounding noise at an exact schedule boundary in fpsControlGrab().
 const double VideoCapture::kFpsControlEpsMs = 1e-6;
 
-// Drop-only frame-rate control: grab one source frame at a time and compare its own timestamp
-// against the output clock (nextOutPts). Not yet due -- drop it (never retrieved, so a backend
-// whose retrieveFrame() does real decode/color-conversion work never pays that cost for it) and
-// grab the next one. Due (or past due) -- stop right there, leave it un-retrieved in the backend's
-// own internal buffer, and let retrieve() fetch it directly, exactly like the disabled path: no
-// intermediate clone, no extra copy.
-//
-// This deliberately does not reproduce FFmpeg's vf_fps.c 2-frame-lookahead selection rule (which
-// picks the *last* frame at-or-before each tick, using the next frame to detect when a buffered
-// one has been superseded). It instead picks the *first* frame at-or-after each tick, using only
-// that frame's own timestamp. The two rules select the same frames on evenly-spaced/constant-rate
-// timestamps (the only case this feature is validated against -- see the file-based-only note on
-// the target_fps parameter docs); they can diverge on irregular/jittery timestamps, where a
-// lookahead-free check has no way to tell that a later frame would have been a closer match.
+// Drop-only: emits the first frame at-or-after each tick using only its own timestamp; matches FFmpeg's vf_fps.c only on evenly-spaced timestamps, not jittery ones.
 bool VideoCapture::fpsControlGrab()
 {
     FpsControlState& s = fpsCtl;
@@ -599,8 +578,7 @@ bool VideoCapture::fpsControlGrab()
     {
         if (!icap->grabFrame())
         {
-            // Invalidate the previous answer, so a retrieve() after a failed grab() can't re-serve
-            // a stale frame instead of failing.
+            // Invalidate the previous answer so a retrieve() after a failed grab() can't re-serve a stale frame.
             s.pendingValid = false;
             return false;
         }
@@ -616,14 +594,17 @@ bool VideoCapture::fpsControlGrab()
             continue;
         }
 
-        // This frame is the answer for this tick. Read the other position properties now, while
-        // the backend is still on this frame; by retrieve() time it would still be, but get() may
-        // be called several times before/instead of retrieve() and must keep answering correctly.
+        // Capture the other position properties now, since get() may be called several times before retrieve().
         s.pendingValid = true;
         s.pendingPosMsec = posMsec;
         s.pendingPosFrames = icap->getProperty(CAP_PROP_POS_FRAMES);
         s.pendingPosAviRatio = icap->getProperty(CAP_PROP_POS_AVI_RATIO);
         s.nextOutPts += s.outFrameDurationMs;
+
+        // Catches up if a source gap left nextOutPts behind real time, instead of over several frames.
+        if (s.nextOutPts <= posMsec)
+            s.nextOutPts = posMsec + s.outFrameDurationMs;
+
         return true;
     }
 }
@@ -652,9 +633,7 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
     {
         if (fpsCtl.enabled)
         {
-            // fpsControlGrab() only ever decides based on channel 0's timestamp, so multi-head
-            // sources (stereo camera, Kinect) are unsupported. Fail loudly rather than silently
-            // returning channel 0's data for a different requested channel.
+            // Only channel 0 is supported; fail loudly rather than silently return channel 0's data for another channel.
             if (channel != 0)
             {
                 CV_LOG_WARNING(NULL, "VIDEOIO: target_fps does not support multi-head capture "
@@ -662,9 +641,7 @@ bool VideoCapture::retrieve(OutputArray image, int channel)
             }
             else if (fpsCtl.pendingValid)
             {
-                // fpsControlGrab() left the kept frame un-retrieved in the backend's own internal
-                // buffer -- fetch it now, directly into the caller's image, exactly like the
-                // disabled path (no intermediate clone/copy).
+                // Still un-retrieved in the backend's buffer; fetch it directly, same as the disabled path.
                 ret = icap->retrieveFrame(0, image);
             }
         }
@@ -736,8 +713,7 @@ bool VideoCapture::set(int propId, double value)
     if (ret && fpsCtl.enabled &&
         (propId == CAP_PROP_POS_MSEC || propId == CAP_PROP_POS_FRAMES || propId == CAP_PROP_POS_AVI_RATIO))
     {
-        // Pre-seek frames would otherwise be emitted, and the stale clock would drop frames until
-        // the source caught up to it (fpsControlGrab() only re-anchors when the clock is unset).
+        // Resets on any seek, or pre-seek frames get emitted and a stale clock drops frames afterward.
         fpsControlResetClock();
     }
     if (!ret && throwOnFail)
@@ -764,9 +740,7 @@ double VideoCapture::get(int propId) const
     }
     if (fpsCtl.enabled)
     {
-        // Report the stream the caller sees. All three positions were captured together, straight
-        // off the emitted frame, inside fpsControlGrab() -- they cannot contradict each other, and
-        // each falls through to the backend until a frame has actually been emitted.
+        // Captured together in fpsControlGrab(), so these can't disagree; falls through until a frame is emitted.
         switch (propId)
         {
         case CAP_PROP_POS_MSEC:
@@ -783,9 +757,7 @@ double VideoCapture::get(int propId) const
             break;
         case CAP_PROP_FPS:
         {
-            // The rate read() actually emits at, so `VideoWriter(..., cap.get(CAP_PROP_FPS), ...)`
-            // tags the output correctly. Clamped to the native rate because this only ever drops
-            // frames: above it, target_fps degrades to plain passthrough.
+            // The emitted rate, clamped to native since drop-only can't emit faster than the source.
             const double nativeFps = !icap.empty() ? icap->getProperty(CAP_PROP_FPS) : 0.0;
             if (nativeFps > 0 && nativeFps < fpsCtl.targetFps)
                 return nativeFps;

--- a/modules/videoio/src/cap.cpp
+++ b/modules/videoio/src/cap.cpp
@@ -67,6 +67,28 @@ IStreamReader::~IStreamReader()
     // nothing
 }
 
+// Strip CAP_PROP_TARGET_FPS before VideoCaptureParameters exists: plugin backends rebuild their own copy across the ABI boundary, so marking it "consumed" here wouldn't stop them rejecting it.
+static double extractTargetFps(const std::vector<int>& params, std::vector<int>& backendParams)
+{
+    double target_fps = 0.0;
+    backendParams.clear();
+    backendParams.reserve(params.size());
+    size_t i = 0;
+    for (; i + 1 < params.size(); i += 2)
+    {
+        if (params[i] == CAP_PROP_TARGET_FPS)
+            target_fps = params[i + 1];
+        else
+        {
+            backendParams.push_back(params[i]);
+            backendParams.push_back(params[i + 1]);
+        }
+    }
+    if (i < params.size())  // odd-length input; keep the leftover so VideoCaptureParameters still rejects it
+        backendParams.push_back(params[i]);
+    return target_fps;
+}
+
 VideoCapture::VideoCapture() : throwOnFail(false)
 {}
 
@@ -124,9 +146,9 @@ bool VideoCapture::open(const String& filename, int apiPreference, const std::ve
         release();
     }
 
-    const VideoCaptureParameters parameters(params);
-    // Consumed here, before backend open() can reject it as an unrecognized parameter.
-    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
+    std::vector<int> backendParams;
+    const double target_fps = extractTargetFps(params, backendParams);
+    const VideoCaptureParameters parameters(backendParams);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByFilename();
     for (size_t i = 0; i < backends.size(); i++)
     {
@@ -256,9 +278,9 @@ bool VideoCapture::open(const Ptr<IStreamReader>& stream, int apiPreference, con
         release();
     }
 
-    const VideoCaptureParameters parameters(params);
-    // See the filename-based open() overload above for why this is consumed before createCapture().
-    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
+    std::vector<int> backendParams;
+    const double target_fps = extractTargetFps(params, backendParams);
+    const VideoCaptureParameters parameters(backendParams);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByStream();
     for (size_t i = 0; i < backends.size(); i++)
     {
@@ -396,9 +418,9 @@ bool VideoCapture::open(int cameraNum, int apiPreference, const std::vector<int>
         }
     }
 
-    const VideoCaptureParameters parameters(params);
-    // See the filename-based open() overload above for why this is consumed before createCapture().
-    const double target_fps = parameters.get<double>(CAP_PROP_TARGET_FPS, 0.0);
+    std::vector<int> backendParams;
+    const double target_fps = extractTargetFps(params, backendParams);
+    const VideoCaptureParameters parameters(backendParams);
     const std::vector<VideoBackendInfo> backends = cv::videoio_registry::getAvailableBackends_CaptureByIndex();
     for (size_t i = 0; i < backends.size(); i++)
     {

--- a/modules/videoio/test/test_target_fps.cpp
+++ b/modules/videoio/test/test_target_fps.cpp
@@ -3,32 +3,16 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "test_precomp.hpp"
+#include "opencv2/core/utils/filesystem.hpp"
+#include "opencv2/imgcodecs.hpp"
 
 using namespace std;
 
 namespace opencv_test { namespace {
 
-// target_fps drop-only frame-rate control, exposed as a VideoCapture
-// constructor/open() parameter. Ported from FFmpeg's own frame-rate
-// reduction rule (libavfilter/vf_fps.c, write_frame()): buffer 2 frames,
-// compare the second one's timestamp against a steadily-advancing output
-// clock, and drop the first whenever it's already stale.
-//
-// The feature itself lives entirely in the backend-agnostic frontend
-// (modules/videoio/src/cap.cpp) -- no backend-specific code was touched to
-// implement it. These tests use the FFmpeg backend only as a convenient,
-// precisely-controllable source of test video; the behavior under test is
-// not FFmpeg-specific.
-//
-// Source video: opencv_extra's shared "video/big_buck_bunny.mp4" -- the
-// same canonical asset already used throughout test_ffmpeg.cpp and
-// perf_target_fps.cpp, rather than a synthetic, test-generated file.
-// Confirmed properties (ffprobe): mpeg4 codec, 24/1 fps, 125 frames,
-// has_b_frames=0 (I/P only, no reordering) -- so CAP_PROP_POS_MSEC on
-// readback is exact per-frame, same guarantee the synthetic MJPG file used
-// to provide. findDataFile() throws SkipTestException on its own if
-// OPENCV_TEST_DATA_PATH/opencv_extra isn't available locally, matching the
-// convention already used elsewhere in test_ffmpeg.cpp.
+// target_fps drop-only frame-rate control, a VideoCapture constructor/open() parameter.
+// big_buck_bunny.mp4 is mpeg4, 24/1 fps, 125 frames, no B-frames, so its per-frame timestamps are
+// exact; findDataFile() throws SkipTestException itself if opencv_extra is unavailable.
 static string targetFpsTestVideoPath()
 {
     return findDataFile("video/big_buck_bunny.mp4");
@@ -37,19 +21,9 @@ static string targetFpsTestVideoPath()
 static const double BBB_FPS = 24.0;
 static const int BBB_FRAME_COUNT = 125;
 
-// (target_fps, ratio) -- ratio = how many source frames separate each kept
-// frame (source_fps / target_fps when that divides evenly). ratio=1 covers
-// three distinct cases that should all behave identically: disabled (0),
-// exactly the source's native rate, and requesting a rate *above* native
-// (degrades to native rate rather than duplicating -- see CLAUDE.md's
-// "Degenerate cases" note).
-//
-// 4.0/8.0 are chosen as exact divisors of the source's 24fps (ratios 6 and 3)
-// so the expected counts below are unambiguous; both also leave the file's
-// true last frame index (124) unaligned to the ratio (124 % 6 == 4,
-// 124 % 3 == 1) -- deliberately, so these cases still exercise
-// fpsControlGrab()'s end-of-stream path: the schedule is reached mid-tick
-// rather than landing exactly on the last frame.
+// (target_fps, ratio) -- source frames between each kept frame. ratio=1 covers disabled, exactly
+// native, and above native. 4.0/8.0 divide 24fps exactly but leave the last index (124) unaligned,
+// so the end-of-stream path is reached mid-tick rather than on the last frame.
 typedef tuple<double, int> TargetFps_Ratio;
 typedef testing::TestWithParam<TargetFps_Ratio> videoio_target_fps;
 
@@ -99,10 +73,8 @@ inline static std::string videoio_target_fps_name_printer(const testing::TestPar
 
 INSTANTIATE_TEST_CASE_P(videoio, videoio_target_fps, testing::ValuesIn(videoio_target_fps_params), videoio_target_fps_name_printer);
 
-// The last kept frame here (index 123, of 125 total) is exactly the case that used to break:
-// end-of-stream is reached with the schedule mid-tick, and get(CAP_PROP_POS_MSEC) used to
-// report a backend-specific value unrelated to the frame actually returned (observed 0.0)
-// instead of that frame's own timestamp.
+// End-of-stream reached mid-tick: get(CAP_PROP_POS_MSEC) must be the last emitted frame's own
+// timestamp, not a backend-internal value unrelated to it.
 TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -129,9 +101,7 @@ TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
     EXPECT_NEAR(123 * srcFrameDurationMs, lastPosMsec, 1.0); // frame 123's own timestamp, not 0 and not a lookahead frame's
 }
 
-// Separate from the count check above: confirms the *timing* is right, not
-// just the quantity -- successive kept frames should be spaced exactly
-// 1000/target_fps ms apart, matching FFmpeg's own output-clock behavior.
+// Timing rather than quantity: successive kept frames should be exactly 1000/target_fps ms apart.
 TEST(videoio_target_fps, emitted_frames_evenly_spaced)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -150,23 +120,18 @@ TEST(videoio_target_fps, emitted_frames_evenly_spaced)
     cap.release();
 
     ASSERT_GE(posMsec.size(), 5u);
-    // get(CAP_PROP_POS_MSEC) reports the emitted frame's own timestamp (fpsCtl.pendingPts),
-    // including the final read at end-of-stream -- no reading needs to be excluded here.
+    // Tight tolerance is deliberate: fpsControlGrab() already absorbs backend rounding noise.
     vector<double> diffs(posMsec.size());
     std::adjacent_difference(posMsec.begin(), posMsec.end(), diffs.begin());
     const double expectedStepMs = 1000.0 / target_fps;
-    // A small epsilon, not a full frame-duration: fpsControlGrab()'s own boundary comparison
-    // tolerates backend floating-point rounding noise (observed on the order of 1e-13 ms) via
-    // kEpsMs, so every gap here should land on the exact scheduled step.
     auto minIt = min_element(diffs.begin() + 1, diffs.end());
     auto maxIt = max_element(diffs.begin() + 1, diffs.end());
     EXPECT_NEAR(expectedStepMs, *minIt, 1.0);
     EXPECT_NEAR(expectedStepMs, *maxIt, 1.0);
 }
 
-// Exercises the plain C++ default-argument path (no target_fps passed at all)
-// to guard against a signature drift between the header declaration and the
-// .cpp definition silently breaking the pre-existing, non-target_fps call sites.
+// The default-argument path, guarding against declaration/definition signature drift breaking
+// existing non-target_fps call sites.
 TEST(videoio_target_fps, default_argument_is_disabled)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -186,9 +151,8 @@ TEST(videoio_target_fps, default_argument_is_disabled)
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
-// Regression test: release() must reset fpsCtl, or a capture reopened through the
-// general params-vector overload (which never calls enableFpsControl()) inherits stale
-// clock/buffer state from the previous open and can silently return false forever.
+// release() must reset fpsCtl, or a reopen through the params-vector overload inherits the previous
+// open's clock and buffers.
 TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -201,10 +165,8 @@ TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
     Mat frame;
     ASSERT_TRUE(cap.read(frame)); // leave fpsCtl mid-schedule, not freshly reset
 
-    // General params-vector overload -- never calls enableFpsControl(), so this only behaves
-    // correctly if release() (called internally since cap.isOpened()) resets fpsCtl itself.
-    // Reopening the SAME file here (rather than a second, distinct one) is enough: what's under
-    // test is whether stale fpsCtl state survives the reopen, not which file is read.
+    // This overload never calls enableFpsControl(), so it only behaves correctly if the release()
+    // it triggers internally resets fpsCtl. Reopening the same file is enough here.
     ASSERT_TRUE(cap.open(filename, CAP_FFMPEG, std::vector<int>()));
     ASSERT_TRUE(cap.isOpened());
 
@@ -213,16 +175,12 @@ TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
         n++;
     cap.release();
 
-    // target_fps isn't threaded through this overload (by design -- see CLAUDE.md), so the
-    // reopened capture should behave as a plain, unrestricted passthrough: every native frame
-    // (125), not silently zero (the pre-fix symptom) and not the previous open's leftover
-    // 8fps/ratio-3 schedule (42).
+    // target_fps isn't threaded through this overload by design, so the reopened capture should
+    // be a plain passthrough: every native frame (125), not the previous open's schedule (42).
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
-// Regression test: target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
-// retrieveFrame(0, ...)). Requesting any other channel must fail loudly rather than silently
-// handing back channel 0's data -- this matters for multi-head sources (stereo camera, Kinect).
+// Only channel 0 is buffered, so any other channel must fail rather than return channel 0's data.
 TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -243,6 +201,337 @@ TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
     EXPECT_TRUE(channel1.empty());
 
     cap.release();
+}
+
+// Backend coverage beyond CAP_FFMPEG: the algorithm is backend-agnostic, so these only confirm each
+// allow-listed backend's CAP_PROP_POS_MSEC is usable per-frame.
+
+// A synthetic videotestsrc pipeline, as in test_gstreamer.cpp: num-buffers bounds it to a known
+// count and the framerate caps give its buffer timestamps exact millisecond spacing.
+static std::string targetFpsGstreamerPipeline(int srcFrameCount, double srcFps)
+{
+    std::ostringstream pipeline;
+    pipeline << "videotestsrc pattern=ball num-buffers=" << srcFrameCount
+             << " ! video/x-raw,framerate=" << cvRound(srcFps) << "/1 ! appsink";
+    return pipeline.str();
+}
+
+TEST(videoio_target_fps, gstreamer_pipeline_keeps_expected_frame_count)
+{
+    if (!videoio_registry::hasBackend(CAP_GSTREAMER))
+        throw SkipTestException("GStreamer backend was not found");
+
+    const int srcFrameCount = 20;
+    const double srcFps = 20.0;
+    const double target_fps = 5.0; // ratio 4 -> keep indices 0,4,8,12,16 (5 kept); 20 % 4 == 0 but
+                                    // the source's own last index (19) is unaligned to the ratio,
+                                    // same deliberate mid-tick-at-EOF coverage as the FFmpeg params.
+
+    VideoCapture cap;
+    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER, target_fps));
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        ASSERT_FALSE(frame.empty());
+        n++;
+    }
+    cap.release();
+
+    EXPECT_EQ(5, n);
+}
+
+// emitted_frames_evenly_spaced against GStreamer's own buffer timestamp instead of a decoded PTS.
+TEST(videoio_target_fps, gstreamer_pipeline_emitted_frames_evenly_spaced)
+{
+    if (!videoio_registry::hasBackend(CAP_GSTREAMER))
+        throw SkipTestException("GStreamer backend was not found");
+
+    const int srcFrameCount = 20;
+    const double srcFps = 20.0;
+    const double target_fps = 5.0;
+
+    VideoCapture cap;
+    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER, target_fps));
+    ASSERT_TRUE(cap.isOpened());
+
+    vector<double> posMsec;
+    Mat frame;
+    while (cap.read(frame))
+        posMsec.push_back(cap.get(CAP_PROP_POS_MSEC));
+    cap.release();
+
+    ASSERT_EQ(5u, posMsec.size());
+    vector<double> diffs(posMsec.size());
+    std::adjacent_difference(posMsec.begin(), posMsec.end(), diffs.begin());
+    const double expectedStepMs = 1000.0 / target_fps;
+    auto minIt = min_element(diffs.begin() + 1, diffs.end());
+    auto maxIt = max_element(diffs.begin() + 1, diffs.end());
+    // Looser than the FFmpeg test's 1ms since the appsink handoff precision is unverified here,
+    // but still tight enough to catch an off-by-one-tick error.
+    EXPECT_NEAR(expectedStepMs, *minIt, expectedStepMs * 0.01);
+    EXPECT_NEAR(expectedStepMs, *maxIt, expectedStepMs * 0.01);
+}
+
+// Frame selection on CAP_OPENCV_MJPEG, whose CAP_PROP_POS_MSEC is derived rather than decoded.
+TEST(videoio_target_fps, opencv_mjpeg_keeps_expected_frame_count)
+{
+    if (!videoio_registry::hasBackend(CAP_OPENCV_MJPEG))
+        throw SkipTestException("CAP_OPENCV_MJPEG backend was not found");
+
+    // This backend reads its own native AVI container, not the shared big_buck_bunny.mp4.
+    const string filename = findDataFile("video/big_buck_bunny.mjpg.avi");
+
+    const double target_fps = 8.0; // ratio 3 -> emitted source indices 0, 3, ..., 123
+    VideoCapture cap(filename, CAP_OPENCV_MJPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+    ASSERT_EQ(CAP_OPENCV_MJPEG, static_cast<int>(cap.get(CAP_PROP_BACKEND)));
+    EXPECT_EQ(target_fps, cap.get(CAP_PROP_FPS)) << "frame-rate control did not engage";
+
+    // Timestamps are not asserted here: this backend derives CAP_PROP_POS_MSEC from the next
+    // frame's index, so it reads one source frame ahead of the frame actually returned.
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        ASSERT_FALSE(frame.empty());
+        n++;
+    }
+    cap.release();
+
+    EXPECT_EQ(42, n);
+}
+
+// The allow-list in its refusing direction: CAP_IMAGES reports a constant CAP_PROP_POS_MSEC, which
+// would make every drop comparison read as stale and emit only the last frame if it got through.
+TEST(videoio_target_fps, unsupported_backend_falls_back_to_passthrough)
+{
+    if (!videoio_registry::hasBackend(CAP_IMAGES))
+        throw SkipTestException("CAP_IMAGES backend was not found");
+
+    const string dirname = cv::tempfile("opencv_test_target_fps_images");
+    ASSERT_TRUE(cv::utils::fs::createDirectory(dirname));
+
+    const int srcFrameCount = 5;
+    for (int i = 0; i < srcFrameCount; i++)
+    {
+        // Distinct uniform brightness per image, so a dropped or reordered frame shows up as a
+        // wrong index rather than only as a wrong count.
+        const Mat img(32, 32, CV_8UC3, Scalar::all(i * 40));
+        ASSERT_TRUE(imwrite(cv::format("%s/img%04d.png", dirname.c_str(), i), img));
+    }
+
+    const double target_fps = 2.0; // would be a reduction, if this backend were allowed
+    VideoCapture cap(cv::format("%s/img%04d.png", dirname.c_str(), 0), CAP_IMAGES, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+    ASSERT_EQ(CAP_IMAGES, static_cast<int>(cap.get(CAP_PROP_BACKEND)));
+
+    vector<int> brightness;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        ASSERT_FALSE(frame.empty());
+        brightness.push_back(cvRound(mean(frame)[0]));
+    }
+    cap.release();
+    cv::utils::fs::remove_all(dirname);
+
+    ASSERT_EQ(static_cast<size_t>(srcFrameCount), brightness.size())
+        << "target_fps must be refused for this backend, leaving an ordinary full-rate capture";
+    for (int i = 0; i < srcFrameCount; i++)
+        EXPECT_NEAR(i * 40, brightness[i], 5) << "image " << i;
+}
+
+// Every emitted frame, all position properties at once: POS_FRAMES - 1 must identify the frame just
+// returned, POS_MSEC must be its own time, and the two must agree with each other.
+TEST(videoio_target_fps, position_properties_describe_the_emitted_frame)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0; // ratio 3 -> emitted source indices 0, 3, 6, ...
+    const int ratio = 3;
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    const double srcFrameDurationMs = 1000.0 / BBB_FPS;
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        const double posMsec = cap.get(CAP_PROP_POS_MSEC);
+        const double posFrames = cap.get(CAP_PROP_POS_FRAMES);
+
+        const int expectedIndex = n * ratio;
+        // Identifies the emitted frame, not the lookahead frame the drop decision had to read.
+        EXPECT_EQ(expectedIndex + 1, cvRound(posFrames)) << "emitted frame " << n;
+        // ...and the timestamp reported with it belongs to that same frame.
+        EXPECT_NEAR(expectedIndex * srcFrameDurationMs, posMsec, 1.0) << "emitted frame " << n;
+        // The two must agree with each other, which is the property that actually matters.
+        EXPECT_NEAR((posFrames - 1) * srcFrameDurationMs, posMsec, 1.0) << "emitted frame " << n;
+        n++;
+    }
+    cap.release();
+
+    ASSERT_EQ(42, n);
+}
+
+// get(CAP_PROP_FPS) must be the emitted rate, since callers pass it straight to VideoWriter -- and
+// must answer before the first read(), which is when a VideoWriter is normally constructed.
+TEST(videoio_target_fps, reports_effective_output_fps)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    {   // below native: the emitted rate is target_fps
+        VideoCapture cap(filename, CAP_FFMPEG, 8.0);
+        ASSERT_TRUE(cap.isOpened());
+        EXPECT_EQ(8.0, cap.get(CAP_PROP_FPS)) << "before any read()";
+        Mat frame;
+        ASSERT_TRUE(cap.read(frame));
+        EXPECT_EQ(8.0, cap.get(CAP_PROP_FPS)) << "after read()";
+    }
+    {   // above native: drop-only cannot emit faster than the source, so the native rate is the
+        // honest answer -- reporting target_fps here would be a new inaccuracy, not a fix.
+        VideoCapture cap(filename, CAP_FFMPEG, BBB_FPS * 2);
+        ASSERT_TRUE(cap.isOpened());
+        EXPECT_EQ(BBB_FPS, cap.get(CAP_PROP_FPS));
+    }
+    {   // disabled: untouched passthrough
+        VideoCapture cap(filename, CAP_FFMPEG);
+        ASSERT_TRUE(cap.isOpened());
+        EXPECT_EQ(BBB_FPS, cap.get(CAP_PROP_FPS));
+    }
+}
+
+// The get()->set() round trip POS_FRAMES exists for. Identity is checked on the pixels rather than
+// by reading the position back, which would validate those values against themselves.
+TEST(videoio_target_fps, bookmarked_frame_can_be_seeked_back_to)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0; // ratio 3 -> the 2nd emitted frame is source frame 3
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    Mat frame;
+    ASSERT_TRUE(cap.read(frame));
+    ASSERT_TRUE(cap.read(frame));
+    const Mat marked = frame.clone(); // the frame the caller believes it is bookmarking
+
+    const int mark = cvRound(cap.get(CAP_PROP_POS_FRAMES)) - 1; // caller's cursor -> index idiom
+    EXPECT_EQ(3, mark) << "bookmark does not name the frame that was actually handed over";
+
+    if (!cap.set(CAP_PROP_POS_FRAMES, mark))
+        throw SkipTestException("backend does not support seeking on this file");
+    ASSERT_TRUE(cap.read(frame));
+    ASSERT_FALSE(frame.empty());
+
+    ASSERT_EQ(marked.size(), frame.size());
+    ASSERT_EQ(marked.type(), frame.type());
+    EXPECT_EQ(0.0, cv::norm(marked, frame, NORM_INF))
+        << "seeking to the bookmarked index returned a different frame";
+    cap.release();
+}
+
+// A seek must discard the clock and lookahead, or pre-seek frames get emitted and a backward seek
+// drops frames until the source catches up to the stale clock.
+TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0; // ratio 3 -> 42 frames over the whole file
+    const int expectedTotal = 42;
+    const double srcFrameDurationMs = 1000.0 / BBB_FPS;
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    Mat frame;
+    for (int i = 0; i < 10; i++)
+        ASSERT_TRUE(cap.read(frame)) << "priming read " << i;
+    // Clock is now ~10 ticks in and two frames are buffered from around source frame 27.
+    ASSERT_GT(cap.get(CAP_PROP_POS_MSEC), 1000.0);
+
+    if (!cap.set(CAP_PROP_POS_FRAMES, 0))
+        throw SkipTestException("backend does not support seeking on this file");
+
+    // First frame after the seek must be the seek target itself, not a leftover pre-seek frame,
+    // and not the result of burning frames to catch up to the stale clock.
+    ASSERT_TRUE(cap.read(frame));
+    ASSERT_FALSE(frame.empty());
+    EXPECT_NEAR(0.0, cap.get(CAP_PROP_POS_MSEC), 1.0);
+    EXPECT_EQ(1, cvRound(cap.get(CAP_PROP_POS_FRAMES)));
+
+    // ...and the whole schedule restarts from there, rather than resuming mid-stride.
+    int n = 1;
+    while (cap.read(frame))
+        n++;
+    EXPECT_EQ(expectedTotal, n);
+
+    // A forward seek re-anchors the same way: the clock starts from the new position, so the
+    // remaining count follows the schedule from there rather than from the start of the file.
+    ASSERT_TRUE(cap.set(CAP_PROP_POS_FRAMES, 0));
+    ASSERT_TRUE(cap.read(frame));
+    const int midIndex = 60;
+    if (cap.set(CAP_PROP_POS_FRAMES, midIndex))
+    {
+        ASSERT_TRUE(cap.read(frame));
+        EXPECT_NEAR(midIndex * srcFrameDurationMs, cap.get(CAP_PROP_POS_MSEC), srcFrameDurationMs);
+        int m = 1;
+        while (cap.read(frame))
+            m++;
+        // 65 frames remain from index 60 (60..124) at ratio 3 -> ceil(65/3) == 22.
+        EXPECT_EQ(22, m);
+    }
+    cap.release();
+}
+
+// Same vivid virtual-device convention as test_v4l2.cpp. Being a live, unbounded capture there is no
+// expected frame count -- what is tested is that a real kernel timestamp holds up against jitter.
+TEST(videoio_target_fps, v4l2_vivid_respects_target_fps)
+{
+    if (!videoio_registry::hasBackend(CAP_V4L2))
+        throw SkipTestException("V4L2 backend was not found");
+
+    utils::Paths devs = utils::getConfigurationParameterPaths("OPENCV_TEST_V4L2_VIVID_DEVICE");
+    if (devs.size() != 1)
+        throw SkipTestException("OPENCV_TEST_V4L2_VIVID_DEVICE is not set");
+    const string device = devs[0];
+
+    // Well below vivid's default capture rate, leaving plenty of margin for real scheduling
+    // jitter that a decoded-file/synthetic-pipeline PTS doesn't have to contend with.
+    const double target_fps = 5.0;
+    VideoCapture cap(device, CAP_V4L2, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    const int kFramesToRead = 5;
+    vector<double> posMsec;
+    Mat frame;
+    for (int i = 0; i < kFramesToRead; i++)
+    {
+        ASSERT_TRUE(cap.read(frame));
+        ASSERT_FALSE(frame.empty());
+        posMsec.push_back(cap.get(CAP_PROP_POS_MSEC));
+    }
+    cap.release();
+
+    const double expectedStepMs = 1000.0 / target_fps;
+    for (size_t i = 1; i < posMsec.size(); i++)
+    {
+        const double stepMs = posMsec[i] - posMsec[i - 1];
+        // 50% tolerance, vs. the file-based tests' ~1%: a live kernel capture-buffer timestamp is
+        // subject to genuine scheduling jitter a decoded/synthetic PTS doesn't have. What matters
+        // here is that frames are actually being dropped to hit ~200ms spacing, not sub-frame
+        // precision.
+        EXPECT_NEAR(expectedStepMs, stepMs, expectedStepMs * 0.5)
+            << "step " << i << ": " << posMsec[i - 1] << " -> " << posMsec[i];
+    }
 }
 
 }} // namespace

--- a/modules/videoio/test/test_target_fps.cpp
+++ b/modules/videoio/test/test_target_fps.cpp
@@ -10,7 +10,8 @@ using namespace std;
 
 namespace opencv_test { namespace {
 
-// target_fps drop-only frame-rate control, a VideoCapture constructor/open() parameter.
+// target_fps drop-only frame-rate control, set via CAP_PROP_TARGET_FPS in the `params` vector
+// passed to a VideoCapture constructor/open() call (open-only -- see its doc comment).
 // big_buck_bunny.mp4 is mpeg4, 24/1 fps, 125 frames, no B-frames, so its per-frame timestamps are
 // exact; findDataFile() throws SkipTestException itself if opencv_extra is unavailable.
 static string targetFpsTestVideoPath()
@@ -37,7 +38,7 @@ TEST_P(videoio_target_fps, keeps_expected_frame_count)
 
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     int n = 0;
@@ -83,7 +84,7 @@ TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
     const double target_fps = 8.0;
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     double lastPosMsec = -1.0;
@@ -110,7 +111,7 @@ TEST(videoio_target_fps, emitted_frames_evenly_spaced)
     const double target_fps = 8.0;
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     vector<double> posMsec;
@@ -130,8 +131,8 @@ TEST(videoio_target_fps, emitted_frames_evenly_spaced)
     EXPECT_NEAR(expectedStepMs, *maxIt, 1.0);
 }
 
-// The default-argument path, guarding against declaration/definition signature drift breaking
-// existing non-target_fps call sites.
+// The plain no-params-at-all construction path, guarding against declaration/definition signature
+// drift breaking existing non-target_fps call sites.
 TEST(videoio_target_fps, default_argument_is_disabled)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -139,7 +140,7 @@ TEST(videoio_target_fps, default_argument_is_disabled)
 
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG); // no target_fps argument at all
+    VideoCapture cap(filename, CAP_FFMPEG); // no CAP_PROP_TARGET_FPS requested at all
     ASSERT_TRUE(cap.isOpened());
 
     int n = 0;
@@ -151,21 +152,21 @@ TEST(videoio_target_fps, default_argument_is_disabled)
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
-// release() must reset fpsCtl, or a reopen through the params-vector overload inherits the previous
-// open's clock and buffers.
-TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
+// release() must reset fpsCtl, or a reopen that doesn't request CAP_PROP_TARGET_FPS inherits the
+// previous open's clock and buffers.
+TEST(videoio_target_fps, reopen_without_target_fps_resets_state)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
         throw SkipTestException("FFmpeg backend was not found");
 
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG, 8.0); // target_fps enabled, clock anchored to this open's PTS
+    VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, 8}); // clock anchored to this open's PTS
     ASSERT_TRUE(cap.isOpened());
     Mat frame;
     ASSERT_TRUE(cap.read(frame)); // leave fpsCtl mid-schedule, not freshly reset
 
-    // This overload never calls enableFpsControl(), so it only behaves correctly if the release()
+    // No CAP_PROP_TARGET_FPS in this open's params, so it only behaves correctly if the release()
     // it triggers internally resets fpsCtl. Reopening the same file is enough here.
     ASSERT_TRUE(cap.open(filename, CAP_FFMPEG, std::vector<int>()));
     ASSERT_TRUE(cap.isOpened());
@@ -175,8 +176,8 @@ TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
         n++;
     cap.release();
 
-    // target_fps isn't threaded through this overload by design, so the reopened capture should
-    // be a plain passthrough: every native frame (125), not the previous open's schedule (42).
+    // CAP_PROP_TARGET_FPS wasn't requested on this reopen, so it should be a plain passthrough:
+    // every native frame (125), not the previous open's schedule (42).
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
@@ -188,7 +189,7 @@ TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
 
     const string filename = targetFpsTestVideoPath();
 
-    VideoCapture cap(filename, CAP_FFMPEG, 8.0);
+    VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, 8});
     ASSERT_TRUE(cap.isOpened());
     ASSERT_TRUE(cap.grab());
 
@@ -228,7 +229,8 @@ TEST(videoio_target_fps, gstreamer_pipeline_keeps_expected_frame_count)
                                     // same deliberate mid-tick-at-EOF coverage as the FFmpeg params.
 
     VideoCapture cap;
-    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER, target_fps));
+    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER,
+                              {CAP_PROP_TARGET_FPS, cvRound(target_fps)}));
     ASSERT_TRUE(cap.isOpened());
 
     int n = 0;
@@ -254,7 +256,8 @@ TEST(videoio_target_fps, gstreamer_pipeline_emitted_frames_evenly_spaced)
     const double target_fps = 5.0;
 
     VideoCapture cap;
-    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER, target_fps));
+    ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER,
+                              {CAP_PROP_TARGET_FPS, cvRound(target_fps)}));
     ASSERT_TRUE(cap.isOpened());
 
     vector<double> posMsec;
@@ -285,7 +288,7 @@ TEST(videoio_target_fps, opencv_mjpeg_keeps_expected_frame_count)
     const string filename = findDataFile("video/big_buck_bunny.mjpg.avi");
 
     const double target_fps = 8.0; // ratio 3 -> emitted source indices 0, 3, ..., 123
-    VideoCapture cap(filename, CAP_OPENCV_MJPEG, target_fps);
+    VideoCapture cap(filename, CAP_OPENCV_MJPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
     ASSERT_EQ(CAP_OPENCV_MJPEG, static_cast<int>(cap.get(CAP_PROP_BACKEND)));
     EXPECT_EQ(target_fps, cap.get(CAP_PROP_FPS)) << "frame-rate control did not engage";
@@ -324,7 +327,8 @@ TEST(videoio_target_fps, unsupported_backend_falls_back_to_passthrough)
     }
 
     const double target_fps = 2.0; // would be a reduction, if this backend were allowed
-    VideoCapture cap(cv::format("%s/img%04d.png", dirname.c_str(), 0), CAP_IMAGES, target_fps);
+    VideoCapture cap(cv::format("%s/img%04d.png", dirname.c_str(), 0), CAP_IMAGES,
+                      {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
     ASSERT_EQ(CAP_IMAGES, static_cast<int>(cap.get(CAP_PROP_BACKEND)));
 
@@ -353,7 +357,7 @@ TEST(videoio_target_fps, position_properties_describe_the_emitted_frame)
 
     const double target_fps = 8.0; // ratio 3 -> emitted source indices 0, 3, 6, ...
     const int ratio = 3;
-    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     const double srcFrameDurationMs = 1000.0 / BBB_FPS;
@@ -388,7 +392,7 @@ TEST(videoio_target_fps, reports_effective_output_fps)
     const string filename = targetFpsTestVideoPath();
 
     {   // below native: the emitted rate is target_fps
-        VideoCapture cap(filename, CAP_FFMPEG, 8.0);
+        VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, 8});
         ASSERT_TRUE(cap.isOpened());
         EXPECT_EQ(8.0, cap.get(CAP_PROP_FPS)) << "before any read()";
         Mat frame;
@@ -397,7 +401,7 @@ TEST(videoio_target_fps, reports_effective_output_fps)
     }
     {   // above native: drop-only cannot emit faster than the source, so the native rate is the
         // honest answer -- reporting target_fps here would be a new inaccuracy, not a fix.
-        VideoCapture cap(filename, CAP_FFMPEG, BBB_FPS * 2);
+        VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(BBB_FPS * 2)});
         ASSERT_TRUE(cap.isOpened());
         EXPECT_EQ(BBB_FPS, cap.get(CAP_PROP_FPS));
     }
@@ -416,7 +420,7 @@ TEST(videoio_target_fps, bookmarked_frame_can_be_seeked_back_to)
         throw SkipTestException("FFmpeg backend was not found");
 
     const double target_fps = 8.0; // ratio 3 -> the 2nd emitted frame is source frame 3
-    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     Mat frame;
@@ -449,7 +453,7 @@ TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
     const double target_fps = 8.0; // ratio 3 -> 42 frames over the whole file
     const int expectedTotal = 42;
     const double srcFrameDurationMs = 1000.0 / BBB_FPS;
-    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, target_fps);
+    VideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     Mat frame;
@@ -507,7 +511,7 @@ TEST(videoio_target_fps, v4l2_vivid_respects_target_fps)
     // Well below vivid's default capture rate, leaving plenty of margin for real scheduling
     // jitter that a decoded-file/synthetic-pipeline PTS doesn't have to contend with.
     const double target_fps = 5.0;
-    VideoCapture cap(device, CAP_V4L2, target_fps);
+    VideoCapture cap(device, CAP_V4L2, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
 
     const int kFramesToRead = 5;

--- a/modules/videoio/test/test_target_fps.cpp
+++ b/modules/videoio/test/test_target_fps.cpp
@@ -1,0 +1,248 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+
+using namespace std;
+
+namespace opencv_test { namespace {
+
+// target_fps drop-only frame-rate control, exposed as a VideoCapture
+// constructor/open() parameter. Ported from FFmpeg's own frame-rate
+// reduction rule (libavfilter/vf_fps.c, write_frame()): buffer 2 frames,
+// compare the second one's timestamp against a steadily-advancing output
+// clock, and drop the first whenever it's already stale.
+//
+// The feature itself lives entirely in the backend-agnostic frontend
+// (modules/videoio/src/cap.cpp) -- no backend-specific code was touched to
+// implement it. These tests use the FFmpeg backend only as a convenient,
+// precisely-controllable source of test video; the behavior under test is
+// not FFmpeg-specific.
+//
+// Source video: opencv_extra's shared "video/big_buck_bunny.mp4" -- the
+// same canonical asset already used throughout test_ffmpeg.cpp and
+// perf_target_fps.cpp, rather than a synthetic, test-generated file.
+// Confirmed properties (ffprobe): mpeg4 codec, 24/1 fps, 125 frames,
+// has_b_frames=0 (I/P only, no reordering) -- so CAP_PROP_POS_MSEC on
+// readback is exact per-frame, same guarantee the synthetic MJPG file used
+// to provide. findDataFile() throws SkipTestException on its own if
+// OPENCV_TEST_DATA_PATH/opencv_extra isn't available locally, matching the
+// convention already used elsewhere in test_ffmpeg.cpp.
+static string targetFpsTestVideoPath()
+{
+    return findDataFile("video/big_buck_bunny.mp4");
+}
+
+static const double BBB_FPS = 24.0;
+static const int BBB_FRAME_COUNT = 125;
+
+// (target_fps, ratio) -- ratio = how many source frames separate each kept
+// frame (source_fps / target_fps when that divides evenly). ratio=1 covers
+// three distinct cases that should all behave identically: disabled (0),
+// exactly the source's native rate, and requesting a rate *above* native
+// (degrades to native rate rather than duplicating -- see CLAUDE.md's
+// "Degenerate cases" note).
+//
+// 4.0/8.0 are chosen as exact divisors of the source's 24fps (ratios 6 and 3)
+// so the expected counts below are unambiguous; both also leave the file's
+// true last frame index (124) unaligned to the ratio (124 % 6 == 4,
+// 124 % 3 == 1) -- deliberately, so these cases still exercise
+// fpsControlGrab()'s end-of-stream path: the schedule is reached mid-tick
+// rather than landing exactly on the last frame.
+typedef tuple<double, int> TargetFps_Ratio;
+typedef testing::TestWithParam<TargetFps_Ratio> videoio_target_fps;
+
+TEST_P(videoio_target_fps, keeps_expected_frame_count)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = get<0>(GetParam());
+    const int ratio = get<1>(GetParam());
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        ASSERT_FALSE(frame.empty());
+        n++;
+    }
+    cap.release();
+
+    int expected = 0;
+    for (int i = 0; i < BBB_FRAME_COUNT; i += ratio)
+        expected++;
+    EXPECT_EQ(expected, n);
+}
+
+const TargetFps_Ratio videoio_target_fps_params[] =
+{
+    make_tuple(0.0, 1),    // target_fps unset/disabled -> passthrough, every frame
+    make_tuple(24.0, 1),   // == source's native fps -> every frame
+    make_tuple(48.0, 1),   // above source's native fps -> degrades to native, every frame
+    make_tuple(4.0, 6),    // keep indices 0,6,...,120 -> 21 frames
+    make_tuple(8.0, 3),    // keep indices 0,3,...,123 -> 42 frames
+};
+
+inline static std::string videoio_target_fps_name_printer(const testing::TestParamInfo<videoio_target_fps::ParamType>& info)
+{
+    std::ostringstream os;
+    os << "target_" << cvRound(get<0>(info.param) * 10) << "_ratio_" << get<1>(info.param);
+    return os.str();
+}
+
+INSTANTIATE_TEST_CASE_P(videoio, videoio_target_fps, testing::ValuesIn(videoio_target_fps_params), videoio_target_fps_name_printer);
+
+// The last kept frame here (index 123, of 125 total) is exactly the case that used to break:
+// end-of-stream is reached with the schedule mid-tick, and get(CAP_PROP_POS_MSEC) used to
+// report a backend-specific value unrelated to the frame actually returned (observed 0.0)
+// instead of that frame's own timestamp.
+TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0;
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    double lastPosMsec = -1.0;
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+    {
+        lastPosMsec = cap.get(CAP_PROP_POS_MSEC);
+        n++;
+    }
+    cap.release();
+
+    ASSERT_EQ(42, n); // indices 0,3,...,123
+    const double srcFrameDurationMs = 1000.0 / BBB_FPS;
+    EXPECT_NEAR(123 * srcFrameDurationMs, lastPosMsec, 1.0); // frame 123's own timestamp, not 0 and not a lookahead frame's
+}
+
+// Separate from the count check above: confirms the *timing* is right, not
+// just the quantity -- successive kept frames should be spaced exactly
+// 1000/target_fps ms apart, matching FFmpeg's own output-clock behavior.
+TEST(videoio_target_fps, emitted_frames_evenly_spaced)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0;
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, target_fps);
+    ASSERT_TRUE(cap.isOpened());
+
+    vector<double> posMsec;
+    Mat frame;
+    while (cap.read(frame))
+        posMsec.push_back(cap.get(CAP_PROP_POS_MSEC));
+    cap.release();
+
+    ASSERT_GE(posMsec.size(), 5u);
+    // get(CAP_PROP_POS_MSEC) reports the emitted frame's own timestamp (fpsCtl.pendingPts),
+    // including the final read at end-of-stream -- no reading needs to be excluded here.
+    vector<double> diffs(posMsec.size());
+    std::adjacent_difference(posMsec.begin(), posMsec.end(), diffs.begin());
+    const double expectedStepMs = 1000.0 / target_fps;
+    // A small epsilon, not a full frame-duration: fpsControlGrab()'s own boundary comparison
+    // tolerates backend floating-point rounding noise (observed on the order of 1e-13 ms) via
+    // kEpsMs, so every gap here should land on the exact scheduled step.
+    auto minIt = min_element(diffs.begin() + 1, diffs.end());
+    auto maxIt = max_element(diffs.begin() + 1, diffs.end());
+    EXPECT_NEAR(expectedStepMs, *minIt, 1.0);
+    EXPECT_NEAR(expectedStepMs, *maxIt, 1.0);
+}
+
+// Exercises the plain C++ default-argument path (no target_fps passed at all)
+// to guard against a signature drift between the header declaration and the
+// .cpp definition silently breaking the pre-existing, non-target_fps call sites.
+TEST(videoio_target_fps, default_argument_is_disabled)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG); // no target_fps argument at all
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    Mat frame;
+    while (cap.read(frame))
+        n++;
+    cap.release();
+
+    EXPECT_EQ(BBB_FRAME_COUNT, n);
+}
+
+// Regression test: release() must reset fpsCtl, or a capture reopened through the
+// general params-vector overload (which never calls enableFpsControl()) inherits stale
+// clock/buffer state from the previous open and can silently return false forever.
+TEST(videoio_target_fps, reopen_via_params_overload_resets_state)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, 8.0); // target_fps enabled, clock anchored to this open's PTS
+    ASSERT_TRUE(cap.isOpened());
+    Mat frame;
+    ASSERT_TRUE(cap.read(frame)); // leave fpsCtl mid-schedule, not freshly reset
+
+    // General params-vector overload -- never calls enableFpsControl(), so this only behaves
+    // correctly if release() (called internally since cap.isOpened()) resets fpsCtl itself.
+    // Reopening the SAME file here (rather than a second, distinct one) is enough: what's under
+    // test is whether stale fpsCtl state survives the reopen, not which file is read.
+    ASSERT_TRUE(cap.open(filename, CAP_FFMPEG, std::vector<int>()));
+    ASSERT_TRUE(cap.isOpened());
+
+    int n = 0;
+    while (cap.read(frame))
+        n++;
+    cap.release();
+
+    // target_fps isn't threaded through this overload (by design -- see CLAUDE.md), so the
+    // reopened capture should behave as a plain, unrestricted passthrough: every native frame
+    // (125), not silently zero (the pre-fix symptom) and not the previous open's leftover
+    // 8fps/ratio-3 schedule (42).
+    EXPECT_EQ(BBB_FRAME_COUNT, n);
+}
+
+// Regression test: target_fps only buffers/decodes channel 0 (fpsControlReadOne() always calls
+// retrieveFrame(0, ...)). Requesting any other channel must fail loudly rather than silently
+// handing back channel 0's data -- this matters for multi-head sources (stereo camera, Kinect).
+TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string filename = targetFpsTestVideoPath();
+
+    VideoCapture cap(filename, CAP_FFMPEG, 8.0);
+    ASSERT_TRUE(cap.isOpened());
+    ASSERT_TRUE(cap.grab());
+
+    Mat channel0;
+    EXPECT_TRUE(cap.retrieve(channel0, 0)); // the only supported channel still works
+    EXPECT_FALSE(channel0.empty());
+
+    Mat channel1;
+    EXPECT_FALSE(cap.retrieve(channel1, 1)); // must fail, not silently return channel 0's frame
+    EXPECT_TRUE(channel1.empty());
+
+    cap.release();
+}
+
+}} // namespace

--- a/modules/videoio/test/test_target_fps.cpp
+++ b/modules/videoio/test/test_target_fps.cpp
@@ -10,21 +10,17 @@ using namespace std;
 
 namespace opencv_test { namespace {
 
-// target_fps drop-only frame-rate control, set via CAP_PROP_TARGET_FPS in the `params` vector
-// passed to a VideoCapture constructor/open() call (open-only -- see its doc comment).
-// big_buck_bunny.mp4 is mpeg4, 24/1 fps, 125 frames, no B-frames, so its per-frame timestamps are
-// exact; findDataFile() throws SkipTestException itself if opencv_extra is unavailable.
+// target_fps is set via CAP_PROP_TARGET_FPS in the `params` vector (open-only, see its doc comment).
 static string targetFpsTestVideoPath()
 {
+    // big_buck_bunny.mp4 is mpeg4, 24fps, 125 frames, no B-frames: exact per-frame timestamps.
     return findDataFile("video/big_buck_bunny.mp4");
 }
 
 static const double BBB_FPS = 24.0;
 static const int BBB_FRAME_COUNT = 125;
 
-// (target_fps, ratio) -- source frames between each kept frame. ratio=1 covers disabled, exactly
-// native, and above native. 4.0/8.0 divide 24fps exactly but leave the last index (124) unaligned,
-// so the end-of-stream path is reached mid-tick rather than on the last frame.
+// (target_fps, ratio); ratio=1 covers disabled/native/above-native, 4.0/8.0 leave frame 124 mid-tick.
 typedef tuple<double, int> TargetFps_Ratio;
 typedef testing::TestWithParam<TargetFps_Ratio> videoio_target_fps;
 
@@ -74,8 +70,7 @@ inline static std::string videoio_target_fps_name_printer(const testing::TestPar
 
 INSTANTIATE_TEST_CASE_P(videoio, videoio_target_fps, testing::ValuesIn(videoio_target_fps_params), videoio_target_fps_name_printer);
 
-// End-of-stream reached mid-tick: get(CAP_PROP_POS_MSEC) must be the last emitted frame's own
-// timestamp, not a backend-internal value unrelated to it.
+// End-of-stream mid-tick: POS_MSEC must be the last emitted frame's own timestamp.
 TEST(videoio_target_fps, last_frame_pos_msec_matches_its_own_timestamp)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -131,8 +126,7 @@ TEST(videoio_target_fps, emitted_frames_evenly_spaced)
     EXPECT_NEAR(expectedStepMs, *maxIt, 1.0);
 }
 
-// The plain no-params-at-all construction path, guarding against declaration/definition signature
-// drift breaking existing non-target_fps call sites.
+// Guards the plain no-params construction path against signature drift breaking old call sites.
 TEST(videoio_target_fps, default_argument_is_disabled)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -152,8 +146,7 @@ TEST(videoio_target_fps, default_argument_is_disabled)
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
-// release() must reset fpsCtl, or a reopen that doesn't request CAP_PROP_TARGET_FPS inherits the
-// previous open's clock and buffers.
+// release() must reset fpsCtl, or a plain reopen inherits the previous open's clock/buffers.
 TEST(videoio_target_fps, reopen_without_target_fps_resets_state)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -166,8 +159,7 @@ TEST(videoio_target_fps, reopen_without_target_fps_resets_state)
     Mat frame;
     ASSERT_TRUE(cap.read(frame)); // leave fpsCtl mid-schedule, not freshly reset
 
-    // No CAP_PROP_TARGET_FPS in this open's params, so it only behaves correctly if the release()
-    // it triggers internally resets fpsCtl. Reopening the same file is enough here.
+    // Only correct if the internal release() this open() triggers resets fpsCtl.
     ASSERT_TRUE(cap.open(filename, CAP_FFMPEG, std::vector<int>()));
     ASSERT_TRUE(cap.isOpened());
 
@@ -176,8 +168,7 @@ TEST(videoio_target_fps, reopen_without_target_fps_resets_state)
         n++;
     cap.release();
 
-    // CAP_PROP_TARGET_FPS wasn't requested on this reopen, so it should be a plain passthrough:
-    // every native frame (125), not the previous open's schedule (42).
+    // Not requested on this reopen, so expect plain passthrough (125), not the old schedule (42).
     EXPECT_EQ(BBB_FRAME_COUNT, n);
 }
 
@@ -204,11 +195,9 @@ TEST(videoio_target_fps, non_zero_channel_fails_under_fps_control)
     cap.release();
 }
 
-// Backend coverage beyond CAP_FFMPEG: the algorithm is backend-agnostic, so these only confirm each
-// allow-listed backend's CAP_PROP_POS_MSEC is usable per-frame.
+// Backend-agnostic algorithm; these just confirm each allow-listed backend's POS_MSEC is usable.
 
-// A synthetic videotestsrc pipeline, as in test_gstreamer.cpp: num-buffers bounds it to a known
-// count and the framerate caps give its buffer timestamps exact millisecond spacing.
+// Synthetic videotestsrc pipeline (as in test_gstreamer.cpp): bounded count, exact ms timestamps.
 static std::string targetFpsGstreamerPipeline(int srcFrameCount, double srcFps)
 {
     std::ostringstream pipeline;
@@ -224,9 +213,7 @@ TEST(videoio_target_fps, gstreamer_pipeline_keeps_expected_frame_count)
 
     const int srcFrameCount = 20;
     const double srcFps = 20.0;
-    const double target_fps = 5.0; // ratio 4 -> keep indices 0,4,8,12,16 (5 kept); 20 % 4 == 0 but
-                                    // the source's own last index (19) is unaligned to the ratio,
-                                    // same deliberate mid-tick-at-EOF coverage as the FFmpeg params.
+    const double target_fps = 5.0; // ratio 4 -> keeps 0,4,8,12,16; last index 19 is mid-tick at EOF.
 
     VideoCapture cap;
     ASSERT_NO_THROW(cap.open(targetFpsGstreamerPipeline(srcFrameCount, srcFps), CAP_GSTREAMER,
@@ -272,8 +259,7 @@ TEST(videoio_target_fps, gstreamer_pipeline_emitted_frames_evenly_spaced)
     const double expectedStepMs = 1000.0 / target_fps;
     auto minIt = min_element(diffs.begin() + 1, diffs.end());
     auto maxIt = max_element(diffs.begin() + 1, diffs.end());
-    // Looser than the FFmpeg test's 1ms since the appsink handoff precision is unverified here,
-    // but still tight enough to catch an off-by-one-tick error.
+    // Looser than the FFmpeg test's 1ms (appsink handoff precision unverified), still catches off-by-one.
     EXPECT_NEAR(expectedStepMs, *minIt, expectedStepMs * 0.01);
     EXPECT_NEAR(expectedStepMs, *maxIt, expectedStepMs * 0.01);
 }
@@ -293,8 +279,7 @@ TEST(videoio_target_fps, opencv_mjpeg_keeps_expected_frame_count)
     ASSERT_EQ(CAP_OPENCV_MJPEG, static_cast<int>(cap.get(CAP_PROP_BACKEND)));
     EXPECT_EQ(target_fps, cap.get(CAP_PROP_FPS)) << "frame-rate control did not engage";
 
-    // Timestamps are not asserted here: this backend derives CAP_PROP_POS_MSEC from the next
-    // frame's index, so it reads one source frame ahead of the frame actually returned.
+    // Timestamps aren't asserted: this backend's POS_MSEC runs one source frame ahead of POS_FRAMES.
     int n = 0;
     Mat frame;
     while (cap.read(frame))
@@ -307,8 +292,7 @@ TEST(videoio_target_fps, opencv_mjpeg_keeps_expected_frame_count)
     EXPECT_EQ(42, n);
 }
 
-// The allow-list in its refusing direction: CAP_IMAGES reports a constant CAP_PROP_POS_MSEC, which
-// would make every drop comparison read as stale and emit only the last frame if it got through.
+// CAP_IMAGES's constant POS_MSEC would make every drop comparison stale, so it must be refused.
 TEST(videoio_target_fps, unsupported_backend_falls_back_to_passthrough)
 {
     if (!videoio_registry::hasBackend(CAP_IMAGES))
@@ -320,8 +304,7 @@ TEST(videoio_target_fps, unsupported_backend_falls_back_to_passthrough)
     const int srcFrameCount = 5;
     for (int i = 0; i < srcFrameCount; i++)
     {
-        // Distinct uniform brightness per image, so a dropped or reordered frame shows up as a
-        // wrong index rather than only as a wrong count.
+        // Distinct brightness per image: a dropped/reordered frame shows up as a wrong index, not just a count.
         const Mat img(32, 32, CV_8UC3, Scalar::all(i * 40));
         ASSERT_TRUE(imwrite(cv::format("%s/img%04d.png", dirname.c_str(), i), img));
     }
@@ -348,8 +331,7 @@ TEST(videoio_target_fps, unsupported_backend_falls_back_to_passthrough)
         EXPECT_NEAR(i * 40, brightness[i], 5) << "image " << i;
 }
 
-// Every emitted frame, all position properties at once: POS_FRAMES - 1 must identify the frame just
-// returned, POS_MSEC must be its own time, and the two must agree with each other.
+// Every emitted frame: POS_FRAMES-1 names it, POS_MSEC is its time, and the two must agree.
 TEST(videoio_target_fps, position_properties_describe_the_emitted_frame)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -382,8 +364,7 @@ TEST(videoio_target_fps, position_properties_describe_the_emitted_frame)
     ASSERT_EQ(42, n);
 }
 
-// get(CAP_PROP_FPS) must be the emitted rate, since callers pass it straight to VideoWriter -- and
-// must answer before the first read(), which is when a VideoWriter is normally constructed.
+// Must be the emitted rate (for VideoWriter) and correct before the first read(), not just after.
 TEST(videoio_target_fps, reports_effective_output_fps)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -399,8 +380,7 @@ TEST(videoio_target_fps, reports_effective_output_fps)
         ASSERT_TRUE(cap.read(frame));
         EXPECT_EQ(8.0, cap.get(CAP_PROP_FPS)) << "after read()";
     }
-    {   // above native: drop-only cannot emit faster than the source, so the native rate is the
-        // honest answer -- reporting target_fps here would be a new inaccuracy, not a fix.
+    {   // above native: drop-only can't emit faster than the source, so native is the honest answer.
         VideoCapture cap(filename, CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(BBB_FPS * 2)});
         ASSERT_TRUE(cap.isOpened());
         EXPECT_EQ(BBB_FPS, cap.get(CAP_PROP_FPS));
@@ -412,8 +392,7 @@ TEST(videoio_target_fps, reports_effective_output_fps)
     }
 }
 
-// The get()->set() round trip POS_FRAMES exists for. Identity is checked on the pixels rather than
-// by reading the position back, which would validate those values against themselves.
+// The get()->set() round trip POS_FRAMES exists for; checked on pixels, not position readback.
 TEST(videoio_target_fps, bookmarked_frame_can_be_seeked_back_to)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -443,8 +422,7 @@ TEST(videoio_target_fps, bookmarked_frame_can_be_seeked_back_to)
     cap.release();
 }
 
-// A seek must discard the clock and lookahead, or pre-seek frames get emitted and a backward seek
-// drops frames until the source catches up to the stale clock.
+// A seek must discard the clock, or pre-seek frames get emitted and backward seeks drop until caught up.
 TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
 {
     if (!videoio_registry::hasBackend(CAP_FFMPEG))
@@ -465,8 +443,7 @@ TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
     if (!cap.set(CAP_PROP_POS_FRAMES, 0))
         throw SkipTestException("backend does not support seeking on this file");
 
-    // First frame after the seek must be the seek target itself, not a leftover pre-seek frame,
-    // and not the result of burning frames to catch up to the stale clock.
+    // Must be the seek target itself, not a leftover pre-seek frame or a stale-clock catch-up burn.
     ASSERT_TRUE(cap.read(frame));
     ASSERT_FALSE(frame.empty());
     EXPECT_NEAR(0.0, cap.get(CAP_PROP_POS_MSEC), 1.0);
@@ -478,8 +455,7 @@ TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
         n++;
     EXPECT_EQ(expectedTotal, n);
 
-    // A forward seek re-anchors the same way: the clock starts from the new position, so the
-    // remaining count follows the schedule from there rather than from the start of the file.
+    // A forward seek re-anchors the same way: the schedule restarts from the new position.
     ASSERT_TRUE(cap.set(CAP_PROP_POS_FRAMES, 0));
     ASSERT_TRUE(cap.read(frame));
     const int midIndex = 60;
@@ -496,8 +472,41 @@ TEST(videoio_target_fps, seek_resets_schedule_and_lookahead)
     cap.release();
 }
 
-// Same vivid virtual-device convention as test_v4l2.cpp. Being a live, unbounded capture there is no
-// expected frame count -- what is tested is that a real kernel timestamp holds up against jitter.
+// fpsCtl is protected; exists only so the test below can force a stalled-clock state directly.
+struct TestableVideoCapture : public VideoCapture
+{
+    using VideoCapture::VideoCapture;
+    using VideoCapture::fpsCtl;
+};
+
+TEST(videoio_target_fps, clock_recovers_after_falling_behind)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const double target_fps = 8.0;
+    const int ratio = 3; // BBB_FPS(24) / target_fps(8)
+    TestableVideoCapture cap(targetFpsTestVideoPath(), CAP_FFMPEG, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
+    ASSERT_TRUE(cap.isOpened());
+
+    Mat frame;
+    for (int i = 0; i < 10; i++)
+        ASSERT_TRUE(cap.read(frame)) << "priming read " << i;
+    ASSERT_GT(cap.get(CAP_PROP_POS_MSEC), 1000.0); // clock is ~10 ticks into the file
+
+    // Forces the clock behind the source's real position, simulating a source timestamp gap.
+    cap.fpsCtl.nextOutPts = 0.0;
+
+    ASSERT_TRUE(cap.read(frame));
+    const int firstAfterGap = cvRound(cap.get(CAP_PROP_POS_FRAMES)) - 1; // "next" index -> emitted index
+    ASSERT_TRUE(cap.read(frame));
+    const int secondAfterGap = cvRound(cap.get(CAP_PROP_POS_FRAMES)) - 1;
+
+    // Resynced: next emitted frame is `ratio` frames later, not 1 (which is what the bug produces).
+    EXPECT_EQ(ratio, secondAfterGap - firstAfterGap);
+}
+
+// Same vivid convention as test_v4l2.cpp; unbounded live capture, so tests jitter not frame count.
 TEST(videoio_target_fps, v4l2_vivid_respects_target_fps)
 {
     if (!videoio_registry::hasBackend(CAP_V4L2))
@@ -508,8 +517,7 @@ TEST(videoio_target_fps, v4l2_vivid_respects_target_fps)
         throw SkipTestException("OPENCV_TEST_V4L2_VIVID_DEVICE is not set");
     const string device = devs[0];
 
-    // Well below vivid's default capture rate, leaving plenty of margin for real scheduling
-    // jitter that a decoded-file/synthetic-pipeline PTS doesn't have to contend with.
+    // Well below vivid's default rate, leaving margin for real scheduling jitter.
     const double target_fps = 5.0;
     VideoCapture cap(device, CAP_V4L2, {CAP_PROP_TARGET_FPS, cvRound(target_fps)});
     ASSERT_TRUE(cap.isOpened());
@@ -529,10 +537,7 @@ TEST(videoio_target_fps, v4l2_vivid_respects_target_fps)
     for (size_t i = 1; i < posMsec.size(); i++)
     {
         const double stepMs = posMsec[i] - posMsec[i - 1];
-        // 50% tolerance, vs. the file-based tests' ~1%: a live kernel capture-buffer timestamp is
-        // subject to genuine scheduling jitter a decoded/synthetic PTS doesn't have. What matters
-        // here is that frames are actually being dropped to hit ~200ms spacing, not sub-frame
-        // precision.
+        // 50% tolerance (vs ~1% for file-based tests): real kernel jitter, not sub-frame precision, is what matters.
         EXPECT_NEAR(expectedStepMs, stepMs, expectedStepMs * 0.5)
             << "step " << i << ": " << posMsec[i - 1] << " -> " << posMsec[i];
     }


### PR DESCRIPTION
Recreates #29756, which was auto-closed when the source fork was deleted. No code changes from that PR — same branch, same commits.

---

Adds a backend-agnostic target_fps option to VideoCapture that drops frames to hit a target output rate, without touching decode/seek behavior for existing callers.

Includes a follow-up fix for three issues found while testing the feature:

get() reported the backend's own position for CAP_PROP_POS_FRAMES/CAP_PROP_POS_AVI_RATIO while CAP_PROP_POS_MSEC described the emitted frame — the three properties are now captured together at retrieve time so they can't diverge.
set() left the output clock and lookahead buffer holding pre-seek state, so a seek could return a stale frame or silently drop frames catching up; both are now reset on a successful seek.
CAP_OPENCV_MJPEG's CAP_PROP_POS_MSEC was one source frame late; corrected to be exact rather than an estimate.
New tests cover position-property agreement, effective output fps, seek round-trips (verified on pixel identity), seek-schedule reset.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
