### PR TITLE
avoid PPL auto_partitioner on ARM64

### DIFF
--- a/modules/core/src/parallel.cpp
+++ b/modules/core/src/parallel.cpp
@@ -449,6 +449,18 @@ namespace {
             this->ParallelLoopBodyWrapper::operator()(cv::Range(i, i + 1));
         }
     };
+
+    // PPL's default auto_partitioner silently skips whole chunks of the range on
+    // ARM64 (unfixed MSVC bug, developercommunity.visualstudio.com/t/1027444).
+    template <typename Body>
+    static inline void pplParallelFor(int first, int last, const Body& body)
+    {
+#if defined(_M_ARM64) || defined(_M_ARM64EC)
+        Concurrency::parallel_for(first, last, body, Concurrency::static_partitioner());
+#else
+        Concurrency::parallel_for(first, last, body);
+#endif
+    }
 #else
     typedef ParallelLoopBodyWrapper ProxyLoopBody;
 #endif
@@ -593,18 +605,18 @@ static void parallel_for_impl(const cv::Range& range, const cv::ParallelLoopBody
 
 #elif defined WINRT
 
-        Concurrency::parallel_for(stripeRange.start, stripeRange.end, pbody);
+        pplParallelFor(stripeRange.start, stripeRange.end, pbody);
 
 #elif defined HAVE_CONCURRENCY
 
         if(!pplScheduler || pplScheduler->Id() == Concurrency::CurrentScheduler::Id())
         {
-            Concurrency::parallel_for(stripeRange.start, stripeRange.end, pbody);
+            pplParallelFor(stripeRange.start, stripeRange.end, pbody);
         }
         else
         {
             pplScheduler->Attach();
-            Concurrency::parallel_for(stripeRange.start, stripeRange.end, pbody);
+            pplParallelFor(stripeRange.start, stripeRange.end, pbody);
             Concurrency::CurrentScheduler::Detach();
         }
 


### PR DESCRIPTION
Backport of #29833 (5.x). Only the `parallel.cpp` change applies here: 4.x has no top-level ASM probe, so it needs no CMakeLists change.

With this PR and https://github.com/opencv/opencv/pull/29833  Windows ARM CI https://github.com/opencv/ci-gha-workflow/pull/273 can be enabled without OPENMP

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
