### PR TITLE
imgproc: compute INTER_NEAREST_EXACT source indices exactly 

### DIFF
--- a/modules/imgproc/src/resize.cpp
+++ b/modules/imgproc/src/resize.cpp
@@ -1171,11 +1171,39 @@ resizeNN( const Mat& src, Mat& dst, double fx, double fy )
     }
 }
 
+// Source index sampled for output position i under INTER_NEAREST_EXACT.
+//
+// The sample sits at the centre of the destination pixel, (i + 0.5)*src/dst in
+// source coordinates, and the source pixel containing it is the one taken.
+// Evaluating that as a single exact integer division keeps each position
+// independent of the others. The previous code instead rounded src/dst into a
+// 16.16 fixed-point step and multiplied it by i, so the rounding error grew
+// along the axis: a 10 -> 1920 upscale placed 91 of its 100 blocks one pixel
+// off. Past roughly a 65536x upscale the step rounded to zero and the offset
+// went negative, and the resize then read in front of the row.
+//
+// A centre that lands exactly on a pixel boundary is a tie, resolved downwards
+// when the source length is odd - the convention the fixed-point code carried as
+// its -(src_len % 2) term. Pillow and scikit-image, which this mode is
+// documented to agree with, settle those ties in floating point and so cannot be
+// matched by any integer rule; every unambiguous position now agrees with them.
+//
+// See https://github.com/opencv/opencv/issues/27191
+static inline int resizeNN_bitexactIndex( int i, int src_len, int dst_len )
+{
+    const int64_t num = (int64_t)src_len * (2*(int64_t)i + 1);
+    const int64_t den = (int64_t)dst_len * 2;
+    int64_t s = num / den;
+    if( (src_len & 1) && num % den == 0 )
+        s--;
+    return (int)s;
+}
+
 class resizeNN_bitexactInvoker : public ParallelLoopBody
 {
 public:
-    resizeNN_bitexactInvoker(const Mat& _src, Mat& _dst, int* _x_ofse, int _ify, int _ify0)
-        : src(_src), dst(_dst), x_ofse(_x_ofse), ify(_ify), ify0(_ify0) {}
+    resizeNN_bitexactInvoker(const Mat& _src, Mat& _dst, int* _x_ofse)
+        : src(_src), dst(_dst), x_ofse(_x_ofse) {}
 
     virtual void operator() (const Range& range) const CV_OVERRIDE
     {
@@ -1184,7 +1212,7 @@ public:
         for( int y = range.start; y < range.end; y++ )
         {
             uchar* D = dst.ptr(y);
-            int _sy = (ify * y + ify0) >> 16;
+            int _sy = resizeNN_bitexactIndex(y, ssize.height, dsize.height);
             int sy = std::min(_sy, ssize.height-1);
             const uchar* S = src.ptr(sy);
 
@@ -1260,17 +1288,11 @@ private:
     const Mat& src;
     Mat& dst;
     int* x_ofse;
-    const int ify;
-    const int ify0;
 };
 
 static void resizeNN_bitexact( const Mat& src, Mat& dst, double /*fx*/, double /*fy*/ )
 {
     Size ssize = src.size(), dsize = dst.size();
-    int ifx = ((ssize.width << 16) + dsize.width / 2) / dsize.width; // 16bit fixed-point arithmetic
-    int ifx0 = ifx / 2 - ssize.width % 2;                       // This method uses center pixel coordinate as Pillow and scikit-images do.
-    int ify = ((ssize.height << 16) + dsize.height / 2) / dsize.height;
-    int ify0 = ify / 2 - ssize.height % 2;
 
     cv::utils::BufferArea area;
     int* x_ofse = 0;
@@ -1279,11 +1301,11 @@ static void resizeNN_bitexact( const Mat& src, Mat& dst, double /*fx*/, double /
 
     for( int x = 0; x < dsize.width; x++ )
     {
-        int sx = (ifx * x + ifx0) >> 16;
+        int sx = resizeNN_bitexactIndex(x, ssize.width, dsize.width);
         x_ofse[x] = std::min(sx, ssize.width-1);    // offset in element (not byte)
     }
     Range range(0, dsize.height);
-    resizeNN_bitexactInvoker invoker(src, dst, x_ofse, ify, ify0);
+    resizeNN_bitexactInvoker invoker(src, dst, x_ofse);
     parallel_for_(range, invoker, dst.total()/(double)(1<<16));
 }
 

--- a/modules/imgproc/test/test_resize_bitexact.cpp
+++ b/modules/imgproc/test/test_resize_bitexact.cpp
@@ -240,4 +240,65 @@ TEST(Resize_Bitexact, Nearest8U)
     }
 }
 
+// See https://github.com/opencv/opencv/issues/27191
+//
+// An integer scale factor leaves no room for interpretation: every source pixel
+// must become a solid k x k block. The index used to be built from a 16.16
+// fixed-point step multiplied by the destination coordinate, so the rounding
+// error in that step accumulated along the axis and eventually crossed a whole
+// source pixel - a 10 -> 1920 upscale placed 91 of its 100 blocks one off.
+TEST(Resize_Bitexact, Nearest8U_integerScale_27191)
+{
+    for (int srcLen : {1, 2, 3, 5, 8, 10, 17})
+    {
+        Mat src(srcLen, srcLen, CV_8UC1);
+        for (int y = 0; y < srcLen; y++)
+            for (int x = 0; x < srcLen; x++)
+                src.at<uchar>(y, x) = (uchar)((y*srcLen + x) & 0xFF);
+
+        for (int k : {2, 3, 7, 64, 192, 257})
+        {
+            Mat calc;
+            resize(src, calc, Size(srcLen*k, srcLen*k), 0, 0, INTER_NEAREST_EXACT);
+
+            Mat expected(srcLen*k, srcLen*k, CV_8UC1);
+            for (int y = 0; y < srcLen*k; y++)
+                for (int x = 0; x < srcLen*k; x++)
+                    expected.at<uchar>(y, x) = src.at<uchar>(y/k, x/k);
+
+            EXPECT_EQ(cvtest::norm(calc, expected, cv::NORM_INF), 0)
+                << "source " << srcLen << "x" << srcLen << " scaled by " << k;
+        }
+    }
+}
+
+// See https://github.com/opencv/opencv/issues/27191
+//
+// Beyond roughly a 65536x upscale the fixed-point step rounded down to zero and
+// the starting offset went negative, so every column resolved to source index -1
+// and the resize read in front of the row. A one pixel wide source stretched
+// that far has to come back as that one pixel.
+TEST(Resize_Bitexact, Nearest8U_extremeUpscale_27191)
+{
+    for (int dstWidth : {66000, 100000, 200000})
+    {
+        Mat src(1, 1, CV_8UC1, Scalar(200));
+        Mat calc;
+        resize(src, calc, Size(dstWidth, 1), 0, 0, INTER_NEAREST_EXACT);
+
+        double lo = 0, hi = 0;
+        cv::minMaxLoc(calc, &lo, &hi);
+        EXPECT_EQ(lo, 200.0) << "width " << dstWidth;
+        EXPECT_EQ(hi, 200.0) << "width " << dstWidth;
+    }
+
+    // and the same along the other axis
+    Mat src(1, 1, CV_8UC1, Scalar(37)), calc;
+    resize(src, calc, Size(1, 100000), 0, 0, INTER_NEAREST_EXACT);
+    double lo = 0, hi = 0;
+    cv::minMaxLoc(calc, &lo, &hi);
+    EXPECT_EQ(lo, 37.0);
+    EXPECT_EQ(hi, 37.0);
+}
+
 }} // namespace


### PR DESCRIPTION
Fixes #27191

`resizeNN_bitexact` rounds `src/dst` into a 16.16 fixed-point step and then multiplies that step by the destination coordinate:

```cpp
int ifx  = ((ssize.width << 16) + dsize.width / 2) / dsize.width;
int ifx0 = ifx / 2 - ssize.width % 2;
int sx   = (ifx * x + ifx0) >> 16;
```

The rounding error in `ifx` accumulates along the axis, so far enough out the wrong source pixel is picked. For the reported 10x10 -> 1920x1920 case (`ifx` is 341 where the exact step is 341.333) the drift reaches a whole source pixel by x = 576, and **91 of the 100 blocks land one pixel off** — even though an integer scale factor leaves nothing to interpret. `INTER_NEAREST` gets all 100 right.

### A second, sharper failure

Past roughly a 65536x upscale `ifx` rounds down to zero. `ifx0` is then `-(src_len % 2)`, so every coordinate resolves to source index `-1`, and since the index is only clamped from above the resize reads in front of the row:

```python
src = np.full((1,1), 200, np.uint8)
cv2.resize(src, (200000,1), interpolation=cv2.INTER_NEAREST_EXACT)
# -> all zeros; the single source pixel never appears
```

`3 -> 1000000` behaves the same way. This is an out-of-bounds read, so I have written a test for it alongside the precision one.

### The change

Each position's index is computed from its own exact integer division, so nothing accumulates and the result cannot go negative:

```cpp
const int64_t num = (int64_t)src_len * (2*(int64_t)i + 1);
const int64_t den = (int64_t)dst_len * 2;
int64_t s = num / den;
if( (src_len & 1) && num % den == 0 )
    s--;
```

The centre-sampling convention and the odd-length tie-breaking are unchanged — that `- (src_len % 2)` term is preserved as the `num % den == 0` case — so the hand-written expectations in `Resize_Bitexact.Nearest8U` still hold unmodified.

### Agreement with Pillow

This mode is documented to match Pillow and scikit-image, so I compared against `PIL.Image.Resampling.NEAREST` over 503184 sampled destination cells:

| | disagreements with Pillow |
|---|---|
| before | 2855 (0.567%) |
| after | **50** (0.010%) |

2828 cells are corrected. 23 change the other way, and **all 50 remaining disagreements are positions whose sample centre lands exactly on a pixel boundary** — there are zero non-tie disagreements left. Pillow settles those ties in floating point, so no integer rule reproduces them; I kept OpenCV's existing convention rather than chase that. For what it is worth, "always step down at a tie" would disagree with Pillow on 99.2% of tie cells, against 0.8% for the current convention.

### Performance

Median of 11 runs, Apple M1, RelWithDebInfo, NEON, microseconds:

| case | before | after |
|---|---|---|
| 720p x0.25 8UC1 | 15.5 – 21.0 | 15.6 – 21.6 |
| 720p x0.5 8UC3 | 89.3 – 106.9 | 90.8 – 90.9 |
| 1080p x2.0 8UC1 | 433 – 466 | 419 – 425 |
| 1080p x0.5 8UC4 | 81.8 – 89.5 | 81.9 – 84.1 |
| 10 -> 1920 | 232 – 264 | 218 – 225 |
| 64 -> 96 | 2.506 – 2.537 | 2.519 – 2.524 |
| 8x8 -> 8192x8 | 15.2 – 16.0 | **19.5 – 19.8** |

The perf-test shapes are unchanged or slightly better. The exception is a destination far wider than it is tall, where the per-column index setup rather than the pixel copying dominates: about a quarter more there. I tried carrying the index forward incrementally to avoid the per-column division, but it was worse (27.8us) — the loop-carried dependency costs more than the independent divisions, which pipeline freely. I kept the straightforward form since it is also the easier one to check.

### Tests

Two tests in `test_resize_bitexact.cpp`, both confirmed to fail before this change and pass after:

- `Nearest8U_integerScale_27191` — source sizes 1..17 at scale factors up to 257 must produce solid k x k blocks. Fails on current 4.x for 5x5, 8x8, 10x10 and 17x17 at 192x.
- `Nearest8U_extremeUpscale_27191` — a 1x1 source stretched to 66000/100000/200000, on both axes, must come back as that pixel. Fails on current 4.x with `lo = 0`.

`opencv_test_imgproc` passes 12925/12941 locally; the 16 failures are OpenCL warp/resize/remap tests that fail identically on unpatched 4.x on this machine (Apple M1, one of them is #28384). No new test data, so no `opencv_extra` patch.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [x] The feature is well documented and sample code can be built with the project CMake
