### PR TITLE
core: add RVV convertScale path for CV_16S -> CV_8U 🤖🤖🤖

### DIFF
--- a/hal/riscv-rvv/src/core/convert_scale.cpp
+++ b/hal/riscv-rvv/src/core/convert_scale.cpp
@@ -221,6 +221,53 @@ inline int convertScale_16U32F(const uchar* src, size_t src_step, uchar* dst, si
     return CV_HAL_ERROR_OK;
 }
 
+inline int convertScale_16S8U(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
+{
+    if (alpha == 1.0 && beta == 0.0)
+    {
+        for (int i = 0; i < height; i++)
+        {
+            const short* src_row = reinterpret_cast<const short*>(src + i * src_step);
+            uchar* dst_row = dst + i * dst_step;
+            int vl;
+            for (int j = 0; j < width; j += vl)
+            {
+                vl = __riscv_vsetvl_e16m4(width - j);
+                auto vec_src = __riscv_vle16_v_i16m4(src_row + j, vl);
+                // clamp the negative half to zero first: vnclipu would wrap it to 255
+                auto vec_src_u16 = __riscv_vreinterpret_v_i16m4_u16m4(__riscv_vmax(vec_src, 0, vl));
+                auto vec_dst = __riscv_vnclipu(vec_src_u16, 0, __RISCV_VXRM_RNU, vl);
+                __riscv_vse8_v_u8m2(dst_row + j, vec_dst, vl);
+            }
+        }
+
+        return CV_HAL_ERROR_OK;
+    }
+
+    int vlmax = __riscv_vsetvlmax_e32m8();
+    auto vec_b = __riscv_vfmv_v_f_f32m8(beta, vlmax);
+    float a = alpha;
+
+    for (int i = 0; i < height; i++)
+    {
+        const short* src_row = reinterpret_cast<const short*>(src + i * src_step);
+        uchar* dst_row = dst + i * dst_step;
+        int vl;
+        for (int j = 0; j < width; j += vl)
+        {
+            vl = __riscv_vsetvl_e16m4(width - j);
+            auto vec_src = __riscv_vle16_v_i16m4(src_row + j, vl);
+            auto vec_src_f32 = __riscv_vfwcvt_f(vec_src, vl);
+            auto vec_fma = __riscv_vfmadd(vec_src_f32, a, vec_b, vl);
+            auto vec_dst_u16 = __riscv_vfncvt_xu(vec_fma, vl);
+            auto vec_dst = __riscv_vnclipu(vec_dst_u16, 0, __RISCV_VXRM_RNU, vl);
+            __riscv_vse8_v_u8m2(dst_row + j, vec_dst, vl);
+        }
+    }
+
+    return CV_HAL_ERROR_OK;
+}
+
 inline int convertScale_16S32F(const uchar* src, size_t src_step, uchar* dst, size_t dst_step, int width, int height, double alpha, double beta)
 {
     int vlmax = __riscv_vsetvlmax_e32m8();
@@ -333,6 +380,8 @@ int convertScale(const uchar* src, size_t src_step, uchar* dst, size_t dst_step,
     case CV_16S:
         switch (ddepth)
         {
+        case CV_8U:
+            return convertScale_16S8U(src, src_step, dst, dst_step, width, height, alpha, beta);
         case CV_32F:
             return convertScale_16S32F(src, src_step, dst, dst_step, width, height, alpha, beta);
         }


### PR DESCRIPTION
### Summary

Adds an RVV HAL `convertScale` implementation for `CV_16S -> CV_8U`.

`CV_16S` currently only has a path to `CV_32F`; `CV_16S -> CV_8U` falls through to
`CV_HAL_ERROR_NOT_IMPLEMENTED`. It is the direct counterpart of the existing
`CV_16U -> CV_8U` path and a common step whenever signed 16-bit intermediates
(Sobel, Laplacian, differences) are brought back to 8-bit for display or export.

The change is confined to `hal/riscv-rvv/src/core/convert_scale.cpp`. It adds one
function and one `case`, and does not touch the generic `convertTo()` path or any
other architecture.

### Implementation

Same structure as the neighbouring kernels:

- scaled path: widening convert to `f32`, FMA, then saturating narrow back through
  `u16` to `u8` - identical to `convertScale_16U8U` apart from the signed load.
- no-scale path (`alpha == 1`, `beta == 0`): integer only. Negatives are clamped to
  zero with `vmax` before the narrowing, because `vnclipu` reads its input as
  unsigned and would otherwise map them to 255. Keeping this path integer-only
  avoids making a plain `convertTo(CV_8U)` pay for float conversion and FMA, for
  the same reason as in #29174.

The column-shaped-source guard added in #29174 already covers the new path.

### Testing

Cross-compiled for `rv64gcv` and run under QEMU, since I do not have RVV hardware:

| Build | Toolchain | Result |
|---|---|---|
| `-march=rv64gcv`, RVV HAL on | GCC 14.2 | 0 warnings |
| `-march=rv64gcv`, RVV HAL on | Clang 19.1.7 | 0 warnings |
| `-march=rv64gc`, no V, HAL off | GCC 14.2 | 0 warnings |

Accuracy, run at `QEMU_CPU=max,vlen=128` and `vlen=256` and on the scalar build:

- `opencv_test_core --gtest_filter=Core_ConvertScale/ElemWiseTest.*` - pass
- `opencv_test_core --gtest_filter=Core_Convert*:*ConvertTo*:Core_ArithmMask*` - 7/7 pass

I also ran a standalone differential check against
`saturate_cast<uchar>(src * (float)alpha + (float)beta)` (and `saturate_cast<uchar>(short)`
for the no-scale path) covering every one of the 65536 `short` values against ~100
`(alpha, beta)` pairs, plus vector-tail widths 1..70, a multi-channel Mat and a
column-shaped Mat: no mismatches in any of the three configurations.

One note on the domain: for `|src * alpha + beta| >= 2^31` the HAL and the generic
path disagree, because the generic path rounds through `cvRound` and overflows
there. That is pre-existing behaviour rather than something this patch introduces -
merged `convertScale_32F8U` diverges from the generic path in exactly the same way,
and in these cases the HAL result is the saturated one. Those inputs are excluded
from the comparison above.

I have not measured throughput, having no RVV silicon here. If someone with a K1 or
BPI-F3 can run `opencv_perf_core --gtest_filter=*convertTo*`, I am happy to add the
numbers.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
