### PR TITLE
ptcloud: bounds-check split() results in PLY header parsing

### DIFF
--- a/modules/ptcloud/src/io_ply.cpp
+++ b/modules/ptcloud/src/io_ply.cpp
@@ -50,9 +50,14 @@ bool PlyDecoder::parseHeader(std::ifstream &file, int& nTexCoords)
     {
         e = trimSpaces(e);
     }
-    if (splitArr[0] != "format")
+    if (splitArr.empty() || splitArr[0] != "format")
     {
         CV_LOG_ERROR(NULL, "Provided file doesn't have format");
+        return false;
+    }
+    if (splitArr.size() < 2)
+    {
+        CV_LOG_ERROR(NULL, "Provided PLY file format is not supported");
         return false;
     }
     if (splitArr[1] == "ascii")
@@ -104,7 +109,13 @@ bool PlyDecoder::parseHeader(std::ifstream &file, int& nTexCoords)
             {
                 e = trimSpaces(e);
             }
-            std::string elemName = splitArrElem.at(1);
+            if (splitArrElem.size() < 2)
+            {
+                CV_LOG_ERROR(NULL, "Element description has " << splitArrElem.size()
+                             << " words instead of at least 2");
+                return false;
+            }
+            std::string elemName = splitArrElem[1];
             if (elemName == "vertex")
             {
                 elemRead = READ_VERTEX;

--- a/modules/ptcloud/test/test_pointcloud_io.cpp
+++ b/modules/ptcloud/test/test_pointcloud_io.cpp
@@ -5,6 +5,7 @@
 #include <opencv2/core.hpp>
 #include <vector>
 #include <cstdio>
+#include <fstream>
 
 #include "test_precomp.hpp"
 #include "opencv2/ts.hpp"
@@ -294,6 +295,45 @@ TEST(PointCloud, SaveBadExtension)
 
     auto folder = cvtest::TS::ptr()->get_data_path();
     cv::savePointCloud(folder + "pointcloudio/fake.fake", points, normals);
+}
+
+TEST(PointCloud, LoadPlyEmptyFormatLine)
+{
+    std::string path = tempfile("empty_format.ply");
+    std::ofstream file(path, std::ios::binary);
+    file << "ply\n\n";
+    file.close();
+
+    std::vector<cv::Point3f> points, normals, rgb;
+    cv::loadPointCloud(path, points, normals, rgb);
+    EXPECT_TRUE(points.empty());
+    std::remove(path.c_str());
+}
+
+TEST(PointCloud, LoadPlyFormatLineNoSeparator)
+{
+    std::string path = tempfile("no_separator_format.ply");
+    std::ofstream file(path, std::ios::binary);
+    file << "ply\nformat\r\r\r\r\r\r\r\r\r\r\r\r\n";
+    file.close();
+
+    std::vector<cv::Point3f> points, normals, rgb;
+    cv::loadPointCloud(path, points, normals, rgb);
+    EXPECT_TRUE(points.empty());
+    std::remove(path.c_str());
+}
+
+TEST(PointCloud, LoadPlyMalformedElementLine)
+{
+    std::string path = tempfile("malformed_element.ply");
+    std::ofstream file(path, std::ios::binary);
+    file << "ply\nformat ascii 1.0\nelement\nend_header\n";
+    file.close();
+
+    std::vector<cv::Point3f> points, normals, rgb;
+    cv::loadPointCloud(path, points, normals, rgb);
+    EXPECT_TRUE(points.empty());
+    std::remove(path.c_str());
 }
 
 }} /* namespace opencv_test */


### PR DESCRIPTION
Fixes #29865.

`PlyDecoder::parseHeader()` splits the format line on spaces and assumes it always has at least two tokens. When that line is empty, `split()` returns an empty vector and `splitArr[0]` reads past the end; when the line has no space separator (e.g. `format` followed only by `\r` characters), `split()` returns a single-element vector and `splitArr[1]` reads past the end. Both are AddressSanitizer SEGV/heap-overflow crashes found by fuzzing.

Added the missing size checks before both accesses, matching the "log and return false" convention already used elsewhere in this function. While there, the `element` line had the same gap (`splitArrElem.at(1)` with no prior size check), so a bare `element` line with no name would throw an uncaught exception instead of failing gracefully; added the same guard there too.

Added regression tests for both reported crashes plus the element-line case, and confirmed all existing PLY/OBJ load/save tests still pass.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (`5.x`, `ptcloud` doesn't exist on `4.x`)
- [x] There is a reference to the original bug report and related work (#29865)
- [x] There is an accuracy test (`PointCloud.LoadPlyEmptyFormatLine`, `PointCloud.LoadPlyFormatLineNoSeparator`, `PointCloud.LoadPlyMalformedElementLine`); not applicable: performance test (not a perf-sensitive change)
- [x] N/A: this is a bug fix, not a new feature -- no new public API or documentation needed