### PR TITLE
 promote NaryEltwise operands to a common type 

### DIFF
--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -185,6 +185,7 @@ public:
 class NaryEltwiseLayerImpl CV_FINAL : public NaryEltwiseLayer
 {
     NaryEltwiseHelper helper;
+    std::vector<Mat> convBufs;  // promoted operands, reused so forward() does not allocate
 public:
     std::string operation;
 
@@ -335,11 +336,116 @@ public:
         return outShape;
     }
 
+    // Rank within the type's own domain; 0 if typeDispatch has no arm for it.
+    static int conversionRank(int type)
+    {
+        switch (type)
+        {
+            case CV_8S: case CV_8U: return 1;
+            case CV_16S: case CV_16U: return 2;
+            case CV_32S: case CV_32U: return 3;
+            case CV_64S: case CV_64U: return 4;
+            case CV_32F: return 1;
+            case CV_64F: return 2;
+        }
+        return 0;
+    }
+
+    static bool isSignedInt(int type)
+    {
+        return type == CV_8S || type == CV_16S || type == CV_32S || type == CV_64S;
+    }
+
+    // Narrowest type representing every value of both operands; pairs without one are rejected.
+    static int commonArithType(int type0, int type1)
+    {
+        if (type0 == type1)
+            return type0;
+
+        int rank0 = conversionRank(type0), rank1 = conversionRank(type1);
+        bool isFloat0 = CV_IS_FLOAT_TYPE(type0) != 0, isFloat1 = CV_IS_FLOAT_TYPE(type1) != 0;
+
+        if (rank0 > 0 && rank1 > 0 && isFloat0 && isFloat1)
+        {
+            return rank0 > rank1 ? type0 : type1;
+        }
+
+        if (rank0 > 0 && rank1 > 0 && !isFloat0 && !isFloat1)
+        {
+            bool isSigned0 = isSignedInt(type0);
+            if (isSigned0 == isSignedInt(type1))
+                return rank0 > rank1 ? type0 : type1;
+
+            // Mixed sign: the signed result sits one rank above the unsigned operand; none past 64.
+            static const int signedTypes[] = { CV_8S, CV_16S, CV_32S, CV_64S };
+            int unsignedRank = isSigned0 ? rank1 : rank0;
+            int signedRank = isSigned0 ? rank0 : rank1;
+            int rank = std::max(unsignedRank + 1, signedRank);
+            if (rank <= 4)
+                return signedTypes[rank - 1];
+        }
+
+        // CV_32F is exact to 2^24 and CV_64F to 2^53: an 8- or 16-bit int keeps the float type,
+        // a 32-bit int forces CV_64F, and a 64-bit int is rejected below.
+        if (rank0 > 0 && rank1 > 0 && isFloat0 != isFloat1)
+        {
+            int intRank = isFloat0 ? rank1 : rank0;
+            if (intRank <= 2)
+                return isFloat0 ? type0 : type1;
+            if (intRank == 3)
+                return CV_64F;
+        }
+
+        CV_Error_(Error::StsBadArg, ("NaryEltwiseLayer: inputs of type %s and %s have no common type",
+                                     typeToString(type0).c_str(), typeToString(type1).c_str()));
+    }
+
+    static int findCommonType(const std::vector<MatType>& inputs)
+    {
+        int commonType = inputs[0];
+        for (size_t i = 1; i < inputs.size(); i++)
+            commonType = commonArithType(commonType, inputs[i]);
+        return commonType;
+    }
+
+    bool isComparison() const
+    {
+        return op == OPERATION::EQUAL || op == OPERATION::GREATER ||
+               op == OPERATION::GREATER_EQUAL || op == OPERATION::LESS ||
+               op == OPERATION::LESS_EQUAL;
+    }
+
+    // typeDispatch instantiates one kernel, so every operand must hold the returned type.
+    int promoteOperands(std::vector<Mat>& operands, const std::vector<Mat>& outputs)
+    {
+        int dispatchType = outputs.front().type();
+        // A comparison declares CV_Bool, so its output type is not the type the kernel computes in.
+        if (isComparison())
+        {
+            dispatchType = operands.front().type();
+            for (size_t i = 1; i < operands.size(); i++)
+                dispatchType = commonArithType(dispatchType, operands[i].type());
+        }
+
+        size_t firstOperand = op == OPERATION::WHERE ? 1 : 0;
+        convBufs.resize(operands.size());
+        for (size_t i = firstOperand; i < operands.size(); i++)
+        {
+            if (operands[i].type() == dispatchType)
+                continue;
+            operands[i].convertTo(convBufs[i], dispatchType);
+            operands[i] = convBufs[i];
+        }
+        return dispatchType;
+    }
+
     virtual void finalize(InputArrayOfArrays inputs_arr, OutputArrayOfArrays outputs_arr) CV_OVERRIDE {
         std::vector<Mat> inputs, outputs;
         inputs_arr.getMatVector(inputs);
         outputs_arr.getMatVector(outputs);
 
+        // helper.init() reads steps and elemsize off the Mats, so convert first.
+        promoteOperands(inputs, outputs);
         helper.init(inputs, outputs);
         CV_CheckTrue(helper.prepare_for_broadcast_op(), "NaryEltwiseLayer: Preparation for broadcasting failed");
     }
@@ -367,8 +473,7 @@ public:
         if (op == OPERATION::WHERE)
         {
             CV_CheckTypeEQ(inputs[0], CV_Bool, "");
-            CV_CheckTypeEQ(inputs[1], inputs[2], "");
-            outputs.assign(1, inputs[1]);
+            outputs.assign(1, commonArithType(inputs[1], inputs[2]));
             return;
         }
 
@@ -384,11 +489,8 @@ public:
         {
             CV_Assert(inputs.size());
             for (auto input : inputs)
-            {
-                CV_CheckTypeEQ(inputs[0], input, "All inputs should have equal types");
                 CV_CheckType(input, input == CV_8S || input == CV_8U || input == CV_16S || input == CV_16U || input == CV_32S || input == CV_32U || input == CV_64S || input == CV_64U, "");
-            }
-            outputs.assign(requiredOutputs, inputs[0]);
+            outputs.assign(requiredOutputs, findCommonType(inputs));
             return;
         }
 
@@ -431,17 +533,17 @@ public:
         CV_Assert(inputs.size());
         for (auto input : inputs)
         {
-            CV_CheckTypeEQ(inputs[0], input, "All inputs should have equal types");
             if (preferableTarget == DNN_TARGET_OPENCL_FP16)
                 CV_CheckType(input, input == CV_16F || input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U || input == CV_16S || input == CV_16U || input == CV_32S || input == CV_32U || input == CV_64S || input == CV_64U, "");
             else
                 CV_CheckType(input, input == CV_32F || input == CV_64F || input == CV_8S || input == CV_8U || input == CV_16S || input == CV_16U || input == CV_32S || input == CV_32U || input == CV_64S || input == CV_64U, "");
         }
+        int commonType = findCommonType(inputs);
 
-        if (op == OPERATION::EQUAL || op == OPERATION::GREATER || op == OPERATION::GREATER_EQUAL || op == OPERATION::LESS || op == OPERATION::LESS_EQUAL)
+        if (isComparison())
             outputs.assign(1, CV_Bool);
         else
-            outputs.assign(requiredOutputs, inputs[0]);
+            outputs.assign(requiredOutputs, commonType);
     }
 
     int getLayouts(const std::vector<DataLayout>& actualInputs,
@@ -934,6 +1036,7 @@ public:
         }
 
         std::vector<Mat> used_inputs = inputs;
+        int type_for_dispatch = promoteOperands(used_inputs, outputs);
 
         const Mat& out0 = outputs[0];
         bool needsCrop = false;
@@ -970,20 +1073,6 @@ public:
             CV_CheckTrue(helper.prepare_for_broadcast_op(), "NaryEltwiseLayer: Preparation for broadcasting failed");
         }
 
-        if (op == OPERATION::POW) {
-            CV_Assert(used_inputs.size() == 2);
-            const int out_type = outputs[0].type();
-            if (used_inputs[0].type() != out_type || used_inputs[1].type() != out_type) {
-                Mat a_conv, b_conv;
-                used_inputs[0].convertTo(a_conv, out_type);
-                used_inputs[1].convertTo(b_conv, out_type);
-                used_inputs = {a_conv, b_conv};
-                helper.init(used_inputs, outputs);
-                CV_CheckTrue(helper.prepare_for_broadcast_op(), "NaryEltwiseLayer: Preparation for broadcasting failed");
-            }
-        }
-
-        int type_for_dispatch = (op == OPERATION::WHERE || op == OPERATION::POW) ? outputs.front().type() : used_inputs.front().type();
         typeDispatch(type_for_dispatch, used_inputs.size(), used_inputs, outputs);
     }
 
@@ -1327,6 +1416,11 @@ public:
         auto context = reinterpret_cast<csl::CSLContext*>(context_);
         std::vector<cuda::GpuMatND> inputs;
         inputs_.getGpuMatNDVector(inputs);
+
+        // The CUDA executor asserts on an empty node, so mismatched types must error.
+        for (size_t i = 1; i < inputs.size(); i++)
+            CV_CheckTypeEQ(inputs[0].type(), inputs[i].type(),
+                           "NaryEltwiseLayer: CUDA requires equal input types");
 
         cuda4dnn::EltwiseOpType op_ = cuda4dnn::EltwiseOpType::SUM;
         switch (op) {

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -357,6 +357,34 @@ public:
     }
 
     // Narrowest type representing every value of both operands; pairs without one are rejected.
+    // Significand bits a float needs to hold every value of an integer type exactly.
+    static int intValueBits(int type)
+    {
+        switch (type)
+        {
+            case CV_8S:  return 7;
+            case CV_8U:  return 8;
+            case CV_16S: return 15;
+            case CV_16U: return 16;
+            case CV_32S: return 31;
+            case CV_32U: return 32;
+            case CV_64S: return 63;
+            case CV_64U: return 64;
+        }
+        return 0;
+    }
+
+    // Narrowest float holding integers up to `bits`, and at least `atLeast`; 0 when none does.
+    // CV_32F is exact to 2^24 and CV_64F to 2^53; the 16-bit floats have no typeDispatch arm.
+    static int narrowestFloat(int bits, int atLeast)
+    {
+        if (atLeast == CV_32F && bits <= 24)
+            return CV_32F;
+        if (atLeast == CV_32F || atLeast == CV_64F)
+            return bits <= 53 ? CV_64F : 0;
+        return 0;
+    }
+
     static int commonArithType(int type0, int type1)
     {
         if (type0 == type1)
@@ -385,15 +413,12 @@ public:
                 return signedTypes[rank - 1];
         }
 
-        // CV_32F is exact to 2^24 and CV_64F to 2^53: an 8- or 16-bit int keeps the float type,
-        // a 32-bit int forces CV_64F, and a 64-bit int is rejected below.
         if (rank0 > 0 && rank1 > 0 && isFloat0 != isFloat1)
         {
-            int intRank = isFloat0 ? rank1 : rank0;
-            if (intRank <= 2)
-                return isFloat0 ? type0 : type1;
-            if (intRank == 3)
-                return CV_64F;
+            int common = isFloat0 ? narrowestFloat(intValueBits(type1), type0)
+                                  : narrowestFloat(intValueBits(type0), type1);
+            if (common != 0)
+                return common;
         }
 
         CV_Error_(Error::StsBadArg, ("NaryEltwiseLayer: inputs of type %s and %s have no common type",
@@ -402,10 +427,34 @@ public:
 
     static int findCommonType(const std::vector<MatType>& inputs)
     {
-        int commonType = inputs[0];
-        for (size_t i = 1; i < inputs.size(); i++)
-            commonType = commonArithType(commonType, inputs[i]);
-        return commonType;
+        // Folding pairwise across the int/float boundary would merge two integers into a wider one
+        // and lose the individual bit counts narrowestFloat() needs, so the two are kept apart.
+        int floatType = -1, intType = -1, intBits = 0;
+        for (auto input : inputs)
+        {
+            if (CV_IS_FLOAT_TYPE(input) != 0)
+                floatType = floatType < 0 ? input : commonArithType(floatType, input);
+            else if (intValueBits(input) > intBits)
+            {
+                intBits = intValueBits(input);
+                intType = input;
+            }
+        }
+
+        if (intType < 0)
+            return floatType;
+
+        if (floatType < 0)
+        {
+            int commonType = inputs[0];
+            for (size_t i = 1; i < inputs.size(); i++)
+                commonType = commonArithType(commonType, inputs[i]);
+            return commonType;
+        }
+
+        // intType carries intBits, so if no float covers it commonArithType raises the error.
+        int common = narrowestFloat(intBits, floatType);
+        return common != 0 ? common : commonArithType(intType, floatType);
     }
 
     bool isComparison() const
@@ -419,12 +468,11 @@ public:
     int promoteOperands(std::vector<Mat>& operands, const std::vector<Mat>& outputs)
     {
         int dispatchType = outputs.front().type();
-        // A comparison declares CV_Bool, so its output type is not the type the kernel computes in.
+        // A comparison declares CV_Bool and is binary, so its compute type is the operand pair.
         if (isComparison())
         {
-            dispatchType = operands.front().type();
-            for (size_t i = 1; i < operands.size(); i++)
-                dispatchType = commonArithType(dispatchType, operands[i].type());
+            CV_CheckEQ(operands.size(), 2u, "");
+            dispatchType = commonArithType(operands[0].type(), operands[1].type());
         }
 
         size_t firstOperand = op == OPERATION::WHERE ? 1 : 0;

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1409,6 +1409,32 @@ INSTANTIATE_TEST_CASE_P(/**/, Layer_Test_Eltwise_unequal, Combine(
 ));
 
 
+static Mat runEltwise(const String& op, const std::vector<Mat>& inputs,
+                      int backend = DNN_BACKEND_OPENCV, int target = DNN_TARGET_CPU)
+{
+    Net net;
+    LayerParams lp;
+    lp.type = "NaryEltwise";
+    lp.name = "testLayer";
+    lp.set("operation", op);
+    int id = net.addLayerToPrev(lp.name, lp.type, lp);
+
+    std::vector<String> names(inputs.size());
+    for (size_t i = 0; i < inputs.size(); i++)
+    {
+        names[i] = cv::format("input%d", (int)i);
+        if (i > 0)
+            net.connect(0, (int)i, id, (int)i);
+    }
+    net.setInputsNames(names);
+    for (size_t i = 0; i < inputs.size(); i++)
+        net.setInput(inputs[i], names[i]);
+
+    net.setPreferableBackend(backend);
+    net.setPreferableTarget(target);
+    return net.forward().clone();
+}
+
 struct Layer_Test_Eltwise_bcast : testing::TestWithParam<tuple<string, int, tuple<Backend, Target>>>
 {
 public:
@@ -1474,26 +1500,7 @@ private:
         Mat a = Mat::zeros((int) a_shape.size(), a_shape.data(), CV_32FC1);
         Mat b = Mat::ones((int) b_shape.size(), b_shape.data(), CV_32FC1);
 
-        Net net;
-        LayerParams lp;
-        lp.type = "NaryEltwise";
-        lp.name = "testLayer";
-        lp.set("operation", op);
-        int id = net.addLayerToPrev(lp.name, lp.type, lp);
-        net.connect(0, 1, id, 1);
-
-        vector<String> inpNames(2);
-        inpNames[0] = "a";
-        inpNames[1] = "b";
-        net.setInputsNames(inpNames);
-        net.setInput(a, inpNames[0]);
-        net.setInput(b, inpNames[1]);
-
-        net.setPreferableBackend(backend);
-        net.setPreferableTarget(target);
-
-        Mat re;
-        re = net.forward();
+        Mat re = runEltwise(op, {a, b}, backend, target);
         auto ptr_re = (float *) re.data;
         for (int i = 0; i < re.total(); i++)
             if (op == "sum"){
@@ -1521,6 +1528,105 @@ INSTANTIATE_TEST_CASE_P(/**/, Layer_Test_Eltwise_bcast, Combine(
         Values(1, 2, 3, 4, 5),
         dnnBackendsAndTargets()
 ));
+
+// One operator suffices: promotion is a shared helper, not per-operator code.
+typedef testing::TestWithParam<tuple<tuple<int, int, int>, tuple<Backend, Target> > >
+        Layer_Test_Eltwise_promote;
+TEST_P(Layer_Test_Eltwise_promote, matches_widened_reference)
+{
+    int matType0 = get<0>(get<0>(GetParam()));
+    int matType1 = get<1>(get<0>(GetParam()));
+    int commonType = get<2>(get<0>(GetParam()));
+    Backend backend = get<0>(get<1>(GetParam()));
+    Target target = get<1>(get<1>(GetParam()));
+
+    // Only the OpenCV backend promotes; initCUDA and the OpenVINO graph reject mixed input types.
+    if (backend != DNN_BACKEND_OPENCV)
+        throw SkipTestException("Mixed input types are supported on the OpenCV backend only");
+
+    const std::vector<int> shape{2, 3, 4, 5};
+    Mat a(shape, matType0), b(shape, matType1), aWide, bWide;
+    cv::randu(a, -100, 100);   // RNG::fill clamps the low bound for unsigned types
+    cv::randu(b, -100, 100);
+    a.convertTo(aWide, commonType);
+    b.convertTo(bWide, commonType);
+
+    Mat reference = runEltwise("add", {aWide, bWide}, backend, target);
+    Mat promoted = runEltwise("add", {a, b}, backend, target);
+    normAssert(reference, promoted, "", 0, 0);
+    EXPECT_EQ(promoted.type(), commonType);
+}
+
+// Both operand orders are listed: the output type used to be taken from inputs[0].
+INSTANTIATE_TEST_CASE_P(/**/, Layer_Test_Eltwise_promote, Combine(
+    Values(std::make_tuple(CV_32S, CV_64S, CV_64S),  // same family, the pair importers produce
+           std::make_tuple(CV_64S, CV_32S, CV_64S),
+           std::make_tuple(CV_8U, CV_8S, CV_16S),  // mixed sign
+           std::make_tuple(CV_8S, CV_8U, CV_16S),
+           std::make_tuple(CV_32F, CV_64F, CV_64F),  // float widening
+           std::make_tuple(CV_64F, CV_32F, CV_64F),
+           std::make_tuple(CV_8U, CV_32F, CV_32F),  // int with float, fp32 is exact to 2^24
+           std::make_tuple(CV_32F, CV_8U, CV_32F),
+           std::make_tuple(CV_32S, CV_32F, CV_64F),  // int32 needs 31 bits, so the float widens
+           std::make_tuple(CV_32F, CV_32S, CV_64F)),
+    dnnBackendsAndTargets()
+));
+
+// A value outside the narrower operand's range must survive: promotion widens, never narrows.
+TEST(Layer_Eltwise_promote, preserves_wide_values)
+{
+    const int64_t big = (int64_t)INT32_MAX + 1;
+    const int64_t values[] = { big, -big, (int64_t)1 << 40 };
+    const int n = (int)(sizeof(values) / sizeof(values[0]));
+
+    Mat narrow(std::vector<int>{1, n}, CV_32S), wide(std::vector<int>{1, n}, CV_64S);
+    narrow.setTo(1);
+    for (int i = 0; i < n; i++)
+        wide.ptr<int64_t>()[i] = values[i];
+
+    Mat sum = runEltwise("add", {narrow, wide});
+    ASSERT_EQ(sum.type(), CV_64S);
+    for (int i = 0; i < n; i++)
+        EXPECT_EQ(sum.ptr<int64_t>()[i], values[i] + 1);
+
+    // Neither candidate holds every value: fp64 is exact only to 2^53, and CV_64S has no fractions.
+    Mat asFloat(std::vector<int>{1, n}, CV_64F);
+    asFloat.setTo(1);
+    EXPECT_ANY_THROW(runEltwise("add", {wide, asFloat}));
+}
+
+// where promotes its two value operands and leaves the CV_Bool condition alone; comparisons
+// promote for the computation but keep a CV_Bool output; bitwise ops promote across signedness.
+TEST(Layer_Eltwise_promote, where_comparison_bitwise)
+{
+    const std::vector<int> shape{2, 3, 4, 5};
+    Mat condition(shape, CV_Bool), x(shape, CV_32S), y(shape, CV_64S), xw;
+    cv::randu(condition, 0, 2);
+    cv::randu(x, -100, 100);
+    cv::randu(y, -100, 100);
+    x.convertTo(xw, CV_64S);
+
+    Mat selected = runEltwise("where", {condition, x, y});
+    normAssert(runEltwise("where", {condition, xw, y}), selected, "", 0, 0);
+    EXPECT_EQ(selected.type(), CV_64S);
+
+    Mat compared = runEltwise("less", {x, y});
+    normAssert(runEltwise("less", {xw, y}), compared, "", 0, 0);
+    EXPECT_EQ(compared.type(), CV_Bool);
+
+    // Assigned rather than randomised: a -100..100 uchar never sets the bit sign extension copies.
+    Mat u(std::vector<int>{1, 2}, CV_8U), s(std::vector<int>{1, 2}, CV_8S), uw, sw;
+    u.ptr<uchar>()[0] = 0x80;
+    u.ptr<uchar>()[1] = 0xff;
+    s.ptr<schar>()[0] = -1;
+    s.ptr<schar>()[1] = -128;
+    u.convertTo(uw, CV_16S);
+    s.convertTo(sw, CV_16S);
+
+    Mat masked = runEltwise("bitwise_and", {u, s});
+    normAssert(runEltwise("bitwise_and", {uw, sw}), masked, "", 0, 0);
+    EXPECT_EQ(masked.type(), CV_16S);
+}
 
 typedef testing::TestWithParam<tuple<Backend, Target> > Layer_Test_Resize;
 TEST_P(Layer_Test_Resize, change_input)

--- a/modules/dnn/test/test_layers.cpp
+++ b/modules/dnn/test/test_layers.cpp
@@ -1595,6 +1595,23 @@ TEST(Layer_Eltwise_promote, preserves_wide_values)
     EXPECT_ANY_THROW(runEltwise("add", {wide, asFloat}));
 }
 
+// Sum/Mean/Max/Min are variadic, and the common type must not depend on operand order: resolving
+// two integers first would build a wider integer that no float covers exactly.
+TEST(Layer_Eltwise_promote, order_independent)
+{
+    const std::vector<int> shape{2, 3};
+    Mat i32(shape, CV_32S), u32(shape, CV_32U), f32(shape, CV_32F);
+    cv::randu(i32, 0, 100);
+    cv::randu(u32, 0, 100);
+    cv::randu(f32, -100, 100);
+
+    Mat intsFirst = runEltwise("sum", {i32, u32, f32});
+    Mat floatFirst = runEltwise("sum", {f32, i32, u32});
+    EXPECT_EQ(intsFirst.type(), CV_64F);
+    EXPECT_EQ(floatFirst.type(), CV_64F);
+    normAssert(intsFirst, floatFirst, "", 0, 0);
+}
+
 // where promotes its two value operands and leaves the CV_Bool condition alone; comparisons
 // promote for the computation but keep a CV_Bool output; bitwise ops promote across signedness.
 TEST(Layer_Eltwise_promote, where_comparison_bitwise)


### PR DESCRIPTION
### PR Changes:

This PR makes `NaryEltwise` accept inputs of different types. It computes a lossless common type and converts the narrower operands up to it before the kernel runs, in place of the `CV_CheckTypeEQ(inputs[0], input, "All inputs should have equal types")` that rejected every mismatch.
 
  ### Promotion rules

  All lossless, so no promotion ever loses a value.

  | operands | common type |
  | --- | --- |
  | same family | the wider: `8S<16S<32S<64S`, `8U<16U<32U<64U`, `32F<64F` |
  | mixed sign | the narrowest signed type covering both, so `8U` with `8S` gives `16S` |
  | integer with float | the narrowest float representing the integer exactly, matching `numpy.promote_types` |
  | `uint64` with any signed | **rejected**, no lossless target |
  | 64-bit integer with any float | **rejected**, `CV_64F` is exact only to 2^53 |


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
