### PR TITLE
imgproc: reject empty input in connected components

### DIFF
--- a/modules/imgproc/src/connectedcomponents.cpp
+++ b/modules/imgproc/src/connectedcomponents.cpp
@@ -5650,6 +5650,7 @@ namespace cv{
     template<typename StatsOp>
     static
     int connectedComponents_sub1(const cv::Mat& I, cv::Mat& L, int connectivity, int ccltype, StatsOp& sop){
+        CV_Assert(!I.empty());
         CV_Assert(L.channels() == 1 && I.channels() == 1);
         CV_Assert(connectivity == 8 || connectivity == 4);
         CV_Assert(ccltype == CCL_SPAGHETTI || ccltype == CCL_BBDT || ccltype == CCL_SAUF || ccltype == CCL_BOLELLI || ccltype == CCL_GRANA || ccltype == CCL_WU || ccltype == CCL_DEFAULT);

--- a/modules/imgproc/test/test_connectedcomponents.cpp
+++ b/modules/imgproc/test/test_connectedcomponents.cpp
@@ -795,5 +795,25 @@ TEST(Imgproc_ConnectedComponents, regression_27568)
     }
 }
 
+TEST(Imgproc_ConnectedComponents, regression_29854)
+{
+    for (const Size& size : {Size(400, 0), Size(0, 400), Size(0, 0)})
+    {
+        Mat image = Mat::zeros(size, CV_8UC1);
+
+        for (const int connectivity : {4, 8})
+        {
+            for (const int ccltype : {CCL_DEFAULT, CCL_WU, CCL_GRANA, CCL_BOLELLI, CCL_SAUF, CCL_BBDT, CCL_SPAGHETTI})
+            {
+                Mat labels, stats, centroids;
+                EXPECT_THROW(connectedComponents(
+                    image, labels, connectivity, CV_32S, ccltype), Exception);
+                EXPECT_THROW(connectedComponentsWithStats(
+                    image, labels, stats, centroids, connectivity, CV_32S, ccltype), Exception);
+            }
+        }
+    }
+}
+
 }
 } // namespace


### PR DESCRIPTION
`connectedComponents` and `connectedComponentsWithStats` crash the process when the input image has a zero-length dimension. Every labeling implementation reads the first image row before it looks at the height, so `img.ptr(0)` on an empty matrix hands them a null pointer and the first scan dereferences it. Reproduced on 4.x with all seven CCL algorithms and both connectivities.

`connectedComponents_sub1` now rejects empty input, which covers both entry points and every algorithm, and matches how the rest of imgproc treats empty images. The reporter also suggested returning an empty result instead of throwing, the way `findContours` does. Throwing keeps the check in one place and does not change any existing behaviour: the only in-tree caller is `distanceTransform` with `DIST_LABEL_CCOMP`, which already throws on an empty image when it builds `src == 0`.

Fixes #29854

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
