### PR TITLE
imgcodecs: avoid copying PNG IDAT data during header parsing 🤖🤖🤖

### DIFF
--- a/modules/imgcodecs/perf/perf_png.cpp
+++ b/modules/imgcodecs/perf/perf_png.cpp
@@ -4,12 +4,104 @@
 
 #include "perf_precomp.hpp"
 
+#include <cstring>
+
 namespace opencv_test
 {
 
 #if defined(HAVE_PNG) || defined(HAVE_SPNG)
 
 using namespace perf;
+
+static size_t pngChunkLength(const vector<uchar>& buffer, size_t offset)
+{
+    return (static_cast<size_t>(buffer[offset]) << 24) |
+           (static_cast<size_t>(buffer[offset + 1]) << 16) |
+           (static_cast<size_t>(buffer[offset + 2]) << 8) |
+           static_cast<size_t>(buffer[offset + 3]);
+}
+
+static void appendPngUint32(vector<uchar>& buffer, uint32_t value)
+{
+    for (int shift = 24; shift >= 0; shift -= 8)
+        buffer.push_back(static_cast<uchar>(value >> shift));
+}
+
+static uint32_t pngCRC(const uchar* data, size_t size)
+{
+    uint32_t table[256];
+    for (uint32_t i = 0; i < 256; ++i)
+    {
+        uint32_t crc = i;
+        for (int bit = 0; bit < 8; ++bit)
+            crc = (crc >> 1) ^ ((crc & 1) ? 0xedb88320U : 0);
+        table[i] = crc;
+    }
+    uint32_t crc = 0xffffffffU;
+    for (size_t i = 0; i < size; ++i)
+        crc = table[(crc ^ data[i]) & 0xff] ^ (crc >> 8);
+    return crc ^ 0xffffffffU;
+}
+
+// The encoder limits its IDAT buffer to 1 MiB. Combine the generated chunks
+// without changing their compressed bytes to exercise a full-image IDAT.
+static vector<uchar> pngSingleIDAT(const vector<uchar>& encoded)
+{
+    size_t first = 0, last = 0, payloadSize = 0;
+    for (size_t offset = 8; offset + 12 <= encoded.size();)
+    {
+        const size_t length = pngChunkLength(encoded, offset);
+        CV_Assert(length <= encoded.size() - offset - 12);
+        if (std::memcmp(&encoded[offset + 4], "IDAT", 4) == 0)
+        {
+            if (first == 0)
+                first = offset;
+            last = offset + length + 12;
+            payloadSize += length;
+        }
+        offset += length + 12;
+    }
+    CV_Assert(first != 0 && payloadSize <= 0x7fffffffU);
+
+    vector<uchar> combined;
+    combined.reserve(encoded.size());
+    combined.insert(combined.end(), encoded.begin(), encoded.begin() + first);
+    appendPngUint32(combined, static_cast<uint32_t>(payloadSize));
+    combined.insert(combined.end(), encoded.begin() + first + 4, encoded.begin() + first + 8);
+    for (size_t offset = first; offset < last;)
+    {
+        CV_Assert(std::memcmp(&encoded[offset + 4], "IDAT", 4) == 0);
+        const size_t length = pngChunkLength(encoded, offset);
+        combined.insert(combined.end(), encoded.begin() + offset + 8,
+                        encoded.begin() + offset + 8 + length);
+        offset += length + 12;
+    }
+    appendPngUint32(combined, pngCRC(&combined[first + 4], payloadSize + 4));
+    combined.insert(combined.end(), encoded.begin() + last, encoded.end());
+    return combined;
+}
+
+typedef perf::TestBaseWithParam<testing::tuple<Size, bool> > PNGDecode;
+
+PERF_TEST_P(PNGDecode, idat_layout,
+    testing::Combine(testing::Values(Size(512, 512), Size(3840, 2160)),
+                     testing::Bool()))
+{
+    const bool singleIDAT = get<1>(GetParam());
+    Mat src(get<0>(GetParam()), CV_8UC3);
+    theRNG().fill(src, RNG::UNIFORM, 0, 256);
+    vector<uchar> encoded;
+    ASSERT_TRUE(imencode(".png", src, encoded,
+        { IMWRITE_PNG_COMPRESSION, 0, IMWRITE_PNG_ZLIBBUFFER_SIZE, 8192 }));
+    if (singleIDAT)
+        encoded = pngSingleIDAT(encoded);
+
+    Mat dst;
+    TEST_CYCLE() dst = imdecode(encoded, IMREAD_UNCHANGED);
+
+    EXPECT_EQ(0, cv::norm(src, dst, NORM_INF));
+    SANITY_CHECK_NOTHING();
+}
 
 CV_ENUM(PNGStrategy, IMWRITE_PNG_STRATEGY_DEFAULT, IMWRITE_PNG_STRATEGY_FILTERED, IMWRITE_PNG_STRATEGY_HUFFMAN_ONLY, IMWRITE_PNG_STRATEGY_RLE, IMWRITE_PNG_STRATEGY_FIXED);
 CV_ENUM(PNGFilters, IMWRITE_PNG_FILTER_NONE, IMWRITE_PNG_FILTER_SUB, IMWRITE_PNG_FILTER_UP, IMWRITE_PNG_FILTER_AVG, IMWRITE_PNG_FILTER_PAETH, IMWRITE_PNG_FAST_FILTERS, IMWRITE_PNG_ALL_FILTERS);

--- a/modules/imgcodecs/src/grfmt_png.cpp
+++ b/modules/imgcodecs/src/grfmt_png.cpp
@@ -301,7 +301,7 @@ bool  PngDecoder::readHeader()
     m_is_fcTL_loaded = false;
     while (true)
     {
-        id = read_chunk(chunk);
+        id = read_chunk(chunk, true);
 
         if (!id || (m_f && feof(m_f)) || (!m_buf.empty() && m_buf_pos > m_buf.total()))
         {
@@ -799,7 +799,7 @@ bool PngDecoder::readFromStreamOrBuffer(void* buffer, size_t num_bytes)
     return true;
 }
 
-uint32_t PngDecoder::read_chunk(Chunk& chunk)
+uint32_t PngDecoder::read_chunk(Chunk& chunk, bool skipIDATPayload)
 {
     unsigned char size_id[8];
     if (!readFromStreamOrBuffer(&size_id, 8))
@@ -807,6 +807,28 @@ uint32_t PngDecoder::read_chunk(Chunk& chunk)
     const size_t size = static_cast<size_t>(png_get_uint_32(size_id)) + 12;
 
     const uint32_t id = png_get_uint_32(size_id + 4);
+    // Header discovery rewinds the input before handing it to libpng. Check
+    // that IDAT is complete without allocating and copying its payload.
+    // libpng will read the image data and validate its CRC during readData().
+    if (skipIDATPayload && id == id_IDAT)
+    {
+        if (!m_f)
+        {
+            if (size - 8 > m_buf.total() * m_buf.elemSize() - m_buf_pos)
+                return 0;
+            m_buf_pos += size - 8;
+            return id;
+        }
+        // Small chunks are cheaper to read through the existing stdio buffer.
+        // Keep the full-read fallback when the offset cannot fit in a long.
+        if (size > 65536 && size - 9 <= static_cast<size_t>(LONG_MAX))
+        {
+            if (fseek(m_f, static_cast<long>(size - 9), SEEK_CUR) != 0 || fgetc(m_f) == EOF)
+                return 0;
+            return id;
+        }
+    }
+
     if (id == id_IHDR) {
         // 8=HDR+size, 13=size of IHDR chunk, 4=CRC
         // http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.IHDR

--- a/modules/imgcodecs/src/grfmt_png.hpp
+++ b/modules/imgcodecs/src/grfmt_png.hpp
@@ -144,7 +144,7 @@ private:
      * @return true if the operation is successful, false otherwise.
      */
     CV_NODISCARD_STD bool readFromStreamOrBuffer(void* buffer, size_t num_bytes);
-    uint32_t  read_chunk(Chunk& chunk);
+    uint32_t  read_chunk(Chunk& chunk, bool skipIDATPayload = false);
     CV_NODISCARD_STD bool InitPngPtr();
     void ClearPngPtr();
 

--- a/modules/imgcodecs/test/test_png.cpp
+++ b/modules/imgcodecs/test/test_png.cpp
@@ -4,6 +4,9 @@
 #include "test_precomp.hpp"
 #include "test_common.hpp"
 
+#include <cstdio>
+#include <cstring>
+
 namespace opencv_test { namespace {
 
 #if defined(HAVE_PNG) || defined(HAVE_SPNG)
@@ -51,6 +54,129 @@ TEST(Imgcodecs_Png, encode)
     EXPECT_FALSE(img.empty());
     EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), img, img_gt);
 }
+
+#ifdef HAVE_PNG
+static size_t pngChunkLength(const vector<uchar>& buffer, size_t offset)
+{
+    return (static_cast<size_t>(buffer[offset]) << 24) |
+           (static_cast<size_t>(buffer[offset + 1]) << 16) |
+           (static_cast<size_t>(buffer[offset + 2]) << 8) |
+           static_cast<size_t>(buffer[offset + 3]);
+}
+
+static vector<size_t> pngIDATOffsets(const vector<uchar>& buffer)
+{
+    vector<size_t> offsets;
+    for (size_t offset = 8; offset + 12 <= buffer.size();)
+    {
+        const size_t length = pngChunkLength(buffer, offset);
+        CV_Assert(length <= buffer.size() - offset - 12);
+        if (std::memcmp(&buffer[offset + 4], "IDAT", 4) == 0)
+            offsets.push_back(offset);
+        offset += length + 12;
+    }
+    return offsets;
+}
+
+class Imgcodecs_Png_ReadIDAT : public testing::Test
+{
+protected:
+    Imgcodecs_Png_ReadIDAT() : filename(cv::tempfile(".png")) {}
+    ~Imgcodecs_Png_ReadIDAT() { std::remove(filename.c_str()); }
+
+    void checkReading(const vector<uchar>& buffer, const Mat& expected, size_t expectedCount = 1)
+    {
+        Mat decoded;
+        ASSERT_NO_THROW(decoded = imdecode(buffer, IMREAD_UNCHANGED));
+        if (expected.empty())
+            EXPECT_TRUE(decoded.empty());
+        else
+            EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), decoded, expected);
+
+        FILE* file = std::fopen(filename.c_str(), "wb");
+        ASSERT_TRUE(file != NULL);
+        const size_t written = std::fwrite(buffer.data(), 1, buffer.size(), file);
+        const int closeResult = std::fclose(file);
+        ASSERT_EQ(buffer.size(), written);
+        ASSERT_EQ(0, closeResult);
+        EXPECT_EQ(expectedCount, imcount(filename));
+        ASSERT_NO_THROW(decoded = imread(filename, IMREAD_UNCHANGED));
+        if (expected.empty())
+            EXPECT_TRUE(decoded.empty());
+        else
+            EXPECT_PRED_FORMAT2(cvtest::MatComparator(0, 0), decoded, expected);
+    }
+
+private:
+    const string filename;
+};
+
+class Imgcodecs_Png_ReadIDAT_RoundTrip
+    : public Imgcodecs_Png_ReadIDAT,
+      public testing::WithParamInterface<testing::tuple<int, int> >
+{};
+
+TEST_P(Imgcodecs_Png_ReadIDAT_RoundTrip, decode)
+{
+    const int layout = get<1>(GetParam()); // Single, multiple, or empty first IDAT.
+    Mat source(256, 256, get<0>(GetParam()));
+    RNG rng(0x12345678);
+    rng.fill(source, RNG::UNIFORM, 0, source.depth() == CV_8U ? 256 : 65536);
+    vector<uchar> buffer;
+    ASSERT_TRUE(imencode(".png", source, buffer,
+        { IMWRITE_PNG_COMPRESSION, 0, IMWRITE_PNG_ZLIBBUFFER_SIZE,
+          layout == 1 ? 8192 : 1024 * 1024 }));
+
+    const vector<size_t> offsets = pngIDATOffsets(buffer);
+    ASSERT_FALSE(offsets.empty());
+    if (layout == 1)
+        ASSERT_GT(offsets.size(), static_cast<size_t>(1));
+    else
+    {
+        ASSERT_EQ(static_cast<size_t>(1), offsets.size());
+        ASSERT_GT(pngChunkLength(buffer, offsets[0]), static_cast<size_t>(8192));
+    }
+
+    if (layout == 2)
+    {
+        // A zero-length IDAT is valid before the first compressed byte.
+        const uchar emptyIDAT[] = { 0, 0, 0, 0, 'I', 'D', 'A', 'T', 0x35, 0xaf, 0x06, 0x1e };
+        buffer.insert(buffer.begin() + offsets[0], emptyIDAT, emptyIDAT + sizeof(emptyIDAT));
+    }
+    checkReading(buffer, source);
+}
+
+INSTANTIATE_TEST_CASE_P(/*nothing*/, Imgcodecs_Png_ReadIDAT_RoundTrip,
+    testing::Combine(testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16UC3, CV_16UC4),
+                     testing::Values(0, 1, 2)));
+
+TEST_F(Imgcodecs_Png_ReadIDAT, damaged_first_IDAT)
+{
+    const Mat source(256, 256, CV_8UC3, Scalar(17, 81, 203));
+    vector<uchar> buffer;
+    ASSERT_TRUE(imencode(".png", source, buffer,
+        { IMWRITE_PNG_COMPRESSION, 0, IMWRITE_PNG_ZLIBBUFFER_SIZE, 1024 * 1024 }));
+    const vector<size_t> offsets = pngIDATOffsets(buffer);
+    ASSERT_EQ(static_cast<size_t>(1), offsets.size());
+    const size_t offset = offsets[0];
+    const size_t length = pngChunkLength(buffer, offset);
+    ASSERT_NO_FATAL_FAILURE(checkReading(buffer, source));
+
+    // Incomplete header, absent/partial payload, and absent/partial CRC.
+    const size_t truncatedSizes[] = { offset + 4, offset + 7, offset + 8,
+        offset + 8 + length / 2, offset + 8 + length, offset + 8 + length + 3 };
+    for (size_t i = 0; i < sizeof(truncatedSizes) / sizeof(truncatedSizes[0]); ++i)
+    {
+        SCOPED_TRACE(format("truncated size: %zu", truncatedSizes[i]));
+        const vector<uchar> truncated(buffer.begin(), buffer.begin() + truncatedSizes[i]);
+        ASSERT_NO_FATAL_FAILURE(checkReading(truncated, Mat(), 0));
+    }
+
+    // Header-only imcount does not validate IDAT CRC, but decoding must do so.
+    buffer[offset + 8 + length] ^= 1;
+    checkReading(buffer, Mat());
+}
+#endif
 
 TEST(Imgcodecs_Png, regression_ImreadVSCvtColor)
 {


### PR DESCRIPTION
`PngDecoder::readHeader()` copies the first IDAT chunk into a temporary vector, discards it, then rewinds the input so libpng can read it again. A PNG stored in one large IDAT chunk therefore incurs an avoidable allocation and payload copy before decoding.

Skip materializing IDAT data during header discovery. For memory input, validate the remaining length and advance the cursor. For file input, seek to and read the final CRC byte to retain early rejection of truncated chunks. Keep buffered reads for small file chunks and when the seek offset cannot fit in `long`; libpng still validates IDAT CRC while decoding static PNGs. APNG frame decoding retains its existing chunk-reading path.

Validation against `52377dee533dbba170d6437a7cf6d42a749a3f8f`, with only this PNG patch applied:

- macOS 26.6.2 / Apple M5 Pro / Apple Clang 21: 579 image-codec cases, four default skips, zero failures; all four new perf smoke cases pass.
- Linux (Ubuntu 24.04.4) / Intel Core i7-6850K / GCC 13.3: the same 579 cases, four default skips, zero failures; all four new perf smoke cases pass.
- All 19 new regression cases also pass against the unchanged baseline libraries on both hosts.
- Matching Release settings within each host, bundled libpng 1.6.57 and zlib 1.3.2.

The revised, committed `PNGDecode` performance cases measure `imdecode(..., IMREAD_UNCHANGED)` on generated random, uncompressed RGB PNGs in memory. Seven alternating baseline/candidate pairs use 30 samples per case and one OpenCV thread; Linux runs are pinned to one CPU. The same revised performance executable is used with each library set, and actual loaded library paths are verified. These measurements are separate from the file-loading results below.

| Memory-decoding workload | Mac speedup | Linux speedup |
| --- | ---: | ---: |
| 512×512, ordinary chunks | 1.001× (0.999–1.003) | 0.999× (0.998–1.002) |
| 512×512, single IDAT | 1.024× (1.022–1.030) | 1.069× (1.067–1.070) |
| 3840×2160, ordinary chunks | 0.999× (0.995–1.011) | 1.001× (1.000–1.001) |
| 3840×2160, single IDAT | 1.022× (1.000–1.024) | 1.383× (1.356–1.419) |

Values are paired median speedups with descriptive bootstrap 95% intervals. Every process passed all four cases with exact pixel comparisons.

Separate C++ `imread(..., IMREAD_COLOR)` measurements use the earlier structured 3840×2160 RGB PNG fixtures, warm filesystem cache, one OpenCV thread, and seven alternating baseline/candidate pairs (minimum 0.15 seconds per batch). Linux runs are pinned to one CPU. Each host checks 100 image/mode cases; decoded dimensions, types, and pixel hashes match across every run and between hosts. The values below are paired median speedups, with bootstrap 95% intervals.

| Workload | Mac speedup | Linux speedup |
| --- | ---: | ---: |
| Uncompressed stream in one ~24.9 MB IDAT | 1.077× (1.046–1.110) | 1.171× (1.170–1.171) |
| Same uncompressed stream in ordinary IDAT chunks | 1.014× (0.945–1.025) | 1.000× (0.997–1.001) |
| Compressed stream in one IDAT | 1.014× (1.007–1.020) | 1.024× (1.021–1.025) |

The large-IDAT case has median latency 16.08→14.83 ms on the Mac and 37.23→31.90 ms on Linux. A separate 15-pair Mac check puts the ordinary chunked control at 1.002× (0.994–1.015). The gain depends on first-IDAT size and decoding cost; ordinary chunked PNGs are approximately neutral.

The new performance tests use the test framework’s `theRNG()` and time `imdecode(encoded, IMREAD_UNCHANGED)` entirely in memory. They generate identical uncompressed RGB images with ordinary 8 KiB IDAT chunks or a single full-image IDAT, at 512×512 and 3840×2160. Encoding and repacking happen outside the timed loop; the performance cases create no temporary files. Run the included cases with the following filters. For an A/B comparison, copy only the test/performance changes to the baseline tree:

```sh
opencv_test_imgcodecs --gtest_filter='*Png_ReadIDAT*'
opencv_perf_imgcodecs --gtest_filter='PNGDecode_idat_layout.idat_layout/*'
```

The regression tests exercise file and memory input, 8/16-bit grayscale/RGB/RGBA, single/multiple/empty-first IDAT layouts, incomplete headers/payloads/CRCs, and corrupt CRCs. They check `imread`, `imdecode`, and `imcount`. All fixtures are generated; no `opencv_extra` patch is needed. Windows was not tested locally.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (`5.x`, optimization).
- [x] Accuracy and performance tests are included; test data is generated.
- Original bug report: none; self-contained performance improvement.
- Documentation/sample changes: not applicable; no public API change.
