### PR TITLE
video: migrate VariationalRefinement SIMD kernels to universal/scalable intrinsics

### DIFF
--- a/modules/video/src/variational_refinement.cpp
+++ b/modules/video/src/variational_refinement.cpp
@@ -633,25 +633,26 @@ void VariationalRefinementImpl::ComputeDataTerm_ParBody::operator()(const Range 
 #undef INIT_ROW_POINTERS
 
         int j = 0;
-#if CV_SIMD128
-        v_float32x4 zeta_vec = v_setall_f32(zeta_squared);
-        v_float32x4 eps_vec = v_setall_f32(epsilon_squared);
-        v_float32x4 delta_vec = v_setall_f32(delta2);
-        v_float32x4 gamma_vec = v_setall_f32(gamma2);
-        v_float32x4 zero_vec = v_setall_f32(0.0f);
-        v_float32x4 pIx_vec, pIy_vec, pIz_vec, pdU_vec, pdV_vec;
-        v_float32x4 pIxx_vec, pIxy_vec, pIyy_vec, pIxz_vec, pIyz_vec;
-        v_float32x4 derivNorm_vec, derivNorm2_vec, weight_vec;
-        v_float32x4 Ik1z_vec, Ik1zx_vec, Ik1zy_vec;
-        v_float32x4 pa11_vec, pa12_vec, pa22_vec, pb1_vec, pb2_vec;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        const int vlanes = VTraits<v_float32>::vlanes();
+        v_float32 zeta_vec = vx_setall_f32(zeta_squared);
+        v_float32 eps_vec = vx_setall_f32(epsilon_squared);
+        v_float32 delta_vec = vx_setall_f32(delta2);
+        v_float32 gamma_vec = vx_setall_f32(gamma2);
+        v_float32 zero_vec = vx_setall_f32(0.0f);
+        v_float32 pIx_vec, pIy_vec, pIz_vec, pdU_vec, pdV_vec;
+        v_float32 pIxx_vec, pIxy_vec, pIyy_vec, pIxz_vec, pIyz_vec;
+        v_float32 derivNorm_vec, derivNorm2_vec, weight_vec;
+        v_float32 Ik1z_vec, Ik1zx_vec, Ik1zy_vec;
+        v_float32 pa11_vec, pa12_vec, pa22_vec, pb1_vec, pb2_vec;
 
-        for (; j < len - 3; j += 4)
+        for (; j <= len - vlanes; j += vlanes)
         {
-            pIx_vec = v_load(pIx + j);
-            pIy_vec = v_load(pIy + j);
-            pIz_vec = v_load(pIz + j);
-            pdU_vec = v_load(pdU + j);
-            pdV_vec = v_load(pdV + j);
+            pIx_vec = vx_load(pIx + j);
+            pIy_vec = vx_load(pIy + j);
+            pIz_vec = vx_load(pIz + j);
+            pdU_vec = vx_load(pdU + j);
+            pdV_vec = vx_load(pdV + j);
 
             derivNorm_vec = v_add(v_add(v_mul(pIx_vec, pIx_vec), v_mul(pIy_vec, pIy_vec)), zeta_vec);
             Ik1z_vec = v_add(v_add(pIz_vec, v_mul(pIx_vec, pdU_vec)), v_mul(pIy_vec, pdV_vec));
@@ -663,11 +664,11 @@ void VariationalRefinementImpl::ComputeDataTerm_ParBody::operator()(const Range 
             pb1_vec = v_sub(zero_vec, v_mul(weight_vec, v_mul(pIz_vec, pIx_vec)));
             pb2_vec = v_sub(zero_vec, v_mul(weight_vec, v_mul(pIz_vec, pIy_vec)));
 
-            pIxx_vec = v_load(pIxx + j);
-            pIxy_vec = v_load(pIxy + j);
-            pIyy_vec = v_load(pIyy + j);
-            pIxz_vec = v_load(pIxz + j);
-            pIyz_vec = v_load(pIyz + j);
+            pIxx_vec = vx_load(pIxx + j);
+            pIxy_vec = vx_load(pIxy + j);
+            pIyy_vec = vx_load(pIyy + j);
+            pIxz_vec = vx_load(pIxz + j);
+            pIyz_vec = vx_load(pIyz + j);
 
             derivNorm_vec = v_add(v_add(v_mul(pIxx_vec, pIxx_vec), v_mul(pIxy_vec, pIxy_vec)), zeta_vec);
             derivNorm2_vec = v_add(v_add(v_mul(pIyy_vec, pIyy_vec), v_mul(pIxy_vec, pIxy_vec)), zeta_vec);
@@ -687,6 +688,7 @@ void VariationalRefinementImpl::ComputeDataTerm_ParBody::operator()(const Range 
             v_store(pb1 + j, pb1_vec);
             v_store(pb2 + j, pb2_vec);
         }
+        vx_cleanup();
 #endif
         for (; j < len; j++)
         {
@@ -840,38 +842,40 @@ void VariationalRefinementImpl::ComputeSmoothnessTermHorPass_ParBody::operator()
     pA_v_next[j] += pWeight[j];
 
         int j = 0;
-#if CV_SIMD128
-        v_float32x4 alpha2_vec = v_setall_f32(alpha2);
-        v_float32x4 eps_vec = v_setall_f32(epsilon_squared);
-        v_float32x4 cW_u_vec, cW_v_vec;
-        v_float32x4 pWeight_vec, ux_vec, vx_vec, uy_vec, vy_vec;
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        const int vlanes = VTraits<v_float32>::vlanes();
+        v_float32 alpha2_vec = vx_setall_f32(alpha2);
+        v_float32 eps_vec = vx_setall_f32(epsilon_squared);
+        v_float32 cW_u_vec, cW_v_vec;
+        v_float32 pWeight_vec, ux_vec, vx_vec, uy_vec, vy_vec;
 
-        for (; j < len - 4; j += 4)
+        for (; j < len - vlanes; j += vlanes)   // leave the rightmost element to the scalar code below (no UPDATE across the right border)
         {
-            cW_u_vec = v_load(cW_u + j);
-            cW_v_vec = v_load(cW_v + j);
+            cW_u_vec = vx_load(cW_u + j);
+            cW_v_vec = vx_load(cW_v + j);
 
-            ux_vec = v_sub(v_load(cW_u_next + j), cW_u_vec);
-            vx_vec = v_sub(v_load(cW_v_next + j), cW_v_vec);
-            uy_vec = v_sub(v_load(cW_u_next_row + j), cW_u_vec);
-            vy_vec = v_sub(v_load(cW_v_next_row + j), cW_v_vec);
+            ux_vec = v_sub(vx_load(cW_u_next + j), cW_u_vec);
+            vx_vec = v_sub(vx_load(cW_v_next + j), cW_v_vec);
+            uy_vec = v_sub(vx_load(cW_u_next_row + j), cW_u_vec);
+            vy_vec = v_sub(vx_load(cW_v_next_row + j), cW_v_vec);
             pWeight_vec =
               v_div(alpha2_vec, v_sqrt(v_add(v_add(v_add(v_add(v_mul(ux_vec, ux_vec), v_mul(vx_vec, vx_vec)), v_mul(uy_vec, uy_vec)), v_mul(vy_vec, vy_vec)), eps_vec)));
             v_store(pWeight + j, pWeight_vec);
 
-            ux_vec = v_mul(pWeight_vec, v_sub(v_load(pW_u_next + j), v_load(pW_u + j)));
-            vx_vec = v_mul(pWeight_vec, v_sub(v_load(pW_v_next + j), v_load(pW_v + j)));
+            ux_vec = v_mul(pWeight_vec, v_sub(vx_load(pW_u_next + j), vx_load(pW_u + j)));
+            vx_vec = v_mul(pWeight_vec, v_sub(vx_load(pW_v_next + j), vx_load(pW_v + j)));
 
-            v_store(pA_u + j, v_add(v_load(pA_u + j), pWeight_vec));
-            v_store(pA_v + j, v_add(v_load(pA_v + j), pWeight_vec));
-            v_store(pB_u + j, v_add(v_load(pB_u + j), ux_vec));
-            v_store(pB_v + j, v_add(v_load(pB_v + j), vx_vec));
+            v_store(pA_u + j, v_add(vx_load(pA_u + j), pWeight_vec));
+            v_store(pA_v + j, v_add(vx_load(pA_v + j), pWeight_vec));
+            v_store(pB_u + j, v_add(vx_load(pB_u + j), ux_vec));
+            v_store(pB_v + j, v_add(vx_load(pB_v + j), vx_vec));
 
-            v_store(pA_u_next + j, v_add(v_load(pA_u_next + j), pWeight_vec));
-            v_store(pA_v_next + j, v_add(v_load(pA_v_next + j), pWeight_vec));
-            v_store(pB_u_next + j, v_sub(v_load(pB_u_next + j), ux_vec));
-            v_store(pB_v_next + j, v_sub(v_load(pB_v_next + j), vx_vec));
+            v_store(pA_u_next + j, v_add(vx_load(pA_u_next + j), pWeight_vec));
+            v_store(pA_v_next + j, v_add(vx_load(pA_v_next + j), pWeight_vec));
+            v_store(pB_u_next + j, v_sub(vx_load(pB_u_next + j), ux_vec));
+            v_store(pB_v_next + j, v_sub(vx_load(pB_v_next + j), vx_vec));
         }
+        vx_cleanup();
 #endif
         for (; j < len - 1; j++)
         {
@@ -952,24 +956,26 @@ void VariationalRefinementImpl::ComputeSmoothnessTermVertPass_ParBody::operator(
 #undef INIT_ROW_POINTERS
 
         int j = 0;
-#if CV_SIMD128
-        v_float32x4 pWeight_vec, uy_vec, vy_vec;
-        for (; j < len - 3; j += 4)
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        const int vlanes = VTraits<v_float32>::vlanes();
+        v_float32 pWeight_vec, uy_vec, vy_vec;
+        for (; j <= len - vlanes; j += vlanes)
         {
-            pWeight_vec = v_load(pWeight + j);
-            uy_vec = v_mul(pWeight_vec, v_sub(v_load(pW_u_next_row + j), v_load(pW_u + j)));
-            vy_vec = v_mul(pWeight_vec, v_sub(v_load(pW_v_next_row + j), v_load(pW_v + j)));
+            pWeight_vec = vx_load(pWeight + j);
+            uy_vec = v_mul(pWeight_vec, v_sub(vx_load(pW_u_next_row + j), vx_load(pW_u + j)));
+            vy_vec = v_mul(pWeight_vec, v_sub(vx_load(pW_v_next_row + j), vx_load(pW_v + j)));
 
-            v_store(pA_u + j, v_add(v_load(pA_u + j), pWeight_vec));
-            v_store(pA_v + j, v_add(v_load(pA_v + j), pWeight_vec));
-            v_store(pB_u + j, v_add(v_load(pB_u + j), uy_vec));
-            v_store(pB_v + j, v_add(v_load(pB_v + j), vy_vec));
+            v_store(pA_u + j, v_add(vx_load(pA_u + j), pWeight_vec));
+            v_store(pA_v + j, v_add(vx_load(pA_v + j), pWeight_vec));
+            v_store(pB_u + j, v_add(vx_load(pB_u + j), uy_vec));
+            v_store(pB_v + j, v_add(vx_load(pB_v + j), vy_vec));
 
-            v_store(pA_u_next_row + j, v_add(v_load(pA_u_next_row + j), pWeight_vec));
-            v_store(pA_v_next_row + j, v_add(v_load(pA_v_next_row + j), pWeight_vec));
-            v_store(pB_u_next_row + j, v_sub(v_load(pB_u_next_row + j), uy_vec));
-            v_store(pB_v_next_row + j, v_sub(v_load(pB_v_next_row + j), vy_vec));
+            v_store(pA_u_next_row + j, v_add(vx_load(pA_u_next_row + j), pWeight_vec));
+            v_store(pA_v_next_row + j, v_add(vx_load(pA_v_next_row + j), pWeight_vec));
+            v_store(pB_u_next_row + j, v_sub(vx_load(pB_u_next_row + j), uy_vec));
+            v_store(pB_v_next_row + j, v_sub(vx_load(pB_v_next_row + j), vy_vec));
         }
+        vx_cleanup();
 #endif
         for (; j < len; j++)
         {
@@ -1056,49 +1062,40 @@ void VariationalRefinementImpl::RedBlackSOR_ParBody::operator()(const Range &ran
 #undef INIT_ROW_POINTERS
 
         j = 0;
-#if CV_SIMD128
-        v_float32x4 pW_prev_vec = v_setall_f32(pW_next[-1]);
-        v_float32x4 pdu_prev_vec = v_setall_f32(pdu_next[-1]);
-        v_float32x4 pdv_prev_vec = v_setall_f32(pdv_next[-1]);
-        v_float32x4 omega_vec = v_setall_f32(var->omega);
-        v_float32x4 pW_vec, pW_next_vec, pW_prev_row_vec;
-        v_float32x4 pdu_next_vec, pdu_prev_row_vec, pdu_next_row_vec;
-        v_float32x4 pdv_next_vec, pdv_prev_row_vec, pdv_next_row_vec;
-        v_float32x4 pW_shifted_vec, pdu_shifted_vec, pdv_shifted_vec;
-        v_float32x4 pa12_vec, sigmaU_vec, sigmaV_vec, pdu_vec, pdv_vec;
-        for (; j < len - 3; j += 4)
+#if (CV_SIMD || CV_SIMD_SCALABLE)
+        const int vlanes = VTraits<v_float32>::vlanes();
+        v_float32 omega_vec = vx_setall_f32(var->omega);
+        v_float32 pW_vec, pW_prev_row_vec;
+        v_float32 pdu_next_vec, pdu_prev_row_vec, pdu_next_row_vec;
+        v_float32 pdv_next_vec, pdv_prev_row_vec, pdv_next_row_vec;
+        v_float32 pW_shifted_vec, pdu_shifted_vec, pdv_shifted_vec;
+        v_float32 pa12_vec, sigmaU_vec, sigmaV_vec, pdu_vec, pdv_vec;
+        for (; j <= len - vlanes; j += vlanes)
         {
-            pW_vec = v_load(pW + j);
-            pW_next_vec = v_load(pW_next + j);
-            pW_prev_row_vec = v_load(pW_prev_row + j);
-            pdu_next_vec = v_load(pdu_next + j);
-            pdu_prev_row_vec = v_load(pdu_prev_row + j);
-            pdu_next_row_vec = v_load(pdu_next_row + j);
-            pdv_next_vec = v_load(pdv_next + j);
-            pdv_prev_row_vec = v_load(pdv_prev_row + j);
-            pdv_next_row_vec = v_load(pdv_next_row + j);
-            pa12_vec = v_load(pa12 + j);
-            pW_shifted_vec = v_reinterpret_as_f32(
-              v_extract<3>(v_reinterpret_as_s32(pW_prev_vec), v_reinterpret_as_s32(pW_next_vec)));
-            pdu_shifted_vec = v_reinterpret_as_f32(
-              v_extract<3>(v_reinterpret_as_s32(pdu_prev_vec), v_reinterpret_as_s32(pdu_next_vec)));
-            pdv_shifted_vec = v_reinterpret_as_f32(
-              v_extract<3>(v_reinterpret_as_s32(pdv_prev_vec), v_reinterpret_as_s32(pdv_next_vec)));
+            pW_vec = vx_load(pW + j);
+            pW_prev_row_vec = vx_load(pW_prev_row + j);
+            pdu_next_vec = vx_load(pdu_next + j);
+            pdu_prev_row_vec = vx_load(pdu_prev_row + j);
+            pdu_next_row_vec = vx_load(pdu_next_row + j);
+            pdv_next_vec = vx_load(pdv_next + j);
+            pdv_prev_row_vec = vx_load(pdv_prev_row + j);
+            pdv_next_row_vec = vx_load(pdv_next_row + j);
+            pa12_vec = vx_load(pa12 + j);
+            pW_shifted_vec = vx_load(pW_next + j - 1);
+            pdu_shifted_vec = vx_load(pdu_next + j - 1);
+            pdv_shifted_vec = vx_load(pdv_next + j - 1);
 
             sigmaU_vec = v_add(v_add(v_add(v_mul(pW_shifted_vec, pdu_shifted_vec), v_mul(pW_vec, pdu_next_vec)), v_mul(pW_prev_row_vec, pdu_prev_row_vec)), v_mul(pW_vec, pdu_next_row_vec));
             sigmaV_vec = v_add(v_add(v_add(v_mul(pW_shifted_vec, pdv_shifted_vec), v_mul(pW_vec, pdv_next_vec)), v_mul(pW_prev_row_vec, pdv_prev_row_vec)), v_mul(pW_vec, pdv_next_row_vec));
 
-            pdu_vec = v_load(pdu + j);
-            pdv_vec = v_load(pdv + j);
-            pdu_vec = v_add(pdu_vec, v_mul(omega_vec, v_sub(v_div(v_sub(v_add(sigmaU_vec, v_load(pb1 + j)), v_mul(pdv_vec, pa12_vec)), v_load(pa11 + j)), pdu_vec)));
-            pdv_vec = v_add(pdv_vec, v_mul(omega_vec, v_sub(v_div(v_sub(v_add(sigmaV_vec, v_load(pb2 + j)), v_mul(pdu_vec, pa12_vec)), v_load(pa22 + j)), pdv_vec)));
+            pdu_vec = vx_load(pdu + j);
+            pdv_vec = vx_load(pdv + j);
+            pdu_vec = v_add(pdu_vec, v_mul(omega_vec, v_sub(v_div(v_sub(v_add(sigmaU_vec, vx_load(pb1 + j)), v_mul(pdv_vec, pa12_vec)), vx_load(pa11 + j)), pdu_vec)));
+            pdv_vec = v_add(pdv_vec, v_mul(omega_vec, v_sub(v_div(v_sub(v_add(sigmaV_vec, vx_load(pb2 + j)), v_mul(pdu_vec, pa12_vec)), vx_load(pa22 + j)), pdv_vec)));
             v_store(pdu + j, pdu_vec);
             v_store(pdv + j, pdv_vec);
-
-            pW_prev_vec = pW_next_vec;
-            pdu_prev_vec = pdu_next_vec;
-            pdv_prev_vec = pdv_next_vec;
         }
+        vx_cleanup();
 #endif
         for (; j < len; j++)
         {


### PR DESCRIPTION
Migrate the four CV_SIMD128 blocks in modules/video/src/variational_refinement.cpp
(ComputeDataTerm, ComputeSmoothnessTermHorPass, ComputeSmoothnessTermVertPass,
RedBlackSOR) from v_float32x4 / v_load / v_setall_f32 / j += 4 to
(CV_SIMD || CV_SIMD_SCALABLE) with v_float32 / vx_load / vx_setall_f32 /
VTraits<v_float32>::vlanes(), plus vx_cleanup() after each vector loop.

These kernels run 5x per frame on DISOpticalFlow PRESET_FAST/MEDIUM
(variational_refinement_iter = 5). On RVV scalable builds CV_SIMD128 and
CV_SIMD are both 0, so they currently execute the scalar tail; there is no
video RVV HAL. With this change they vectorize at the native VLEN.

Changes
- Type/stride substitution only; arithmetic and evaluation order unchanged.
- RedBlackSOR: the v_extract<3>(prev, next) "previous lane" construction is
  replaced by an unaligned vx_load(p_next + j - 1). p_next carries a +1/+2
  offset from INIT_ROW_POINTERS, so [-1] is in-bounds (the scalar tail already
  reads it). v_extract<3> is only "previous lane" when vlanes == 4, so this
  replacement is required for any wider lane count.
- HorPass keeps a strict bound, j < len - vlanes, while the other three use
  j <= len - vlanes. The vector body applies UPDATE to all lanes, and the
  rightmost element must not receive UPDATE when it touches the right border
  (handled by the scalar code after the loop). The strict bound is the exact
  generalization of the existing j < len - 4.
- No SVE claim: there is no SVE backend in-tree; "scalable" means RVV today.

Verification
- opencv_test_video --gtest_filter=*VariationalRefinement*: PASS on Apple M1
  (NEON), RVV QEMU at VLEN 128, 256 and 512, an x86 AMD EPYC build at the
  default SSE baseline and at CPU_BASELINE=AVX2, and an ARM (Ampere/Neoverse,
  independent of M1) build.
- Old vs new output on M1 (same lane width, 4, before and after): 62/62 cases
  bit-identical (cv::norm NORM_INF == 0) - RubberWhale reference, random
  frames/params at 127x61 / 320x240 / 640x480, and every tail length from
  width 7 to 65 at heights 5 and 6 (both multi-thread and single-thread),
  which exercises every SIMD-loop/scalar-tail split and both right-border
  branches.
- RVV cross-VLEN (128 vs 256 vs 512, same binary): outputs agree exactly
  wherever the vector loop doesn't execute at a given VLEN (small cases at
  VLEN 512); where it does execute, differences are ULP-scale per SOR/FP
  iteration and compound over iteration count on ill-conditioned (random
  noise) inputs, up to ~7e-4 on flow values for 640x480 at 25 SOR/25 FP
  iterations. The same pattern and magnitude appears when comparing PR
  (any VLEN) against the pre-migration scalar RVV build directly, confirming
  this is vector-vs-scalar floating-point rounding, not a lane-indexing bug.
  RubberWhale specifically shows the same ~1.9e-5 offset from scalar
  regardless of VLEN. ReferenceAccuracy (RMSE tolerance 0.86) passes at
  every VLEN.

Performance (opencv_perf_video DenseOpticalFlow_VariationalRefinement.perf,
min of 10-15 runs)

| platform | size, SOR, FP | before (ms) | after (ms) | ratio |
| Apple M1, NEON | 320x240, 5, 5   |  3.44 |  3.69 | 1.07 |
| Apple M1, NEON | 320x240, 10, 10 | 12.93 | 13.35 | 1.03 |
| Apple M1, NEON | 640x480, 5, 5   | 16.58 | 16.77 | 1.01 |
| Apple M1, NEON | 640x480, 10, 10 | 43.93 | 44.43 | 1.01 |
| AMD EPYC, SSE (default baseline) | 320x240, 5, 10  |  9.10 |  8.83 | 0.97 |
| AMD EPYC, SSE (default baseline) | 640x480, 10, 10 | 40.56 | 39.06 | 0.96 |
| AMD EPYC, CPU_BASELINE=AVX2      | 320x240, 5, 10  |  9.10 |  7.41 | 0.81 |
| AMD EPYC, CPU_BASELINE=AVX2      | 320x240, 10, 10 | 11.10 |  8.53 | 0.77 |
| AMD EPYC, CPU_BASELINE=AVX2      | 640x480, 5, 10  | 32.51 | 25.85 | 0.80 |
| AMD EPYC, CPU_BASELINE=AVX2      | 640x480, 10, 10 | 40.56 | 30.43 | 0.75 |
| Ampere (Neoverse), NEON          | 320x240, 5, 10  | 14.53 | 14.79 | 1.02 |
| Ampere (Neoverse), NEON          | 640x480, 10, 10 | 66.34 | 62.60 | 0.94 |

NEON and default-baseline SSE are 128-bit before and after, so parity is the
expected result and what was measured (all within noise). AVX2 gives real
256-bit lanes and shows a consistent ~20-25% improvement across sizes. RVV
hardware numbers welcome (QEMU wall-clock is not meaningful).

A dispatch split (ocv_add_dispatched_file, as lkpyramid has) for default-build
AVX2 coverage is not included; can be a follow-up if wanted.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or an incompatible license
- [x] The PR is proposed to the proper branch (4.x)
