### PR TITLE
doc: fix broken opencv.js download link in js_usage tutorial

### DIFF
--- a/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
+++ b/doc/js_tutorials/js_setup/js_usage/js_usage.markdown
@@ -5,7 +5,7 @@ Steps
 -----
 
 In this tutorial, you will learn how to include and start to use `opencv.js` inside a web page.
-You can get a copy of `opencv.js` from `opencv-{VERSION_NUMBER}-docs.zip` in each [release](https://github.com/opencv/opencv/releases), or simply download the prebuilt script from the online documentations at "https://docs.opencv.org/{VERSION_NUMBER}/opencv.js" (For example, [https://docs.opencv.org/4.5.0/opencv.js](https://docs.opencv.org/4.5.0/opencv.js). Use `4.x` if you want the latest build).
+You can get a copy of `opencv.js` from `opencv-{VERSION_NUMBER}-docs.zip` in each [release](https://github.com/opencv/opencv/releases), or simply download the prebuilt script from the online documentation at "https://docs.opencv.org/{BRANCH}/opencv.js" (For example, [https://docs.opencv.org/4.x/opencv.js](https://docs.opencv.org/4.x/opencv.js). Use `4.x` to always get the latest build).
 You can also build your own copy by following the tutorial @ref tutorial_js_setup.
 
 ### Create a web page


### PR DESCRIPTION
The OpenCV.js usage tutorial tells the reader to download the prebuilt script from `https://docs.opencv.org/{VERSION_NUMBER}/opencv.js`, and illustrates it with https://docs.opencv.org/4.5.0/opencv.js. That link is dead, and so is the pattern behind it: `opencv.js` is not published under every tagged release (4.10.0, 4.11.0, 4.12.0 and 4.14.0 all return 404), only under the branch directories. Documenting the branch form instead gives a URL that keeps working across releases.

The 5.0 docs page named in the issue has the same sentence with a `5.0.0` example, so the two branches differ here and the forward merge will conflict. The intended 5.x wording is the same change with `{BRANCH}` illustrated by https://docs.opencv.org/5.x/opencv.js.

Fixes #29818

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
