### PR TITLE
doc: fix image arithmetics tutorial to use 2D arrays so cv.add example matches documented output

### DIFF
--- a/doc/py_tutorials/py_core/py_image_arithmetics/py_image_arithmetics.markdown
+++ b/doc/py_tutorials/py_core/py_image_arithmetics/py_image_arithmetics.markdown
@@ -19,14 +19,14 @@ saturated operation while Numpy addition is a modulo operation.
 
 For example, consider the below sample:
 @code{.py}
->>> x = np.uint8([250])
->>> y = np.uint8([10])
+>>> x = np.uint8([[250]])
+>>> y = np.uint8([[10]])
 
 >>> print( cv.add(x,y) ) # 250+10 = 260 => 255
 [[255]]
 
 >>> print( x+y )          # 250+10 = 260 % 256 = 4
-[4]
+[[4]]
 @endcode
 This will be more visible when you add two images. Stick with OpenCV functions, because they will provide a better result.
 


### PR DESCRIPTION
Summary

The tutorial's `cv.add()` example used 1D arrays, which no longer reproduces
the documented output. The doc is wrong, not `cv.add()` — this matches the
known, accepted behavior described in #25165.

Root cause

`np.uint8([250])` creates a 1D array with shape `(1,)`. `cv.add()` expects
image-like inputs, and a 1D array does not behave as a single-pixel image the
way a 2D array does. Wrapping the values as `np.uint8([[250]])` gives a
proper 2D array (shape `(1, 1)`), which `cv.add()` handles as intended and
which reproduces the documented output exactly.

For the reported inputs, `250 + 10 = 260`, which saturates to `255` under
`cv.add()`'s saturated arithmetic, giving `[[255]]`. Under plain NumPy
addition (`x + y`), the same operands wrap modulo 256, giving
`260 % 256 = 4`, which becomes `[[4]]` once shaped as a 2D array.

Changes

- Change `x = np.uint8([250])` to `x = np.uint8([[250]])` in the
  `cv.add()` example.
- Change `y = np.uint8([10])` to `y = np.uint8([[10]])` in the same example.
- Update the printed result of `x+y` from `[4]` to `[[4]]` to match the
  added dimension.

No library code is changed. This is a documentation-only fix to
`doc/py_tutorials/py_core/py_image_arithmetics/py_image_arithmetics.markdown`.

Verification

Windows, Python 3.14.7, numpy + opencv-python:

​```
>>> import numpy as np
>>> import cv2 as cv
>>> x = np.uint8([[250]])
>>> y = np.uint8([[10]])
>>> print(cv.add(x,y))
[[255]]
>>> print(x+y)
[[4]]
​```

Output matches the corrected documentation exactly for both `cv.add()` and
plain NumPy addition.

Fixes #29870

Pull Request Readiness Checklist
See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake