### PR TITLE
imgproc: support CV_Bool in morphology filters 🤖🤖🤖

### DIFF
--- a/modules/imgproc/src/morph.simd.hpp
+++ b/modules/imgproc/src/morph.simd.hpp
@@ -724,7 +724,7 @@ Ptr<BaseRowFilter> getMorphologyRowFilter(int op, int type, int ksize, int ancho
     CV_Assert( op == MORPH_ERODE || op == MORPH_DILATE );
     if( op == MORPH_ERODE )
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphRowFilter<MinOp<uchar>,
                                       ErodeRowVec8u> >(ksize, anchor);
         if( depth == CV_16U )
@@ -742,7 +742,7 @@ Ptr<BaseRowFilter> getMorphologyRowFilter(int op, int type, int ksize, int ancho
     }
     else
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphRowFilter<MaxOp<uchar>,
                                       DilateRowVec8u> >(ksize, anchor);
         if( depth == CV_16U )
@@ -772,7 +772,7 @@ Ptr<BaseColumnFilter> getMorphologyColumnFilter(int op, int type, int ksize, int
     CV_Assert( op == MORPH_ERODE || op == MORPH_DILATE );
     if( op == MORPH_ERODE )
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphColumnFilter<MinOp<uchar>,
                                          ErodeColumnVec8u> >(ksize, anchor);
         if( depth == CV_16U )
@@ -790,7 +790,7 @@ Ptr<BaseColumnFilter> getMorphologyColumnFilter(int op, int type, int ksize, int
     }
     else
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphColumnFilter<MaxOp<uchar>,
                                          DilateColumnVec8u> >(ksize, anchor);
         if( depth == CV_16U )
@@ -819,7 +819,7 @@ Ptr<BaseFilter> getMorphologyFilter(int op, int type, const Mat& kernel, Point a
     CV_Assert( op == MORPH_ERODE || op == MORPH_DILATE );
     if( op == MORPH_ERODE )
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphFilter<MinOp<uchar>, ErodeVec8u> >(kernel, anchor);
         if( depth == CV_16U )
             return makePtr<MorphFilter<MinOp<ushort>, ErodeVec16u> >(kernel, anchor);
@@ -832,7 +832,7 @@ Ptr<BaseFilter> getMorphologyFilter(int op, int type, const Mat& kernel, Point a
     }
     else
     {
-        if( depth == CV_8U )
+        if( depth == CV_8U || depth == CV_Bool )
             return makePtr<MorphFilter<MaxOp<uchar>, DilateVec8u> >(kernel, anchor);
         if( depth == CV_16U )
             return makePtr<MorphFilter<MaxOp<ushort>, DilateVec16u> >(kernel, anchor);

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -737,6 +737,24 @@ TEST(Imgproc_Morphology, iterated)
     }
 }
 
+TEST(Imgproc_Morphology, bool_dilate)
+{
+    Mat_<bool> src = (Mat_<bool>(3, 3) <<
+        false, true, false,
+        false, false, false,
+        false, false, false);
+    Mat_<bool> dst;
+
+    cv::dilate(src, dst, Mat(), Point(-1, -1), 1);
+
+    Mat_<bool> expected = (Mat_<bool>(3, 3) <<
+        true, true, true,
+        true, true, true,
+        false, false, false);
+    EXPECT_EQ(expected.type(), dst.type());
+    EXPECT_EQ(0.0, cvtest::norm(expected, dst, NORM_INF));
+}
+
 TEST(Imgproc_Sobel, borderTypes)
 {
     int kernelSize = 3;


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      A focused regression test is included in `modules/imgproc/test/test_filter.cpp`; no external test data is needed.
- [ ] The feature is well documented and sample code can be built with the project CMake

## Summary

Fixes #29798.

`cv::dilate` now accepts `CV_Bool` matrices by routing the boolean depth through the existing one-byte morphology SIMD implementations for row, column, and full-kernel filters.

Added `Imgproc_Morphology.bool_dilate` to verify a boolean mask is dilated correctly and retains `CV_Bool` output type.

## Validation

- `git diff --check` passes.
- Native OpenCV tests were not run locally because this environment has no CMake, Ninja, or OpenCV source build.
- OpenCV CI should validate the change across supported compilers and architectures.
