### PR TITLE
geometry: saturate out-of-range float coordinates in boundingRect 5.x

### DIFF
--- a/modules/geometry/include/opencv2/geometry/2d.hpp
+++ b/modules/geometry/include/opencv2/geometry/2d.hpp
@@ -826,6 +826,9 @@ CV_EXPORTS_W double contourArea( InputArray contour, bool oriented = false );
  * non-zero pixels of gray-scale image.
  *
  * @param array Input gray-scale image or 2D point set, stored in std::vector or Mat.
+ *
+ * @note Point coordinates that the resulting Rect cannot represent - outside of the int range,
+ * or infinite - are saturated to INT_MIN / INT_MAX, and its width and height are clamped to INT_MAX.
  */
 CV_EXPORTS_W Rect boundingRect( InputArray array );
 

--- a/modules/geometry/src/geometry.cpp
+++ b/modules/geometry/src/geometry.cpp
@@ -591,6 +591,24 @@ static Rect maskBoundingRect( const Mat& img )
     return Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1);
 }
 
+// Converts an extremum of a CV_32F point set to an int coordinate of a Rect, flooring it and
+// clamping it to the range a Rect can represent. cvFloor() is undefined outside of that range, so
+// a coordinate beyond it used to leak the raw conversion result into the rectangle: 1e10 floored
+// to INT_MIN, and +inf/-inf gave INT_MIN and INT_MAX, inverting it.
+// See https://github.com/opencv/opencv/issues/29837
+static inline int floorSaturate( float value )
+{
+    // the clamp is in double, where the bounds are exact - INT_MAX is not representable in float -
+    // and it cannot be left to saturate_cast<int>(), which rounds but does not clip 32-bit
+    // integers. Reversing the first comparison keeps a NaN out of the undefined conversion too.
+    const double v = std::floor((double)value);
+    if( !(v > (double)INT_MIN) )
+        return INT_MIN;
+    if( v >= (double)INT_MAX )
+        return INT_MAX;
+    return saturate_cast<int>(v);
+}
+
 // Calculates bounding rectangle of a point set or retrieves already calculated
 static Rect pointSetBoundingRect( const Mat& points )
 {
@@ -655,8 +673,9 @@ static Rect pointSetBoundingRect( const Mat& points )
         const float* pts = points.ptr<float>();
         int64_t firstval = 0;
         std::memcpy(&firstval, pts, sizeof(pts[0]) * 2);
-        xmin = xmax = cvFloor(pts[0]);
-        ymin = ymax = cvFloor(pts[1]);
+        // the extrema are searched for in floats and converted to int once, below
+        float xmin_f = pts[0], xmax_f = pts[0];
+        float ymin_f = pts[1], ymax_f = pts[1];
         #if CV_SIMD || CV_SIMD_SCALABLE
         v_float32 minval, maxval;
         minval = maxval = v_reinterpret_as_f32(vx_setall_s64(firstval)); //min[0]=pt.x, min[1]=pt.y, min[2]=pt.x, min[3]=pt.y
@@ -679,29 +698,35 @@ static Rect pointSetBoundingRect( const Mat& points )
         vx_store(arr_maxval, maxval);
         for (int j = 0; j < nlanes; j++)
         {
-            int _xmin = cvFloor(arr_minval[2*j]), _ymin = cvFloor(arr_minval[2*j+1]);
-            int _xmax = cvFloor(arr_maxval[2*j]), _ymax = cvFloor(arr_maxval[2*j+1]);
-            xmin = std::min(xmin, _xmin);
-            ymin = std::min(ymin, _ymin);
-            xmax = std::max(xmax, _xmax);
-            ymax = std::max(ymax, _ymax);
+            xmin_f = std::min(xmin_f, arr_minval[2*j]);
+            ymin_f = std::min(ymin_f, arr_minval[2*j+1]);
+            xmax_f = std::max(xmax_f, arr_maxval[2*j]);
+            ymax_f = std::max(ymax_f, arr_maxval[2*j+1]);
         }
         #endif
         for( ; i < npoints; i++ )
         {
-            // because right and bottom sides of the bounding rectangle are not inclusive
-            // (note +1 in width and height calculation below), cvFloor is used here instead of cvCeil
-            int pt_x = cvFloor(pts[2*i]);
-            int pt_y = cvFloor(pts[2*i+1]);
+            float pt_x = pts[2*i];
+            float pt_y = pts[2*i+1];
 
-            xmin = std::min(xmin, pt_x);
-            xmax = std::max(xmax, pt_x);
-            ymin = std::min(ymin, pt_y);
-            ymax = std::max(ymax, pt_y);
+            xmin_f = std::min(xmin_f, pt_x);
+            xmax_f = std::max(xmax_f, pt_x);
+            ymin_f = std::min(ymin_f, pt_y);
+            ymax_f = std::max(ymax_f, pt_y);
         }
+
+        // because right and bottom sides of the bounding rectangle are not inclusive
+        // (note +1 in width and height calculation below), the extrema are floored, not rounded
+        xmin = floorSaturate(xmin_f);
+        xmax = floorSaturate(xmax_f);
+        ymin = floorSaturate(ymin_f);
+        ymax = floorSaturate(ymax_f);
     }
 
-    return Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1);
+    // xmax - xmin overflows int once the extrema saturate, so the sides are computed in int64
+    const int64_t width  = (int64_t)xmax - (int64_t)xmin + 1;
+    const int64_t height = (int64_t)ymax - (int64_t)ymin + 1;
+    return Rect(xmin, ymin, (int)std::min<int64_t>(width, INT_MAX), (int)std::min<int64_t>(height, INT_MAX));
 }
 
 cv::Rect boundingRect(InputArray array)

--- a/modules/geometry/test/test_boundingrect.cpp
+++ b/modules/geometry/test/test_boundingrect.cpp
@@ -123,4 +123,42 @@ TEST(Imgproc_BoundingRect, bool_mask_29578)
     }
 }
 
+// See https://github.com/opencv/opencv/issues/29837
+// A CV_32F coordinate outside of the int range used to reach cvFloor(), which is undefined
+// there: points spanning 1e10 collapsed to a 1x1 rect at INT_MIN, and +inf/-inf gave
+// INT_MIN/INT_MAX, an inverted rectangle. They are saturated to the representable bounds now.
+TEST(Imgproc_BoundingRect, out_of_int_range_29837)
+{
+    const int imin = std::numeric_limits<int>::min();
+    const int imax = std::numeric_limits<int>::max();
+    const float inf = std::numeric_limits<float>::infinity();
+
+    // in-range point sets are unaffected
+    std::vector<Point2f> in_range { Point2f(1e4f, 1e4f), Point2f(2e4f, 2e4f) };
+    EXPECT_EQ(boundingRect(in_range), Rect(10000, 10000, 10001, 10001));
+
+    // out of range: saturated, orientation preserved
+    std::vector<Point2f> above { Point2f(1e10f, 1e10f), Point2f(2e10f, 2e10f) };
+    EXPECT_EQ(boundingRect(above), Rect(imax, imax, 1, 1));
+
+    std::vector<Point2f> below { Point2f(-1e10f, -1e10f), Point2f(-2e10f, -2e10f) };
+    EXPECT_EQ(boundingRect(below), Rect(imin, imin, 1, 1));
+
+    // infinities saturate the same way, and the sides are clamped instead of overflowing
+    std::vector<Point2f> plus_inf { Point2f(inf, 0.f), Point2f(1.f, 1.f), Point2f(2.f, 0.f) };
+    EXPECT_EQ(boundingRect(plus_inf), Rect(1, 0, imax, 2));
+
+    std::vector<Point2f> minus_inf { Point2f(-inf, 0.f), Point2f(1.f, 1.f), Point2f(2.f, 0.f) };
+    EXPECT_EQ(boundingRect(minus_inf), Rect(imin, 0, imax, 2));
+
+    // long enough to go through the SIMD path as well
+    std::vector<Point2f> simd(64, Point2f(5.f, 5.f));
+    simd[37] = Point2f(1e10f, -1e10f);
+    EXPECT_EQ(boundingRect(simd), Rect(5, imin, imax - 4, imax));
+
+    // CV_32S needs no conversion, but its sides can overflow int just the same
+    std::vector<Point> ints { Point(imin, imin), Point(imax, imax) };
+    EXPECT_EQ(boundingRect(ints), Rect(imin, imin, imax, imax));
+}
+
 }} // namespace


### PR DESCRIPTION
`pointSetBoundingRect()` passes `CV_32F` coordinates to `cvFloor()` without honouring its
documented `INT_MIN..INT_MAX` precondition, so a point set outside the int range collapses to a
1x1 rect at `INT_MIN`, while `+inf` and `-inf` give `INT_MIN` and `INT_MAX` — an inverted
rectangle. Coordinates are now saturated to the closest representable bound.

The sides are computed in `int64` and clamped to `INT_MAX`: `xmax - xmin + 1` overflows int
once the extrema saturate, and already did so for a `CV_32S` point set spanning the whole int
range.

Fixes #29837

### Before / after

```python
import numpy as np, cv2
rect = lambda p: cv2.boundingRect(np.array(p, np.float32).reshape(-1, 1, 2))
```

| input | before | after |
|---|---|---|
| `[1e10,1e10], [2e10,2e10]` | `(-2147483648, -2147483648, 1, 1)` | `(2147483647, 2147483647, 1, 1)` |
| `+inf` in x | `(-2147483648, 0, 1, 2)` | `(1, 0, 2147483647, 2)` |
| `-inf` in x | `(2147483647, 0, 1, 2)` | `(-2147483648, 0, 2147483647, 2)` |
| `[1e4,1e4], [2e4,2e4]` | `(10000, 10000, 10001, 10001)` | unchanged |

In-range point sets are bit-for-bit unchanged — the conversion is still `cvFloor()`, only its
argument range is now guarded.

### Changes

`modules/imgproc/src/geometry.cpp`

- `floorSaturate()` clamps to `INT_MIN`/`INT_MAX` before `cvFloor()`, replacing the three
  existing `cvFloor()` call sites in the `CV_32F` branch (seed, SIMD reduction, scalar tail).
- The rectangle sides are computed in `int64` and clamped to `INT_MAX`. This is required by the
  change above — once both extrema saturate, `xmax - xmin + 1` is 2^32 — and it also fixes the
  pre-existing signed overflow for a `CV_32S` point set spanning the int range.

`modules/imgproc/include/opencv2/imgproc.hpp`

- A `@note` on `boundingRect()` documents the saturation, since it is now a guarantee.

### Why saturation

The issue offered three options and asked which was preferred. This implements saturation
(option 1) together with the documentation note (option 3), because saturation is already the
convention in-tree rather than a new behaviour:

- `cv::checkRange()` clamps values to the int range before calling `cvFloor()`/`cvCeil()` for
  exactly this reason (`modules/core/src/mathfuncs.cpp`).
- The `value > 0 ? INT_MAX : INT_MIN` form matches `saturate_cast<int>(int64)` in
  `modules/core/include/opencv2/core/saturate.hpp`.
- Drawing code widens to `int64`/`Point2l` for out-of-range geometry rather than rejecting it.

Rejecting non-representable input with `CV_Assert` (option 2) was avoided deliberately: it would
turn calls that currently return into exceptions on the maintenance branch, and
`boundingRect()` is called internally from other OpenCV code paths.

NaN remains unsupported and is documented as such. It no longer reaches `cvFloor()`'s undefined
path, but whether a NaN survives to the conversion depends on how `min`/`max` propagate it, so
no specific result is promised.

### Testing

- New regression test `Imgproc_BoundingRect.out_of_int_range_29837` covering finite
  out-of-range coordinates, both infinities, the SIMD path, and the `CV_32S` overflow. It fails
  on 5 assertions without the fix, including a negative height, and passes with it.
- All `Imgproc_BoundingRect*` tests pass (6/6), including the randomized accuracy test that
  compares against a reference implementation.
- Full `opencv_test_imgproc`: 1576 passed; the remaining failures are all missing `opencv_extra`
  data locally and are unrelated to this change.
- Checked on x86-64 with AVX2/AVX-512, and with the SIMD block disabled to exercise the scalar
  tail. Other SIMD backends rely on the monotonicity of `floor`.

No new test data, so no `opencv_extra` patch is needed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well 