### PR TITLE
DNN: allow smaller GatherElements dimensions outside the axis 🤖🤖🤖

### DIFF
--- a/modules/dnn/src/layers/gather_elements_layer.cpp
+++ b/modules/dnn/src/layers/gather_elements_layer.cpp
@@ -52,7 +52,8 @@ public:
         CV_CheckLT(normalized_axis, static_cast<int>(data.size()), "GatherElements: axis out of range");
         for (size_t i = 0; i < data.size(); i++) {
             if (i != normalized_axis) {
-                CV_CheckEQ(data[i], indices[i], "GatherElements: shape mismatched");
+                CV_CheckLE(indices[i], data[i],
+                           "GatherElements: indices shape must not exceed data shape outside axis");
             }
         }
 

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -289,6 +289,88 @@ TEST(Layer_Test_Reshape, Accuracy)
     }
 }
 
+static Mat runGatherElementsLayer(const Mat& data, const Mat& indices, int axis)
+{
+    LayerParams params;
+    params.set("axis", axis);
+    Ptr<Layer> layer = LayerFactory::createLayerInstance("GatherElements", params);
+
+    std::vector<Mat> inputs{data.clone(), indices.clone()};
+    std::vector<MatShape> inputShapes{shape(inputs[0]), shape(inputs[1])};
+    std::vector<MatShape> outputShapes, internalShapes;
+    layer->getMemoryShapes(inputShapes, 0, outputShapes, internalShapes);
+
+    CV_Assert(outputShapes.size() == 1);
+    std::vector<Mat> outputs{Mat(outputShapes[0], data.type())};
+    std::vector<Mat> internals;
+    for (size_t i = 0; i < internalShapes.size(); ++i)
+        internals.push_back(Mat(internalShapes[i], data.type()));
+
+    layer->finalize(inputs, outputs);
+    layer->forward(inputs, outputs, internals);
+    return outputs[0];
+}
+
+TEST(Layer_Test_GatherElements, SmallerNonAxisDimensionsNonInnermostAxis)
+{
+    Mat data({2, 4, 3}, CV_32S);
+    int32_t* dataPtr = data.ptr<int32_t>();
+    for (size_t i = 0; i < data.total(); ++i)
+        dataPtr[i] = static_cast<int32_t>(i);
+
+    Mat indices({1, 3, 2}, CV_32S);
+    int32_t* indicesPtr = indices.ptr<int32_t>();
+    indicesPtr[0] = 3;
+    indicesPtr[1] = 0;
+    indicesPtr[2] = 1;
+    indicesPtr[3] = 2;
+    indicesPtr[4] = 0;
+    indicesPtr[5] = 3;
+
+    Mat output = runGatherElementsLayer(data, indices, 1);
+    EXPECT_EQ(shape(1, 3, 2), shape(output));
+
+    const int32_t expected[] = {9, 1, 3, 7, 0, 10};
+    const int32_t* outputPtr = output.ptr<int32_t>();
+    ASSERT_EQ(sizeof(expected) / sizeof(expected[0]), output.total());
+    for (size_t i = 0; i < output.total(); ++i)
+        EXPECT_EQ(expected[i], outputPtr[i]);
+}
+
+TEST(Layer_Test_GatherElements, SmallerNonAxisDimensionsInnermostAxis)
+{
+    Mat data({2, 3, 4}, CV_32S);
+    int32_t* dataPtr = data.ptr<int32_t>();
+    for (size_t i = 0; i < data.total(); ++i)
+        dataPtr[i] = static_cast<int32_t>(i);
+
+    Mat indices({1, 2, 3}, CV_32S);
+    int32_t* indicesPtr = indices.ptr<int32_t>();
+    indicesPtr[0] = 3;
+    indicesPtr[1] = 0;
+    indicesPtr[2] = 1;
+    indicesPtr[3] = 2;
+    indicesPtr[4] = 3;
+    indicesPtr[5] = 0;
+
+    Mat output = runGatherElementsLayer(data, indices, 2);
+    EXPECT_EQ(shape(1, 2, 3), shape(output));
+
+    const int32_t expected[] = {3, 0, 1, 6, 7, 4};
+    const int32_t* outputPtr = output.ptr<int32_t>();
+    ASSERT_EQ(sizeof(expected) / sizeof(expected[0]), output.total());
+    for (size_t i = 0; i < output.total(); ++i)
+        EXPECT_EQ(expected[i], outputPtr[i]);
+}
+
+TEST(Layer_Test_GatherElements, RejectsOversizedNonAxisDimension)
+{
+    Mat data({1, 2, 3}, CV_32S);
+    Mat indices({1, 3, 3}, CV_32S);
+
+    EXPECT_THROW(runGatherElementsLayer(data, indices, 2), cv::Exception);
+}
+
 TEST_P(Test_Caffe_layers, BatchNorm)
 {
     testLayerUsingCaffeModels("layer_batch_norm", true);


### PR DESCRIPTION
Fixes #29826

### Summary

`GatherElementsLayerImpl::getMemoryShapes()` currently requires `data` and `indices` to have equal sizes in every dimension other than `axis`. The ONNX coordinate equations are compatible with an indices dimension being smaller in those positions, and ONNX Runtime implements that behavior.

This patch changes the non-axis validation from:

```cpp
data[i] == indices[i]
```

to:

```cpp
indices[i] <= data[i]
```

The output shape remains the indices shape. Oversized indices dimensions outside `axis` remain invalid.

### Compatibility basis and specification caveat

- The [ONNX GatherElements schema](https://onnx.ai/onnx/operators/onnx__GatherElements.html) explicitly requires equal ranks, makes the output shape equal to the `indices` shape, and defines output values with coordinate equations. It does not separately state either equality or a non-axis `<=` rule. The `<=` bound is the shape-level condition implied by applying those equations to every non-empty output coordinate.
- The original ONNX proposal [onnx/onnx#2143](https://github.com/onnx/onnx/pull/2143) says GatherElements aligns with PyTorch Gather. The [`torch.gather` documentation](https://docs.pytorch.org/docs/stable/generated/torch.gather.html) explicitly documents `index.size(d) <= input.size(d)` outside the gather dimension.
- ONNX Runtime's [CPU shape validation](https://github.com/microsoft/onnxruntime/blob/e79a40aa7d80a99764b9384f256a855abb4171ee/onnxruntime/core/providers/cpu/tensor/gather_elements.cc#L156-L187) implements that `<=` rule. ONNX Runtime 1.24.3 accepts the first positive regression case and returns the same expected values.
- One implementation differs: ONNX's current Python [ReferenceEvaluator helper](https://github.com/onnx/onnx/blob/3ab9181bbe2bb73cfd9ab88d4bdb8fad539d59b3/onnx/reference/ops/op_gather_elements.py#L18-L25) requires equality outside `axis` and rejects the same case. This PR follows ONNX Runtime, PyTorch, the schema's coordinate semantics, and the real exported model; it does not claim that the ONNX schema explicitly spells out `<=`.
- OpenCV's optional OpenVINO path constructs `ov::op::v6::GatherElements`; the published [OpenVINO GatherElements-6 contract](https://docs.openvino.ai/2023.3/openvino_docs_ops_movement_GatherElements_6.html) describes equal non-axis shapes. The tests and compatibility claim here cover the native OpenCV CPU implementation. OpenVINO fallback/compatibility for this shape case remains a review item.

The existing OpenCV forward implementation already derives non-axis coordinates from the indices shape. Regression coverage exercises both native CPU branches (innermost and non-innermost `axis`); no kernel rewrite is needed.

### Changes

- Relax the non-axis shape check in `modules/dnn/src/layers/gather_elements_layer.cpp`.
- Add in-memory `CV_32S` regression tests in `modules/dnn/test/test_layers.cpp` for:
  - smaller non-axis dimensions when `axis` is not the innermost dimension;
  - smaller non-axis dimensions when `axis` is the innermost dimension;
  - rejection when an indices dimension is larger than the data dimension outside `axis`.

No external test data or `opencv_extra` change is needed.

### Real-world validation case

The public [DEIMv2-HGNetV2-N Wholebody49 model](https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment/releases/download/weights/deimv2_hgnetv2_n_wholebody49_ins_s08_maskhead64x2_center_1240query_masks.onnx) used by the [HRFFA demo](https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment/blob/add0c37fc46cc52fac169d7270c0cdc3097b2f90/demo/demo_hrffa_onnx.py) contains node `/model/decoder/GatherElements` with:

```text
data       FLOAT [1, 2000, 4]
indices    INT64 [1, 1240, 1]
axis       1
output           [1, 1240, 1]
```

The model release records SHA-256 `a40c0e9aeb9869364921abc6376a143436486a72d279c80ca1db33e3d5aef9c3`. Its non-axis dimensions satisfy `1 <= 1` and `1 <= 4`; the old equality check rejects the final pair.

This is validation of the shape case. The model is not added as test data, and this focused PR does not claim to address other operators or complete end-to-end model support.

### Tested revisions

- OpenCV `4.x` base: [`755546643a671420fae0c20ec5d4cd24a228da8e`](https://github.com/opencv/opencv/commit/755546643a671420fae0c20ec5d4cd24a228da8e)
- `opencv_extra` `4.x`: [`67aac02d4d8d2ae1e252ae253a341732d150879d`](https://github.com/opencv/opencv_extra/commit/67aac02d4d8d2ae1e252ae253a341732d150879d)
- Current OpenCV `5.x` source inspected: [`390c4fdcb9fea6e58fb635bf88277f2a51e8d4b3`](https://github.com/opencv/opencv/commit/390c4fdcb9fea6e58fb635bf88277f2a51e8d4b3)
- Supplemental `5.x` integration-test base: open PR [#29594](https://github.com/opencv/opencv/pull/29594) head [`c511ff06f25c68467b38f39995da04a513fb3a3d`](https://github.com/opencv/opencv/commit/c511ff06f25c68467b38f39995da04a513fb3a3d)
- HRFFA source inspected at [`add0c37fc46cc52fac169d7270c0cdc3097b2f90`](https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment/commit/add0c37fc46cc52fac169d7270c0cdc3097b2f90)

### Test results

#### macOS isolated `4.x` patch

Platform: macOS 26.6.2 / Darwin 25.6.0 arm64, Apple Clang `21.0.0.21000101`, Release build. The worktree contained only the intended two-file diff and passed `git diff --check`.

Focused regression tests:

```text
Filter: Layer_Test_GatherElements.*
3 tests from 1 test case ran
3 passed
```

Complete DNN test suite using the `4.x` OpenCV and `opencv_extra` revisions above:

```text
5,625 tests registered
5,610 tests run
5,610 passed
15 disabled
0 failures
```

Command form:

```bash
OPENCV_TEST_DATA_PATH="$OPENCV_EXTRA_4X/testdata" \
  "$BUILD_DIR/bin/opencv_test_dnn"
```

The default OpenCV test configuration emitted 1,788 internal skip markers within cases that GoogleTest records as passed. The totals above are the exact GoogleTest summary.

#### Linux isolated `4.x` patch

Platform: Ubuntu 24.04.4 LTS, kernel `6.17.0-40-generic`, x86_64, Intel Core i7-6850K (6 cores / 12 threads), GCC 13.3.0, CMake 3.28.3, Ninja 1.11.1, Release CPU build. The build and full-suite test thread pool were capped at five; the focused-test XML reported OpenCV's default 12 test threads.

The separate worktree used the same OpenCV and `opencv_extra` SHAs, contained only the intended two-file diff, and passed `git diff --check`:

```text
Focused GatherElements tests: 3/3 passed
Full opencv_test_dnn: 8,336/8,336 executed tests passed
Disabled: 22
Failures/errors: 0
```

The macOS and Linux full-suite totals differ because their build configurations enable different test sets; every test executed in each configuration passed.

macOS whitespace validation (the Linux worktree also passed the same check):

```text
git diff --check
# no output
```

#### macOS supplemental `5.x` integration check

Forward-port check in the combined OpenCV `5.1.0-dev` integration tree based on open PR #29594 head `c511ff06f25c68467b38f39995da04a513fb3a3d`:

```text
Target opencv_test_dnn built successfully
Filter: Layer_Test_GatherElements.*
3 tests run
3 passed
```

Only the focused tests were run for this forward-port. The tree also contained the changes from PR #29594 and other local HRFFA work, so this is neither an isolated result nor a test of current `5.x`; it does not claim a complete `5.x` suite result.

#### Linux supplemental current-`5.x` integration check

A separate Ubuntu 24.04.4 LTS Release CPU build used current `5.x` commit `390c4fdcb9fea6e58fb635bf88277f2a51e8d4b3`, `opencv_extra` PR #1406 head `617ffb9ad4ec4c5f391343226b63dd894214b24c`, and the combined GatherElements, MatMul, and Einsum candidate patch. The combined patch ID was `c8663c1af866630f10feb6d1a727fb245589a080`, matching the local combined patch exactly.

```text
Five new regressions (3 GatherElements + 1 MatMul + 1 Einsum): 5/5 passed
GatherElements/MatMul/Einsum family selection: 891/891 passed
Full opencv_test_dnn: 12,972/12,972 executed tests passed
XML total: 12,973, including 1 disabled
Failures/errors: 0
```

This verifies the GatherElements change in the combined current-`5.x` integration tree; it is not an isolated GatherElements result. Its larger full-suite total reflects the Linux `5.x` build configuration and enabled test set.

### Scope and risk

The change only relaxes shape validation to the condition implied by the operator's coordinate semantics. It does not alter index-value handling, supported data types, backend-specific kernels or selection, public APIs, or performance-sensitive loops. The added negative test preserves rejection of oversized off-axis indices shapes. The new accuracy tests exercise the native CPU implementation; backend-specific execution was not separately tested for this shape case.

### Related work

- [#24092](https://github.com/opencv/opencv/pull/24092): original GatherElements implementation.
- [#29786](https://github.com/opencv/opencv/pull/29786): `5.x` data-type support expansion.
- [#26112](https://github.com/opencv/opencv/issues/26112): closed broad tracker for new-engine layer implementations; not a duplicate of this bug.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (`4.x`).
- [x] There is a reference to the original bug report and related work.
      The original bug report is linked above and related work is linked in this description.
- [x] There is an accuracy test, performance test and test data in the `opencv_extra` repository, if applicable.
      Three in-memory accuracy tests are included. No performance test or external test data is applicable to this validation-only change.
- [x] The feature is well documented and sample code can be built with the project CMake.
      Not applicable to a private shape-validation bug fix with no public API, feature or sample change.
