### PR TITLE
Fix infinite loop in warpAffine

### DIFF
--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -336,6 +336,8 @@ static inline int borderInterpolate_fast( int p, int len, int borderType )
         p = p < 0 ? 0 : len - 1;
     else if( borderType == BORDER_REFLECT || borderType == BORDER_REFLECT_101 )
     {
+        if( len == 1 )
+            return 0;
         int delta = borderType == BORDER_REFLECT_101;
         do
         {

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -43,6 +43,10 @@
 #include "opencv2/ts/ts_gtest.h"
 #include "test_precomp.hpp"
 
+#include <chrono>
+#include <future>
+#include <thread>
+
 namespace opencv_test { namespace {
 
 class CV_ImgWarpBaseTest : public cvtest::ArrayTest
@@ -1197,6 +1201,32 @@ TEST(Imgproc_Warping, DISABLED_playground)
         if ((waitKey() & 255) == 27)
             break;
     }
+}
+
+TEST(Imgproc_Warping, infinite_loop)
+{
+    std::promise<void> promise;
+    auto future = promise.get_future();
+
+    std::thread worker([&promise]() {
+        cv::Mat src(1, 10, CV_8UC1, cv::Scalar(128));
+        cv::Mat dst;
+        cv::Matx23f M(1.f, 0.f, 0.f, 0.f, 1.f, 0.f);
+
+        cv::warpAffine(src, dst, M, cv::Size(10, 10), cv::INTER_CUBIC,
+                       cv::BORDER_REFLECT_101);
+        promise.set_value();
+    });
+
+    auto status = future.wait_for(std::chrono::seconds(1));
+    if (status == std::future_status::ready) {
+        worker.join();
+    } else {
+        worker.detach();
+    }
+
+    EXPECT_EQ(status, std::future_status::ready)
+        << "cv::warpAffine hung in an infinite loop!";
 }
 
 }} // namespace


### PR DESCRIPTION
Otherwise, p alternates between 1 and -1
That fix is already present in borderInterpolate
https://github.com/opencv/opencv/blob/3a718750a4d4bcde78bc93bcaf18b0303e956e55/modules/core/src/copy.cpp#L975

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
