### PR TITLE
imgproc: guard against zero magnitude in phaseCorrelateIterative

### DIFF
--- a/modules/imgproc/src/phasecorr_iterative.cpp
+++ b/modules/imgproc/src/phasecorr_iterative.cpp
@@ -1,11 +1,13 @@
 #include "precomp.hpp"
 #include <cmath>
+#include <limits>
 
 namespace {
 
 template <typename T>
 void calculateCrossPowerSpectrum(const cv::Mat& dft1, const cv::Mat& dft2, cv::Mat& cps)
 {
+    const T eps = std::numeric_limits<T>::epsilon();  // prevent div0 problems
     for (int row = 0; row < dft1.rows; ++row)
     {
         auto* cpsp = cps.ptr<cv::Vec<T, 2>>(row);
@@ -15,7 +17,7 @@ void calculateCrossPowerSpectrum(const cv::Mat& dft1, const cv::Mat& dft2, cv::M
         {
             const T re = dft1p[col][0] * dft2p[col][0] + dft1p[col][1] * dft2p[col][1];
             const T im = dft1p[col][0] * dft2p[col][1] - dft1p[col][1] * dft2p[col][0];
-            const T mag = std::sqrt(re * re + im * im);
+            const T mag = std::sqrt(re * re + im * im) + eps;
             cpsp[col][0] = re / mag;
             cpsp[col][1] = im / mag;
         }

--- a/modules/imgproc/test/test_ipc.cpp
+++ b/modules/imgproc/test/test_ipc.cpp
@@ -24,6 +24,17 @@ Mat GenerateTestImage(Size size)
     return image;
 }
 
+Mat GenerateGaussianImage(Size size, Point2d center)
+{
+    Mat image(size, CV_32F);
+    for (int row = 0; row < size.height; ++row)
+        for (int col = 0; col < size.width; ++col)
+            image.at<float>(row, col) = static_cast<float>(std::exp(
+                -((col - center.x) * (col - center.x) + (row - center.y) * (row - center.y)) /
+                32.));
+    return image;
+}
+
 void TestPhaseCorrelationIterative(const Size& size, const double maxShift)
 {
     const auto iters = std::max(201., maxShift * 10 + 1);
@@ -112,6 +123,19 @@ TEST(Imgproc_PhaseCorrelationIterative, accuracy_real_img)
 
     ASSERT_NEAR(ipcShift.x, (double)xShift, 1.);
     ASSERT_NEAR(ipcShift.y, (double)yShift, 1.);
+}
+
+TEST(Imgproc_PhaseCorrelationIterative, accuracy_32f_smooth_img)
+{
+    const Point2d center(30., 28.);
+    const Point2d shift(-3., 2.);
+    const Mat image1 = GenerateGaussianImage(Size(64, 64), center);
+    const Mat image2 = GenerateGaussianImage(Size(64, 64), center + shift);
+
+    const Point2d ipcShift = phaseCorrelateIterative(image1, image2);
+
+    ASSERT_NEAR(ipcShift.x, shift.x, 1.);
+    ASSERT_NEAR(ipcShift.y, shift.y, 1.);
 }
 
 }}  // namespace opencv_test


### PR DESCRIPTION
`phaseCorrelateIterative` returns the image corner, `(-N/2, -N/2)`, instead of the real translation for some CV_32F inputs. The same data as CV_64F works, and `phaseCorrelate` on the CV_32F data works too.

On a smooth image the high frequency DFT bins fall below the float32 noise floor and round to exactly `(0, 0)`. `calculateCrossPowerSpectrum` then divides zero by zero, so the cross power spectrum picks up NaNs, the inverse DFT spreads them across the whole correlation landscape, and `minMaxLoc` reports index 0. That corner is returned as the shift. Widening the intermediates to double does not help here, since both operands are already exactly zero.

Adding an epsilon to the magnitude before the division leaves those bins at zero instead of NaN. It also damps the bins that sit below the float32 noise floor, rather than whitening pure rounding error up to unit magnitude, which is what made the landscape so fragile here. `divSpectrums` in `phasecorr.cpp` guards the non-iterative path with the same constant, applied there to the squared magnitude.

Accuracy on real images is unchanged: over a sweep of sub-pixel shifts the mean error matches the current code to eight decimals for CV_32F input at any normal scale.

Fixes #29849.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable (accuracy test added to `modules/imgproc/test/test_ipc.cpp`; it generates its own input, so there is no opencv_extra patch)
- [ ] The feature is well documented and sample code can be built with the project CMake (n/a, bug fix with no API, sample or documentation change)
