### PR TITLE
imgcodecs : add NEON fast paths for inflate copy loops

### DIFF
--- a/3rdparty/zlib/inffast.c
+++ b/3rdparty/zlib/inffast.c
@@ -7,6 +7,7 @@
 #include "inftrees.h"
 #include "inflate.h"
 #include "inffast.h"
+#include "zarm.h"
 
 #ifdef ASMINF
 #  pragma message("Assembler code may have bugs -- use at your own risk")
@@ -199,9 +200,13 @@ void ZLIB_INTERNAL inflate_fast(z_streamp strm, unsigned start) {
                         from += wsize - op;
                         if (op < len) {         /* some from window */
                             len -= op;
+#ifdef Z_ARM64_NEON
+                            out = neon_copy_disjoint(out, from, op);
+#else
                             do {
                                 *out++ = *from++;
                             } while (--op);
+#endif
                             from = out - dist;  /* rest from output */
                         }
                     }
@@ -210,16 +215,24 @@ void ZLIB_INTERNAL inflate_fast(z_streamp strm, unsigned start) {
                         op -= wnext;
                         if (op < len) {         /* some from end of window */
                             len -= op;
+#ifdef Z_ARM64_NEON
+                            out = neon_copy_disjoint(out, from, op);
+#else
                             do {
                                 *out++ = *from++;
                             } while (--op);
+#endif
                             from = window;
                             if (wnext < len) {  /* some from start of window */
                                 op = wnext;
                                 len -= op;
+#ifdef Z_ARM64_NEON
+                                out = neon_copy_disjoint(out, from, op);
+#else
                                 do {
                                     *out++ = *from++;
                                 } while (--op);
+#endif
                                 from = out - dist;      /* rest from output */
                             }
                         }
@@ -228,9 +241,13 @@ void ZLIB_INTERNAL inflate_fast(z_streamp strm, unsigned start) {
                         from += wnext - op;
                         if (op < len) {         /* some from window */
                             len -= op;
+#ifdef Z_ARM64_NEON
+                            out = neon_copy_disjoint(out, from, op);
+#else
                             do {
                                 *out++ = *from++;
                             } while (--op);
+#endif
                             from = out - dist;  /* rest from output */
                         }
                     }
@@ -247,6 +264,9 @@ void ZLIB_INTERNAL inflate_fast(z_streamp strm, unsigned start) {
                     }
                 }
                 else {
+#ifdef Z_ARM64_NEON
+                    out = neon_copy_lz77(out, dist, len);
+#else
                     from = out - dist;          /* copy direct from output */
                     do {                        /* minimum length is three */
                         *out++ = *from++;
@@ -259,6 +279,7 @@ void ZLIB_INTERNAL inflate_fast(z_streamp strm, unsigned start) {
                         if (len > 1)
                             *out++ = *from++;
                     }
+#endif
                 }
             }
             else if ((op & 64) == 0) {          /* 2nd level distance code */

--- a/3rdparty/zlib/zarm.h
+++ b/3rdparty/zlib/zarm.h
@@ -1,0 +1,77 @@
+#ifndef ZARM_H
+#define ZARM_H
+
+#include "zutil.h"
+
+#if defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
+
+#  if defined(_MSC_VER)
+#    include <arm64_neon.h>
+#  else
+#    include <arm_neon.h>
+#  endif
+
+#  define Z_ARM64_NEON 1
+
+static inline unsigned char FAR *neon_copy_disjoint(unsigned char FAR *out,
+                                                    unsigned char FAR *from,
+                                                    unsigned len) {
+    while (len >= 16) {
+        vst1q_u8(out, vld1q_u8(from));
+        out += 16;
+        from += 16;
+        len -= 16;
+    }
+    while (len--)
+        *out++ = *from++;
+    return out;
+}
+
+static inline unsigned char FAR *neon_copy_lz77(unsigned char FAR *out,
+                                                unsigned dist, unsigned len) {
+    unsigned char FAR *from = out - dist;
+
+    if (dist >= 16) {
+        while (len >= 16) {
+            vst1q_u8(out, vld1q_u8(from));
+            out += 16;
+            from += 16;
+            len -= 16;
+        }
+    }
+    else if (len >= 16) {
+        uint8x16_t pattern;
+        unsigned step = (16 / dist) * dist;
+
+        if (dist == 1) {
+            pattern = vdupq_n_u8(*from);
+        }
+        else {
+            unsigned char idx[16];
+            unsigned i, k = 0;
+            for (i = 0; i < 16; i++) {
+                idx[i] = (unsigned char)k;
+                if (++k == dist)
+                    k = 0;
+            }
+            pattern = vqtbl1q_u8(vld1q_u8(from), vld1q_u8(idx));
+        }
+
+        do {
+            vst1q_u8(out, pattern);
+            out += step;
+            len -= step;
+        } while (len >= 16);
+
+        from = out - dist;
+    }
+
+    while (len--)
+        *out++ = *from++;
+
+    return out;
+}
+
+#endif
+
+#endif


### PR DESCRIPTION
## Summary

- The decode function in the imgcodecs module internally uses scalar loops from inffast.c for computation, and this scalar implementation runs slower on Windows-ARM64 compared to Windows-x64.
- Enabled`-DWITH_ZLIB_NG=ON `as an alternative, but it caused 21 accuracy tests to fail on Windows-ARM64.

## Fix

- Added the NEON implementation of those scalar copy loops in a new file 3rdparty/zlib/zarm.h, and called it from inffast.c for ARM64 platforms. All accuracy and performance tests are passing with this change.
- All other platforms still use the existing scalar loops, no change in behavior.

## Performance Benchmarks:
<img width="834" height="130" alt="image" src="https://github.com/user-attachments/assets/3c29eeaa-e912-4242-9ac8-1e8ce3d67790" />

