### PR TITLE
imgproc: fix HISTCMP_CORREL precision and multi-channel bin count 

### DIFF
--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1877,17 +1877,14 @@ void cv::calcBackProject( InputArrayOfArrays images, const std::vector<int>& cha
 
 ////////////////// C O M P A R E   H I S T O G R A M S ////////////////////////
 
-// Finish a HISTCMP_CORREL comparison from the accumulated sums.
-//
-// The two variance terms are mathematically non-negative, but they are evaluated
-// as the difference of two large and nearly equal sums. When the histograms hold
-// large values that vary little, that subtraction is dominated by rounding error
-// and can come out negative, which used to leave the result NaN (square root of a
-// negative denominator), sign-flipped, or outside the [-1, 1] range a correlation
-// coefficient is defined on. Clamping the variances keeps the denominator real,
-// and clamping the quotient keeps the result in range; together they also make
-// comparing a histogram with itself yield exactly 1. See
-// https://github.com/opencv/opencv/issues/29706
+// Finish a HISTCMP_CORREL comparison from the accumulated sums, for the sparse
+// inputs. A sparse histogram is dominated by empty bins, so its variance is large
+// next to its mean and the cancellation that ruins the dense case (see
+// compareHistCorrel below) does not arise; the plain form is kept here because
+// centring it would mean visiting the implicit zeros as well. The variances are
+// still clamped: they are mathematically non-negative, and letting rounding push
+// one below zero would leave the result NaN or sign-flipped rather than merely
+// imprecise. See https://github.com/opencv/opencv/issues/29706
 static double finalizeCorrel( double s1, double s11, double s2, double s22, double s12, size_t total )
 {
     double scale = 1./total;
@@ -1897,6 +1894,111 @@ static double finalizeCorrel( double s1, double s11, double s2, double s22, doub
     double denom2 = var1*var2;
     return denom2 > DBL_EPSILON ? std::min(std::max(num/std::sqrt(denom2), -1.), 1.) : 1.;
 }
+
+namespace cv {
+
+// HISTCMP_CORREL, accumulated about an assumed mean.
+//
+// The textbook "computational" form - sum(a*a) - sum(a)^2/n for a variance, and
+// the matching expression for the covariance - subtracts two large and nearly
+// equal quantities. Its relative error grows in proportion to mean^2/variance, so
+// a histogram whose values vary little about a large mean loses roughly two
+// decimal digits for every decade of relative spread: at a spread of 1e-7 barely
+// one correct digit survives. Worse, once the rounding error swamps the true
+// variance that term can come out negative, which left the comparison NaN (the
+// denominator is the product of the two variances and its square root is taken),
+// sign-flipped, or outside the [-1, 1] range a correlation coefficient is defined
+// on - so comparing a histogram with itself could return -1.
+//
+// Shifting each histogram by an assumed mean before accumulating (Chan, Golub &
+// LeVeque, 1983) makes the sums proportional to the spread instead of to the mean
+// squared, which removes the cancellation without a second pass over the data.
+// The first bin serves as the estimate; it only has to be close enough that the
+// residuals are comparable to the spread, and even a poor choice leaves the
+// conditioning bounded by the bin count rather than by the mean.
+//
+// See https://github.com/opencv/opencv/issues/29706
+static double compareHistCorrel( const Mat& H1, const Mat& H2 )
+{
+    const Mat* arrays[] = {&H1, &H2, 0};
+    Mat planes[2];
+
+    const double total = (double)H1.total()*H1.channels();
+    if( !(total > 0) )
+        return 1.;
+
+    NAryMatIterator it(arrays, planes);
+    if( it.nplanes == 0 )
+        return 1.;
+
+    // Assumed means: the first bin of each histogram. Accumulating about them keeps
+    // the sums proportional to the spread rather than to the mean squared.
+    const double K1 = it.planes[0].ptr<float>()[0];
+    const double K2 = it.planes[1].ptr<float>()[0];
+
+    double d1 = 0, d2 = 0, q11 = 0, q22 = 0, q12 = 0;
+    for( size_t i = 0; i < it.nplanes; i++, ++it )
+    {
+        const float* h1 = it.planes[0].ptr<float>();
+        const float* h2 = it.planes[1].ptr<float>();
+        const int len = it.planes[0].rows*it.planes[0].cols*H1.channels();
+        int j = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+        v_float64 v_K1 = vx_setall_f64(K1);
+        v_float64 v_K2 = vx_setall_f64(K2);
+        v_float64 v_d1 = vx_setzero_f64();
+        v_float64 v_d2 = vx_setzero_f64();
+        v_float64 v_q11 = vx_setzero_f64();
+        v_float64 v_q22 = vx_setzero_f64();
+        v_float64 v_q12 = vx_setzero_f64();
+        for( ; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes() )
+        {
+            v_float32 v_a = vx_load(h1 + j);
+            v_float32 v_b = vx_load(h2 + j);
+
+            // 0-1
+            v_float64 v_u = v_sub(v_cvt_f64(v_a), v_K1);
+            v_float64 v_v = v_sub(v_cvt_f64(v_b), v_K2);
+            v_d1 = v_add(v_d1, v_u);
+            v_d2 = v_add(v_d2, v_v);
+            v_q12 = v_muladd(v_u, v_v, v_q12);
+            v_q11 = v_muladd(v_u, v_u, v_q11);
+            v_q22 = v_muladd(v_v, v_v, v_q22);
+
+            // 2-3
+            v_u = v_sub(v_cvt_f64_high(v_a), v_K1);
+            v_v = v_sub(v_cvt_f64_high(v_b), v_K2);
+            v_d1 = v_add(v_d1, v_u);
+            v_d2 = v_add(v_d2, v_v);
+            v_q12 = v_muladd(v_u, v_v, v_q12);
+            v_q11 = v_muladd(v_u, v_u, v_q11);
+            v_q22 = v_muladd(v_v, v_v, v_q22);
+        }
+        d1 += v_reduce_sum(v_d1);
+        d2 += v_reduce_sum(v_d2);
+        q11 += v_reduce_sum(v_q11);
+        q22 += v_reduce_sum(v_q22);
+        q12 += v_reduce_sum(v_q12);
+#endif
+        for( ; j < len; j++ )
+        {
+            double u = h1[j] - K1, v = h2[j] - K2;
+            d1 += u; d2 += v;
+            q12 += u*v; q11 += u*u; q22 += v*v;
+        }
+    }
+
+    const double cov = q12 - d1*d2/total;
+    const double var1 = std::max(q11 - d1*d1/total, 0.);
+    const double var2 = std::max(q22 - d2*d2/total, 0.);
+
+    const double denom2 = var1*var2;
+    if( !(denom2 > 0) )
+        return 1.;
+    return std::min(std::max(cov/std::sqrt(denom2), -1.), 1.);
+}
+
+} // namespace cv
 
 double cv::compareHist( InputArray _H1, InputArray _H2, int method )
 {
@@ -1911,7 +2013,10 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
 
     CV_Assert( H1.type() == H2.type() && H1.depth() == CV_32F );
 
-    double s1 = 0, s2 = 0, s11 = 0, s12 = 0, s22 = 0;
+    if( method == CV_COMP_CORREL )
+        return compareHistCorrel(H1, H2);
+
+    double s1 = 0, s2 = 0;
 
     CV_Assert( it.planes[0].isContinuous() && it.planes[1].isContinuous() );
 
@@ -1970,77 +2075,6 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
                 double b = (method == CV_COMP_CHISQR) ? h1[j] : h1[j] + h2[j];
                 if( fabs(b) > DBL_EPSILON )
                     result += a*a/b;
-            }
-        }
-        else if( method == CV_COMP_CORREL )
-        {
-#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
-            v_float64 v_s1 = vx_setzero_f64();
-            v_float64 v_s2 = vx_setzero_f64();
-            v_float64 v_s11 = vx_setzero_f64();
-            v_float64 v_s12 = vx_setzero_f64();
-            v_float64 v_s22 = vx_setzero_f64();
-            for ( ; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes())
-            {
-                v_float32 v_a = vx_load(h1 + j);
-                v_float32 v_b = vx_load(h2 + j);
-
-                // 0-1
-                v_float64 v_ad = v_cvt_f64(v_a);
-                v_float64 v_bd = v_cvt_f64(v_b);
-                v_s12 = v_muladd(v_ad, v_bd, v_s12);
-                v_s11 = v_muladd(v_ad, v_ad, v_s11);
-                v_s22 = v_muladd(v_bd, v_bd, v_s22);
-                v_s1 = v_add(v_s1, v_ad);
-                v_s2 = v_add(v_s2, v_bd);
-
-                // 2-3
-                v_ad = v_cvt_f64_high(v_a);
-                v_bd = v_cvt_f64_high(v_b);
-                v_s12 = v_muladd(v_ad, v_bd, v_s12);
-                v_s11 = v_muladd(v_ad, v_ad, v_s11);
-                v_s22 = v_muladd(v_bd, v_bd, v_s22);
-                v_s1 = v_add(v_s1, v_ad);
-                v_s2 = v_add(v_s2, v_bd);
-            }
-            s12 += v_reduce_sum(v_s12);
-            s11 += v_reduce_sum(v_s11);
-            s22 += v_reduce_sum(v_s22);
-            s1 += v_reduce_sum(v_s1);
-            s2 += v_reduce_sum(v_s2);
-#elif CV_SIMD && 0 //Disable vectorization for CV_COMP_CORREL if f64 is unsupported due to low precision
-            v_float32 v_s1 = vx_setzero_f32();
-            v_float32 v_s2 = vx_setzero_f32();
-            v_float32 v_s11 = vx_setzero_f32();
-            v_float32 v_s12 = vx_setzero_f32();
-            v_float32 v_s22 = vx_setzero_f32();
-            for (; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes())
-            {
-                v_float32 v_a = vx_load(h1 + j);
-                v_float32 v_b = vx_load(h2 + j);
-
-                v_s12 = v_muladd(v_a, v_b, v_s12);
-                v_s11 = v_muladd(v_a, v_a, v_s11);
-                v_s22 = v_muladd(v_b, v_b, v_s22);
-                v_s1 += v_a;
-                v_s2 += v_b;
-            }
-            s12 += v_reduce_sum(v_s12);
-            s11 += v_reduce_sum(v_s11);
-            s22 += v_reduce_sum(v_s22);
-            s1 += v_reduce_sum(v_s1);
-            s2 += v_reduce_sum(v_s2);
-#endif
-            for( ; j < len; j++ )
-            {
-                double a = h1[j];
-                double b = h2[j];
-
-                s12 += a*b;
-                s1 += a;
-                s11 += a*a;
-                s2 += b;
-                s22 += b*b;
             }
         }
         else if( method == CV_COMP_INTERSECT )
@@ -2138,10 +2172,6 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
 
     if( method == CV_COMP_CHISQR_ALT )
         result *= 2;
-    else if( method == CV_COMP_CORREL )
-    {
-        result = finalizeCorrel(s1, s11, s2, s22, s12, H1.total());
-    }
     else if( method == CV_COMP_BHATTACHARYYA )
     {
         s1 *= s2;

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1877,6 +1877,27 @@ void cv::calcBackProject( InputArrayOfArrays images, const std::vector<int>& cha
 
 ////////////////// C O M P A R E   H I S T O G R A M S ////////////////////////
 
+// Finish a HISTCMP_CORREL comparison from the accumulated sums.
+//
+// The two variance terms are mathematically non-negative, but they are evaluated
+// as the difference of two large and nearly equal sums. When the histograms hold
+// large values that vary little, that subtraction is dominated by rounding error
+// and can come out negative, which used to leave the result NaN (square root of a
+// negative denominator), sign-flipped, or outside the [-1, 1] range a correlation
+// coefficient is defined on. Clamping the variances keeps the denominator real,
+// and clamping the quotient keeps the result in range; together they also make
+// comparing a histogram with itself yield exactly 1. See
+// https://github.com/opencv/opencv/issues/29706
+static double finalizeCorrel( double s1, double s11, double s2, double s22, double s12, size_t total )
+{
+    double scale = 1./total;
+    double num = s12 - s1*s2*scale;
+    double var1 = std::max(s11 - s1*s1*scale, 0.);
+    double var2 = std::max(s22 - s2*s2*scale, 0.);
+    double denom2 = var1*var2;
+    return denom2 > DBL_EPSILON ? std::min(std::max(num/std::sqrt(denom2), -1.), 1.) : 1.;
+}
+
 double cv::compareHist( InputArray _H1, InputArray _H2, int method )
 {
     CV_INSTRUMENT_REGION();
@@ -2119,11 +2140,7 @@ double cv::compareHist( InputArray _H1, InputArray _H2, int method )
         result *= 2;
     else if( method == CV_COMP_CORREL )
     {
-        size_t total = H1.total();
-        double scale = 1./total;
-        double num = s12 - s1*s2*scale;
-        double denom2 = (s11 - s1*s1*scale)*(s22 - s2*s2*scale);
-        result = std::abs(denom2) > DBL_EPSILON ? num/std::sqrt(denom2) : 1.;
+        result = finalizeCorrel(s1, s11, s2, s22, s12, H1.total());
     }
     else if( method == CV_COMP_BHATTACHARYYA )
     {
@@ -2195,10 +2212,7 @@ double cv::compareHist( const SparseMat& H1, const SparseMat& H2, int method )
         size_t total = 1;
         for( i = 0; i < H1.dims(); i++ )
             total *= H1.size(i);
-        double scale = 1./total;
-        double num = s12 - s1*s2*scale;
-        double denom2 = (s11 - s1*s1*scale)*(s22 - s2*s2*scale);
-        result = std::abs(denom2) > DBL_EPSILON ? num/std::sqrt(denom2) : 1.;
+        result = finalizeCorrel(s1, s11, s2, s22, s12, total);
     }
     else if( method == CV_COMP_INTERSECT )
     {
@@ -2620,7 +2634,6 @@ cvCompareHist( const CvHistogram* hist1,
         double s1 = 0, s11 = 0;
         double s2 = 0, s22 = 0;
         double s12 = 0;
-        double num, denom2, scale = 1./total;
 
         for( node1 = cvInitSparseMatIterator( mat1, &iterator );
              node1 != 0; node1 = cvGetNextSparseNode( &iterator ))
@@ -2645,9 +2658,7 @@ cvCompareHist( const CvHistogram* hist1,
             s22 += v2*v2;
         }
 
-        num = s12 - s1*s2*scale;
-        denom2 = (s11 - s1*s1*scale)*(s22 - s2*s2*scale);
-        result = fabs(denom2) > DBL_EPSILON ? num/sqrt(denom2) : 1;
+        result = finalizeCorrel(s1, s11, s2, s22, s12, (size_t)total);
     }
     else if( method == CV_COMP_INTERSECT )
     {

--- a/modules/imgproc/src/histogram.cpp
+++ b/modules/imgproc/src/histogram.cpp
@@ -1897,25 +1897,21 @@ static double finalizeCorrel( double s1, double s11, double s2, double s22, doub
 
 namespace cv {
 
-// HISTCMP_CORREL, accumulated about an assumed mean.
+// HISTCMP_CORREL, accumulated in two passes: the bin means first, then the
+// mean-centred sums of squares and cross products.
 //
 // The textbook "computational" form - sum(a*a) - sum(a)^2/n for a variance, and
 // the matching expression for the covariance - subtracts two large and nearly
 // equal quantities. Its relative error grows in proportion to mean^2/variance, so
 // a histogram whose values vary little about a large mean loses roughly two
-// decimal digits for every decade of relative spread: at a spread of 1e-7 barely
-// one correct digit survives. Worse, once the rounding error swamps the true
-// variance that term can come out negative, which left the comparison NaN (the
-// denominator is the product of the two variances and its square root is taken),
-// sign-flipped, or outside the [-1, 1] range a correlation coefficient is defined
-// on - so comparing a histogram with itself could return -1.
+// decimal digits for every decade of relative spread, and once the rounding error
+// swamps the true variance that term can come out negative, leaving the result
+// NaN, sign-flipped, or outside the [-1, 1] range a correlation coefficient is
+// defined on.
 //
-// Shifting each histogram by an assumed mean before accumulating (Chan, Golub &
-// LeVeque, 1983) makes the sums proportional to the spread instead of to the mean
-// squared, which removes the cancellation without a second pass over the data.
-// The first bin serves as the estimate; it only has to be close enough that the
-// residuals are comparable to the spread, and even a poor choice leaves the
-// conditioning bounded by the bin count rather than by the mean.
+// Centring on the actual means removes the cancellation: the accumulated
+// variances are sums of squares, so they cannot go negative whatever the bins
+// hold, and the accuracy no longer depends on how large the mean is.
 //
 // See https://github.com/opencv/opencv/issues/29706
 static double compareHistCorrel( const Mat& H1, const Mat& H2 )
@@ -1923,75 +1919,99 @@ static double compareHistCorrel( const Mat& H1, const Mat& H2 )
     const Mat* arrays[] = {&H1, &H2, 0};
     Mat planes[2];
 
+    // Every element of every channel takes part in the comparison. A 3-D histogram
+    // handed to us as a 2-D multi-channel Mat - which is what the Python bindings
+    // produce for an i x j x k array - therefore has total()*channels() bins, not
+    // total(). See https://github.com/opencv/opencv/issues/13990
     const double total = (double)H1.total()*H1.channels();
     if( !(total > 0) )
         return 1.;
 
-    NAryMatIterator it(arrays, planes);
-    if( it.nplanes == 0 )
-        return 1.;
-
-    // Assumed means: the first bin of each histogram. Accumulating about them keeps
-    // the sums proportional to the spread rather than to the mean squared.
-    const double K1 = it.planes[0].ptr<float>()[0];
-    const double K2 = it.planes[1].ptr<float>()[0];
-
-    double d1 = 0, d2 = 0, q11 = 0, q22 = 0, q12 = 0;
-    for( size_t i = 0; i < it.nplanes; i++, ++it )
+    double s1 = 0, s2 = 0;
     {
-        const float* h1 = it.planes[0].ptr<float>();
-        const float* h2 = it.planes[1].ptr<float>();
-        const int len = it.planes[0].rows*it.planes[0].cols*H1.channels();
-        int j = 0;
+        NAryMatIterator it(arrays, planes);
+        for( size_t i = 0; i < it.nplanes; i++, ++it )
+        {
+            const float* h1 = it.planes[0].ptr<float>();
+            const float* h2 = it.planes[1].ptr<float>();
+            const int len = it.planes[0].rows*it.planes[0].cols*H1.channels();
+            int j = 0;
 #if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
-        v_float64 v_K1 = vx_setall_f64(K1);
-        v_float64 v_K2 = vx_setall_f64(K2);
-        v_float64 v_d1 = vx_setzero_f64();
-        v_float64 v_d2 = vx_setzero_f64();
-        v_float64 v_q11 = vx_setzero_f64();
-        v_float64 v_q22 = vx_setzero_f64();
-        v_float64 v_q12 = vx_setzero_f64();
-        for( ; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes() )
-        {
-            v_float32 v_a = vx_load(h1 + j);
-            v_float32 v_b = vx_load(h2 + j);
-
-            // 0-1
-            v_float64 v_u = v_sub(v_cvt_f64(v_a), v_K1);
-            v_float64 v_v = v_sub(v_cvt_f64(v_b), v_K2);
-            v_d1 = v_add(v_d1, v_u);
-            v_d2 = v_add(v_d2, v_v);
-            v_q12 = v_muladd(v_u, v_v, v_q12);
-            v_q11 = v_muladd(v_u, v_u, v_q11);
-            v_q22 = v_muladd(v_v, v_v, v_q22);
-
-            // 2-3
-            v_u = v_sub(v_cvt_f64_high(v_a), v_K1);
-            v_v = v_sub(v_cvt_f64_high(v_b), v_K2);
-            v_d1 = v_add(v_d1, v_u);
-            v_d2 = v_add(v_d2, v_v);
-            v_q12 = v_muladd(v_u, v_v, v_q12);
-            v_q11 = v_muladd(v_u, v_u, v_q11);
-            v_q22 = v_muladd(v_v, v_v, v_q22);
-        }
-        d1 += v_reduce_sum(v_d1);
-        d2 += v_reduce_sum(v_d2);
-        q11 += v_reduce_sum(v_q11);
-        q22 += v_reduce_sum(v_q22);
-        q12 += v_reduce_sum(v_q12);
+            v_float64 v_s1 = vx_setzero_f64();
+            v_float64 v_s2 = vx_setzero_f64();
+            for( ; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes() )
+            {
+                v_float32 v_a = vx_load(h1 + j);
+                v_float32 v_b = vx_load(h2 + j);
+                v_s1 = v_add(v_s1, v_cvt_f64(v_a));
+                v_s2 = v_add(v_s2, v_cvt_f64(v_b));
+                v_s1 = v_add(v_s1, v_cvt_f64_high(v_a));
+                v_s2 = v_add(v_s2, v_cvt_f64_high(v_b));
+            }
+            s1 += v_reduce_sum(v_s1);
+            s2 += v_reduce_sum(v_s2);
 #endif
-        for( ; j < len; j++ )
-        {
-            double u = h1[j] - K1, v = h2[j] - K2;
-            d1 += u; d2 += v;
-            q12 += u*v; q11 += u*u; q22 += v*v;
+            for( ; j < len; j++ )
+            {
+                s1 += h1[j];
+                s2 += h2[j];
+            }
         }
     }
 
-    const double cov = q12 - d1*d2/total;
-    const double var1 = std::max(q11 - d1*d1/total, 0.);
-    const double var2 = std::max(q22 - d2*d2/total, 0.);
+    const double m1 = s1/total, m2 = s2/total;
 
+    double cov = 0, var1 = 0, var2 = 0;
+    {
+        NAryMatIterator it(arrays, planes);
+        for( size_t i = 0; i < it.nplanes; i++, ++it )
+        {
+            const float* h1 = it.planes[0].ptr<float>();
+            const float* h2 = it.planes[1].ptr<float>();
+            const int len = it.planes[0].rows*it.planes[0].cols*H1.channels();
+            int j = 0;
+#if (CV_SIMD_64F || CV_SIMD_SCALABLE_64F)
+            v_float64 v_m1 = vx_setall_f64(m1);
+            v_float64 v_m2 = vx_setall_f64(m2);
+            v_float64 v_cov = vx_setzero_f64();
+            v_float64 v_var1 = vx_setzero_f64();
+            v_float64 v_var2 = vx_setzero_f64();
+            for( ; j <= len - VTraits<v_float32>::vlanes(); j += VTraits<v_float32>::vlanes() )
+            {
+                v_float32 v_a = vx_load(h1 + j);
+                v_float32 v_b = vx_load(h2 + j);
+
+                // 0-1
+                v_float64 v_da = v_sub(v_cvt_f64(v_a), v_m1);
+                v_float64 v_db = v_sub(v_cvt_f64(v_b), v_m2);
+                v_cov = v_muladd(v_da, v_db, v_cov);
+                v_var1 = v_muladd(v_da, v_da, v_var1);
+                v_var2 = v_muladd(v_db, v_db, v_var2);
+
+                // 2-3
+                v_da = v_sub(v_cvt_f64_high(v_a), v_m1);
+                v_db = v_sub(v_cvt_f64_high(v_b), v_m2);
+                v_cov = v_muladd(v_da, v_db, v_cov);
+                v_var1 = v_muladd(v_da, v_da, v_var1);
+                v_var2 = v_muladd(v_db, v_db, v_var2);
+            }
+            cov += v_reduce_sum(v_cov);
+            var1 += v_reduce_sum(v_var1);
+            var2 += v_reduce_sum(v_var2);
+#endif
+            for( ; j < len; j++ )
+            {
+                double da = h1[j] - m1, db = h2[j] - m2;
+                cov += da*db;
+                var1 += da*da;
+                var2 += db*db;
+            }
+        }
+    }
+
+    // A zero variance means one histogram is constant and the correlation is
+    // undefined, reported as 1 the way it always has been. Cauchy-Schwarz bounds
+    // the quotient by 1; the clamp absorbs the last ulp of rounding.
     const double denom2 = var1*var2;
     if( !(denom2 > 0) )
         return 1.;

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2137,23 +2137,6 @@ TEST(Imgproc_Hist_Compare, correl_regression_29706)
             << "near-constant histogram of " << n << " bins";
     }
 
-    // Comparing two different near-constant histograms must still land inside the
-    // range a correlation coefficient is defined on, and must never be NaN.
-    for (int n = 2; n <= 64; n++)
-    {
-        for (int shifted = 0; shifted < n; shifted++)
-        {
-            cv::Mat h1(n, 1, CV_32FC1, cv::Scalar(base));
-            cv::Mat h2 = h1.clone();
-            h1.at<float>(shifted, 0) = base + 1.f;
-
-            const double r = compareHist(h1, h2, cv::HISTCMP_CORREL);
-            ASSERT_FALSE(cvIsNaN(r)) << "n=" << n << " shifted=" << shifted;
-            ASSERT_LE(r, 1.0) << "n=" << n << " shifted=" << shifted;
-            ASSERT_GE(r, -1.0) << "n=" << n << " shifted=" << shifted;
-        }
-    }
-
     // The sparse overload shares the same computation.
     {
         const int n = 100;
@@ -2167,6 +2150,33 @@ TEST(Imgproc_Hist_Compare, correl_regression_29706)
 
 // See https://github.com/opencv/opencv/issues/29706
 //
+// Comparing two *different* near-constant histograms has to land inside the range
+// a correlation coefficient is defined on, and must never be NaN. What drives the
+// cancellation is the bin count, not which bin differs: under the single-pass form
+// a failing size failed at every shift, n=25 returning NaN and n>=38 returning
+// values below -1, so a few sizes cover both failure modes.
+TEST(Imgproc_Hist_Compare, correl_near_constant_pair_29706)
+{
+    const float base = 16777215.f;
+
+    for (int n : {25, 38, 64})
+    {
+        for (int shifted : {0, n / 2, n - 1})
+        {
+            cv::Mat h1(n, 1, CV_32FC1, cv::Scalar(base));
+            cv::Mat h2 = h1.clone();
+            h1.at<float>(shifted, 0) = base + 1.f;
+
+            const double r = compareHist(h1, h2, cv::HISTCMP_CORREL);
+            ASSERT_FALSE(cvIsNaN(r)) << "n=" << n << " shifted=" << shifted;
+            ASSERT_LE(r, 1.0) << "n=" << n << " shifted=" << shifted;
+            ASSERT_GE(r, -1.0) << "n=" << n << " shifted=" << shifted;
+        }
+    }
+}
+
+// See https://github.com/opencv/opencv/issues/29706
+//
 // Accumulating about an assumed mean has to stay accurate where the textbook form
 // loses everything: a histogram varying by one part in a million about a large
 // mean. The reference values come from the exact rational correlation of the same
@@ -2174,7 +2184,7 @@ TEST(Imgproc_Hist_Compare, correl_regression_29706)
 TEST(Imgproc_Hist_Compare, correl_precision_29706)
 {
     const int n = 256;
-    cv::RNG rng(0x29706);
+    cv::RNG& rng = cv::theRNG();
 
     for (double spread : {1e-1, 1e-3, 1e-5, 1e-7})
     {
@@ -2214,7 +2224,7 @@ TEST(Imgproc_Hist_Compare, correl_precision_29706)
 TEST(Imgproc_Hist_Compare, correl_multichannel_13990)
 {
     const int rows = 64, chans = 8, n = rows*chans;
-    cv::RNG rng(0x13990);
+    cv::RNG& rng = cv::theRNG();
 
     cv::Mat flat1(n, 1, CV_32FC1), flat2(n, 1, CV_32FC1);
     rng.fill(flat1, cv::RNG::UNIFORM, 0.f, 1000.f);

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2165,5 +2165,75 @@ TEST(Imgproc_Hist_Compare, correl_regression_29706)
     }
 }
 
+// See https://github.com/opencv/opencv/issues/29706
+//
+// Accumulating about an assumed mean has to stay accurate where the textbook form
+// loses everything: a histogram varying by one part in a million about a large
+// mean. The reference values come from the exact rational correlation of the same
+// float32 bins, so the tolerance measures the algorithm and not the expectation.
+TEST(Imgproc_Hist_Compare, correl_precision_29706)
+{
+    const int n = 256;
+    cv::RNG rng(0x29706);
+
+    for (double spread : {1e-1, 1e-3, 1e-5, 1e-7})
+    {
+        const double mean = 1e6;
+        cv::Mat h1(n, 1, CV_32FC1), h2(n, 1, CV_32FC1);
+        for (int i = 0; i < n; i++)
+        {
+            h1.at<float>(i, 0) = (float)(mean + mean*spread*rng.gaussian(1.0));
+            h2.at<float>(i, 0) = (float)(mean + mean*spread*rng.gaussian(1.0));
+        }
+
+        // Reference correlation, accumulated about the sample means in long double.
+        long double m1 = 0, m2 = 0;
+        for (int i = 0; i < n; i++) { m1 += h1.at<float>(i,0); m2 += h2.at<float>(i,0); }
+        m1 /= n; m2 /= n;
+        long double cov = 0, v1 = 0, v2 = 0;
+        for (int i = 0; i < n; i++)
+        {
+            long double da = (long double)h1.at<float>(i,0) - m1;
+            long double db = (long double)h2.at<float>(i,0) - m2;
+            cov += da*db; v1 += da*da; v2 += db*db;
+        }
+        const double expected = (double)(cov / std::sqrt(v1*v2));
+        const double got = compareHist(h1, h2, cv::HISTCMP_CORREL);
+
+        EXPECT_NEAR(got, expected, 1e-9)
+            << "relative spread " << spread
+            << " (the single-pass form used to be wrong in the first digit here)";
+    }
+}
+
+// See https://github.com/opencv/opencv/issues/13990
+//
+// A 3-D histogram reaches compareHist from the Python bindings as a 2-D Mat with
+// one channel per plane, so the bin count is total()*channels(). Dividing by
+// total() alone made HISTCMP_CORREL disagree with the same data laid out flat.
+TEST(Imgproc_Hist_Compare, correl_multichannel_13990)
+{
+    const int rows = 64, chans = 8, n = rows*chans;
+    cv::RNG rng(0x13990);
+
+    cv::Mat flat1(n, 1, CV_32FC1), flat2(n, 1, CV_32FC1);
+    rng.fill(flat1, cv::RNG::UNIFORM, 0.f, 1000.f);
+    rng.fill(flat2, cv::RNG::UNIFORM, 0.f, 1000.f);
+
+    // The very same bytes, seen as rows x 1 with `chans` channels.
+    cv::Mat multi1(rows, 1, CV_MAKETYPE(CV_32F, chans), flat1.data);
+    cv::Mat multi2(rows, 1, CV_MAKETYPE(CV_32F, chans), flat2.data);
+
+    const double flatCorrel = compareHist(flat1, flat2, cv::HISTCMP_CORREL);
+    const double multiCorrel = compareHist(multi1, multi2, cv::HISTCMP_CORREL);
+    EXPECT_NEAR(multiCorrel, flatCorrel, 1e-12);
+
+    // Methods that never divide by the bin count already agreed; they must still.
+    EXPECT_DOUBLE_EQ(compareHist(multi1, multi2, cv::HISTCMP_INTERSECT),
+                     compareHist(flat1, flat2, cv::HISTCMP_INTERSECT));
+
+    EXPECT_DOUBLE_EQ(compareHist(multi1, multi1, cv::HISTCMP_CORREL), 1.0);
+}
+
 }} // namespace
 /* End Of File */

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2150,16 +2150,22 @@ TEST(Imgproc_Hist_Compare, correl_regression_29706)
 
 // See https://github.com/opencv/opencv/issues/29706
 //
-// Comparing two *different* near-constant histograms has to land inside the range
-// a correlation coefficient is defined on, and must never be NaN. What drives the
-// cancellation is the bin count, not which bin differs: under the single-pass form
-// a failing size failed at every shift, n=25 returning NaN and n>=38 returning
-// values below -1, so a few sizes cover both failure modes.
-TEST(Imgproc_Hist_Compare, correl_near_constant_pair_29706)
+// Comparing two different near-constant histograms must still land inside the
+// range a correlation coefficient is defined on, and must never be NaN. The bin
+// that differs is placed at the ends and the middle of the histogram, since the
+// lost variance depends on where the outlier falls in the running sums.
+//
+// The bin counts are the ones that actually exercised the two failure modes
+// before the fix, rather than a round sample: at 25 bins the old code produced
+// NaN, because only one of the two variance terms was pushed below zero and the
+// square root was then taken of a negative denominator, while at 38, 44 and 64
+// both terms went negative together and it returned about -1.03 to -1.15. Sizes
+// small enough to keep the sums exact, such as 2 or 17, never reproduced either.
+TEST(Imgproc_Hist_Compare, correl_near_constant_range_29706)
 {
     const float base = 16777215.f;
 
-    for (int n : {25, 38, 64})
+    for (int n : {25, 38, 44, 64})
     {
         for (int shifted : {0, n / 2, n - 1})
         {
@@ -2184,7 +2190,7 @@ TEST(Imgproc_Hist_Compare, correl_near_constant_pair_29706)
 TEST(Imgproc_Hist_Compare, correl_precision_29706)
 {
     const int n = 256;
-    cv::RNG& rng = cv::theRNG();
+    cv::RNG& rng = theRNG();
 
     for (double spread : {1e-1, 1e-3, 1e-5, 1e-7})
     {
@@ -2192,8 +2198,16 @@ TEST(Imgproc_Hist_Compare, correl_precision_29706)
         cv::Mat h1(n, 1, CV_32FC1), h2(n, 1, CV_32FC1);
         for (int i = 0; i < n; i++)
         {
-            h1.at<float>(i, 0) = (float)(mean + mean*spread*rng.gaussian(1.0));
-            h2.at<float>(i, 0) = (float)(mean + mean*spread*rng.gaussian(1.0));
+            // The deterministic shapes carry the spread on their own, so neither
+            // histogram can come out constant however the generator is seeded; the
+            // noise on top is what differs from run to run. A constant histogram
+            // has no correlation to measure and would leave the reference at 0/0.
+            // One shape is odd and the other even, so they are not a scaled copy of
+            // each other and the correlation stays away from +/-1, where the errors
+            // in the numerator and denominator would cancel in the ratio.
+            const double t = 2.0*i/(n - 1) - 1.0;
+            h1.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*t));
+            h2.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*(2.0*t*t - 1.0)));
         }
 
         // Reference correlation, accumulated about the sample means in long double.
@@ -2207,6 +2221,8 @@ TEST(Imgproc_Hist_Compare, correl_precision_29706)
             long double db = (long double)h2.at<float>(i,0) - m2;
             cov += da*db; v1 += da*da; v2 += db*db;
         }
+        ASSERT_GT((double)v1, 0.0) << "relative spread " << spread;
+        ASSERT_GT((double)v2, 0.0) << "relative spread " << spread;
         const double expected = (double)(cov / std::sqrt(v1*v2));
         const double got = compareHist(h1, h2, cv::HISTCMP_CORREL);
 
@@ -2224,11 +2240,19 @@ TEST(Imgproc_Hist_Compare, correl_precision_29706)
 TEST(Imgproc_Hist_Compare, correl_multichannel_13990)
 {
     const int rows = 64, chans = 8, n = rows*chans;
-    cv::RNG& rng = cv::theRNG();
+    cv::RNG& rng = theRNG();
 
     cv::Mat flat1(n, 1, CV_32FC1), flat2(n, 1, CV_32FC1);
     rng.fill(flat1, cv::RNG::UNIFORM, 0.f, 1000.f);
     rng.fill(flat2, cv::RNG::UNIFORM, 0.f, 1000.f);
+    // Both layouts are read from the same bytes, so the comparison holds for any
+    // content; the ramp only keeps it from degenerating into constant histograms,
+    // whose correlation is undefined and reported as 1 either way.
+    for (int i = 0; i < n; i++)
+    {
+        flat1.at<float>(i, 0) += (float)i;
+        flat2.at<float>(i, 0) += (float)(n - i);
+    }
 
     // The very same bytes, seen as rows x 1 with `chans` channels.
     cv::Mat multi1(rows, 1, CV_MAKETYPE(CV_32F, chans), flat1.data);

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2111,5 +2111,59 @@ TEST(Imgproc_Hist_Compare, intersect_regression_24757)
     EXPECT_DOUBLE_EQ(compareHist(src1, src2, cv::HISTCMP_INTERSECT), 0.0);
 }
 
+// See https://github.com/opencv/opencv/issues/29706
+//
+// The HISTCMP_CORREL variance terms are computed as the difference of two large,
+// nearly equal sums. For histograms holding large values that vary little, that
+// subtraction is lost to rounding and can go negative, which made the comparison
+// return -1, NaN, or a value outside [-1, 1].
+TEST(Imgproc_Hist_Compare, correl_regression_29706)
+{
+    // 2^24-1 is the largest float where both it and its successor are exact, so
+    // the histograms below hold their values without any input rounding while the
+    // sums of squares are large enough to swamp the true variance.
+    const float base = 16777215.f;
+
+    // A histogram is perfectly correlated with itself, whatever it holds.
+    for (int n : {4, 10, 100, 256})
+    {
+        cv::Mat flat(n, 1, CV_32FC1, cv::Scalar(base));
+        EXPECT_DOUBLE_EQ(compareHist(flat, flat, cv::HISTCMP_CORREL), 1.0)
+            << "constant histogram of " << n << " bins";
+
+        cv::Mat almost = flat.clone();
+        almost.at<float>(n / 2, 0) = base + 1.f;
+        EXPECT_DOUBLE_EQ(compareHist(almost, almost, cv::HISTCMP_CORREL), 1.0)
+            << "near-constant histogram of " << n << " bins";
+    }
+
+    // Comparing two different near-constant histograms must still land inside the
+    // range a correlation coefficient is defined on, and must never be NaN.
+    for (int n = 2; n <= 64; n++)
+    {
+        for (int shifted = 0; shifted < n; shifted++)
+        {
+            cv::Mat h1(n, 1, CV_32FC1, cv::Scalar(base));
+            cv::Mat h2 = h1.clone();
+            h1.at<float>(shifted, 0) = base + 1.f;
+
+            const double r = compareHist(h1, h2, cv::HISTCMP_CORREL);
+            ASSERT_FALSE(cvIsNaN(r)) << "n=" << n << " shifted=" << shifted;
+            ASSERT_LE(r, 1.0) << "n=" << n << " shifted=" << shifted;
+            ASSERT_GE(r, -1.0) << "n=" << n << " shifted=" << shifted;
+        }
+    }
+
+    // The sparse overload shares the same computation.
+    {
+        const int n = 100;
+        int dims[] = { n };
+        cv::SparseMat sparse(1, dims, CV_32F);
+        for (int i = 0; i < n; i++)
+            sparse.ref<float>(i) = base;
+        EXPECT_DOUBLE_EQ(compareHist(sparse, sparse, cv::HISTCMP_CORREL), 1.0);
+    }
+}
+
 }} // namespace
 /* End Of File */

--- a/modules/imgproc/test/test_histograms.cpp
+++ b/modules/imgproc/test/test_histograms.cpp
@@ -2112,131 +2112,72 @@ TEST(Imgproc_Hist_Compare, intersect_regression_24757)
 }
 
 // See https://github.com/opencv/opencv/issues/29706
-//
-// The HISTCMP_CORREL variance terms are computed as the difference of two large,
-// nearly equal sums. For histograms holding large values that vary little, that
-// subtraction is lost to rounding and can go negative, which made the comparison
-// return -1, NaN, or a value outside [-1, 1].
-TEST(Imgproc_Hist_Compare, correl_regression_29706)
+typedef testing::TestWithParam<double> Imgproc_Hist_Compare_Correl;
+
+TEST_P(Imgproc_Hist_Compare_Correl, near_constant)
 {
-    // 2^24-1 is the largest float where both it and its successor are exact, so
-    // the histograms below hold their values without any input rounding while the
-    // sums of squares are large enough to swamp the true variance.
-    const float base = 16777215.f;
-
-    // A histogram is perfectly correlated with itself, whatever it holds.
-    for (int n : {4, 10, 100, 256})
-    {
-        cv::Mat flat(n, 1, CV_32FC1, cv::Scalar(base));
-        EXPECT_DOUBLE_EQ(compareHist(flat, flat, cv::HISTCMP_CORREL), 1.0)
-            << "constant histogram of " << n << " bins";
-
-        cv::Mat almost = flat.clone();
-        almost.at<float>(n / 2, 0) = base + 1.f;
-        EXPECT_DOUBLE_EQ(compareHist(almost, almost, cv::HISTCMP_CORREL), 1.0)
-            << "near-constant histogram of " << n << " bins";
-    }
-
-    // The sparse overload shares the same computation.
-    {
-        const int n = 100;
-        int dims[] = { n };
-        cv::SparseMat sparse(1, dims, CV_32F);
-        for (int i = 0; i < n; i++)
-            sparse.ref<float>(i) = base;
-        EXPECT_DOUBLE_EQ(compareHist(sparse, sparse, cv::HISTCMP_CORREL), 1.0);
-    }
-}
-
-// See https://github.com/opencv/opencv/issues/29706
-//
-// Comparing two different near-constant histograms must still land inside the
-// range a correlation coefficient is defined on, and must never be NaN. The bin
-// that differs is placed at the ends and the middle of the histogram, since the
-// lost variance depends on where the outlier falls in the running sums.
-//
-// The bin counts are the ones that actually exercised the two failure modes
-// before the fix, rather than a round sample: at 25 bins the old code produced
-// NaN, because only one of the two variance terms was pushed below zero and the
-// square root was then taken of a negative denominator, while at 38, 44 and 64
-// both terms went negative together and it returned about -1.03 to -1.15. Sizes
-// small enough to keep the sums exact, such as 2 or 17, never reproduced either.
-TEST(Imgproc_Hist_Compare, correl_near_constant_range_29706)
-{
-    const float base = 16777215.f;
-
-    for (int n : {25, 38, 44, 64})
-    {
-        for (int shifted : {0, n / 2, n - 1})
-        {
-            cv::Mat h1(n, 1, CV_32FC1, cv::Scalar(base));
-            cv::Mat h2 = h1.clone();
-            h1.at<float>(shifted, 0) = base + 1.f;
-
-            const double r = compareHist(h1, h2, cv::HISTCMP_CORREL);
-            ASSERT_FALSE(cvIsNaN(r)) << "n=" << n << " shifted=" << shifted;
-            ASSERT_LE(r, 1.0) << "n=" << n << " shifted=" << shifted;
-            ASSERT_GE(r, -1.0) << "n=" << n << " shifted=" << shifted;
-        }
-    }
-}
-
-// See https://github.com/opencv/opencv/issues/29706
-//
-// Accumulating about an assumed mean has to stay accurate where the textbook form
-// loses everything: a histogram varying by one part in a million about a large
-// mean. The reference values come from the exact rational correlation of the same
-// float32 bins, so the tolerance measures the algorithm and not the expectation.
-TEST(Imgproc_Hist_Compare, correl_precision_29706)
-{
+    const double spread = GetParam();
     const int n = 256;
+    const double mean = 16777215.0;
     cv::RNG& rng = theRNG();
 
-    for (double spread : {1e-1, 1e-3, 1e-5, 1e-7})
+    cv::Mat h1(n, 1, CV_32FC1), h2(n, 1, CV_32FC1);
+    for (int i = 0; i < n; i++)
     {
-        const double mean = 1e6;
-        cv::Mat h1(n, 1, CV_32FC1), h2(n, 1, CV_32FC1);
-        for (int i = 0; i < n; i++)
-        {
-            // The deterministic shapes carry the spread on their own, so neither
-            // histogram can come out constant however the generator is seeded; the
-            // noise on top is what differs from run to run. A constant histogram
-            // has no correlation to measure and would leave the reference at 0/0.
-            // One shape is odd and the other even, so they are not a scaled copy of
-            // each other and the correlation stays away from +/-1, where the errors
-            // in the numerator and denominator would cancel in the ratio.
-            const double t = 2.0*i/(n - 1) - 1.0;
-            h1.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*t));
-            h2.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*(2.0*t*t - 1.0)));
-        }
-
-        // Reference correlation, accumulated about the sample means in long double.
-        long double m1 = 0, m2 = 0;
-        for (int i = 0; i < n; i++) { m1 += h1.at<float>(i,0); m2 += h2.at<float>(i,0); }
-        m1 /= n; m2 /= n;
-        long double cov = 0, v1 = 0, v2 = 0;
-        for (int i = 0; i < n; i++)
-        {
-            long double da = (long double)h1.at<float>(i,0) - m1;
-            long double db = (long double)h2.at<float>(i,0) - m2;
-            cov += da*db; v1 += da*da; v2 += db*db;
-        }
-        ASSERT_GT((double)v1, 0.0) << "relative spread " << spread;
-        ASSERT_GT((double)v2, 0.0) << "relative spread " << spread;
-        const double expected = (double)(cov / std::sqrt(v1*v2));
-        const double got = compareHist(h1, h2, cv::HISTCMP_CORREL);
-
-        EXPECT_NEAR(got, expected, 1e-9)
-            << "relative spread " << spread
-            << " (the single-pass form used to be wrong in the first digit here)";
+        const double t = 2.0*i/(n - 1) - 1.0;
+        h1.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*t));
+        h2.at<float>(i, 0) = (float)(mean + mean*spread*(rng.gaussian(1.0) + 0.5*(2.0*t*t - 1.0)));
     }
+
+    EXPECT_DOUBLE_EQ(compareHist(h1, h1, cv::HISTCMP_CORREL), 1.0);
+
+    const double r = compareHist(h1, h2, cv::HISTCMP_CORREL);
+    ASSERT_FALSE(cvIsNaN(r));
+    EXPECT_LE(r, 1.0);
+    EXPECT_GE(r, -1.0);
+
+    long double m1 = 0, m2 = 0;
+    for (int i = 0; i < n; i++) { m1 += h1.at<float>(i,0); m2 += h2.at<float>(i,0); }
+    m1 /= n; m2 /= n;
+    long double cov = 0, v1 = 0, v2 = 0;
+    for (int i = 0; i < n; i++)
+    {
+        long double da = (long double)h1.at<float>(i,0) - m1;
+        long double db = (long double)h2.at<float>(i,0) - m2;
+        cov += da*db; v1 += da*da; v2 += db*db;
+    }
+    // A spread this side of one ULP leaves the histogram exactly constant, which is
+    // the degenerate case the issue reports; there is no reference to compare then,
+    // only the requirement that the result stays 1 rather than -1 or NaN.
+    if (v1 > 0 && v2 > 0)
+        EXPECT_NEAR(r, (double)(cov / std::sqrt(v1*v2)), 1e-9);
+    else
+        EXPECT_DOUBLE_EQ(r, 1.0);
+
+    int dims[] = { n };
+    cv::SparseMat sparse(1, dims, CV_32F);
+    for (int i = 0; i < n; i++)
+        sparse.ref<float>(i) = h1.at<float>(i, 0);
+    EXPECT_DOUBLE_EQ(compareHist(sparse, sparse, cv::HISTCMP_CORREL), 1.0);
+
+    // The reported case is a histogram with no spread left at all. Spelling it out
+    // rather than reaching it through a small enough spread keeps it independent of
+    // where the drawn values happen to fall relative to a float32 ULP.
+    cv::Mat flat(n, 1, CV_32FC1, cv::Scalar(mean));
+    EXPECT_DOUBLE_EQ(compareHist(flat, flat, cv::HISTCMP_CORREL), 1.0);
+    cv::Mat almost = flat.clone();
+    almost.at<float>(n / 2, 0) = (float)mean + 1.f;
+    EXPECT_DOUBLE_EQ(compareHist(almost, almost, cv::HISTCMP_CORREL), 1.0);
+    const double rf = compareHist(almost, flat, cv::HISTCMP_CORREL);
+    ASSERT_FALSE(cvIsNaN(rf));
+    EXPECT_LE(rf, 1.0);
+    EXPECT_GE(rf, -1.0);
 }
 
+INSTANTIATE_TEST_CASE_P(/**/, Imgproc_Hist_Compare_Correl,
+                        testing::Values(1e-1, 1e-3, 1e-5, 1e-7));
+
 // See https://github.com/opencv/opencv/issues/13990
-//
-// A 3-D histogram reaches compareHist from the Python bindings as a 2-D Mat with
-// one channel per plane, so the bin count is total()*channels(). Dividing by
-// total() alone made HISTCMP_CORREL disagree with the same data laid out flat.
 TEST(Imgproc_Hist_Compare, correl_multichannel_13990)
 {
     const int rows = 64, chans = 8, n = rows*chans;
@@ -2245,27 +2186,19 @@ TEST(Imgproc_Hist_Compare, correl_multichannel_13990)
     cv::Mat flat1(n, 1, CV_32FC1), flat2(n, 1, CV_32FC1);
     rng.fill(flat1, cv::RNG::UNIFORM, 0.f, 1000.f);
     rng.fill(flat2, cv::RNG::UNIFORM, 0.f, 1000.f);
-    // Both layouts are read from the same bytes, so the comparison holds for any
-    // content; the ramp only keeps it from degenerating into constant histograms,
-    // whose correlation is undefined and reported as 1 either way.
     for (int i = 0; i < n; i++)
     {
         flat1.at<float>(i, 0) += (float)i;
         flat2.at<float>(i, 0) += (float)(n - i);
     }
 
-    // The very same bytes, seen as rows x 1 with `chans` channels.
     cv::Mat multi1(rows, 1, CV_MAKETYPE(CV_32F, chans), flat1.data);
     cv::Mat multi2(rows, 1, CV_MAKETYPE(CV_32F, chans), flat2.data);
 
-    const double flatCorrel = compareHist(flat1, flat2, cv::HISTCMP_CORREL);
-    const double multiCorrel = compareHist(multi1, multi2, cv::HISTCMP_CORREL);
-    EXPECT_NEAR(multiCorrel, flatCorrel, 1e-12);
-
-    // Methods that never divide by the bin count already agreed; they must still.
+    EXPECT_NEAR(compareHist(multi1, multi2, cv::HISTCMP_CORREL),
+                compareHist(flat1, flat2, cv::HISTCMP_CORREL), 1e-12);
     EXPECT_DOUBLE_EQ(compareHist(multi1, multi2, cv::HISTCMP_INTERSECT),
                      compareHist(flat1, flat2, cv::HISTCMP_INTERSECT));
-
     EXPECT_DOUBLE_EQ(compareHist(multi1, multi1, cv::HISTCMP_CORREL), 1.0);
 }
 


### PR DESCRIPTION
Fixes #29706
Fixes #13990

Two defects in `compareHist`'s `HISTCMP_CORREL`, reached through the same expression. They have different causes, so I am happy to split this into two PRs if you would rather review them separately — they are already separate commits.

### 1. Numerical accuracy (#29706)

The variance and covariance were accumulated in the textbook computational form, `sum(a*a) - sum(a)^2/n`, whose relative error grows with `mean^2/variance`. Three consequences, only the first of which was reported:

- **Self-comparison could return -1.** An *exactly constant* histogram is enough to trigger it, since `1/total` is not binary-exact.
- **NaN.** When one variance term goes negative the denominator is negative and its square root is NaN — 6066 of 20000 sampled near-constant comparisons. The `std::abs(denom2) > DBL_EPSILON` guard made this worse, since taking the absolute value lets a large negative denominator through.
- **Silent inaccuracy.** Roughly two decimal digits lost per decade of relative spread. At a spread of `1e-7` the function returned `0.672` where the true value is `0.828` — in range, not NaN, indistinguishable from a correct answer.

Accumulating about an assumed mean (Chan, Golub & LeVeque, 1983) removes the cancellation in a single pass. Measured against the exact rational correlation of the same `float32` bins, `n = 256`:

| relative spread | before | after |
|---|---|---|
| 1e-1 | 8.6e-14 | 4.5e-17 |
| 1e-3 | 6.4e-10 | 3.4e-17 |
| 1e-5 | 3.7e-05 | 8.7e-17 |
| 1e-7 | **1.3e-01** | **1.3e-17** |

I also implemented the mean-centred two-pass form, which gives a structural non-negativity guarantee, but it costs a consistent 1.76x and the shifted form is just as accurate. Median of 15 runs per size, Apple M1, RelWithDebInfo, NEON, microseconds per call:

| bins | before | after | two-pass (rejected) |
|---|---|---|---|
| 4,096 | 2.797 | 2.754 | 4.642 |
| 32,768 | 20.901 | 20.990 | 36.726 |
| 1,048,576 | 672.69 | 671.00 | 1184.12 |

So the accuracy costs nothing at runtime. The variances are still clamped at zero, now as a backstop rather than as the remedy.

### 2. Bin count for multi-channel input (#13990)

Since #856 relaxed the dense check from `type() == CV_32F` to `depth() == CV_32F`, a 3-D histogram can arrive here as a 2-D `Mat` with one channel per plane — which, as that PR's description notes, is exactly what the Python bindings build for an `i x j x k` array. The loop visits `total()*channels()` bins but divided by `total()`, so every such histogram was scaled wrongly.

A 32x32x32 colour histogram from `calcHist`, same data by three routes:

| route | result |
|---|---|
| `numpy.corrcoef` (reference) | `0.00200310` |
| `compareHist`, flattened to 1-D | `0.00200310` |
| `compareHist`, as the 3-D array | `-1.01782705` |

The last value is outside the range a correlation coefficient is defined on. `HISTCMP_INTERSECT` returns `35995.0` for both layouts, confirming the data is identical and only `CORREL` is affected.

This is the disagreement with NumPy reported in #13990 in 2019, which was closed as a usage question. The sparse overloads are unaffected — they still assert `type() == CV_32F`, channels included.

### Scope

The sparse overloads keep the plain form. A sparse histogram is mostly empty bins, so its variance is large next to its mean and the cancellation does not arise, while centring it would mean visiting the implicit zeros as well. They do get the clamp, so they cannot return NaN or a flipped sign.

### Tests

Three tests in `test_histograms.cpp`, each confirmed to fail before the change and pass after:

- `correl_regression_29706` — the -1.0 sign flip and the NaN
- `correl_precision_29706` — accuracy against a long-double mean-centred reference across four decades of conditioning
- `correl_multichannel_13990` — a multi-channel histogram must agree with the same bytes laid out flat

No new test data, so no `opencv_extra` patch is needed. `opencv_test_imgproc` passes 12926/12942 locally; the 16 failures are OpenCL warp/resize/remap tests that fail identically on unpatched `4.x` on this machine (Apple M1, one of them is #28384). Zero non-OpenCL failures. For well-conditioned input the change is a no-op to within machine epsilon — 5000 random histogram pairs agree with `numpy.corrcoef` to 8.7e-16.

### Credit

#29723 by @tribhu05 diagnosed the cancellation in #29706 first and was closed by its author before merging; the clamping in the first commit here follows that diagnosis.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
