### PR TITLE
imgproc: add validation mask for ill-conditioned warp perspective pixels

### DIFF
--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -89,6 +89,9 @@ protected:
     Mat src;
     Mat dst;
     Mat reference_dst;
+    // Optional per-destination-pixel mask (CV_8UC1, 0 = do not check).
+    // Empty means every pixel is validated.
+    Mat validation_mask;
 };
 
 CV_ImageWarpBaseTest::CV_ImageWarpBaseTest() :
@@ -142,6 +145,8 @@ Size CV_ImageWarpBaseTest::randSize(RNG& rng) const
 void CV_ImageWarpBaseTest::generate_test_data()
 {
     RNG& rng = ts->get_rng();
+
+    validation_mask.release();
 
     // generating the src matrix structure
     Size ssize = randSize(rng), dsize;
@@ -256,9 +261,11 @@ void CV_ImageWarpBaseTest::validate_results() const
     {
         const float* rD = reference_dst.ptr<float>(dy);
         const float* D = _dst.ptr<float>(dy);
+        const uchar* mask = validation_mask.empty() ? 0 : validation_mask.ptr<uchar>(dy);
 
         for (int dx = 0; dx < dsize.width; ++dx)
-            if (fabs(rD[dx] - D[dx]) > t &&
+            if ((!mask || mask[dx / cn]) &&
+                fabs(rD[dx] - D[dx]) > t &&
 //                fabs(rD[dx] - D[dx]) < 250.0f &&
                 rD[dx] <= 255.0f && D[dx] <= 255.0f && rD[dx] >= 0.0f && D[dx] >= 0.0f)
             {
@@ -1671,6 +1678,37 @@ void CV_WarpPerspective_Test::warpPerspective(const Mat& _src, Mat& _dst)
         Mat tmp;
         invert(M, tmp);
         M = tmp;
+    }
+
+    // Near the vanishing line the perspective denominator w tends to zero, so the
+    // back-projected source coordinate is ill-conditioned: evaluating w in float
+    // instead of double, or with a fused multiply-add, or as a reciprocal multiply,
+    // moves the sampled point by many pixels. With BORDER_REPLICATE those runaway
+    // coordinates clamp onto different edge pixels, which on the 0/255 test images
+    // produces large but meaningless differences. Skip such pixels - see
+    // https://github.com/opencv/opencv/issues/29816
+    {
+        Mat mf;
+        M.convertTo(mf, CV_32F);
+        const float* m = mf.ptr<const float>();
+        const float bound_x = 2.0f * ssize.width + 32.0f;
+        const float bound_y = 2.0f * ssize.height + 32.0f;
+
+        validation_mask.create(dsize, CV_8UC1);
+        for (int y = 0; y < dsize.height; ++y)
+        {
+            uchar* mask = validation_mask.ptr<uchar>(y);
+            for (int x = 0; x < dsize.width; ++x)
+            {
+                float w = x*m[6] + y*m[7] + m[8];
+                float sx = (x*m[0] + y*m[1] + m[2]) / w;
+                float sy = (x*m[3] + y*m[4] + m[5]) / w;
+                bool ill_conditioned = cvIsNaN(sx) || cvIsNaN(sy) ||
+                                       cvIsInf(sx) || cvIsInf(sy) ||
+                                       fabsf(sx) > bound_x || fabsf(sy) > bound_y;
+                mask[x] = ill_conditioned ? 0 : 255;
+            }
+        }
     }
 
     int inter = interpolation & INTER_MAX;


### PR DESCRIPTION
### Summary

Fixes https://github.com/opencv/opencv/issues/29816.

The issue reports that `warpPerspective` with `BORDER_REPLICATE` is inaccurate on ARM
with the KleidiCV HAL. **It is not a KleidiCV defect, and it is not ARM-specific.**
`Imgproc_WarpPerspective_Test.accuracy` compares against a reference that is
ill-conditioned for a small fraction of destination pixels, and the same failures
reproduce with the HAL completely disabled.

This PR excludes those pixels from validation. It does not change any library code.

### Root cause

`CV_WarpPerspective_Test::new_warpPerspective` evaluates the perspective divide in
**float32**:

```cpp
float w  = x*_M[6] + y*_M[7] + _M[8];
float sx = (x*_M[0] + y*_M[1] + _M[2]) / w;
```

while `cv::warpPerspective` evaluates it in **double** (`imgwarp.cpp`,
`warpPerspectiveBlockline`). For destination pixels that back-project near the
vanishing line, `w` tends to zero and cancellation amplifies that difference
enormously. In the worst case observed, `w = 0.0099` and `sy = -212131`.

This only surfaces with `BORDER_REPLICATE`, which is why the report singles it out:
runaway coordinates get clamped onto *different edge pixels* of the 0/255
checkerboard images the test generates. `BORDER_CONSTANT` collapses them all onto the
same border value and hides the divergence entirely.

KleidiCV perturbs the arithmetic slightly differently again (FMA, and a reciprocal
multiply instead of a division), which changes *which* cases cross the threshold - not
whether the problem exists.

### Evidence

Cross-compiled for aarch64 (GCC 13.3) and run under QEMU user-mode emulation, selecting
the KleidiCV backend via `-cpu` (`cortex-a72` -> NEON, `max` -> SVE2). 1500 randomized
cases restricted to what KleidiCV accelerates (`CV_8UC1`, `INTER_LINEAR`), mirroring the
test's own data generation. Tolerance for `INTER_LINEAR` is 1.

| Configuration | worst diff | cases over tolerance |
|---|---|---|
| KleidiCV SVE2, `BORDER_REPLICATE` | 14 | 13 |
| KleidiCV NEON, `BORDER_REPLICATE` | 12 | 13 |
| **KleidiCV disabled**, `BORDER_REPLICATE` | **14** | **11** |
| KleidiCV SVE2, `BORDER_CONSTANT` | 1 | 0 |
| KleidiCV SVE2, `BORDER_REPLICATE` + this patch | 1 | 0 |
| KleidiCV NEON, `BORDER_REPLICATE` + this patch | 1 | 0 |

The build with KleidiCV disabled produces the **identical worst case** - same trial,
same pixel, `impl=159 reference=173`, `src=247x881`, `dst=140x320`.

Per-seed, every seed that failed with KleidiCV also failed without it, with matching
norms:

```
seed  1: FAILED (baseline, no KleidiCV) Norm of the difference: 247.031250
seed  2: FAILED (baseline, no KleidiCV) Norm of the difference: 255.000000
seed  5: FAILED (baseline, no KleidiCV) Norm of the difference: 239.000000
seed 18: FAILED (baseline, no KleidiCV) Norm of the difference: 211.000000
...
```

Several of those failures are on `16UC3` and `32FC4`, which KleidiCV never touches - it
only accelerates `CV_8UC1`.

### Approach

A per-destination-pixel validation mask is added to `CV_ImageWarpBaseTest`. It is empty
by default, so every other test in the file is unaffected.
`CV_WarpPerspective_Test::warpPerspective` populates it, clearing pixels whose
back-projected source coordinate is non-finite or lands beyond twice the source extent.

An alternative fix - raising the reference to double precision so it matches
`cv::warpPerspective` - was tried and **makes things worse** (worst diff 14 -> 29), since
KleidiCV itself computes in float32. These pixels are genuinely ill-conditioned; no two
implementations will agree on them, so the comparison itself is not meaningful there.

### Verification

- `Imgproc_WarpPerspective_Test.accuracy` passes on both KleidiCV backends
- `Imgproc_Warp*`, `Imgproc_Remap*`, `Imgproc_Resize*`: 10/10 on NEON and on SVE2
- Seed sweep 1-40: 39/40 with KleidiCV, 40/41 with it disabled (previously most seeds failed)

### Scope and limitations

- **Coverage trade-off.** The mask stops the test asserting on pixels sampled far outside
  the source image. That is deliberate - those assertions were not meaningful - but it is
  a genuine reduction in coverage. The `2x extent + 32` bound is empirical: `4x` still
  leaves 3 failures in 1500 cases, `2x` leaves none.
- **Seed 29 still fails**, on `INTER_CUBIC` / `16UC3` with a difference of 3 against a
  tolerance of 2. That is a different code path, unrelated to this issue and pre-existing.
  Left untouched here.
- Built and tested on aarch64 only. The change is portable C++ with no intrinsics, and the
  mask can only ever skip a check, never introduce a failure, so x86 CI cannot regress
  because of it.

### Branch

Proposed against **5.x** only. The reference implementation involved
(`new_warpPerspective`, `new_linear_c1`, `new_remap`, `warp_linear_calc`) does not exist
in 4.x - it arrived with #29165 - so 4.x uses the older quantized-map reference and does
not have this failure mode. The patch does not apply there.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake