### PR TITLE
DNN: reset Einsum shape state when operand dimensions change 🤖🤖🤖

### DIFF
--- a/modules/dnn/src/layers/einsum_layer.cpp
+++ b/modules/dnn/src/layers/einsum_layer.cpp
@@ -380,6 +380,27 @@ public:
     mutable bool outputShapeComputed;
     mutable MatShape cachedOutputShape;
 
+    // Equation parsing maps labels to concrete dimensions, so every derived
+    // table must be rebuilt together when any operand shape changes.
+    void resetShapeState()
+    {
+        einsumInpShapes.clear();
+        preProcessedInputs.clear();
+        homogenizedInputDims.clear();
+        einsumOutDims.clear();
+        inputSubscriptIndices.clear();
+        subscriptIndicesToLastInput.clear();
+        subscriptIndicesToDimValue.clear();
+        subscriptIndicesToOutputIndices.clear();
+        letter2count.fill(0);
+        letter2index.fill(-1);
+        numLetterIndices = 0;
+        numOfEllipsisDims = 0;
+        numInputs = 0;
+        cachedOutputShape.clear();
+        outputShapeComputed = false;
+    }
+
     void parseEquation(String equation);
     void processEquation(const std::vector<MatShape>& inputs);
     void processBroadcastedDims();
@@ -404,12 +425,13 @@ public:
     );
 
     void computeOutputShape(const std::vector<MatShape>& inputs) const {
-        if (!outputShapeComputed) {
-            // Copy of the existing computation logic
-            const_cast<LayerEinsumImpl*>(this)->processEquation(inputs);
-            const_cast<LayerEinsumImpl*>(this)->processBroadcastedDims();
-            const_cast<LayerEinsumImpl*>(this)->validateOutputSubscript();
-            const_cast<LayerEinsumImpl*>(this)->calculateOutputShape();
+        if (!outputShapeComputed || inputs != einsumInpShapes) {
+            LayerEinsumImpl* self = const_cast<LayerEinsumImpl*>(this);
+            self->resetShapeState();
+            self->processEquation(inputs);
+            self->processBroadcastedDims();
+            self->validateOutputSubscript();
+            self->calculateOutputShape();
 
             cachedOutputShape = einsumOutDims;
             outputShapeComputed = true;
@@ -471,19 +493,6 @@ public:
     {
         CV_UNUSED(requiredOutputs);
         CV_UNUSED(internals);
-
-        // check if input einsumInputShapes is empty
-        if (einsumInpShapes.empty()) {
-            outputShapeComputed = false;
-        } else {
-            // check weather shapes in inputs are compatible with shapes in einsumInpShapes
-            for (int i = 0; i < inputs.size(); i++) {
-                if (inputs[i] != einsumInpShapes[i]) {
-                    outputShapeComputed = false;
-                    break;
-                }
-            }
-        }
 
         computeOutputShape(inputs);
 

--- a/modules/dnn/test/test_layers_1d.cpp
+++ b/modules/dnn/test/test_layers_1d.cpp
@@ -1659,5 +1659,30 @@ INSTANTIATE_TEST_CASE_P(/*nothing*/, Layer_Einsum_Test, testing::Values(
     std::make_tuple(std::vector<int>({4, 4}), std::vector<int>({4, 4}), "ij,ij->i")
     ));
 
+TEST(Layer_Einsum, DynamicLeadingDimensionReusesLayer)
+{
+    LayerParams lp;
+    lp.type = "Einsum";
+    lp.name = "dynamic_leading_dimension";
+    lp.set("equation", "mc,mchw->mhw");
+    Ptr<Layer> layer = EinsumLayer::create(lp);
+
+    const int channels = 3, height = 2, width = 2;
+    const int leadingDimensions[] = {2, 5, 2};
+    for (const int leadingDimension : leadingDimensions)
+    {
+        Mat coefficients(MatShape{leadingDimension, channels}, CV_32F, Scalar::all(1));
+        Mat features(MatShape{leadingDimension, channels, height, width}, CV_32F, Scalar::all(2));
+        std::vector<Mat> inputs{coefficients, features}, outputs;
+
+        runLayer(layer, inputs, outputs);
+
+        ASSERT_EQ(outputs.size(), (size_t)1);
+        EXPECT_EQ(shape(outputs[0]), MatShape({leadingDimension, height, width}));
+        Mat expected(MatShape{leadingDimension, height, width}, CV_32F, Scalar::all(6));
+        normAssert(outputs[0], expected);
+    }
+}
+
 
 }}


### PR DESCRIPTION
Fixes #29827

Target branch: `5.x`

### What this fixes

`LayerEinsumImpl` cached both its output shape and the intermediate tables produced while parsing an equation against concrete operand shapes. When a reused layer received different shapes, `getMemoryShapes()` invalidated only `outputShapeComputed`. The old input shapes, homogenized dimensions, output dimensions, subscript mappings, and counters remained populated.

Calling `processEquation()` again then mixed the new operands with the previous inference's dimension values. A real DEIMv2 detector demonstrates the problem with:

```text
equation: mc,mchw->mhw
first image:  [50, 192] x [50, 192, 80, 80]
second image: [114, 192] x [114, 192, 80, 80]
```

The leading dimension is content-dependent because it comes from upstream `NonZero` and `Gather` nodes. The first image succeeds, but the second image on the same `Net` fails in `processEquation()` when the new `m = 114` is compared with cached `m = 50`.

### Change

- Add one `resetShapeState()` method that clears every value derived from operand shapes:
  - recorded input shapes and preprocessed inputs;
  - homogenized input and output dimensions;
  - input-subscript and subscript-mapping vectors;
  - letter counts/indices and unique-letter, ellipsis, and input counts;
  - cached output shape and its validity flag.
- Make `computeOutputShape()` compare current operands with `einsumInpShapes`, reset all derived state when they differ, and then rebuild the equation state and output shape from the new shapes.
- Remove the partial invalidation loop from `getMemoryShapes()`.

The check belongs in `computeOutputShape()` because both `getMemoryShapes()` and `getFLOPS()` use it and require state derived from the current shapes.

Same-shape calls keep the existing cached fast path. Reprocessing occurs only after a real operand-shape transition, where rebuilding the derived tables is required for correctness.

### Regression test

The in-memory test creates one `EinsumLayer` for the production equation and runs it with leading dimensions `2 -> 5 -> 2`:

```cpp
TEST(Layer_Einsum, DynamicLeadingDimensionReusesLayer)
{
    LayerParams lp;
    lp.type = "Einsum";
    lp.name = "dynamic_leading_dimension";
    lp.set("equation", "mc,mchw->mhw");
    Ptr<Layer> layer = EinsumLayer::create(lp);

    const int channels = 3, height = 2, width = 2;
    const int leadingDimensions[] = {2, 5, 2};
    for (const int leadingDimension : leadingDimensions)
    {
        Mat coefficients(MatShape{leadingDimension, channels},
                         CV_32F, Scalar::all(1));
        Mat features(MatShape{leadingDimension, channels, height, width},
                     CV_32F, Scalar::all(2));
        std::vector<Mat> inputs{coefficients, features}, outputs;

        runLayer(layer, inputs, outputs);

        ASSERT_EQ(outputs.size(), (size_t)1);
        EXPECT_EQ(shape(outputs[0]),
                  MatShape({leadingDimension, height, width}));
        Mat expected(MatShape{leadingDimension, height, width},
                     CV_32F, Scalar::all(6));
        normAssert(outputs[0], expected);
    }
}
```

This covers growth, shrinkage, and returning to a previously used shape on the same layer. It needs no ONNX file, model weights, images, or `opencv_extra` change.

### Validation

Target base at validation time: OpenCV `5.x` at `390c4fdcb9fea6e58fb635bf88277f2a51e8d4b3`.

Isolated-patch platform: macOS 26.6.2 / Darwin 25.6.0 arm64, Apple M5 Pro, AppleClang `21.0.0.21000101`, CMake 3.29.3, Release source build.

#### Isolated two-file patch

```sh
build/bin/opencv_test_dnn \
  --gtest_filter=Layer_Einsum.DynamicLeadingDimensionReusesLayer \
  --test_threads=1
# 1/1 passed

OPENCV_TEST_DATA_PATH=/path/to/opencv_extra/testdata \
build/bin/opencv_test_dnn \
  '--gtest_filter=Test_GetFLOPS.Einsum*:Layer_Einsum.*:Layer_Einsum_Test.*:Test_ONNX_layers.Einsum*' \
  --test_threads=1
# 40/40 passed: 2 FLOPS + 1 regression + 13 direct + 24 importer

OPENCV_TEST_DATA_PATH=/path/to/opencv_extra/testdata \
build/bin/opencv_test_dnn \
  '--gtest_filter=Test_ONNX_conformance.Layer_Test/test_einsum_*' \
  --test_threads=1 \
  --test_tag_enable=dnn_skip_onnx_conformance
# 12/12 passed
```

`git diff --check` also passed. The isolated diff changes only:

- `modules/dnn/src/layers/einsum_layer.cpp`
- `modules/dnn/test/test_layers_1d.cpp`

#### macOS full DNN integration suite

The broader validation build included this fix and independent GatherElements/MatMul work. It used the test data from opencv/opencv_extra#1406 at exact head `617ffb9ad4ec4c5f391343226b63dd894214b24c`:

```sh
OPENCV_TEST_DATA_PATH=/path/to/opencv_extra-pr1406/testdata \
build/bin/opencv_test_dnn \
  --gtest_output=xml:/tmp/opencv-dnn-full.xml
```

- 9,052/9,052 enabled tests passed across 147 test cases.
- XML summary: 9,053 total entries, 1 disabled, 0 failures, 0 errors.

This is supplemental integration evidence; the 1 + 40 + 12 focused results above are from the isolated patch on the current `5.x` head.

#### Linux combined integration suite

A separate Ubuntu 24.04.4 LTS, kernel `6.17.0-40-generic`, x86_64 Intel Core i7-6850K Release CPU build used current `5.x` commit `390c4fdcb9fea6e58fb635bf88277f2a51e8d4b3`, `opencv_extra` PR #1406 head `617ffb9ad4ec4c5f391343226b63dd894214b24c`, and the combined Einsum, GatherElements, and MatMul candidate patch. The combined patch ID was `c8663c1af866630f10feb6d1a727fb245589a080`, exactly matching the local combined patch.

```text
Five new regressions (1 Einsum + 3 GatherElements + 1 MatMul): 5/5 passed
GatherElements/MatMul/Einsum family selection: 891/891 passed
Full opencv_test_dnn: 12,972/12,972 executed tests passed
XML total: 12,973, including 1 disabled
Failures/errors: 0
```

The Linux result is supplemental combined-patch evidence, not an isolated Einsum result. It used GCC 13.3.0, CMake 3.28.3, and Ninja 1.11.1. Its larger full-suite total reflects the Linux build configuration and enabled test set.

The source-built Python 3.12.3 binding reported OpenCV `5.1.0-dev` and `cv2.dnn.ENGINE_OPENCV == 1`. The same combined build passed full HRFFA validation:

- 10/10 ONNX models and 18/18 deterministic cases passed.
- One detector was reused in `Lena -> Messi -> Basketball` order.
- OpenCV and ONNX Runtime each produced 1, 9, and 2 real-image heads: 12/12 semantic matches.
- Minimum detection IoU: `0.9999981671`.
- Maximum box-coordinate error: `0.000152588 px`; maximum score error: `2.16365e-5`.
- Maximum landmark error: `0.00915805 px`; worst per-head mean: `0.00455846 px`.
- Visibility agreement: 100%.

#### macOS reused detector and HRFFA integration

Before this change, one native `ENGINE_OPENCV` detector `Net` failed on the `Lena -> Messi` transition (`m: 50 -> 114`). After this change, the same object completed the preserved harness order `Lena -> Messi -> Basketball`.

The complete CPU validation used the [High-Angle Robust Fast FaceAlignment](https://github.com/PINTO0309/High-Angle_Robust_Fast_FaceAlignment) models, Python 3.13.2, separate ONNX Runtime 1.24.3 references, and explicit native `cv2.dnn.ENGINE_OPENCV` (enum `1`, not the ORT-delegating engine `2`):

```sh
PYTHONPATH=/path/to/source-build/lib/python3 \
python3.13 validate_hrffa.py \
  --mode full \
  --expected-cv2-path /path/to/source-build
```

- 10/10 ONNX models passed, covering 18/18 deterministic synthetic cases.
- All 16 HRFFA aligner cases passed raw `allclose` and exact visibility `argmax` agreement.
- In the end-to-end phase, one detector and one default VITT aligner per backend were reused in order for `lena.jpg`, `messi5.jpg`, and `basketball1.png`.
- OpenCV and ONNX Runtime both produced 1, 9, and 2 heads respectively: 12/12 semantic matches.
- Minimum detection IoU: `0.999996869`.
- Maximum box-coordinate error: `0.000320435 px`.
- Maximum landmark error: `0.209564 px`; worst per-head mean: `0.0840808 px`.
- Visibility agreement: 100%.

The full model validation also relies on separate GatherElements and MatMul fixes. It is included as end-to-end integration coverage; the reused-Net failure and the data-free regression isolate the Einsum cache defect addressed here. No model weights are added to OpenCV tests.

### Related work

Duplicate searches found no existing issue or PR for shape-state invalidation on a reused Einsum layer. #25077/#25100, #26193, #28563, #29418, and #26059 address different equation, scalar/1-D, bounds, or allocation defects.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (`5.x`).
- [x] There is a reference to the original bug report and related work. The original bug report is linked above and related work is linked in this description.
- [x] There is accuracy test, performance test and test data in `opencv_extra` repository, if applicable. This correctness regression is self-contained and data-free, so no `opencv_extra` patch or performance test applies.
- [x] The feature is well documented and sample code can be built with the project CMake. This is an internal bug fix with no public API, feature documentation, or sample-code change required.
