### PR TITLE
Improve warpPerspective and remap documentation regarding interpolati…

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2489,6 +2489,14 @@ borderMode=#BORDER_TRANSPARENT, it means that the pixels in the destination imag
 the "outliers" in the source image are not modified by the function.
 @param borderValue value used in case of a constant border; by default, it is 0.
 
+@note The interpolation coordinates are rounded to a fixed-point grid of INTER_BITS
+fractional bits, that is to 1/32 of a pixel, before the source is sampled, so the
+interpolation weights are quantized to 32 steps. This is usually invisible, but it shows
+up as banding when the source is strongly upscaled, and it bounds the accuracy of the
+result: for an 8-bit image the output can differ by up to 8 levels from an
+implementation that interpolates at full precision, so a HAL replacing this function may
+legitimately return slightly different values.
+
 @sa  warpPerspective, resize, remap, getRectSubPix, transform
  */
 CV_EXPORTS_W void warpAffine( InputArray src, OutputArray dst,
@@ -2520,6 +2528,14 @@ optional flag #WARP_INVERSE_MAP, that sets M as the inverse transformation (
 \f$\texttt{dst}\rightarrow\texttt{src}\f$ ).
 @param borderMode pixel extrapolation method (#BORDER_CONSTANT or #BORDER_REPLICATE).
 @param borderValue value used in case of a constant border; by default, it equals 0.
+
+@note The interpolation coordinates are rounded to a fixed-point grid of INTER_BITS
+fractional bits, that is to 1/32 of a pixel, before the source is sampled, so the
+interpolation weights are quantized to 32 steps. This is usually invisible, but it shows
+up as banding when the source is strongly upscaled, and it bounds the accuracy of the
+result: for an 8-bit image the output can differ by up to 8 levels from an
+implementation that interpolates at full precision, so a HAL replacing this function may
+legitimately return slightly different values.
 
 @sa  warpAffine, resize, remap, getRectSubPix, perspectiveTransform
  */
@@ -2568,6 +2584,14 @@ corresponds to the "outliers" in the source image are not modified by the functi
 @param borderValue Value used in case of a constant border. By default, it is 0.
 @note
 Due to current implementation limitations the size of an input and output images should be less than 32767x32767.
+
+@note The interpolation coordinates are rounded to a fixed-point grid of INTER_BITS
+fractional bits, that is to 1/32 of a pixel, before the source is sampled, so the
+interpolation weights are quantized to 32 steps. This is usually invisible, but it shows
+up as banding when the source is strongly upscaled, and it bounds the accuracy of the
+result: for an 8-bit image the output can differ by up to 8 levels from an
+implementation that interpolates at full precision, so a HAL replacing this function may
+legitimately return slightly different values.
  */
 CV_EXPORTS_W void remap( InputArray src, OutputArray dst,
                          InputArray map1, InputArray map2,

--- a/modules/imgproc/test/test_imgwarp_strict.cpp
+++ b/modules/imgproc/test/test_imgwarp_strict.cpp
@@ -1206,9 +1206,7 @@ void CV_WarpPerspective_Test::generate_test_data()
     int depth = depths[rng.uniform(0, 2)];
     M.clone().convertTo(M, depth);
 
-    // BUG: https://github.com/opencv/opencv/issues/29816
-    // BORDER_REPLICATE disabled due to KleidiCV accuracy issue on ARM
-    static const int borderTypes[] = { /*BORDER_REPLICATE,*/ BORDER_REFLECT, BORDER_TRANSPARENT };
+    static const int borderTypes[] = { BORDER_REPLICATE, BORDER_REFLECT, BORDER_TRANSPARENT };
     borderType = borderTypes[rng.uniform(0, sizeof(borderTypes) / sizeof(borderTypes[0]))];
 }
 
@@ -1219,6 +1217,17 @@ void CV_WarpPerspective_Test::run_func()
 
 float CV_WarpPerspective_Test::get_success_error_level(int _interpolation, int _depth) const
 {
+    // The reference above rounds the interpolation coordinates to INTER_BITS fractional
+    // bits, as cv::warpPerspective itself does, so the interpolation weights are taken
+    // from a grid of 1/INTER_TAB_SIZE. An implementation that interpolates at full
+    // precision - a HAL, for instance - is more accurate but does not reproduce that
+    // rounding: each of the two coordinates is off by up to 1/(2*INTER_TAB_SIZE), and on
+    // the 0/255 images generated here a coordinate carries a weight of 255, so bilinear
+    // interpolation can differ by almost 2 * 255 / (2 * INTER_TAB_SIZE) = 7.97.
+    // See https://github.com/opencv/opencv/issues/29816
+    if (_interpolation == INTER_LINEAR)
+        return 8.0f;
+
     return CV_ImageWarpBaseTest::get_success_error_level(_interpolation, _depth);
 }
 


### PR DESCRIPTION
### Summary

`Imgproc_WarpPerspective_Test.accuracy` fails on ARM with KleidiCV enabled.
KleidiCV is not wrong — it is the more accurate of the two. The test reference
is the approximate one, and the test did not allow for that.

### Root cause

The test reference rounds the interpolation coordinates to `INTER_BITS` (= 5)
fractional bits, a grid of 1/32 of a pixel, exactly as `cv::warpPerspective`
does. A HAL that interpolates at full precision does not reproduce that
rounding.

For the reported pixel the coordinate is 0.518317, giving
`255 * (1 - 0.518317) = 122.83` → **123**, which is what KleidiCV returns.
Rounded to the fixed-point grid it becomes 17/32, giving `255 * 15/32 = 119.53`
→ **120**, which is what the reference returns.

The difference is bounded: each of the two coordinates is off by at most
`1/(2*INTER_TAB_SIZE)`, and on the 0/255 images this test generates a
coordinate carries a weight of 255, so bilinear interpolation can differ by
almost `2 * 255 / (2 * INTER_TAB_SIZE) = 7.97`.

### Changes

- Raise the `INTER_LINEAR` tolerance for `CV_WarpPerspective_Test` to 8. Other
  interpolation methods are untouched.
- Re-enable `BORDER_REPLICATE` for this test.
- Document the coordinate quantization in `remap()`, `warpAffine()` and
  `warpPerspective()`.

No library code is changed.

### Verification

x86-64, GCC 13.3, Release, no HAL:

- `Imgproc_WarpPerspective_Test.accuracy` passes on 25/25 seeds with
  `BORDER_REPLICATE` re-enabled.
- `Imgproc_Resize_Test`, `Imgproc_Remap_Test`, `Imgproc_WarpAffine_Test` and
  `Imgproc_WarpPerspective_Test` all pass.
- The maximum `|reference - implementation|` over 720 generated cases across 18
  seeds is **0.000 for every interpolation method**, so re-enabling
  `BORDER_REPLICATE` regresses nothing on x86 and the raised tolerance hides no
  x86 difference.

Fixes #29816

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake