### PR TITLE
dnn: SAM2 decoder perf — deconvolution threading + TransformLayout/Add fusion

### DIFF
--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -1830,6 +1830,10 @@ CV__DNN_INLINE_NS_BEGIN
     public:
         DataLayout layout;
         int C0;
+        // Set by graph_fusion_transform_add.cpp when a following elementwise Add
+        // (same-shape, no broadcasting) has been folded into this layer's
+        // deinterleave pass: inputs then holds [data, residual] instead of [data].
+        bool fusedAdd = false;
         static Ptr<TransformLayoutLayer> create(const LayerParams& params);
     };
 

--- a/modules/dnn/include/opencv2/dnn/all_layers.hpp
+++ b/modules/dnn/include/opencv2/dnn/all_layers.hpp
@@ -375,8 +375,6 @@ CV__DNN_INLINE_NS_BEGIN
         virtual bool fuseBatchNorm(const Ptr<Layer>& bn) = 0;
         virtual bool fuseActivation(const Ptr<Layer>& activ) = 0;
         virtual bool fuseAddResidual(Arg residual) = 0;
-        // Folds a trailing scalar multiply into the pre-activation scale/bias; requires scale >= 0 and act(x)*s == act(x*s).
-        virtual bool fuseTrailingScale(InputArray scale) = 0;
 
         std::vector<int> strides, dilations, pads;
         int ngroups;

--- a/modules/dnn/include/opencv2/dnn/dnn.hpp
+++ b/modules/dnn/include/opencv2/dnn/dnn.hpp
@@ -62,6 +62,12 @@ CV__DNN_INLINE_NS_BEGIN
 //! @addtogroup dnn
 //! @{
 
+    //! Fusion IR, defined in dnn/src/fusion_graph.hpp. Only the two Layer
+    //! virtuals below refer to these, and only by reference.
+    class AdjacencyGraph;
+    struct LayerMath;
+    struct ConstOperand;
+
     typedef int MatType;
 
     /**
@@ -512,6 +518,27 @@ CV__DNN_INLINE_NS_BEGIN
          *  LayerInfo::weightEpoch, unlike finalize(). Default: no-op.
          */
         virtual void prepackWeights();
+
+        /** @brief States this layer's math as a small expression, so a fusion pass can
+         *  absorb it into whatever produces its input.
+         *
+         *  @param out receives the expression, built through LayerMath's emitters.
+         *  @param side describes the layer's non-flowing inputs when it has any, e.g.
+         *         the constant operand of an Add. Empty for a plain unary op.
+         *  @return false if the layer cannot be expressed, which also means it can
+         *          never be absorbed. Default: false.
+         */
+        virtual bool unfoldOp(LayerMath& out, const ConstOperand& side) const;
+
+        /** @brief Offers a trailing expression for this layer to absorb into its own
+         *  computation. The layer decides; refusing is always safe.
+         *
+         *  The pass offers the longest chain first and retries with shorter ones, so
+         *  an implementation must finish validating before it mutates any state.
+         *  @return true if the expression was taken on, in which case the layer is now
+         *          responsible for computing it. Default: false.
+         */
+        virtual bool absorbMath(const Ptr<AdjacencyGraph>& expr);
 
         CV_PROP int preferableTarget; //!< prefer target for layer forwarding
 

--- a/modules/dnn/src/adjacency_graph.hpp
+++ b/modules/dnn/src/adjacency_graph.hpp
@@ -1,0 +1,451 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+// Copyright (C) 2026, BigVision LLC, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#ifndef __OPENCV_DNN_SRC_ADJACENCY_GRAPH_HPP__
+#define __OPENCV_DNN_SRC_ADJACENCY_GRAPH_HPP__
+
+#include <cmath>
+#include <unordered_map>
+#include <vector>
+#include <opencv2/core.hpp>
+#include "opencv2/dnn/all_layers.hpp"   // ActivationFunc
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+enum {
+    FUSION_MAX_EXPR_NODES   = 64,      //!< cap on one extracted expression
+    FUSION_MAX_MATH_NODES = 16,      //!< cap on one layer's math
+    FUSION_MAX_ARENA_NODES  = 1 << 16  //!< cap on the shared arena for a whole graph
+};
+
+enum class FusionEltwiseOp
+{
+    INPUT = 0,
+    CONST = 1,
+    PER_CHANNEL_CONST = 2,
+    ADD = 3,
+    SUB = 4,
+    MUL = 5,
+    MAX = 6,
+    MIN = 7,
+    ERF = 8,
+    TANH = 9,
+    EXP = 10,
+    SQRT = 11,
+    CLAMP = 12,
+    RECIP = 13
+};
+
+namespace fusion { namespace detail {
+
+inline int arity(FusionEltwiseOp op)
+{
+    switch (op) {
+    case FusionEltwiseOp::INPUT:
+    case FusionEltwiseOp::CONST:
+    case FusionEltwiseOp::PER_CHANNEL_CONST:
+        return 0;
+    case FusionEltwiseOp::ADD:
+    case FusionEltwiseOp::SUB:
+    case FusionEltwiseOp::MUL:
+    case FusionEltwiseOp::MAX:
+    case FusionEltwiseOp::MIN:
+        return 2;
+    case FusionEltwiseOp::ERF:
+    case FusionEltwiseOp::TANH:
+    case FusionEltwiseOp::EXP:
+    case FusionEltwiseOp::SQRT:
+    case FusionEltwiseOp::CLAMP:
+    case FusionEltwiseOp::RECIP:
+        return 1;
+    }
+    CV_Error(Error::StsBadArg, "DNN/fusion: unknown FusionEltwiseOp");
+}
+
+inline unsigned bits(float f) { Cv32suf s; s.f = f; return s.u; }
+
+}} // namespace fusion::detail
+
+/** @brief The constant operand(s) a layer has alongside the value flowing into it,
+ *  e.g. the 3 in `x + 3`, or Clip's two bounds. A layer with none gets hasValue false.
+ */
+struct ConstOperand
+{
+    bool  hasValue         = false;  //!< false means there is no constant operand
+    bool  flowIsFirstInput = true;   //!< the flowing value is the layer's input 0
+    float value            = 0.f;    //!< scalar constant, or Clip's lower bound
+    float value2           = 0.f;    //!< Clip's upper bound; unused otherwise
+    int   bufferId         = -1;     //!< >=0 for a per-channel constant, indexes constBufs
+};
+
+struct LayerMathNode
+{
+    FusionEltwiseOp op = FusionEltwiseOp::CONST;
+    int   left = -1, right = -1;
+    float scalar = 0.f, scalar2 = 0.f;
+    int   bufferId = -1;
+};
+
+/** @brief Straight-line description of one layer's elementwise math.
+ *
+ * A layer builds its math by appending nodes; each call returns the index of
+ * the node it added, and an operand is either one of those indices or
+ * INPUT_VALUE, standing for the value arriving from the layer being fused into.
+ * Since nodes can only be added this way, a math is always well formed.
+ */
+struct LayerMath
+{
+    enum { INPUT_VALUE = -1 };
+
+    enum { MAX_KERNEL_PARAMS = 4 };
+
+    //! The layer's own kernel for exactly this math, when it has one. A backend that
+    //! also has it can run it directly instead of walking the decomposed form.
+    ActivationFunc kernel = nullptr;
+    float kernelParams[MAX_KERNEL_PARAMS] = { 0.f, 0.f, 0.f, 0.f };
+    int   kernelParamCount = 0;
+
+    void setKernel(ActivationFunc fn, const std::vector<float>& params)
+    {
+        if (params.size() > (size_t)MAX_KERNEL_PARAMS)
+            return;
+        kernel = fn;
+        kernelParamCount = (int)params.size();
+        for (int i = 0; i < kernelParamCount; i++)
+            kernelParams[i] = params[i];
+    }
+
+    int nodeCount() const { return nodeCount_; }
+    const LayerMathNode& nodeAt(int i) const
+    {
+        CV_DbgAssert(i >= 0 && i < nodeCount_);
+        return nodes_[i];
+    }
+
+    int constant(float value)
+    { return appendNode(FusionEltwiseOp::CONST, INPUT_VALUE, INPUT_VALUE, value, 0.f, -1); }
+
+    int perChannelConstant(int bufferId)
+    {
+        CV_Assert(bufferId >= 0);
+        return appendNode(FusionEltwiseOp::PER_CHANNEL_CONST, INPUT_VALUE, INPUT_VALUE,
+                          0.f, 0.f, bufferId);
+    }
+
+    int unary(FusionEltwiseOp op, int operand)
+    {
+        CV_Assert(fusion::detail::arity(op) == 1);
+        return appendNode(op, operand, INPUT_VALUE, 0.f, 0.f, -1);
+    }
+
+    int binary(FusionEltwiseOp op, int left, int right)
+    {
+        CV_Assert(fusion::detail::arity(op) == 2);
+        return appendNode(op, left, right, 0.f, 0.f, -1);
+    }
+
+    int clamp(int operand, float lo, float hi)
+    { return appendNode(FusionEltwiseOp::CLAMP, operand, INPUT_VALUE, lo, hi, -1); }
+
+private:
+    int appendNode(FusionEltwiseOp op, int a, int b, float s0, float s1, int buf)
+    {
+        CV_Assert(nodeCount_ < FUSION_MAX_MATH_NODES);
+        CV_Assert(a >= INPUT_VALUE && a < nodeCount_);
+        CV_Assert(b >= INPUT_VALUE && b < nodeCount_);
+        LayerMathNode& nd = nodes_[nodeCount_];
+        nd.op = op; nd.left = a; nd.right = b; nd.scalar = s0; nd.scalar2 = s1; nd.bufferId = buf;
+        return nodeCount_++;
+    }
+
+    int nodeCount_ = 0;
+    LayerMathNode nodes_[FUSION_MAX_MATH_NODES];
+};
+
+// Sigmoid and Gelu are each built twice - by their own layer, and by the
+// reference table matchKnownActivation compares against - and the two have to
+// emit nodes in the same order, so they share one definition.
+namespace fusion {
+
+inline void sigmoid(LayerMath& r)
+{
+    const int one      = r.constant(1.f);
+    const int minusOne = r.constant(-1.f);
+    const int negated  = r.binary(FusionEltwiseOp::MUL, LayerMath::INPUT_VALUE, minusOne);
+    const int exponent = r.unary(FusionEltwiseOp::EXP, negated);
+    const int denom    = r.binary(FusionEltwiseOp::ADD, one, exponent);
+    r.unary(FusionEltwiseOp::RECIP, denom);
+}
+
+inline void gelu(LayerMath& r)
+{
+    const int half     = r.constant(0.5f);
+    const int one      = r.constant(1.f);
+    const int invSqrt2 = r.constant(0.70710678118654752440f);
+    const int scaled   = r.binary(FusionEltwiseOp::MUL, LayerMath::INPUT_VALUE, invSqrt2);
+    const int erfTerm  = r.unary(FusionEltwiseOp::ERF, scaled);
+    const int gate     = r.binary(FusionEltwiseOp::ADD, one, erfTerm);
+    const int halfX    = r.binary(FusionEltwiseOp::MUL, half, LayerMath::INPUT_VALUE);
+    r.binary(FusionEltwiseOp::MUL, halfX, gate);
+}
+
+} // namespace fusion
+
+struct FusionNode
+{
+    FusionEltwiseOp op = FusionEltwiseOp::INPUT;
+    std::vector<int> inputs;
+    float scalar = 0.f;
+    float scalar2 = 0.f;
+    int constBufferId = -1;
+
+    bool operator==(const FusionNode& o) const noexcept
+    {
+        return op == o.op && inputs == o.inputs
+            && fusion::detail::bits(scalar)  == fusion::detail::bits(o.scalar)
+            && fusion::detail::bits(scalar2) == fusion::detail::bits(o.scalar2)
+            && constBufferId   == o.constBufferId;
+    }
+};
+
+struct FusionNodeHash
+{
+    size_t operator()(const FusionNode& n) const noexcept
+    {
+        size_t h = std::hash<int>()((int)n.op);
+        for (int i : n.inputs) h = h * 1000003u ^ (size_t)i;
+        h = h * 1000003u ^ (size_t)fusion::detail::bits(n.scalar);
+        h = h * 1000003u ^ (size_t)fusion::detail::bits(n.scalar2);
+        h = h * 1000003u ^ (size_t)n.constBufferId;
+        return h;
+    }
+};
+
+class AdjacencyGraph
+{
+public:
+    const std::vector<FusionNode>& nodes() const { return nodes_; }
+    size_t size() const { return nodes_.size(); }
+    int outputNode = -1;
+    std::vector<Mat> constBufs;
+
+    //! Set when this whole expression is one layer that already has a kernel.
+    ActivationFunc kernel = nullptr;
+    float kernelParams[LayerMath::MAX_KERNEL_PARAMS] = { 0.f, 0.f, 0.f, 0.f };
+    int   kernelParamCount = 0;
+
+private:
+    std::vector<FusionNode> nodes_;
+    int append(FusionNode n)
+    {
+        nodes_.push_back(std::move(n));
+        return (int)nodes_.size() - 1;
+    }
+    friend class AdjacencyGraphBuilder;
+};
+
+class AdjacencyGraphBuilder
+{
+public:
+    AdjacencyGraphBuilder() : gp_(makePtr<AdjacencyGraph>()) {}
+
+    /** @brief Adds one node, reusing an identical existing one if there is
+     *  already one in this graph. Returns the node's index either way. */
+    int internNode(FusionEltwiseOp op, std::vector<int> inputs, float scalar = 0.f,
+                   float scalar2 = 0.f, int constBufferId = -1)
+    {
+        CV_Assert((gp_->size() == 0) == (op == FusionEltwiseOp::INPUT));
+        CV_Assert((int)inputs.size() == fusion::detail::arity(op));
+        CV_DbgAssert(gp_->size() < (size_t)FUSION_MAX_ARENA_NODES);
+        for (int i : inputs)
+            CV_Assert(i >= 0 && i < (int)gp_->size());
+
+        if ((op == FusionEltwiseOp::ADD || op == FusionEltwiseOp::MUL) && inputs[0] > inputs[1])
+            std::swap(inputs[0], inputs[1]);
+
+        if (op != FusionEltwiseOp::CONST && op != FusionEltwiseOp::CLAMP) scalar = 0.f;
+        if (op != FusionEltwiseOp::CLAMP)                                 scalar2 = 0.f;
+        if (op != FusionEltwiseOp::PER_CHANNEL_CONST)                     constBufferId = -1;
+
+        FusionNode cand;
+        cand.op = op;
+        cand.inputs = std::move(inputs);
+        cand.scalar = scalar;
+        cand.scalar2 = scalar2;
+        cand.constBufferId = constBufferId;
+
+        std::unordered_map<FusionNode, int, FusionNodeHash>::const_iterator it = interned_.find(cand);
+        if (it != interned_.end())
+            return it->second;
+
+        const int idx = gp_->append(cand);
+        interned_.emplace(std::move(cand), idx);
+        return idx;
+    }
+
+    size_t size() const { return gp_->size(); }
+    const AdjacencyGraph& graph() const { return *gp_; }
+
+    Ptr<AdjacencyGraph> finish(int output)
+    {
+        CV_Assert(output == (int)gp_->size() - 1);
+        gp_->outputNode = output;
+        return gp_;
+    }
+
+    //! The graph as built so far; the builder keeps writing to it.
+    Ptr<AdjacencyGraph> sharedGraph() { return gp_; }
+
+private:
+    Ptr<AdjacencyGraph> gp_;
+    std::unordered_map<FusionNode, int, FusionNodeHash> interned_;
+};
+
+namespace fusion {
+
+inline int instantiate(AdjacencyGraphBuilder& builder, int inputNode,
+                             const LayerMath& math)
+{
+    if (inputNode < 0 || math.nodeCount() <= 0)
+        return -1;
+
+    int graphIndex[FUSION_MAX_MATH_NODES];
+    for (int i = 0; i < math.nodeCount(); i++) {
+        const LayerMathNode& nd = math.nodeAt(i);
+        const int k = detail::arity(nd.op);
+        std::vector<int> inputs;
+        inputs.reserve((size_t)k);
+        if (k >= 1) inputs.push_back(nd.left  < 0 ? inputNode : graphIndex[nd.left]);
+        if (k >= 2) inputs.push_back(nd.right < 0 ? inputNode : graphIndex[nd.right]);
+        graphIndex[i] = builder.internNode(nd.op, inputs, nd.scalar, nd.scalar2, nd.bufferId);
+    }
+    return graphIndex[math.nodeCount() - 1];
+}
+
+inline float evalElement(const AdjacencyGraph& g, float x,
+                             const std::vector<const float*>& constBufs, int channelIdx)
+{
+    const std::vector<FusionNode>& nodes = g.nodes();
+    const int out = g.outputNode;
+    CV_DbgAssert(out == (int)nodes.size() - 1);
+    CV_Assert(nodes.size() <= (size_t)FUSION_MAX_EXPR_NODES);
+
+    float v[FUSION_MAX_EXPR_NODES];
+
+    for (int i = 0; i <= out; i++) {
+        const FusionNode& n = nodes[i];
+        const float a = n.inputs.size() > 0 ? v[n.inputs[0]] : 0.f;
+        const float b = n.inputs.size() > 1 ? v[n.inputs[1]] : 0.f;
+
+        switch (n.op) {
+        case FusionEltwiseOp::INPUT: v[i] = x; break;
+        case FusionEltwiseOp::CONST: v[i] = n.scalar; break;
+        case FusionEltwiseOp::PER_CHANNEL_CONST:
+            CV_DbgAssert(n.constBufferId >= 0 && n.constBufferId < (int)constBufs.size());
+            v[i] = constBufs[n.constBufferId][channelIdx];
+            break;
+        case FusionEltwiseOp::ADD:   v[i] = a + b; break;
+        case FusionEltwiseOp::SUB:   v[i] = a - b; break;
+        case FusionEltwiseOp::MUL:   v[i] = a * b; break;
+        case FusionEltwiseOp::MAX:   v[i] = a < b ? b : a; break;
+        case FusionEltwiseOp::MIN:   v[i] = b < a ? b : a; break;
+        case FusionEltwiseOp::ERF:   v[i] = std::erf(a); break;
+        case FusionEltwiseOp::TANH:  v[i] = std::tanh(a); break;
+        case FusionEltwiseOp::EXP:   v[i] = std::exp(a); break;
+        case FusionEltwiseOp::SQRT:  v[i] = std::sqrt(a); break;
+        case FusionEltwiseOp::RECIP: v[i] = 1.f / a; break;
+        case FusionEltwiseOp::CLAMP:
+            v[i] = a < n.scalar ? n.scalar : (a > n.scalar2 ? n.scalar2 : a);
+            break;
+        }
+    }
+    return v[out];
+}
+
+namespace detail {
+
+inline int markLive(const AdjacencyGraph& g, int root, std::vector<char>& live)
+{
+    const std::vector<FusionNode>& nodes = g.nodes();
+    CV_Assert(root >= 0 && root < (int)nodes.size());
+    live.assign((size_t)root + 1, 0);
+    live[root] = 1;
+    int nlive = 0;
+    for (int i = root; i >= 0; i--) {
+        if (!live[i]) continue;
+        nlive++;
+        for (int in : nodes[i].inputs) {
+            CV_DbgAssert(in >= 0 && in < i);
+            live[in] = 1;
+        }
+    }
+    return nlive;
+}
+
+} // namespace detail
+
+inline Ptr<AdjacencyGraph> extract(const AdjacencyGraph& arena, int root,
+                                          const std::vector<Mat>& constBufs)
+{
+    const std::vector<FusionNode>& src = arena.nodes();
+    if (root < 0 || root >= (int)src.size())
+        return Ptr<AdjacencyGraph>();
+
+    std::vector<char> live;
+    detail::markLive(arena, root, live);
+    CV_DbgAssert(src[0].op == FusionEltwiseOp::INPUT);
+    if (!live[0])
+        return Ptr<AdjacencyGraph>();
+
+    std::vector<int> remap(live.size(), -1);
+    AdjacencyGraphBuilder out;
+    remap[0] = out.internNode(FusionEltwiseOp::INPUT, {});
+
+    std::vector<int> pending(1, root);
+    while (!pending.empty()) {
+        const int i = pending.back();
+        if (remap[i] >= 0) {
+            pending.pop_back();
+            continue;
+        }
+        const FusionNode& n = src[i];
+        bool waiting = false;
+        for (size_t k = n.inputs.size(); k > 0; k--) {
+            if (remap[n.inputs[k - 1]] < 0) {
+                pending.push_back(n.inputs[k - 1]);
+                waiting = true;
+            }
+        }
+        if (waiting)
+            continue;
+        pending.pop_back();
+
+        if (out.size() >= (size_t)FUSION_MAX_EXPR_NODES)
+            return Ptr<AdjacencyGraph>();
+        if (n.op == FusionEltwiseOp::PER_CHANNEL_CONST &&
+            (n.constBufferId < 0 || n.constBufferId >= (int)constBufs.size()))
+            return Ptr<AdjacencyGraph>();
+        std::vector<int> ins(n.inputs.size());
+        for (size_t k = 0; k < ins.size(); k++)
+            ins[k] = remap[n.inputs[k]];
+        remap[i] = out.internNode(n.op, ins, n.scalar, n.scalar2, n.constBufferId);
+    }
+    if (remap[root] != (int)out.size() - 1)
+        return Ptr<AdjacencyGraph>();
+
+    Ptr<AdjacencyGraph> g = out.finish(remap[root]);
+    g->constBufs = constBufs;
+    return g;
+}
+
+
+} // namespace fusion
+
+CV__DNN_INLINE_NS_END
+}} // namespace cv::dnn
+
+#endif

--- a/modules/dnn/src/graph_fusion_basic.cpp
+++ b/modules/dnn/src/graph_fusion_basic.cpp
@@ -131,24 +131,6 @@ struct ModelFusionBasic
                     }
                 }
 
-                // fold a trailing scalar multiply into 'conv' (e.g. exported "Conv -> ReLU -> Mul(scale)"); safety is checked inside fuseTrailingScale().
-                if (elemwise && elemwise->op == NaryEltwiseLayer::OPERATION::PROD &&
-                    ninputs == 2) {
-                    int const_idx = netimpl->isConstArg(inputs[0]) ? 0 :
-                                     netimpl->isConstArg(inputs[1]) ? 1 : -1;
-                    if (const_idx >= 0) {
-                        Arg conv_out = inputs[1 - const_idx];
-                        int conv_layer_idx = producer_of.at(conv_out.idx);
-                        Conv2Layer* conv = getLayer<Conv2Layer>(newprog, conv_layer_idx);
-                        if (conv && usecounts.at(conv_out.idx) == 1 &&
-                            conv->fuseTrailingScale(netimpl->argTensor(inputs[const_idx]))) {
-                            fused_layer_idx = conv_layer_idx;
-                            removed_args.push_back(conv_out);
-                            break;
-                        }
-                    }
-                }
-
                 // fuse Reshape + InstanceNorm(scale=ones,bias=zeros) + Reshape + Mul + Add
                 if (elemwise && elemwise->op == NaryEltwiseLayer::OPERATION::ADD &&
                     ninputs == 2) {

--- a/modules/dnn/src/graph_fusion_chain.cpp
+++ b/modules/dnn/src/graph_fusion_chain.cpp
@@ -1,0 +1,356 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+// Copyright (C) 2026, BigVision LLC, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+#include "adjacency_graph.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+using std::vector;
+
+namespace {
+
+void firstConsumerOf(const vector<Ptr<LayerInfo> >& prog, int nargs,
+                     vector<int>& firstConsumer)
+{
+    firstConsumer.assign((size_t)nargs, -1);
+    for (size_t j = 0; j < prog.size(); j++) {
+        if (!prog[j]) continue;
+        for (Arg in : prog[j]->inputs) {
+            if (in.idx > 0 && in.idx < nargs && firstConsumer[in.idx] < 0)
+                firstConsumer[in.idx] = (int)j;
+        }
+    }
+}
+
+class ChainFuser
+{
+public:
+    ChainFuser(Net::Impl& net, const Ptr<Graph>& graph, const vector<int>& usecounts)
+        : net_(net), graph_(graph), usecounts_(usecounts)
+    {
+        CV_Assert((int)usecounts_.size() == (int)net_.args.size());
+        claimed_.assign(prog().size(), false);
+        const int inputNode = arena_.internNode(FusionEltwiseOp::INPUT, {});
+        CV_Assert(inputNode == 0);
+    }
+    ChainFuser(const ChainFuser&) = delete;
+    ChainFuser& operator=(const ChainFuser&) = delete;
+
+    bool fuse()
+    {
+        collectChains();
+        if (chains_.empty())
+            return false;
+        freezeArena();
+        fuseLongestChains();
+        if (nfused_ == 0)
+            return false;
+        dropAbsorbedLayers();
+        return true;
+    }
+
+private:
+    struct ChainCandidate
+    {
+        vector<int> layerIdx;
+        vector<Arg> constArgs;
+        vector<int> rootAfterStep;
+        vector<Mat> constBufs;
+        ActivationFunc singleStepKernel = nullptr;
+        float singleStepKernelParams[LayerMath::MAX_KERNEL_PARAMS] = { 0.f, 0.f, 0.f, 0.f };
+        int   singleStepKernelParamCount = 0;
+    };
+
+    const vector<Ptr<LayerInfo> >& prog() const { return graph_->prog(); }
+
+    bool isFusableConstArg(Arg a, bool& isScalar, float& scalarVal) const
+    {
+        if (!net_.isConstArg(a))
+            return false;
+        Mat t = net_.argTensor(a);
+        if (t.total() == 1) {
+            if (t.type() == CV_32F) { isScalar = true; scalarVal = t.ptr<float>()[0]; return true; }
+            if (t.type() == CV_64F) { isScalar = true; scalarVal = (float)t.ptr<double>()[0]; return true; }
+            return false;
+        }
+        if (t.type() != CV_32F)
+            return false;
+        int nonUnit = 0;
+        for (int d = 0; d < t.dims; d++)
+            if (t.size[d] != 1) nonUnit++;
+        if (nonUnit != 1)
+            return false;
+        isScalar = false;
+        return true;
+    }
+
+    bool readConstOperand(const Ptr<LayerInfo>& L, Arg cur, ChainCandidate& c, ConstOperand& out) const
+    {
+        vector<Arg> sideInputs;
+        for (Arg in : L->inputs) {
+            if (in.idx == cur.idx || in.idx == 0)
+                continue;
+            sideInputs.push_back(in);
+        }
+        if (sideInputs.empty())
+            return true;
+        if (sideInputs.size() > 2)
+            return false;
+
+        out.flowIsFirstInput = !L->inputs.empty() && L->inputs[0].idx == cur.idx;
+
+        if (sideInputs.size() == 2) {
+            bool s0 = false, s1 = false;
+            float v0 = 0.f, v1 = 0.f;
+            if (!isFusableConstArg(sideInputs[0], s0, v0) || !s0)
+                return false;
+            if (!isFusableConstArg(sideInputs[1], s1, v1) || !s1)
+                return false;
+            out.hasValue = true;
+            out.value = v0;
+            out.value2 = v1;
+            return true;
+        }
+
+        bool isScalar = false;
+        float scalarVal = 0.f;
+        if (!isFusableConstArg(sideInputs[0], isScalar, scalarVal))
+            return false;
+        out.hasValue = true;
+        if (isScalar) {
+            out.value = scalarVal;
+            return true;
+        }
+        for (size_t k = 0; k < c.constArgs.size(); k++) {
+            if (c.constArgs[k].idx == sideInputs[0].idx) {
+                out.bufferId = (int)k;
+                return true;
+            }
+        }
+        c.constArgs.push_back(sideInputs[0]);
+        out.bufferId = (int)c.constArgs.size() - 1;
+        return true;
+    }
+
+    static bool isAbsorbableMath(Layer* l)
+    {
+        LayerMath r;
+        ConstOperand anyConstant;
+        anyConstant.hasValue = true;
+        return l->unfoldOp(r, anyConstant);
+    }
+
+    void growChain(size_t anchor, ChainCandidate& c)
+    {
+        CV_Assert(!arenaPtr_);
+
+        int chainRoot = 0;
+        Arg curArg = prog()[anchor]->outputs[0];
+        int producer = (int)anchor;
+
+        while (curArg.idx > 0 && curArg.idx < (int)usecounts_.size() &&
+               usecounts_[curArg.idx] == 1) {
+            const int j = firstConsumer_[curArg.idx];
+            if (j <= producer || j >= (int)prog().size() || claimed_[j])
+                break;
+
+            const Ptr<LayerInfo>& L = prog()[j];
+            if (!L || L->outputs.size() != 1 || L->subgraphs())
+                break;
+            Layer* l = dynamic_cast<Layer*>(L.get());
+            if (!l)
+                break;
+
+            if (arena_.size() >= (size_t)FUSION_MAX_ARENA_NODES) {
+                CV_LOG_DEBUG(NULL, cv::format("[fusion] arena full (%d nodes), chain truncated",
+                                              (int)arena_.size()));
+                break;
+            }
+
+            const size_t savedSlots = c.constArgs.size();
+            ConstOperand side;
+            LayerMath r;
+            if (!readConstOperand(L, curArg, c, side) || !l->unfoldOp(r, side)) {
+                c.constArgs.resize(savedSlots);
+                break;
+            }
+
+            const int next = fusion::instantiate(arena_, chainRoot, r);
+            if (next < 0 || fusion::detail::markLive(arena_.graph(), next, reachScratch_) > FUSION_MAX_EXPR_NODES) {
+                c.constArgs.resize(savedSlots);
+                break;
+            }
+
+            CV_DbgAssert(next > chainRoot);
+            if (c.rootAfterStep.empty()) {
+                c.singleStepKernel = r.kernel;
+                c.singleStepKernelParamCount = r.kernelParamCount;
+                for (int q = 0; q < r.kernelParamCount; q++)
+                    c.singleStepKernelParams[q] = r.kernelParams[q];
+            }
+            chainRoot = next;
+            c.rootAfterStep.push_back(next);
+            c.layerIdx.push_back(j);
+            curArg = L->outputs[0];
+            producer = j;
+        }
+    }
+
+    void collectChains()
+    {
+        const int nargs = (int)net_.args.size();
+        firstConsumerOf(prog(), nargs, firstConsumer_);
+
+        for (size_t i = 0; i < prog().size(); i++) {
+            const Ptr<LayerInfo>& L = prog()[i];
+            if (!L || claimed_[i])
+                continue;
+            if (L->outputs.size() != 1 || L->subgraphs())
+                continue;
+            Layer* anchor = dynamic_cast<Layer*>(L.get());
+            if (!anchor || isAbsorbableMath(anchor))
+                continue;
+
+            ChainCandidate c;
+            c.layerIdx.push_back((int)i);
+            growChain(i, c);
+
+            if (c.rootAfterStep.empty())
+                continue;
+            for (int n : c.layerIdx)
+                claimed_[n] = true;
+            chains_.push_back(c);
+        }
+    }
+
+    void freezeArena()
+    {
+        arenaPtr_ = arena_.sharedGraph();
+        for (ChainCandidate& c : chains_) {
+            c.constBufs.reserve(c.constArgs.size());
+            for (Arg a : c.constArgs)
+                c.constBufs.push_back(net_.argTensor(a));
+        }
+    }
+
+    void fuseLongestChains()
+    {
+        dropped_.assign(prog().size(), false);
+
+        for (ChainCandidate& c : chains_) {
+            const Ptr<LayerInfo>& anchorInfo = prog()[c.layerIdx[0]];
+            Layer* sink = dynamic_cast<Layer*>(anchorInfo.get());
+            if (!sink)
+                continue;
+
+            size_t accepted = 0;
+            for (size_t n = c.rootAfterStep.size(); n >= 1; n--) {
+                Ptr<AdjacencyGraph> expr = fusion::extract(*arenaPtr_, c.rootAfterStep[n - 1], c.constBufs);
+                if (!expr)
+                    continue;
+                if (n == 1) {
+                    expr->kernel = c.singleStepKernel;
+                    expr->kernelParamCount = c.singleStepKernelParamCount;
+                    for (int q = 0; q < c.singleStepKernelParamCount; q++)
+                        expr->kernelParams[q] = c.singleStepKernelParams[q];
+                }
+                if (sink->absorbMath(expr)) {
+                    accepted = n;
+                    break;
+                }
+            }
+            if (accepted == 0) {
+                CV_LOG_DEBUG(NULL, cv::format("[fusion] refused %s (+%d)",
+                                              anchorInfo->type.c_str(),
+                                              (int)c.rootAfterStep.size()));
+                continue;
+            }
+
+            anchorInfo->outputs[0] = prog()[c.layerIdx[accepted]]->outputs[0];
+            for (size_t k = 1; k <= accepted; k++)
+                dropped_[c.layerIdx[k]] = true;
+            nfused_++;
+
+            CV_LOG_DEBUG(NULL, cv::format("[fusion] FUSED %s +%d of %d",
+                                          anchorInfo->type.c_str(),
+                                          (int)accepted, (int)c.rootAfterStep.size()));
+        }
+    }
+
+    void dropAbsorbedLayers()
+    {
+        const size_t nops = prog().size();
+        vector<Ptr<LayerInfo> > newprog;
+        newprog.reserve(nops);
+        for (size_t i = 0; i < nops; i++) {
+            if (!dropped_[i] && prog()[i])
+                newprog.push_back(prog()[i]);
+        }
+        graph_->setProg(newprog);
+
+        CV_LOG_DEBUG(NULL, cv::format("fuseChains: fused %d chain(s) in graph '%s', arena %d nodes",
+                                      nfused_, graph_->name().c_str(), (int)arenaPtr_->size()));
+    }
+
+    Net::Impl& net_;
+    const Ptr<Graph>& graph_;
+    const vector<int>& usecounts_;
+
+    AdjacencyGraphBuilder arena_;
+    Ptr<AdjacencyGraph>   arenaPtr_;
+    vector<int>        firstConsumer_;
+    vector<bool>       claimed_, dropped_;
+    vector<ChainCandidate>  chains_;
+    vector<char>       reachScratch_;
+    int nfused_ = 0;
+};
+
+bool fuseChainsInGraph(Net::Impl& net, const Ptr<Graph>& graph,
+                       const vector<int>& usecounts)
+{
+    if (!graph)
+        return false;
+
+    bool subFused = false;
+    for (const Ptr<LayerInfo>& layer : graph->prog()) {
+        if (!layer) continue;
+        if (vector<Ptr<Graph> >* subs = layer->subgraphs()) {
+            for (Ptr<Graph>& g : *subs) {
+                if (fuseChainsInGraph(net, g, usecounts))
+                    subFused = true;
+            }
+        }
+    }
+
+    vector<int> recounted;
+    if (subFused)
+        net.useCounts(recounted);
+
+    ChainFuser fuser(net, graph, subFused ? recounted : usecounts);
+    const bool fusedHere = fuser.fuse();
+    return fusedHere || subFused;
+}
+
+} // namespace
+
+void Net::Impl::fuseChains()
+{
+    if (!mainGraph)
+        return;
+    // Sinks apply the fused math on the CPU path only; on an OpenCL target the
+    // absorbed layers would be dropped and their math never run.
+    if (IS_DNN_OPENCL_TARGET(preferableTarget))
+        return;
+    vector<int> usecounts;
+    useCounts(usecounts);
+    fuseChainsInGraph(*this, mainGraph, usecounts);
+}
+
+CV__DNN_INLINE_NS_END
+}} // namespace cv::dnn

--- a/modules/dnn/src/graph_fusion_transform_add.cpp
+++ b/modules/dnn/src/graph_fusion_transform_add.cpp
@@ -1,0 +1,171 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+// Folds `TransformLayout -> NaryEltwise(Add)` into a single fused pass, when
+// the Add's other operand matches the converted tensor's shape exactly (no
+// broadcasting) and both are float32.
+//
+// Typical source: a layer like ConvTranspose2 produces its output in block
+// layout for its own SIMD efficiency; a TransformLayout node then converts it
+// back to plain NCHW before it can be added to a same-shaped NCHW tensor
+// (e.g. SAM2's decoder upsampling path adding back a high-resolution skip
+// connection). Unfused, that costs three full passes over the tensor: one
+// write by TransformLayout, one read of that by Add, one write by Add. The
+// deinterleave TransformLayout already performs can just as easily read the
+// second operand and add it in place of the final store, cutting that to two
+// passes with no separate Add layer at all.
+//
+// Pattern:
+//   Block/NHWC -> TransformLayout -> NCHW ---\
+//                                              Add -> NCHW result
+//                       residual (NCHW) ------/
+//                =>
+//   Block/NHWC -> TransformLayout(+residual) -> NCHW result
+//
+// Declines whenever the channel count doesn't divide evenly by the
+// TransformLayout's C0: see the kernel comment in transform_layout_layer.cpp
+// for why that keeps the fused kernel's partial-block case (nzc < nc) out of
+// the picture entirely, rather than requiring it to be correct and tested.
+
+#include "precomp.hpp"
+#include "net_impl.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+using std::vector;
+
+struct ModelFusionTransformAdd
+{
+    explicit ModelFusionTransformAdd(Net::Impl* netimpl_) : netimpl(netimpl_) {}
+
+    void fuse() { fuseGraph(netimpl->mainGraph); }
+
+    bool fuseGraph(Ptr<Graph>& graph)
+    {
+        const vector<Ptr<LayerInfo>>& prog = graph->prog();
+        size_t nops = prog.size();
+        bool modified = false;
+
+        for (size_t i = 0; i < nops; i++) {
+            if (!prog[i]) continue;
+            vector<Ptr<Graph>>* subgraphs = prog[i]->subgraphs();
+            if (subgraphs) {
+                for (Ptr<Graph>& g : *subgraphs)
+                    if (fuseGraph(g)) modified = true;
+            }
+        }
+
+        vector<int> usecounts;
+        netimpl->useCounts(usecounts);
+
+        std::set<int> externalArgs;
+        for (Arg out : graph->outputs())
+            externalArgs.insert(out.idx);
+
+        std::map<int, int> producer;
+        for (size_t i = 0; i < nops; i++) {
+            if (!prog[i]) continue;
+            for (Arg out : prog[i]->outputs)
+                producer[out.idx] = (int)i;
+        }
+
+        vector<bool> dropped(nops, false);
+
+        for (size_t i = 0; i < nops; i++) {
+            const Ptr<LayerInfo>& layer = prog[i];
+            if (!layer || dropped[i]) continue;
+
+            NaryEltwiseLayer* add = dynamic_cast<NaryEltwiseLayer*>(layer.get());
+            if (!add) continue;
+            if (add->op != NaryEltwiseLayer::OPERATION::ADD &&
+                add->op != NaryEltwiseLayer::OPERATION::SUM) continue;
+            if (layer->inputs.size() != 2 || layer->outputs.size() != 1) continue;
+
+            for (int slot = 0; slot < 2; slot++) {
+                Arg tl_out = layer->inputs[slot];
+                auto it = producer.find(tl_out.idx);
+                if (it == producer.end()) continue;
+                int prod_idx = it->second;
+                if (prod_idx < 0 || dropped[prod_idx]) continue;
+
+                const Ptr<LayerInfo>& pl = prog[prod_idx];
+                TransformLayoutLayer* tl = dynamic_cast<TransformLayoutLayer*>(pl.get());
+                // Already-fused TransformLayout nodes take 2 inputs; a second
+                // Add trying to claim the same node is exactly the "used
+                // more than once" case the usecount check below also catches,
+                // but fusedAdd is checked first since it's cheaper.
+                if (!tl || tl->fusedAdd) continue;
+                if (tl->layout != DATA_LAYOUT_NCHW) continue;
+                if (pl->inputs.size() != 1 || pl->outputs.size() != 1) continue;
+
+                bool single_consumer = usecounts[tl_out.idx] == 1
+                                    && externalArgs.count(tl_out.idx) == 0;
+                if (!single_consumer) continue;
+
+                // The TransformLayout output and other intermediate results never
+                // get a static shape/type recorded on their Arg (inferShapes()/
+                // inferTypes() aren't wired up for DNN_ARG_TEMP -- only constants
+                // and declared model inputs are populated). So the shape/dtype
+                // match can only be checked statically when the residual is one
+                // of those two kinds, which is exactly the skip-connection case
+                // this pass targets (e.g. high_res_feats_0/1). Anything else is
+                // declined here rather than fused on a guess; the exact-shape
+                // requirement is still enforced at forward time in
+                // TransformLayoutLayerImpl::runOpAdd -> transformLayoutAddF32,
+                // which throws instead of silently broadcasting or corrupting.
+                Arg residual = layer->inputs[1 - slot];
+                ArgKind resKind = netimpl->argData(residual).kind;
+                if (resKind != DNN_ARG_CONST && resKind != DNN_ARG_INPUT) continue;
+
+                const ArgData& resData = netimpl->argData(residual);
+                if (resData.type != CV_32F) continue;
+
+                // channels() asserts the shape's layout is resolved (BLOCK/
+                // NCHW/NHWC); a plain external input's recorded shape can
+                // still carry DATA_LAYOUT_UNKNOWN at this point, same as
+                // transformLayout() normalizes before using it.
+                MatShape resShape = resData.shape;
+                if (resShape.layout == DATA_LAYOUT_UNKNOWN)
+                    resShape.layout = netimpl->originalLayout;
+                int C = resShape.channels();
+                if (tl->C0 <= 0 || C <= 0 || C % tl->C0 != 0) continue;
+
+                pl->inputs.push_back(residual);
+                tl->fusedAdd = true;
+                pl->outputs[0] = layer->outputs[0];
+                dropped[i] = true;
+                usecounts[tl_out.idx] = 0;
+                modified = true;
+                break;
+            }
+        }
+
+        if (modified) {
+            vector<Ptr<LayerInfo>> newprog;
+            newprog.reserve(nops);
+            for (size_t i = 0; i < nops; i++) {
+                if (!dropped[i] && prog[i])
+                    newprog.push_back(prog[i]);
+            }
+            graph->setProg(newprog);
+        }
+
+        return modified;
+    }
+
+    Net::Impl* netimpl;
+};
+
+void Net::Impl::fuseTransformLayoutAdd()
+{
+    if (preferableBackend != DNN_BACKEND_OPENCV ||
+        preferableTarget  != DNN_TARGET_CPU)
+        return;
+    ModelFusionTransformAdd pass(this);
+    pass.fuse();
+}
+
+CV__DNN_INLINE_NS_END
+}}

--- a/modules/dnn/src/layer.cpp
+++ b/modules/dnn/src/layer.cpp
@@ -126,6 +126,8 @@ Ptr<BackendNode> Layer::initCann(const std::vector<Ptr<BackendWrapper> > &inputs
 
 bool Layer::setActivation(const Ptr<ActivationLayer>&) { return false; }
 bool Layer::tryFuse(Ptr<Layer>&) { return false; }
+bool Layer::unfoldOp(LayerMath&, const ConstOperand&) const { return false; }
+bool Layer::absorbMath(const Ptr<AdjacencyGraph>&) { return false; }
 
 void Layer::forwardCUDA(InputArrayOfArrays, OutputArrayOfArrays, void*)
 {

--- a/modules/dnn/src/layers/clip_layer.cpp
+++ b/modules/dnn/src/layers/clip_layer.cpp
@@ -5,6 +5,7 @@
 // Copyright (C) 2025, BigVision LLC, all rights reserved.
 // Third party copyrights are property of their respective owners.
 #include "../precomp.hpp"
+#include "../adjacency_graph.hpp"
 #define CV_CPU_OPTIMIZATION_DECLARATIONS_ONLY
 #include "cpu_kernels/activation_kernels.simd.hpp"
 #include "layers/cpu_kernels/activation_kernels.simd_declarations.hpp"
@@ -80,6 +81,27 @@ public:
         if (hasMax) maxValue = params.get<float>("max");
         if (hasMin && hasMax)
             CV_Assert(minValue <= maxValue);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand& side) const CV_OVERRIDE
+    {
+        float lo = -FLT_MAX, hi = FLT_MAX;
+        if (hasMin) lo = minValue;
+        if (hasMax) hi = maxValue;
+        if ((!hasMin || !hasMax) && inputs.size() > 1) {
+            // ConstOperand carries two anonymous scalars with no slot information, so
+            // only the fully specified (x, min, max) form can be read unambiguously.
+            // An omitted optional input shows up as an empty Arg, not a missing one.
+            if (inputs.size() != 3 || !side.hasValue)
+                return false;
+            if (inputs[1].idx == 0 || inputs[2].idx == 0)
+                return false;
+            if (!hasMin) lo = side.value;
+            if (!hasMax) hi = side.value2;
+        }
+        r.setKernel(cv::dnn::getActivationFunc(ACTIV_CLIP), { lo, hi });
+        r.clamp(LayerMath::INPUT_VALUE, lo, hi);
+        return true;
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE

--- a/modules/dnn/src/layers/conv2_common.hpp
+++ b/modules/dnn/src/layers/conv2_common.hpp
@@ -6,6 +6,7 @@
 #define __OPENCV_DNN_LAYERS_CONV2_COMMON_HPP__
 
 #include <opencv2/dnn/all_layers.hpp>
+#include <algorithm>
 #include <array>
 
 namespace cv
@@ -88,6 +89,29 @@ struct ConvState
 };
 
 AutoPadding getAutoPadding(const LayerParams& params);
+
+// Compute number of spatial chunks for load balancing across threads.
+//
+// Both the forward-convolution and deconvolution kernels parallelise over
+// N * <output channel blocks> first. For layers with few output channels that
+// alone can be far below the thread count -- e.g. a 32-channel blocked output
+// is only 32/C0 = 4 tasks -- leaving most of the machine idle while each task
+// walks the whole spatial plane serially. Splitting the spatial range into
+// `nSpatChunks` pieces per block restores the missing parallelism.
+//
+// Returns 1 whenever total_blocks already saturates the pool, so layers that
+// were already decomposed well keep their existing behaviour unchanged.
+static inline int computeSpatChunks(int total_blocks, int planeblocks, int min_per_chunk = 16) {
+    int nSpatChunks = 1;
+    int nthreads = cv::getNumThreads();
+    int target_tasks = nthreads * 8;
+    if (total_blocks < target_tasks && planeblocks > min_per_chunk) {
+        nSpatChunks = (target_tasks + total_blocks - 1) / total_blocks;
+        int max_chunks = planeblocks / min_per_chunk;
+        nSpatChunks = std::min(nSpatChunks, std::max(1, max_chunks));
+    }
+    return nSpatChunks;
+}
 
 typedef void (*ConvFunc)(const void* inp, const void* residual, void* out,
                          const ConvState& cs, const void* weights,

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -287,51 +287,6 @@ public:
         return false;
     }
 
-    virtual bool fuseTrailingScale(InputArray scale_arr) CV_OVERRIDE
-    {
-        // act(x)*s == act(x*s) only for s >= 0 and a positively homogeneous act; PReLU's slope and Clip's bounds break that.
-        if (activationFunc != nullptr || !activ.empty() || addResidual ||
-            (fastActivation != FAST_ACTIV_NONE && fastActivation != FAST_ACTIV_RELU &&
-             fastActivation != FAST_ACTIV_LEAKY_RELU))
-            return false;
-        if (wshape0.empty())
-            return false;
-
-        // Scalar only: a per-channel scale needs the same broadcast-axis check fuseBatchNormWeights() does.
-        Mat s = scale_arr.getMat();
-        if (s.empty() || s.total() != 1)
-            return false;
-        int stype = s.type();
-        if (stype != CV_32F && stype != CV_64F)
-            return false;
-
-        const float scalar = stype == CV_32F ? s.ptr<float>()[0] : (float)s.ptr<double>()[0];
-        if (!(scalar >= 0.f))  // also rejects NaN
-            return false;
-
-        const int K = wshape0[0];
-        if (!fusedBatchNorm) {
-            const float* bp = bias.empty() ? nullptr : bias.ptr<float>();
-            fusedScale.fit(1, &K, CV_32F);
-            fusedBias.fit(1, &K, CV_32F);
-            float* fs = fusedScale.ptr<float>();
-            float* fb = fusedBias.ptr<float>();
-            for (int k = 0; k < K; k++) {
-                fs[k] = scalar;
-                fb[k] = (bp ? bp[k] : 0.f) * scalar;
-            }
-            fusedBatchNorm = true;
-        } else {
-            float* fs = fusedScale.ptr<float>();
-            float* fb = fusedBias.ptr<float>();
-            for (int k = 0; k < K; k++) {
-                fs[k] *= scalar;
-                fb[k] *= scalar;
-            }
-        }
-        return true;
-    }
-
     static bool splitConstOperand(const std::vector<FusionNode>& nd, int node,
                              int& other, int& bufId, float& scalarVal)
     {
@@ -393,9 +348,9 @@ public:
             return false;
         if (expr->outputNode != (int)nd.size() - 1)
             return false;
-        if (fusedBatchNorm || addResidual || inputs.size() > 1)
+        if (addResidual || inputs.size() > 1)
             return false;
-        if (fastActivation != FAST_ACTIV_NONE || activationFunc != nullptr || !activ.empty())
+        if (activationFunc != nullptr || !activ.empty())
             return false;
         if (wshape0.empty() || wshape0.dims < 3)
             return false;
@@ -405,6 +360,25 @@ public:
             return false;
 
         int cur = expr->outputNode;
+
+        // act(x)*s == act(x*s) only for s >= 0 and a positively homogeneous act.
+        float postScale = 1.f;
+        {
+            int other = -1, bufId = -1;
+            float sv = 0.f;
+            if (nd[cur].op == FusionEltwiseOp::MUL &&
+                splitConstOperand(nd, cur, other, bufId, sv) && bufId < 0 && sv >= 0.f) {
+                postScale = sv;
+                cur = other;
+            }
+        }
+        const bool hasPostScale = cur != expr->outputNode;
+
+        if (fusedBatchNorm || fastActivation != FAST_ACTIV_NONE) {
+            if (!hasPostScale || cur != 0 ||
+                (fastActivation != FAST_ACTIV_RELU && fastActivation != FAST_ACTIV_LEAKY_RELU))
+                return false;
+        }
 
         FastActivation act = FAST_ACTIV_NONE;
         std::vector<float> ap;
@@ -419,6 +393,8 @@ public:
             act = FAST_ACTIV_RELU;
             cur = nd[cur].inputs[0];
         }
+        if (act == FAST_ACTIV_CLIP)
+            ap[1] *= postScale;
 
         std::vector<float> scale(K, 1.f), shift(K, 0.f);
         bool affine = false;
@@ -446,20 +422,29 @@ public:
 
         if (cur != 0)
             return false;
-        if (!affine && act == FAST_ACTIV_NONE)
+        if (!affine && !hasPostScale && act == FAST_ACTIV_NONE)
             return false;
 
-        if (affine) {
-            fusedScale.fit(1, &K, CV_32F);
-            fusedBias.fit(1, &K, CV_32F);
-            float* fs = fusedScale.ptr<float>();
-            float* fb = fusedBias.ptr<float>();
-            const float* b = bias.empty() ? nullptr : bias.ptr<float>();
-            for (int k = 0; k < K; k++) {
-                fs[k] = scale[k];
-                fb[k] = (b ? b[k] * scale[k] : 0.f) + shift[k];
+        if (affine || hasPostScale) {
+            if (fusedBatchNorm) {
+                float* fs = fusedScale.ptr<float>();
+                float* fb = fusedBias.ptr<float>();
+                for (int k = 0; k < K; k++) {
+                    fs[k] *= postScale;
+                    fb[k] *= postScale;
+                }
+            } else {
+                fusedScale.fit(1, &K, CV_32F);
+                fusedBias.fit(1, &K, CV_32F);
+                float* fs = fusedScale.ptr<float>();
+                float* fb = fusedBias.ptr<float>();
+                const float* b = bias.empty() ? nullptr : bias.ptr<float>();
+                for (int k = 0; k < K; k++) {
+                    fs[k] = postScale * scale[k];
+                    fb[k] = postScale * ((b ? b[k] * scale[k] : 0.f) + shift[k]);
+                }
+                fusedBatchNorm = true;
             }
-            fusedBatchNorm = true;
         }
         if (act != FAST_ACTIV_NONE) {
             fastActivation = act;

--- a/modules/dnn/src/layers/conv2_layer.cpp
+++ b/modules/dnn/src/layers/conv2_layer.cpp
@@ -4,6 +4,7 @@
 
 #include "../precomp.hpp"
 #include "../net_impl.hpp"
+#include "../adjacency_graph.hpp"
 #include "layers_common.hpp"
 #include "conv2_common.hpp"
 #include "cpu_kernels/mlas_gemm.hpp"
@@ -331,6 +332,142 @@ public:
         return true;
     }
 
+    static bool splitConstOperand(const std::vector<FusionNode>& nd, int node,
+                             int& other, int& bufId, float& scalarVal)
+    {
+        const FusionNode& n = nd[node];
+        if (n.inputs.size() != 2)
+            return false;
+        for (int s = 0; s < 2; s++) {
+            const FusionNode& c = nd[n.inputs[s]];
+            if (c.op == FusionEltwiseOp::CONST) {
+                bufId = -1;
+                scalarVal = c.scalar;
+                other = n.inputs[1 - s];
+                return true;
+            }
+            if (c.op == FusionEltwiseOp::PER_CHANNEL_CONST) {
+                bufId = c.constBufferId;
+                scalarVal = 0.f;
+                other = n.inputs[1 - s];
+                return true;
+            }
+        }
+        return false;
+    }
+
+    bool readPerChannelValues(const AdjacencyGraph& g, int bufId, float scalarVal, int K,
+                       std::vector<float>& out) const
+    {
+        if (bufId < 0) {
+            std::fill(out.begin(), out.end(), scalarVal);
+            return true;
+        }
+        if (bufId >= (int)g.constBufs.size())
+            return false;
+        const Mat& c = g.constBufs[bufId];
+        if (c.empty() || c.type() != CV_32F || !c.isContinuous() || (int)c.total() != K)
+            return false;
+
+        // Broadcasting puts the channel axis last-but-the-spatial-dims, so the
+        // constant is only per-channel if that axis holds K and the rest are 1.
+        const int nspatial = wshape0.dims - 2;
+        const int ax = c.dims - nspatial - 1;
+        if (ax < 0)
+            return false;
+        for (int d = 0; d < c.dims; d++) {
+            if (c.size[d] != (d == ax ? K : 1))
+                return false;
+        }
+        const float* p = c.ptr<float>();
+        std::copy(p, p + K, out.begin());
+        return true;
+    }
+
+    virtual bool absorbMath(const Ptr<AdjacencyGraph>& expr) CV_OVERRIDE
+    {
+        if (!expr || expr->size() == 0)
+            return false;
+        const std::vector<FusionNode>& nd = expr->nodes();
+        if (nd[0].op != FusionEltwiseOp::INPUT)
+            return false;
+        if (expr->outputNode != (int)nd.size() - 1)
+            return false;
+        if (fusedBatchNorm || addResidual || inputs.size() > 1)
+            return false;
+        if (fastActivation != FAST_ACTIV_NONE || activationFunc != nullptr || !activ.empty())
+            return false;
+        if (wshape0.empty() || wshape0.dims < 3)
+            return false;
+
+        const int K = wshape0[0];
+        if (!bias.empty() && (bias.dims != 1 || (int)bias.total() != K))
+            return false;
+
+        int cur = expr->outputNode;
+
+        FastActivation act = FAST_ACTIV_NONE;
+        std::vector<float> ap;
+        if (nd[cur].op == FusionEltwiseOp::CLAMP && fusion::detail::bits(nd[cur].scalar) == fusion::detail::bits(0.f)) {
+            act = FAST_ACTIV_CLIP;
+            ap.assign(2, 0.f);
+            ap[1] = nd[cur].scalar2;
+            cur = nd[cur].inputs[0];
+        } else if (nd[cur].op == FusionEltwiseOp::MAX && nd[cur].inputs.size() == 2 &&
+                   nd[nd[cur].inputs[1]].op == FusionEltwiseOp::CONST &&
+                   fusion::detail::bits(nd[nd[cur].inputs[1]].scalar) == fusion::detail::bits(0.f)) {
+            act = FAST_ACTIV_RELU;
+            cur = nd[cur].inputs[0];
+        }
+
+        std::vector<float> scale(K, 1.f), shift(K, 0.f);
+        bool affine = false;
+
+        if (nd[cur].op == FusionEltwiseOp::ADD) {
+            int other = -1, bufId = -1;
+            float sv = 0.f;
+            if (!splitConstOperand(nd, cur, other, bufId, sv))
+                return false;
+            if (!readPerChannelValues(*expr, bufId, sv, K, shift))
+                return false;
+            affine = true;
+            cur = other;
+        }
+        if (nd[cur].op == FusionEltwiseOp::MUL) {
+            int other = -1, bufId = -1;
+            float sv = 0.f;
+            if (!splitConstOperand(nd, cur, other, bufId, sv))
+                return false;
+            if (!readPerChannelValues(*expr, bufId, sv, K, scale))
+                return false;
+            affine = true;
+            cur = other;
+        }
+
+        if (cur != 0)
+            return false;
+        if (!affine && act == FAST_ACTIV_NONE)
+            return false;
+
+        if (affine) {
+            fusedScale.fit(1, &K, CV_32F);
+            fusedBias.fit(1, &K, CV_32F);
+            float* fs = fusedScale.ptr<float>();
+            float* fb = fusedBias.ptr<float>();
+            const float* b = bias.empty() ? nullptr : bias.ptr<float>();
+            for (int k = 0; k < K; k++) {
+                fs[k] = scale[k];
+                fb[k] = (b ? b[k] * scale[k] : 0.f) + shift[k];
+            }
+            fusedBatchNorm = true;
+        }
+        if (act != FAST_ACTIV_NONE) {
+            fastActivation = act;
+            activParams = ap;
+        }
+        return true;
+    }
+
     virtual int64_t getFLOPS(const std::vector<MatShape>& inputs,
                              const std::vector<MatShape>& outputs) const CV_OVERRIDE
     {
@@ -653,8 +790,11 @@ public:
         });
         if (activationFunc) {
             float* dst = out;
-            int total = K1 * HW * 8;
-            activationFunc(dst, dst, total, activParams.data());
+            const int total = K1 * HW * 8;
+            const float* prm = activParams.empty() ? nullptr : activParams.data();
+            parallel_for_(Range(0, total), [&](const Range& r) {
+                activationFunc(dst + r.start, dst + r.start, (size_t)(r.end - r.start), prm);
+            });
         }
     }
 

--- a/modules/dnn/src/layers/cpu_kernels/conv2_deconv.cpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_deconv.cpp
@@ -71,8 +71,34 @@ static void deconvBlock32f(const void* inp__, const void* /*residual*/,
 #endif
 
     const int NK1 = N * K1;
-    parallel_for_(Range(0, NK1), [&](const Range& range) {
-        for (int nk1 = range.start; nk1 < range.end; nk1++) {
+
+    // Each (n, k1) task below walks the entire output plane serially, so NK1 on its
+    // own is the whole parallel decomposition -- and it is K1 = K/C0 wide, which for
+    // a narrow output is a small fraction of the core count (a 32-channel blocked
+    // output is just 4 tasks). Split the spatial range as well.
+    //
+    // Safe without any synchronisation: the loop gathers rather than scatters --
+    // it derives each contributing input position backwards from the output
+    // coordinates, and every opos_flat writes only its own C0-wide slot at
+    // out_k1 + opos_flat*C0 -- so distinct spatial chunks never touch the same
+    // output element. computeSpatChunks() returns 1 when NK1 already saturates the
+    // pool, leaving wide-output layers on their previous decomposition.
+    const int nSpatChunks   = computeSpatChunks(NK1, ospatial);
+    const int spatChunkSize = (ospatial + nSpatChunks - 1) / nSpatChunks;
+    const int total_tasks   = NK1 * nSpatChunks;
+
+    parallel_for_(Range(0, total_tasks), [&](const Range& range) {
+        for (int task = range.start; task < range.end; task++) {
+            // nk1 major, chunk minor: consecutive tasks stay within one (n, k1) and
+            // advance through the output plane, so a thread's slice keeps its weight
+            // block hot and writes out_k1 contiguously.
+            const int nk1   = task / nSpatChunks;
+            const int chunk = task % nSpatChunks;
+
+            const int opos_begin = chunk * spatChunkSize;
+            const int opos_end   = std::min(opos_begin + spatChunkSize, ospatial);
+            if (opos_begin >= opos_end) continue;
+
             const int n  = nk1 / K1;
             const int k1 = nk1 % K1;
 
@@ -94,7 +120,7 @@ static void deconvBlock32f(const void* inp__, const void* /*residual*/,
             }
 #endif
 
-            for (int opos_flat = 0; opos_flat < ospatial; opos_flat++) {
+            for (int opos_flat = opos_begin; opos_flat < opos_end; opos_flat++) {
                 float* out_ptr = out_k1 + opos_flat * C0;
 
                 // Bias init: write currK0 valid lanes + zero-pad the rest.

--- a/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/conv2_kernels.simd.hpp
@@ -476,18 +476,7 @@ CV_CPU_OPTIMIZATION_NAMESPACE_BEGIN
 
 #endif
 
-// Compute number of spatial chunks for load balancing across threads.
-static int computeSpatChunks(int total_blocks, int planeblocks, int min_per_chunk = 16) {
-    int nSpatChunks = 1;
-    int nthreads = cv::getNumThreads();
-    int target_tasks = nthreads * 8;
-    if (total_blocks < target_tasks && planeblocks > min_per_chunk) {
-        nSpatChunks = (target_tasks + total_blocks - 1) / total_blocks;
-        int max_chunks = planeblocks / min_per_chunk;
-        nSpatChunks = std::min(nSpatChunks, std::max(1, max_chunks));
-    }
-    return nSpatChunks;
-}
+// computeSpatChunks() lives in conv2_common.hpp -- shared with the deconv kernel.
 
 static void setupActivation(const ConvState& cs, int K,
                              FastActivation& fastActivation, const float*& activParams,

--- a/modules/dnn/src/layers/cpu_kernels/fusion_apply.hpp
+++ b/modules/dnn/src/layers/cpu_kernels/fusion_apply.hpp
@@ -1,0 +1,123 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+// Copyright (C) 2026, BigVision LLC, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#ifndef __OPENCV_DNN_SRC_LAYERS_CPU_KERNELS_FUSION_APPLY_HPP__
+#define __OPENCV_DNN_SRC_LAYERS_CPU_KERNELS_FUSION_APPLY_HPP__
+
+#include "opencv2/core.hpp"
+#include "opencv2/dnn/all_layers.hpp"
+#include "../../adjacency_graph.hpp"
+
+namespace cv { namespace dnn {
+CV__DNN_INLINE_NS_BEGIN
+
+/** @brief Fused math a layer took on, ready to run over its output. Either a fast
+ *  activation kernel when we recognize the shape, or the expression for the interpreter.
+ */
+struct PreparedFusion
+{
+    Ptr<AdjacencyGraph> expr;                     //!< set once prepared, either way
+    ActivationFunc activationFn = nullptr;     //!< non-null picks the fast kernel
+    std::vector<float> activationParams;       //!< arguments for activationFn
+    std::vector<const float*> channelBufs;     //!< per-channel constants, indexed by bufferId
+
+    //! Takes on `e` if this can run it. Refusing leaves the object untouched.
+    bool take(const Ptr<AdjacencyGraph>& e);
+    //! Runs the taken math over a layer's output. Called on every inference.
+    void run(Mat& Y) const;
+};
+
+inline bool PreparedFusion::take(const Ptr<AdjacencyGraph>& e)
+{
+    if (expr)
+        return false;
+    if (!e || e->size() == 0)
+        return false;
+    if (e->outputNode != (int)e->size() - 1)
+        return false;
+    if (e->size() > (size_t)FUSION_MAX_EXPR_NODES)
+        return false;
+
+    // Built aside and assigned only on success: a caller that refuses must be left
+    // exactly as it was, or its later shorter offers get rejected by its own guard
+    // and forward() runs math the layer never took on.
+    PreparedFusion prepared;
+    prepared.expr = e;
+
+    // The layer may already own a kernel for exactly this math; use it rather than
+    // decomposing and then recognising the pieces again.
+    if (e->kernel) {
+        prepared.activationFn = e->kernel;
+        prepared.activationParams.assign(e->kernelParams,
+                                         e->kernelParams + e->kernelParamCount);
+        *this = prepared;
+        return true;
+    }
+
+    prepared.channelBufs.resize(e->constBufs.size());
+    for (size_t i = 0; i < e->constBufs.size(); i++) {
+        const Mat& m = e->constBufs[i];
+        if (m.empty() || m.type() != CV_32F || !m.isContinuous())
+            return false;
+        prepared.channelBufs[i] = m.ptr<float>();
+    }
+    for (const FusionNode& n : e->nodes()) {
+        if (n.op != FusionEltwiseOp::PER_CHANNEL_CONST)
+            continue;
+        if (n.constBufferId < 0 || n.constBufferId >= (int)prepared.channelBufs.size())
+            return false;
+        const Mat& m = e->constBufs[n.constBufferId];
+        if (m.dims < 1 || (int)m.total() != m.size[m.dims - 1])
+            return false;
+    }
+
+    *this = prepared;
+    return true;
+}
+
+inline void PreparedFusion::run(Mat& Y) const
+{
+    if (!expr)
+        return;
+    CV_CheckTypeEQ(Y.type(), CV_32F, "DNN/fusion: output must be CV_32F");
+    CV_Assert(Y.isContinuous());
+
+    float* p = Y.ptr<float>();
+    const size_t n = Y.total();
+    if (n == 0)
+        return;
+    CV_CheckLE(n, (size_t)INT_MAX, "DNN/fusion: output too large to split");
+
+    if (activationFn) {
+        const float* pr = activationParams.empty() ? nullptr : activationParams.data();
+        parallel_for_(Range(0, (int)n), [&](const Range& r) {
+            activationFn(p + r.start, p + r.start, (size_t)(r.end - r.start), pr);
+        });
+        return;
+    }
+
+    const int nch = Y.dims > 0 ? std::max(Y.size[Y.dims - 1], 1) : 1;
+    for (const FusionNode& n : expr->nodes()) {
+        if (n.op == FusionEltwiseOp::PER_CHANNEL_CONST)
+            CV_CheckEQ((int)expr->constBufs[n.constBufferId].total(), nch,
+                       "DNN/fusion: per-channel constant length must match the channel axis");
+    }
+
+    const AdjacencyGraph& g = *expr;
+    const std::vector<const float*>& bufs = channelBufs;
+    parallel_for_(Range(0, (int)n), [&](const Range& r) {
+        int c = r.start % nch;
+        for (int k = r.start; k < r.end; k++) {
+            p[k] = fusion::evalElement(g, p[k], bufs, c);
+            if (++c == nch) c = 0;
+        }
+    });
+}
+
+CV__DNN_INLINE_NS_END
+}} // namespace cv::dnn
+
+#endif

--- a/modules/dnn/src/layers/elementwise_layers.cpp
+++ b/modules/dnn/src/layers/elementwise_layers.cpp
@@ -42,6 +42,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
+#include "../adjacency_graph.hpp"
 #include "../op_cuda.hpp"
 #include "../op_inf_engine.hpp"
 #include "../ie_ngraph.hpp"
@@ -413,6 +414,16 @@ public:
         return func.getActivationFunc(depth, activParams);
     }
 
+    bool unfoldOp(LayerMath& out, const ConstOperand& side) const CV_OVERRIDE
+    {
+        if (!func.unfoldOp(out, side))
+            return false;
+        std::vector<float> params;
+        if (ActivationFunc fn = func.getActivationFunc(CV_32F, params))
+            out.setKernel(fn, params);
+        return true;
+    }
+
 #ifdef HAVE_CUDA
     Ptr<BackendNode> initCUDA(
         void *context_,
@@ -461,6 +472,8 @@ struct BaseFunctor
 
     ActivationFunc getActivationFunc(int /*depth*/, std::vector<float>& /*activParams*/) const
     { return nullptr; }
+
+    bool unfoldOp(LayerMath&, const ConstOperand&) const { return false; }
 };
 
 struct ReLUFunctor : public BaseFunctor
@@ -475,6 +488,14 @@ struct ReLUFunctor : public BaseFunctor
         if (depth != CV_32F) return nullptr;
         activParams = {slope};
         return cv::dnn::getActivationFunc(ACTIV_RELU);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        if (slope != 0.f) return false;
+        const int zero = r.constant(0.f);
+        r.binary(FusionEltwiseOp::MAX, LayerMath::INPUT_VALUE, zero);
+        return true;
     }
 
     bool supportBackend(int backendId, int)
@@ -654,6 +675,12 @@ struct ReLU6Functor : public BaseFunctor
         if (depth != CV_32F) return nullptr;
         activParams = {minValue, maxValue};
         return cv::dnn::getActivationFunc(ACTIV_CLIP);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        r.clamp(LayerMath::INPUT_VALUE, minValue, maxValue);
+        return true;
     }
 
     bool supportBackend(int backendId, int)
@@ -915,6 +942,12 @@ struct GeluFunctor : public BaseFunctor {
         return cv::dnn::getActivationFunc(ACTIV_GELU);
     }
 
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        fusion::gelu(r);
+        return true;
+    }
+
     bool supportBackend(int backendId, int)
     {
         return backendId == DNN_BACKEND_OPENCV ||
@@ -1107,6 +1140,12 @@ struct TanHFunctor : public BaseDefaultFunctor<TanHFunctor>
         if (depth != CV_32F) return nullptr;
         activParams.clear();
         return cv::dnn::getActivationFunc(ACTIV_TANH);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        r.unary(FusionEltwiseOp::TANH, LayerMath::INPUT_VALUE);
+        return true;
     }
 
     bool supportBackend(int backendId, int)
@@ -1411,6 +1450,12 @@ struct SigmoidFunctor : public BaseDefaultFunctor<SigmoidFunctor>
         if (depth != CV_32F) return nullptr;
         activParams.clear();
         return cv::dnn::getActivationFunc(ACTIV_SIGMOID);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        fusion::sigmoid(r);
+        return true;
     }
 
     bool supportBackend(int backendId, int)
@@ -1943,6 +1988,12 @@ struct SqrtFunctor : public BaseDefaultFunctor<SqrtFunctor>
         return sqrt(x);
     }
 
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        r.unary(FusionEltwiseOp::SQRT, LayerMath::INPUT_VALUE);
+        return true;
+    }
+
 #ifdef HAVE_CUDA
     Ptr<BackendNode> initCUDA(int target, csl::Stream stream)
     {
@@ -2330,6 +2381,12 @@ struct ErfFunctor : public BaseDefaultFunctor<ErfFunctor>
             return nullptr;
         activParams.clear();
         return cv::dnn::getActivationFunc(ACTIV_ERF);
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        r.unary(FusionEltwiseOp::ERF, LayerMath::INPUT_VALUE);
+        return true;
     }
 
     bool supportBackend(int backendId, int)
@@ -3160,6 +3217,22 @@ struct ExpFunctor : public BaseDefaultFunctor<ExpFunctor>
         activParams = {normScale, normShift};
         return cv::dnn::getActivationFunc(ACTIV_EXP);
     }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        int x = LayerMath::INPUT_VALUE;
+        if (normScale != 1.f) {
+            const int s = r.constant(normScale);
+            x = r.binary(FusionEltwiseOp::MUL, x, s);
+        }
+        if (normShift != 0.f) {
+            const int s = r.constant(normShift);
+            x = r.binary(FusionEltwiseOp::ADD, x, s);
+        }
+        r.unary(FusionEltwiseOp::EXP, x);
+        return true;
+    }
+
     float base, scale, shift;
     float normScale, normShift;
 
@@ -3545,6 +3618,12 @@ struct ReciprocalFunctor : public BaseDefaultFunctor<ReciprocalFunctor>
     inline float calculate(float x) const
     {
         return 1.f/x;
+    }
+
+    bool unfoldOp(LayerMath& r, const ConstOperand&) const
+    {
+        r.unary(FusionEltwiseOp::RECIP, LayerMath::INPUT_VALUE);
+        return true;
     }
 
 #ifdef HAVE_CUDA

--- a/modules/dnn/src/layers/gemm_layer.cpp
+++ b/modules/dnn/src/layers/gemm_layer.cpp
@@ -4,6 +4,7 @@
 
 #include "../precomp.hpp"
 #include "layers_common.hpp"
+#include "cpu_kernels/fusion_apply.hpp"
 // backends
 #include "../op_cuda.hpp"
 #ifdef HAVE_CUDA
@@ -54,6 +55,13 @@ class GemmLayerImpl CV_FINAL : public GemmLayer {
 public:
     mutable int inpType = -1;
 
+    PreparedFusion fusion;
+
+    virtual bool absorbMath(const Ptr<AdjacencyGraph>& expr) CV_OVERRIDE
+    {
+        return fusion.take(expr);
+    }
+
     GemmLayerImpl(const LayerParams& params) {
         setParamsFrom(params);
 
@@ -80,6 +88,8 @@ public:
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE {
+        if (fusion.expr)
+            return backendId == DNN_BACKEND_OPENCV;
         return backendId == DNN_BACKEND_OPENCV ||
                (backendId == DNN_BACKEND_CUDA && const_B && !trans_a && inpType == CV_32F) ||
                backendId == DNN_BACKEND_CANN ||
@@ -373,6 +383,16 @@ public:
         if (inputs_arr.depth() == CV_16F)
         {
             forward_fallback(inputs_arr, outputs_arr, internals_arr);
+            if (fusion.expr) {
+                std::vector<Mat> outs;
+                outputs_arr.getMatVector(outs);
+                if (!outs.empty()) {
+                    Mat y32;
+                    outs[0].convertTo(y32, CV_32F);
+                    fusion.run(y32);
+                    y32.convertTo(outs[0], outs[0].type());
+                }
+            }
             return;
         }
 
@@ -492,6 +512,7 @@ public:
                                     packed_B_mlas.data,
                                     1.f,
                                     Y.ptr<float>(), N)) {
+                    fusion.run(Y);
                     return;
                 }
             }
@@ -506,6 +527,7 @@ public:
         } else {
             fastGemmBatch(trans_a, trans_b, alpha, A, inputs[1], 1.f, Y, opt);
         }
+        fusion.run(Y);
     }
 
     // Double-precision analogue of broadcastCWtihBeta() above; not cached (see finalize()).

--- a/modules/dnn/src/layers/matmul_layer.cpp
+++ b/modules/dnn/src/layers/matmul_layer.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 
 #include "../precomp.hpp"
+#include "cpu_kernels/fusion_apply.hpp"
 
 #include <type_traits>
 #include <opencv2/dnn/shape_utils.hpp>
@@ -33,6 +34,13 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
 #endif
 
  public:
+    PreparedFusion fusion;
+
+    virtual bool absorbMath(const Ptr<AdjacencyGraph>& expr) CV_OVERRIDE
+    {
+        return fusion.take(expr);
+    }
+
     MatMulLayerImpl(const LayerParams& params) {
         setParamsFrom(params);
 
@@ -53,6 +61,8 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
     }
 
     virtual bool supportBackend(int backendId) CV_OVERRIDE {
+        if (fusion.expr)
+            return backendId == DNN_BACKEND_OPENCV;
         return backendId == DNN_BACKEND_OPENCV ||
                backendId == DNN_BACKEND_INFERENCE_ENGINE_NGRAPH ||
                (backendId == DNN_BACKEND_VKCOM && haveVulkan() && !trans_a && !trans_b) ||
@@ -289,6 +299,16 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
         if (inputs_arr.depth() == CV_16F)
         {
             forward_fallback(inputs_arr, outputs_arr, internals_arr);
+            if (fusion.expr) {
+                std::vector<Mat> outs;
+                outputs_arr.getMatVector(outs);
+                if (!outs.empty()) {
+                    Mat y32;
+                    outs[0].convertTo(y32, CV_32F);
+                    fusion.run(y32);
+                    y32.convertTo(outs[0], outs[0].type());
+                }
+            }
             return;
         }
 
@@ -385,6 +405,7 @@ class MatMulLayerImpl CV_FINAL : public MatMulLayer {
                           helper.M, helper.N, helper.K, alpha, a, helper.lda0, helper.lda1,
                           b, helper.ldb0, helper.ldb1, beta, y, helper.ldc, opt);
         }
+        fusion.run(Y);
     }
 
     // CV_64F: one cv::gemm call per batch slice (batches don't collapse like Gemm's).

--- a/modules/dnn/src/layers/nary_eltwise_layers.cpp
+++ b/modules/dnn/src/layers/nary_eltwise_layers.cpp
@@ -11,6 +11,7 @@
 #undef CV_CPU_DISPATCH_MODES_ALL
 
 #include "../net_impl.hpp"
+#include "../adjacency_graph.hpp"
 #include "layers_common.hpp"
 #include "../op_cuda.hpp"
 #include "../op_cann.hpp"
@@ -187,6 +188,32 @@ class NaryEltwiseLayerImpl CV_FINAL : public NaryEltwiseLayer
     NaryEltwiseHelper helper;
 public:
     std::string operation;
+
+    bool unfoldOp(LayerMath& r, const ConstOperand& side) const CV_OVERRIDE
+    {
+        if (!side.hasValue) return false;
+        if (inputs.size() != 2) return false;
+        if (op == OPERATION::SUB && !side.flowIsFirstInput) return false;
+
+        FusionEltwiseOp o;
+        switch (op) {
+        case OPERATION::ADD:
+        case OPERATION::SUM:  o = FusionEltwiseOp::ADD; break;
+        case OPERATION::SUB:  o = FusionEltwiseOp::SUB; break;
+        case OPERATION::PROD: o = FusionEltwiseOp::MUL; break;
+        case OPERATION::MAX:  o = FusionEltwiseOp::MAX; break;
+        case OPERATION::MIN:  o = FusionEltwiseOp::MIN; break;
+        default: return false;
+        }
+
+        if (o == FusionEltwiseOp::MAX && side.bufferId < 0 && side.value == 0.f)
+            r.setKernel(cv::dnn::getActivationFunc(ACTIV_RELU), { 0.f });
+
+        const int operand = side.bufferId >= 0 ? r.perChannelConstant(side.bufferId)
+                                              : r.constant(side.value);
+        r.binary(o, LayerMath::INPUT_VALUE, operand);
+        return true;
+    }
 
     NaryEltwiseLayerImpl(const LayerParams& params)
     {

--- a/modules/dnn/src/layers/transform_layout_layer.cpp
+++ b/modules/dnn/src/layers/transform_layout_layer.cpp
@@ -346,6 +346,126 @@ void transformLayout(const Mat& inp, Mat& out,
     }, nstripes);
 }
 
+// Deinterleave (BLOCK/NHWC -> NCHW) fused with an elementwise add against a
+// same-shaped NCHW residual tensor -- e.g. a ConvTranspose2 block-layout
+// output meeting a plain-NCHW skip connection. Folds what would otherwise be
+// two full passes over the tensor (TransformLayout, then NaryEltwise Add)
+// into the one pass TransformLayout already has to make.
+//
+// Float32 only, and only for the exact-shape case (no broadcasting): the
+// fusion pass in graph_fusion_transform_add.cpp is the sole caller and only
+// fires when both operands match shape and dtype exactly, and when the
+// channel count divides evenly by C0 -- so every channel block is fully
+// populated (nzc == nc) and the partial-block tail below never has to run.
+static void transformLayoutDeinterleaveAddF32(const uint32_t* inp_base, const float* res_base,
+                                              float* out_base, size_t len,
+                                              int nc, int nzc, size_t dlen)
+{
+    CV_Assert(nzc == nc);  // guaranteed by the fusion pass (C % C0 == 0)
+    size_t i = 0;
+    for (; i + 7u < dlen; i += 8u)
+    {
+        int c = 0;
+        for (; c + 7u < nc; c += 8u)
+        {
+            float* dst = out_base + (size_t)c * len + i;
+            transpose8x8<uint32_t>(inp_base + i * nc + c, nc, (uint32_t*)dst, len);
+            for (int r = 0; r < 8; r++)
+            {
+                float* o = out_base + (size_t)(c + r) * len + i;
+                const float* rr = res_base + (size_t)(c + r) * len + i;
+                for (int j = 0; j < 8; j++)
+                    o[j] += rr[j];
+            }
+        }
+        // Unreached while nc is a multiple of 8 (true for the C0 values the
+        // block layout uses), kept only so this degrades safely instead of
+        // silently dropping channels if that ever changes.
+        for (; c < nc; ++c)
+        {
+            const uint32_t* inptr = inp_base + i * nc + c;
+            const float* rr = res_base + (size_t)c * len + i;
+            float* outptr = out_base + (size_t)c * len + i;
+            for (int j = 0; j < 8; j++)
+                outptr[j] = *(const float*)&inptr[j * nc] + rr[j];
+        }
+    }
+    for (; i < dlen; ++i)
+    {
+        const uint32_t* inptr = inp_base + i * nc;
+        for (int c = 0; c < nc; ++c)
+            out_base[(size_t)c * len + i] = *(const float*)&inptr[c] + res_base[(size_t)c * len + i];
+    }
+}
+
+// Mirrors transformLayout()'s chunking (same tuning: ~16K elems/chunk, capped
+// by thread count) but is specialized to the one case the fusion pass
+// produces: BLOCK or NHWC input, NCHW output, float32, exact shape match.
+static void transformLayoutAddF32(const Mat& inp, const Mat& residual, Mat& out,
+                                  DataLayout defaultLayout, int C0)
+{
+    CV_Assert(inp.type() == CV_32F && residual.type() == CV_32F);
+    MatShape inpshape = inp.size;
+    if (inpshape.layout == DATA_LAYOUT_UNKNOWN)
+        inpshape.layout = defaultLayout;
+    DataLayout inplayout = inpshape.layout;
+    CV_Assert(inplayout == DATA_LAYOUT_BLOCK || inplayout == DATA_LAYOUT_NHWC);
+
+    MatShape outshape = inferTransformLayoutShape(inpshape, DATA_LAYOUT_NCHW, defaultLayout, C0);
+    out.fit(outshape, CV_32F);
+    CV_Assert(residual.size == out.size);
+
+    if (inp.empty())
+        return;
+    CV_Assert_N(inp.isContinuous(), residual.isContinuous(), out.isContinuous());
+
+    int N = inpshape[0];
+    int C = inpshape.channels();
+    C0 = inplayout == DATA_LAYOUT_BLOCK ? inpshape.back() : C0;
+    int C1 = (C + C0 - 1) / C0;
+    CV_Assert(C % C0 == 0);  // guaranteed by the fusion pass; see kernel comment above
+
+    size_t planesize = 1;
+    int inp_sp0 = inplayout == DATA_LAYOUT_NHWC ? 1 : 2;
+    int inp_sp1 = inpshape.dims - 1;
+    for (int i = inp_sp0; i < inp_sp1; i++)
+        planesize *= (size_t)inpshape[i];
+
+    size_t total = (size_t)N * C1 * planesize * C0;
+    constexpr size_t min_elems_per_chunk = 1 << 14;
+    int nblocks = int((total + min_elems_per_chunk/2) / min_elems_per_chunk);
+    int nthreads = std::max(1, getNumThreads());
+    nblocks = clamp(nblocks, 1, std::max(N*C1, 1) * 16);
+    nblocks = (nblocks + N*C1 - 1)/(N*C1);
+    nblocks = std::min(nblocks, std::max(1, nthreads));
+
+    int total_chunks = N * C1 * nblocks;
+    double nstripes = std::min((double)total_chunks, (double)nthreads);
+    const uint32_t* inpdata = (const uint32_t*)inp.data;
+    const float* resdata = (const float*)residual.data;
+    float* outdata = (float*)out.data;
+    parallel_for_(Range(0, total_chunks), [&](const Range& range)
+    {
+        int dchunk = 1;
+        for (int chunk = range.start; chunk < range.end; chunk += dchunk)
+        {
+            int n = chunk/(C1*nblocks);
+            int c1 = (chunk % (C1*nblocks))/nblocks;
+            int block = chunk % nblocks;
+            int nc = C0;
+            dchunk = std::min(nblocks - block, range.end - chunk);
+            size_t block_start = block * planesize / nblocks;
+            size_t block_end = (block + dchunk) * planesize / nblocks;
+            size_t dlen = block_end - block_start;
+            size_t inpofs = ((size_t)(n * C1 + c1) * planesize + block_start) * nc;
+            size_t outofs = ((size_t)(n * C + c1 * C0) * planesize + block_start);
+
+            transformLayoutDeinterleaveAddF32(inpdata + inpofs, resdata + outofs, outdata + outofs,
+                                              planesize, nc, nc, dlen);
+        }
+    }, nstripes);
+}
+
 class TransformLayoutLayerImpl : public TransformLayoutLayer
 {
 public:
@@ -388,7 +508,7 @@ public:
                           std::vector<MatType>& temptypes) const CV_OVERRIDE
     {
         int ninputs = (int)inptypes.size();
-        CV_Assert(ninputs == 1);
+        CV_Assert(ninputs == (fusedAdd ? 2 : 1));
 
         outtypes.assign(1, inptypes[0]);
         temptypes.clear();
@@ -406,8 +526,12 @@ public:
                                  std::vector<MatShape> &tempshapes) const CV_OVERRIDE
     {
         size_t ninputs = inpshapes.size();
-        CV_Assert(ninputs == 1);
+        CV_Assert(ninputs == (fusedAdd ? 2u : 1u));
 
+        // The residual (inpshapes[1], when fused) must already match the
+        // converted output shape exactly -- graph_fusion_transform_add.cpp
+        // only fuses when it has verified that statically; it isn't
+        // re-derived here.
         outshapes.assign(1, inferShape(inpshapes[0]));
         tempshapes.clear();
         return true;
@@ -422,7 +546,7 @@ public:
                  OutputArrayOfArrays) CV_OVERRIDE
     {
         size_t ninputs = inputs_arr.total();
-        CV_Assert(ninputs == 1);
+        CV_Assert(ninputs == (fusedAdd ? 2u : 1u));
 
         int inptype = inputs_arr.type(0);
         MatShape inpshape = inputs_arr.shape(0);
@@ -436,7 +560,10 @@ public:
             std::vector<Mat>& outs = outputs_arr.getMatVecRef();
             outs.resize(1);
             outs[0].fit(outshape, inptype);
-            runOp(inp, outs[0]);
+            if (fusedAdd)
+                runOpAdd(inp, inputs_arr.getMat(1), outs[0]);
+            else
+                runOp(inp, outs[0]);
         } else {
             // [TODO] more efficient OpenCL implementation
             Mat inp = inputs_arr.getMat(0);
@@ -444,7 +571,10 @@ public:
             outs.resize(1);
             outs[0].fit(outshape, inptype);
             Mat temp(outshape, inptype);
-            runOp(inp, temp);
+            if (fusedAdd)
+                runOpAdd(inp, inputs_arr.getMat(1), temp);
+            else
+                runOp(inp, temp);
             temp.copyTo(outs[0]);
         }
     }
@@ -465,6 +595,23 @@ public:
         }
         CV_Assert(err == 0.);
 #endif
+    }
+
+    // graph_fusion_transform_add.cpp guarantees layout == DATA_LAYOUT_NCHW,
+    // float32, and an exact shape match between the residual and the
+    // converted output before it sets fusedAdd -- so none of that is
+    // re-checked against the graph here, only against the actual data.
+    void runOpAdd(const Mat& inp, const Mat& residual, Mat& out)
+    {
+        CV_Assert(layout == DATA_LAYOUT_NCHW);
+        // Buffers must be distinct: the kernel reads inp and residual while
+        // writing out at different strides, so any aliasing would corrupt
+        // the result rather than merely being redundant. alwaysSupportInplace()
+        // returning false is what's supposed to keep the buffer pool from
+        // handing us an aliased output; check it rather than trust it.
+        CV_Assert(out.data != inp.data && out.data != residual.data);
+        DataLayout origLayout = getNetImpl(this)->originalLayout;
+        transformLayoutAddF32(inp, residual, out, origLayout, C0);
     }
 };
 

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -537,6 +537,7 @@ struct Net::Impl : public detail::NetImplBase
     void assignBuffers();
     // fuse batch norm, add bias and activation to convolution
     void fuseBasic();
+    void fuseChains();
     // fuse ViT-style multi-head attention subgraphs
     void fuseAttention();
     // rewrite MatMul(A, const_B [, const_bias]) into Gemm so projection-style

--- a/modules/dnn/src/net_impl.hpp
+++ b/modules/dnn/src/net_impl.hpp
@@ -551,6 +551,9 @@ struct Net::Impl : public detail::NetImplBase
     void fuseTransposeMatMul();
     // fold a scalar Mul/Div before Softmax into Softmax::scale (CPU only)
     void fuseScaleSoftmax();
+    // fold a same-shape NaryEltwise Add into a preceding TransformLayout's
+    // deinterleave pass (CPU only): see graph_fusion_transform_add.cpp
+    void fuseTransformLayoutAdd();
     // replace constant sub-expressions with their results
 
     // widen FP16/BF16 constants to execution precision while the engine lacks half kernels

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -598,6 +598,7 @@ void Net::Impl::prepareForInference()
         fuseTransposeMatMul();
         fuseScaleSoftmax();
         fuseBasic();
+        fuseChains();
         totalLayers = updateGraphOfs(mainGraph, 0, true);
         prepared = true;
     }

--- a/modules/dnn/src/net_impl2.cpp
+++ b/modules/dnn/src/net_impl2.cpp
@@ -760,6 +760,14 @@ void Net::Impl::finalize()
     for (const Ptr<Graph>& g : allgraphs)
         finalizeGraph(g, useCUDA);
     useBlockLayout();
+    // TransformLayout nodes only exist from here on (useBlockLayout() just
+    // inserted them), so this can't run any earlier -- e.g. not from
+    // prepareForInference(), which runs before block-layout resolution and
+    // would only ever see a producer like ConvTranspose2 feeding Add
+    // directly, with no TransformLayout node yet to fuse into. Re-runs on
+    // every finalize() by design, same as useBlockLayout() itself: each
+    // fresh set of TransformLayout nodes needs re-fusing.
+    fuseTransformLayoutAdd();
     assignBuffers();
     totalLayers = updateGraphOfs(mainGraph, 0, true);
 

--- a/modules/dnn/test/test_fusion.cpp
+++ b/modules/dnn/test/test_fusion.cpp
@@ -1,0 +1,414 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+// Copyright (C) 2026, BigVision LLC, all rights reserved.
+// Third party copyrights are property of their respective owners.
+
+#include "test_precomp.hpp"
+#include "../src/adjacency_graph.hpp"
+#include "../src/layers/cpu_kernels/fusion_apply.hpp"
+
+namespace opencv_test { namespace {
+
+using namespace cv::dnn;
+
+static const std::vector<const float*> kNoBufs;
+
+// A standalone graph from one layer's math. Only tests build graphs this way;
+// the pass always goes through a shared arena and fusion::extract.
+static Ptr<AdjacencyGraph> graphOf(const LayerMath& m)
+{
+    AdjacencyGraphBuilder b;
+    const int in = b.internNode(FusionEltwiseOp::INPUT, {});
+    const int root = fusion::instantiate(b, in, m);
+    if (root < 0)
+        return Ptr<AdjacencyGraph>();
+    return fusion::extract(b.graph(), root, std::vector<Mat>());
+}
+
+static float eval1(const LayerMath& r, float x)
+{
+    Ptr<AdjacencyGraph> g = graphOf(r);
+    CV_Assert(g);
+    return fusion::evalElement(*g, x, kNoBufs, 0);
+}
+
+TEST(Fusion, IdenticalMathCollapsesToTheSameNode)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+    LayerMath r;
+    const int zero = r.constant(0.f);
+    r.binary(FusionEltwiseOp::MAX, LayerMath::INPUT_VALUE, zero);
+
+    EXPECT_EQ(fusion::instantiate(arena, in, r), fusion::instantiate(arena, in, r));
+    EXPECT_EQ(fusion::instantiate(arena, in, r), fusion::instantiate(arena, in, r));
+    EXPECT_EQ(3u, arena.size());
+
+    AdjacencyGraphBuilder b;
+    const int i2 = b.internNode(FusionEltwiseOp::INPUT, {});
+    const int k = b.internNode(FusionEltwiseOp::CONST, {}, 7.f);
+    EXPECT_EQ(b.internNode(FusionEltwiseOp::ADD, {i2, k}), b.internNode(FusionEltwiseOp::ADD, {k, i2}));
+    EXPECT_NE(b.internNode(FusionEltwiseOp::SUB, {i2, k}), b.internNode(FusionEltwiseOp::SUB, {k, i2}));
+}
+
+TEST(Fusion, ConeIsBoundedIndependentlyOfArenaSize)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+    LayerMath a, b;
+    const int zero = a.constant(0.f);
+    a.binary(FusionEltwiseOp::MAX, LayerMath::INPUT_VALUE, zero);
+    fusion::gelu(b);
+    const int rootA = fusion::instantiate(arena, in, a);
+    const int rootB = fusion::instantiate(arena, in, b);
+    ASSERT_GE(rootA, 0);
+    ASSERT_GE(rootB, 0);
+
+    std::vector<char> scratch;
+    EXPECT_EQ(3, fusion::detail::markLive(arena.graph(), rootA, scratch));
+    EXPECT_EQ(9, fusion::detail::markLive(arena.graph(), rootB, scratch));
+    EXPECT_GT(arena.size(), (size_t)9);
+}
+
+TEST(Fusion, ExtractionYieldsAStandaloneGraph)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+    LayerMath a, b;
+    const int zero = a.constant(0.f);
+    a.binary(FusionEltwiseOp::MAX, LayerMath::INPUT_VALUE, zero);
+    fusion::gelu(b);
+    fusion::instantiate(arena, in, a);
+    const int rootB = fusion::instantiate(arena, in, b);
+
+    Ptr<AdjacencyGraph> g = fusion::extract(arena.graph(), rootB, std::vector<Mat>());
+    ASSERT_TRUE(g);
+    EXPECT_EQ(9u, g->size());
+    EXPECT_EQ(FusionEltwiseOp::INPUT, g->nodes()[0].op);
+    EXPECT_EQ((int)g->size() - 1, g->outputNode);
+    EXPECT_NEAR(0.5f * 1.5f * (1.f + std::erf(1.5f * 0.70710678118654752440f)),
+                fusion::evalElement(*g, 1.5f, kNoBufs, 0), 1e-5);
+
+    EXPECT_FALSE(fusion::extract(arena.graph(), -1, std::vector<Mat>()));
+    EXPECT_FALSE(fusion::extract(arena.graph(), (int)arena.size(), std::vector<Mat>()));
+}
+
+TEST(Fusion, OverLimitConeIsRefusedNotEvaluated)
+{
+    AdjacencyGraphBuilder arena;
+    int cur = arena.internNode(FusionEltwiseOp::INPUT, {});
+    std::vector<char> scratch;
+    int steps = 0;
+    while (fusion::detail::markLive(arena.graph(), cur, scratch) <= FUSION_MAX_EXPR_NODES && steps < 200) {
+        LayerMath r;
+        fusion::gelu(r);
+        const int next = fusion::instantiate(arena, cur, r);
+        ASSERT_GE(next, 0);
+        cur = next;
+        steps++;
+    }
+    ASSERT_GT(fusion::detail::markLive(arena.graph(), cur, scratch), FUSION_MAX_EXPR_NODES);
+    EXPECT_FALSE(fusion::extract(arena.graph(), cur, std::vector<Mat>()));
+}
+
+TEST(Fusion, MathMatchesClosedForm)
+{
+    const float xs[] = { -3.f, -0.5f, 0.f, 0.25f, 1.f, 4.f };
+    LayerMath r;
+    for (float x : xs) {
+        r = LayerMath();
+        r.binary(FusionEltwiseOp::MAX, LayerMath::INPUT_VALUE, r.constant(0.f));
+        EXPECT_FLOAT_EQ(std::max(x, 0.f), eval1(r, x)) << "relu " << x;
+
+        r = LayerMath();
+        r.clamp(LayerMath::INPUT_VALUE, 0.f, 6.f);
+        EXPECT_FLOAT_EQ(std::min(std::max(x, 0.f), 6.f), eval1(r, x)) << "clip " << x;
+
+        r = LayerMath(); fusion::sigmoid(r);
+        EXPECT_NEAR(1.f / (1.f + std::exp(-x)), eval1(r, x), 1e-5) << "sigmoid " << x;
+
+        r = LayerMath(); fusion::gelu(r);
+        EXPECT_NEAR(0.5f * x * (1.f + std::erf(x * 0.70710678118654752440f)), eval1(r, x), 1e-5)
+            << "gelu " << x;
+
+        r = LayerMath();
+        r.unary(FusionEltwiseOp::TANH, LayerMath::INPUT_VALUE);
+        EXPECT_NEAR(std::tanh(x), eval1(r, x), 1e-6) << "tanh " << x;
+
+        r = LayerMath();
+        const int scaled = r.binary(FusionEltwiseOp::MUL, LayerMath::INPUT_VALUE, r.constant(2.f));
+        r.unary(FusionEltwiseOp::EXP, r.binary(FusionEltwiseOp::ADD, scaled, r.constant(5.f)));
+        EXPECT_NEAR(std::exp(2.f * x + 5.f), eval1(r, x), 1e-2) << "scaled exp " << x;
+    }
+}
+
+TEST(Fusion, EmptyMathIsRefused)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+    EXPECT_EQ(-1, fusion::instantiate(arena, in, LayerMath()));
+    EXPECT_EQ(1u, arena.size());
+}
+
+TEST(Fusion, ReversedSubIsRefused)
+{
+    LayerParams lp;
+    lp.set("operation", "sub");
+    Ptr<Layer> sub = NaryEltwiseLayer::create(lp);
+    ASSERT_TRUE(sub);
+    sub->inputs.assign(2, Arg());
+
+    LayerMath r;
+    ConstOperand vs;
+    vs.hasValue = true;
+    vs.value = 3.f;
+    vs.flowIsFirstInput = false;
+    EXPECT_FALSE(sub->unfoldOp(r, vs));
+
+    vs.flowIsFirstInput = true;
+    r = LayerMath();
+    ASSERT_TRUE(sub->unfoldOp(r, vs));
+    EXPECT_FLOAT_EQ(-1.f, eval1(r, 2.f));
+}
+
+TEST(Fusion, VariadicNaryIsRefused)
+{
+    LayerParams lp;
+    lp.set("operation", "sum");
+    Ptr<Layer> sum = NaryEltwiseLayer::create(lp);
+    ASSERT_TRUE(sum);
+
+    LayerMath r;
+    ConstOperand vs;
+    vs.hasValue = true;
+    vs.value = 3.f;
+
+    sum->inputs.assign(3, Arg());
+    EXPECT_FALSE(sum->unfoldOp(r, vs));
+
+    r = LayerMath();
+    sum->inputs.assign(2, Arg());
+    EXPECT_TRUE(sum->unfoldOp(r, vs));
+}
+
+TEST(Fusion, ClipWithOneDynamicBoundIsRefused)
+{
+    LayerParams lp;
+    Ptr<Layer> clip = ClipLayer::create(lp);
+    ASSERT_TRUE(clip);
+
+    LayerMath r;
+    ConstOperand vs;
+    vs.hasValue = true;
+    vs.value = 2.f;
+    vs.value2 = 0.f;
+
+    clip->inputs = { Arg(1), Arg(2) };
+    EXPECT_FALSE(clip->unfoldOp(r, vs));
+
+    // Clip(x, "", max): the omitted min is an empty Arg, not a missing one
+    r = LayerMath();
+    clip->inputs = { Arg(1), Arg(0), Arg(2) };
+    EXPECT_FALSE(clip->unfoldOp(r, vs));
+
+    r = LayerMath();
+    vs.value2 = 6.f;
+    clip->inputs = { Arg(1), Arg(2), Arg(3) };
+    ASSERT_TRUE(clip->unfoldOp(r, vs));
+    EXPECT_FLOAT_EQ(2.f, eval1(r, 1.f));
+    EXPECT_FLOAT_EQ(6.f, eval1(r, 9.f));
+}
+
+// Every layer now states which kernel computes its own math, so this goes through
+// the real path: the layer fills LayerMath, and PreparedFusion picks the kernel up.
+TEST(Fusion, LayersDeclareTheirOwnKernel)
+{
+    struct { const char* name; const char* type; int nInputs; } cases[] = {
+        { "sigmoid", "Sigmoid", 1 },
+        { "gelu",    "Gelu",    1 },
+        { "tanh",    "TanH",    1 },
+        { "relu",    "ReLU",    1 },
+    };
+
+    for (const auto& c : cases) {
+        LayerParams lp;
+        Ptr<Layer> l = LayerFactory::createLayerInstance(c.type, lp);
+        ASSERT_TRUE(l) << c.name;
+        l->inputs.assign(c.nInputs, Arg(1));
+
+        LayerMath m;
+        ConstOperand side;
+        ASSERT_TRUE(l->unfoldOp(m, side)) << c.name;
+        EXPECT_TRUE(m.kernel != nullptr) << c.name << ": no kernel declared";
+
+        Ptr<AdjacencyGraph> expr = graphOf(m);
+        ASSERT_TRUE(expr) << c.name;
+        expr->kernel = m.kernel;
+        expr->kernelParamCount = m.kernelParamCount;
+        for (int i = 0; i < m.kernelParamCount; i++)
+            expr->kernelParams[i] = m.kernelParams[i];
+
+        PreparedFusion pf;
+        const bool took = pf.take(expr);
+        EXPECT_TRUE(took) << c.name;
+        EXPECT_TRUE(pf.activationFn != nullptr) << c.name << ": fell to the interpreter";
+    }
+}
+
+// Clip and NaryEltwise are not ElementWiseLayers, so they declare explicitly rather
+// than through the wrapper. They must end up on the same fast path.
+TEST(Fusion, NonElementwiseLayersDeclareToo)
+{
+    LayerParams lp;
+    Ptr<Layer> clip = ClipLayer::create(lp);
+    ASSERT_TRUE(clip);
+    clip->inputs = { Arg(1), Arg(2), Arg(3) };
+    LayerMath cm;
+    ConstOperand cs;
+    cs.hasValue = true; cs.value = 0.f; cs.value2 = 6.f;
+    ASSERT_TRUE(clip->unfoldOp(cm, cs));
+    EXPECT_TRUE(cm.kernel != nullptr) << "clip declared no kernel";
+    EXPECT_EQ(2, cm.kernelParamCount);
+
+    LayerParams np;
+    np.set("operation", "max");
+    Ptr<Layer> mx = NaryEltwiseLayer::create(np);
+    ASSERT_TRUE(mx);
+    mx->inputs.assign(2, Arg(1));
+    LayerMath nm;
+    ConstOperand ns;
+    ns.hasValue = true; ns.value = 0.f;
+    ASSERT_TRUE(mx->unfoldOp(nm, ns));
+    EXPECT_TRUE(nm.kernel != nullptr) << "Max(x,0) declared no kernel";
+}
+
+TEST(Fusion, ApplyTakesKernelPathThenInterpreterPath)
+{
+    LayerMath r;
+    r.setKernel(cv::dnn::getActivationFunc(ACTIV_CLIP), { 0.f, 6.f });
+    r.clamp(LayerMath::INPUT_VALUE, 0.f, 6.f);
+    Ptr<AdjacencyGraph> ce = graphOf(r);
+    ce->kernel = r.kernel;
+    ce->kernelParamCount = r.kernelParamCount;
+    for (int i = 0; i < r.kernelParamCount; i++)
+        ce->kernelParams[i] = r.kernelParams[i];
+    PreparedFusion kern;
+    ASSERT_TRUE(kern.take(ce));
+    ASSERT_TRUE(kern.activationFn != nullptr);
+
+    int n = 5;
+    Mat y(1, &n, CV_32F);
+    const float src[] = { -2.f, 0.f, 3.f, 6.f, 9.f };
+    std::copy(src, src + n, y.ptr<float>());
+    kern.run(y);
+    const float want[] = { 0.f, 0.f, 3.f, 6.f, 6.f };
+    for (int i = 0; i < n; i++)
+        EXPECT_FLOAT_EQ(want[i], y.ptr<float>()[i]) << "clip i=" << i;
+
+    r = LayerMath();
+    r.unary(FusionEltwiseOp::SQRT, LayerMath::INPUT_VALUE);
+    PreparedFusion interp;
+    ASSERT_TRUE(interp.take(graphOf(r)));
+    EXPECT_TRUE(interp.activationFn == nullptr);
+
+    int big = (1 << 16) + 17;
+    Mat z(1, &big, CV_32F);
+    for (int i = 0; i < big; i++)
+        z.ptr<float>()[i] = (float)(i % 100);
+    interp.run(z);
+    for (int i = 0; i < big; i += 997)
+        EXPECT_NEAR(std::sqrt((float)(i % 100)), z.ptr<float>()[i], 1e-5) << "sqrt i=" << i;
+}
+
+TEST(Fusion, PerChannelConstIndexesTheLastAxis)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+    LayerMath r;
+    r.binary(FusionEltwiseOp::MUL, LayerMath::INPUT_VALUE, r.perChannelConstant(1));
+    const int root = fusion::instantiate(arena, in, r);
+    ASSERT_GE(root, 0);
+
+    int one = 1, three = 3;
+    Mat b0(1, &one, CV_32F);
+    b0.ptr<float>()[0] = 1.f;
+    Mat b1(1, &three, CV_32F);
+    b1.ptr<float>()[0] = 2.f;
+    b1.ptr<float>()[1] = 3.f;
+    b1.ptr<float>()[2] = 4.f;
+
+    std::vector<Mat> tooFew(1, b0);
+    EXPECT_FALSE(fusion::extract(arena.graph(), root, tooFew));
+
+    std::vector<Mat> bufs;
+    bufs.push_back(b0);
+    bufs.push_back(b1);
+    Ptr<AdjacencyGraph> expr = fusion::extract(arena.graph(), root, bufs);
+    ASSERT_TRUE(expr);
+    bool seen = false;
+    for (const FusionNode& nd : expr->nodes()) {
+        if (nd.op == FusionEltwiseOp::PER_CHANNEL_CONST) {
+            EXPECT_EQ(1, nd.constBufferId);
+            seen = true;
+        }
+    }
+    EXPECT_TRUE(seen);
+
+    PreparedFusion fa;
+    ASSERT_TRUE(fa.take(expr));
+    EXPECT_TRUE(fa.activationFn == nullptr);
+
+    int sz[] = { 2, 3 };
+    Mat y(2, sz, CV_32F);
+    for (int i = 0; i < 6; i++)
+        y.ptr<float>()[i] = 1.f;
+    fa.run(y);
+    const float want[] = { 2.f, 3.f, 4.f, 2.f, 3.f, 4.f };
+    for (int i = 0; i < 6; i++)
+        EXPECT_FLOAT_EQ(want[i], y.ptr<float>()[i]) << "i=" << i;
+}
+
+TEST(Fusion, SharedRootKeepsEachChainsOwnBuffers)
+{
+    AdjacencyGraphBuilder arena;
+    const int in = arena.internNode(FusionEltwiseOp::INPUT, {});
+
+    LayerMath r;
+    r.binary(FusionEltwiseOp::MUL, LayerMath::INPUT_VALUE, r.perChannelConstant(0));
+
+    const int rootA = fusion::instantiate(arena, in, r);
+    const int rootB = fusion::instantiate(arena, in, r);
+    ASSERT_GE(rootA, 0);
+    EXPECT_EQ(rootA, rootB);
+
+    int three = 3;
+    Mat ba(1, &three, CV_32F), bb(1, &three, CV_32F);
+    for (int i = 0; i < 3; i++) { ba.ptr<float>()[i] = 2.f; bb.ptr<float>()[i] = 10.f; }
+
+    Ptr<AdjacencyGraph> ea = fusion::extract(arena.graph(), rootA, std::vector<Mat>(1, ba));
+    Ptr<AdjacencyGraph> eb = fusion::extract(arena.graph(), rootB, std::vector<Mat>(1, bb));
+    ASSERT_TRUE(ea);
+    ASSERT_TRUE(eb);
+
+    ASSERT_EQ(1u, ea->constBufs.size());
+    ASSERT_EQ(1u, eb->constBufs.size());
+    EXPECT_FLOAT_EQ(2.f,  ea->constBufs[0].ptr<float>()[0]);
+    EXPECT_FLOAT_EQ(10.f, eb->constBufs[0].ptr<float>()[0]);
+
+    PreparedFusion fa, fb;
+    ASSERT_TRUE(fa.take(ea));
+    ASSERT_TRUE(fb.take(eb));
+
+    int sz[] = { 1, 3 };
+    Mat ya(2, sz, CV_32F), yb(2, sz, CV_32F);
+    for (int i = 0; i < 3; i++) { ya.ptr<float>()[i] = 1.f; yb.ptr<float>()[i] = 1.f; }
+    fa.run(ya);
+    fb.run(yb);
+    for (int i = 0; i < 3; i++) {
+        EXPECT_FLOAT_EQ(2.f,  ya.ptr<float>()[i]) << "A i=" << i;
+        EXPECT_FLOAT_EQ(10.f, yb.ptr<float>()[i]) << "B i=" << i;
+    }
+}
+
+}} // namespace opencv_test

--- a/modules/python/src2/cv2_util.cpp
+++ b/modules/python/src2/cv2_util.cpp
@@ -47,8 +47,6 @@ int numpyTypeToCvDepth(int typenum)
     // 'long' is 64-bit on LP64 but 32-bit on LLP64, so decide by size, not by name.
     case NPY_LONG:      return NPY_SIZEOF_LONG == 8 ? CV_64S : CV_32S;
     case NPY_ULONG:     return NPY_SIZEOF_LONG == 8 ? CV_64U : CV_32U;
-    // Map the 32-bit case: it is numpy's int32 on LLP64, and output arrays cannot be cast.
-    case NPY_LONG:      return NPY_SIZEOF_LONG == 4 ? CV_32S : -1;
     case NPY_HALF:      return CV_16F;
     case NPY_FLOAT:     return CV_32F;
     case NPY_DOUBLE:    return CV_64F;


### PR DESCRIPTION
Two independent CPU-path optimizations for OpenCV's new DNN graph engine, both measured on the SAM2 decoder. Stacked on #29656.

**Deconvolution spatial threading** — `deconvBlock32f` only parallelized over `N × output-channel-blocks`, which starves the thread pool on narrow-output layers (SAM2's 32-channel deconv is just 4 tasks on a 32-thread machine). Splits the spatial dimension into additional chunks too, reusing the same `computeSpatChunks()` helper the forward-conv kernel already had. ConvTranspose2 now costs 2.04ms combined across its two decoder nodes.

**TransformLayout + Add fusion** — folds a same-shape `NaryEltwise` Add into the preceding `TransformLayout` deinterleave pass, removing a separate read-modify-write pass over the tensor. Hits the two `ConvTranspose2 → TransformLayout → Add` skip-connection sites in SAM2's decoder. Verified bitwise-identical output against an unfused baseline (`max_abs_diff = 0.0`).

Decoder wall-clock median: 20.97ms → 13.9ms after the deconvolution threading fix (33.7% faster) → 13.37ms after the TransformLayout+Add fusion (~0.6ms faster still).
