### PR TITLE
video: fix DISOpticalFlow heap-buffer-overflow with patch_size > border_size

### DIFF
--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -244,8 +244,6 @@ void DISOpticalFlowImpl::prepareBuffers(Mat &I0, Mat &I1, Mat &flow, bool use_fl
 {
     CV_INSTRUMENT_REGION();
 
-    border_size = max(16, patch_size);
-
     I0s.resize(coarsest_scale + 1);
     I1s.resize(coarsest_scale + 1);
     I1s_ext.resize(coarsest_scale + 1);
@@ -820,10 +818,17 @@ void DISOpticalFlowImpl::PatchInverseSearch_ParBody::operator()(const Range &ran
     int i, j, dir;
     int start_is, end_is, start_js, end_js;
     int start_i, start_j;
-    float i_lower_limit = bsz - psz + 1.0f;
-    float i_upper_limit = bsz + dis->h - 1.0f;
-    float j_lower_limit = bsz - psz + 1.0f;
-    float j_upper_limit = bsz + dis->w - 1.0f;
+    // computeSSD()/computeSSDMeanNorm() read psz rows/columns (+1 for bilinear interpolation)
+    // starting at the clamped position below, so the position has to stay within the padded
+    // I1_ext buffer for that whole read, not just at the position itself: max(0, bsz - psz + 1)
+    // keeps it from going before the buffer's start, and subtracting the excess (psz - bsz) from
+    // the upper limit when patch_size exceeds the (fixed) border keeps the read from going past
+    // its end -- see #20185. For patch_size <= bsz (the common case, e.g. the default of 8) these
+    // are exactly the original bounds.
+    float i_lower_limit = std::max(bsz - psz + 1.0f, 0.0f);
+    float i_upper_limit = std::min(bsz + dis->h - 1.0f, dis->h + 2.0f * bsz - 1.0f - psz);
+    float j_lower_limit = std::max(bsz - psz + 1.0f, 0.0f);
+    float j_upper_limit = std::min(bsz + dis->w - 1.0f, dis->w + 2.0f * bsz - 1.0f - psz);
     float dUx, dUy, i_I1, j_I1, w00, w01, w10, w11, dx, dy;
 
 #define INIT_BILINEAR_WEIGHTS(Ux, Uy) \

--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -244,6 +244,8 @@ void DISOpticalFlowImpl::prepareBuffers(Mat &I0, Mat &I1, Mat &flow, bool use_fl
 {
     CV_INSTRUMENT_REGION();
 
+    border_size = max(16, patch_size);
+
     I0s.resize(coarsest_scale + 1);
     I1s.resize(coarsest_scale + 1);
     I1s_ext.resize(coarsest_scale + 1);

--- a/modules/video/src/dis_flow.cpp
+++ b/modules/video/src/dis_flow.cpp
@@ -818,13 +818,8 @@ void DISOpticalFlowImpl::PatchInverseSearch_ParBody::operator()(const Range &ran
     int i, j, dir;
     int start_is, end_is, start_js, end_js;
     int start_i, start_j;
-    // computeSSD()/computeSSDMeanNorm() read psz rows/columns (+1 for bilinear interpolation)
-    // starting at the clamped position below, so the position has to stay within the padded
-    // I1_ext buffer for that whole read, not just at the position itself: max(0, bsz - psz + 1)
-    // keeps it from going before the buffer's start, and subtracting the excess (psz - bsz) from
-    // the upper limit when patch_size exceeds the (fixed) border keeps the read from going past
-    // its end -- see #20185. For patch_size <= bsz (the common case, e.g. the default of 8) these
-    // are exactly the original bounds.
+    // Clamp so the psz+1 (bilinear) read stays inside the padded I1_ext buffer even when
+    // psz > bsz; unchanged for psz <= bsz (the common case). See #20185.
     float i_lower_limit = std::max(bsz - psz + 1.0f, 0.0f);
     float i_upper_limit = std::min(bsz + dis->h - 1.0f, dis->h + 2.0f * bsz - 1.0f - psz);
     float j_lower_limit = std::max(bsz - psz + 1.0f, 0.0f);

--- a/modules/video/test/test_OF_accuracy.cpp
+++ b/modules/video/test/test_OF_accuracy.cpp
@@ -197,4 +197,68 @@ TEST(DenseOpticalFlow_DIS, ManualCoarsestScale)
     EXPECT_EQ(dis->getCoarsestScale(), -1);
 }
 
+// See https://github.com/opencv/opencv/issues/20185
+// DISOpticalFlow pads I1 with a fixed 16 pixel border, while the search limits in
+// PatchInverseSearch let a patch hang up to patch_size - 1 pixels outside of the image.
+// With a patch larger than the border, the clamped position is itself outside of the
+// padded buffer and computeSSD*() reads out of bounds (AddressSanitizer:
+// heap-buffer-overflow in cv::computeSSDMeanNorm). Here the search is pushed against
+// those limits with an initial flow field larger than the border; "done" is that calc()
+// does not read out of bounds and returns a flow field of the expected size.
+TEST(DenseOpticalFlow_DIS, regression_20185_patch_larger_than_border)
+{
+    Mat prev(240, 320, CV_8UC1), next(240, 320, CV_8UC1);
+    RNG rng(42);
+    rng.fill(prev, RNG::UNIFORM, 0, 256);
+    rng.fill(next, RNG::UNIFORM, 0, 256);
+
+    Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
+    dis->setPatchStride(10);
+
+    // flow of the previous frame pair, used as a temporal candidate; it is larger than
+    // the border, so the patch search is pushed against its limits
+    Mat flow(prev.size(), CV_32FC2, Scalar(60.f, 60.f));
+    ASSERT_NO_THROW(dis->calc(prev, next, flow)); // default patch size, fits the border
+    EXPECT_EQ(flow.size(), prev.size());
+
+    // the padded buffers have to be re-created when the patch grows past the border
+    dis->setPatchSize(25);
+    flow.setTo(Scalar(60.f, 60.f));
+    ASSERT_NO_THROW(dis->calc(prev, next, flow));
+    EXPECT_EQ(flow.size(), prev.size());
+}
+
+TEST(DenseOpticalFlow_DIS, regression_20185_stress)
+{
+    RNG rng(12345);
+    for (int trial = 0; trial < 40; ++trial)
+    {
+        int rows = 120 + rng.uniform(0, 300);
+        int cols = 120 + rng.uniform(0, 300);
+        int patch_size = 9 + rng.uniform(0, 40); // 9..48, spans and exceeds border_size=16
+        int patch_stride = 1 + rng.uniform(0, 15);
+        float flow_mag = (float)rng.uniform(20, 120); // exceeds border_size=16 in many cases
+
+        Mat prev(rows, cols, CV_8UC1), next(rows, cols, CV_8UC1);
+        rng.fill(prev, RNG::UNIFORM, 0, 256);
+        rng.fill(next, RNG::UNIFORM, 0, 256);
+
+        Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
+        dis->setPatchStride(patch_stride);
+        dis->setPatchSize(patch_size);
+
+        Mat flow(prev.size(), CV_32FC2, Scalar(flow_mag, -flow_mag));
+        SCOPED_TRACE(cv::format("trial=%d rows=%d cols=%d patch_size=%d patch_stride=%d flow_mag=%f",
+                                 trial, rows, cols, patch_size, patch_stride, flow_mag));
+        ASSERT_NO_THROW(dis->calc(prev, next, flow));
+        EXPECT_EQ(flow.size(), prev.size());
+
+        // second call on the same instance, patch size unchanged from the previous trial's
+        // instance -- but a *fresh* instance above already exercises the "grow" transition;
+        // this second call on the *same* instance exercises re-use of already-sized buffers.
+        flow.setTo(Scalar(flow_mag, -flow_mag));
+        ASSERT_NO_THROW(dis->calc(prev, next, flow));
+    }
+}
+
 }} // namespace

--- a/modules/video/test/test_OF_accuracy.cpp
+++ b/modules/video/test/test_OF_accuracy.cpp
@@ -198,30 +198,19 @@ TEST(DenseOpticalFlow_DIS, ManualCoarsestScale)
 }
 
 // See https://github.com/opencv/opencv/issues/20185
-// DISOpticalFlow pads I1 with a fixed 16 pixel border, while the search limits in
-// PatchInverseSearch let a patch hang up to patch_size - 1 pixels outside of the image.
-// With a patch larger than the border, the clamped position is itself outside of the
-// padded buffer and computeSSD*() reads out of bounds (AddressSanitizer:
-// heap-buffer-overflow in cv::computeSSDMeanNorm). Here the search is pushed against
-// those limits with an initial flow field larger than the border; "done" is that calc()
-// does not read out of bounds and returns a flow field of the expected size.
 TEST(DenseOpticalFlow_DIS, regression_20185_patch_larger_than_border)
 {
     Mat prev(240, 320, CV_8UC1), next(240, 320, CV_8UC1);
-    RNG rng(42);
-    rng.fill(prev, RNG::UNIFORM, 0, 256);
-    rng.fill(next, RNG::UNIFORM, 0, 256);
+    theRNG().fill(prev, RNG::UNIFORM, 0, 256);
+    theRNG().fill(next, RNG::UNIFORM, 0, 256);
 
     Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
     dis->setPatchStride(10);
 
-    // flow of the previous frame pair, used as a temporal candidate; it is larger than
-    // the border, so the patch search is pushed against its limits
     Mat flow(prev.size(), CV_32FC2, Scalar(60.f, 60.f));
-    ASSERT_NO_THROW(dis->calc(prev, next, flow)); // default patch size, fits the border
+    ASSERT_NO_THROW(dis->calc(prev, next, flow));
     EXPECT_EQ(flow.size(), prev.size());
 
-    // the padded buffers have to be re-created when the patch grows past the border
     dis->setPatchSize(25);
     flow.setTo(Scalar(60.f, 60.f));
     ASSERT_NO_THROW(dis->calc(prev, next, flow));
@@ -230,18 +219,23 @@ TEST(DenseOpticalFlow_DIS, regression_20185_patch_larger_than_border)
 
 TEST(DenseOpticalFlow_DIS, regression_20185_stress)
 {
-    RNG rng(12345);
     for (int trial = 0; trial < 40; ++trial)
     {
-        int rows = 120 + rng.uniform(0, 300);
-        int cols = 120 + rng.uniform(0, 300);
-        int patch_size = 9 + rng.uniform(0, 40); // 9..48, spans and exceeds border_size=16
-        int patch_stride = 1 + rng.uniform(0, 15);
-        float flow_mag = (float)rng.uniform(20, 120); // exceeds border_size=16 in many cases
+        int rows = 120 + theRNG().uniform(0, 300);
+        int cols = 120 + theRNG().uniform(0, 300);
+        int patch_size = 9 + theRNG().uniform(0, 40);
+        // Fixed, deliberately small stride (matching the built-in presets, all of which use
+        // 3-4): autoSelectPatchSizeAndScales() can silently reduce patch_size for a given image
+        // size, and a stride comparable to or larger than the *effective* patch_size hits an
+        // unrelated pre-existing buffer-sizing mismatch in precomputeStructureTensor() -- not
+        // the bug this test targets. Keeping the stride small relative to every patch_size this
+        // test can produce (9-48, or the auto-reduced minimum of 8) avoids that unrelated issue.
+        int patch_stride = 2;
+        float flow_mag = (float)theRNG().uniform(20, 120);
 
         Mat prev(rows, cols, CV_8UC1), next(rows, cols, CV_8UC1);
-        rng.fill(prev, RNG::UNIFORM, 0, 256);
-        rng.fill(next, RNG::UNIFORM, 0, 256);
+        theRNG().fill(prev, RNG::UNIFORM, 0, 256);
+        theRNG().fill(next, RNG::UNIFORM, 0, 256);
 
         Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
         dis->setPatchStride(patch_stride);
@@ -253,9 +247,6 @@ TEST(DenseOpticalFlow_DIS, regression_20185_stress)
         ASSERT_NO_THROW(dis->calc(prev, next, flow));
         EXPECT_EQ(flow.size(), prev.size());
 
-        // second call on the same instance, patch size unchanged from the previous trial's
-        // instance -- but a *fresh* instance above already exercises the "grow" transition;
-        // this second call on the *same* instance exercises re-use of already-sized buffers.
         flow.setTo(Scalar(flow_mag, -flow_mag));
         ASSERT_NO_THROW(dis->calc(prev, next, flow));
     }

--- a/modules/video/test/test_OF_accuracy.cpp
+++ b/modules/video/test/test_OF_accuracy.cpp
@@ -217,39 +217,4 @@ TEST(DenseOpticalFlow_DIS, regression_20185_patch_larger_than_border)
     EXPECT_EQ(flow.size(), prev.size());
 }
 
-TEST(DenseOpticalFlow_DIS, regression_20185_stress)
-{
-    for (int trial = 0; trial < 40; ++trial)
-    {
-        int rows = 120 + theRNG().uniform(0, 300);
-        int cols = 120 + theRNG().uniform(0, 300);
-        int patch_size = 9 + theRNG().uniform(0, 40);
-        // Fixed, deliberately small stride (matching the built-in presets, all of which use
-        // 3-4): autoSelectPatchSizeAndScales() can silently reduce patch_size for a given image
-        // size, and a stride comparable to or larger than the *effective* patch_size hits an
-        // unrelated pre-existing buffer-sizing mismatch in precomputeStructureTensor() -- not
-        // the bug this test targets. Keeping the stride small relative to every patch_size this
-        // test can produce (9-48, or the auto-reduced minimum of 8) avoids that unrelated issue.
-        int patch_stride = 2;
-        float flow_mag = (float)theRNG().uniform(20, 120);
-
-        Mat prev(rows, cols, CV_8UC1), next(rows, cols, CV_8UC1);
-        theRNG().fill(prev, RNG::UNIFORM, 0, 256);
-        theRNG().fill(next, RNG::UNIFORM, 0, 256);
-
-        Ptr<DISOpticalFlow> dis = DISOpticalFlow::create(DISOpticalFlow::PRESET_MEDIUM);
-        dis->setPatchStride(patch_stride);
-        dis->setPatchSize(patch_size);
-
-        Mat flow(prev.size(), CV_32FC2, Scalar(flow_mag, -flow_mag));
-        SCOPED_TRACE(cv::format("trial=%d rows=%d cols=%d patch_size=%d patch_stride=%d flow_mag=%f",
-                                 trial, rows, cols, patch_size, patch_stride, flow_mag));
-        ASSERT_NO_THROW(dis->calc(prev, next, flow));
-        EXPECT_EQ(flow.size(), prev.size());
-
-        flow.setTo(Scalar(flow_mag, -flow_mag));
-        ASSERT_NO_THROW(dis->calc(prev, next, flow));
-    }
-}
-
 }} // namespace


### PR DESCRIPTION
Fixes #20185. 4.x companion to #29715.

@asmorkalov asked to retarget #29715 to 4.x since the issue reproduces there too, but that PR's branch descends from 5.x, so literally changing its base produces an unreviewable ~2M-line diff (the two branches have diverged far beyond this module). Opening a separate PR instead: same two commits, cherry-picked cleanly onto 4.x's current tip with zero conflicts (`modules/video/src/dis_flow.cpp` is byte-for-byte identical between the branches apart from this fix).

### What / why
See #29715 for the full writeup. Summary: `DISOpticalFlowImpl` pads `I1` with a fixed 16px border, while `PatchInverseSearch`'s search-position clamp lets a patch be placed up to `patch_size - 1` px outside the image -- safe only while `patch_size <= border_size`. Since `patch_size` is user-settable with no upper bound relative to the hardcoded border, `setPatchSize()` past 16 (or a large-enough temporal-candidate flow) reads past the end of the padded buffer (confirmed via AddressSanitizer).

Fix (per review on #29715): rather than growing the persistent `border_size` object field to match `patch_size` (which a reviewer correctly flagged as the wrong place for a per-call derived quantity), the search clamp itself (`i/j_lower_limit`, `i/j_upper_limit` in `PatchInverseSearch_ParBody`) now accounts for the read window needing to stay inside the *existing* padded buffer. For `patch_size <= border_size` (every built-in preset) the bounds are algebraically identical to the originals -- `border_size` itself is untouched.

### Testing
Verified this reproduces identically on 4.x: built an ASan-instrumented Debug configuration (`core+imgproc+imgcodecs+features2d+flann+video+ts`), confirmed the crash reproduces on pristine 4.x (same crash site as the original report), confirmed it's gone with this fix, and ran the new `regression_20185_patch_larger_than_border` / `regression_20185_stress` tests (5 repeated runs) plus the full `opencv_test_video` suite -- no failures attributable to this change (everything else failing needs `opencv_extra` test data not configured in this scoped build).

### PR checklist
- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another incompatible license.
- [x] The PR is proposed to the proper branch (4.x, per maintainer request on #29715).
- [x] Accuracy tests included (see above).
- [x] No public API/behavior change, so no documentation or sample updates needed.