### PR TITLE
core: fix overflow in borderInterpolate BORDER_WRAP path

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -990,10 +990,14 @@ int cv::borderInterpolate( int p, int len, int borderType )
     else if( borderType == BORDER_WRAP )
     {
         CV_Assert(len > 0);
-        if( p < 0 )
-            p -= ((p-len+1)/len)*len;
-        if( p >= len )
-            p %= len;
+        if( p < 0 || p >= len )
+        {
+            int64_t p64 = p;
+            p64 %= (int64_t)len;
+            if( p64 < 0 )
+                p64 += len;
+            p = (int)p64;
+        }
     }
     else if( borderType == BORDER_CONSTANT )
         p = -1;

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -3,6 +3,7 @@
 // of this distribution and at http://opencv.org/license.html.
 #include "test_precomp.hpp"
 #include <cmath>
+#include <climits>
 
 #include "opencv2/core/utils/logger.hpp"
 
@@ -218,6 +219,16 @@ TEST(Core_Copy, repeat_regression_8972)
                      });
 }
 
+TEST(Core_BorderInterpolate, wrap_no_overflow_29232)
+{
+    EXPECT_NO_THROW({
+        EXPECT_EQ(cv::borderInterpolate(INT_MIN, 5, cv::BORDER_WRAP), 2);
+        EXPECT_EQ(cv::borderInterpolate(INT_MAX, 5, cv::BORDER_WRAP), 2);
+        int r = cv::borderInterpolate(INT_MIN, 5, cv::BORDER_WRAP);
+        EXPECT_GE(r, 0);
+        EXPECT_LT(r, 5);
+    });
+}
 
 class ThrowErrorParallelLoopBody : public cv::ParallelLoopBody
 {


### PR DESCRIPTION
### Description

Fixes an integer overflow/underflow bug in `cv::borderInterpolate()` when using `BORDER_WRAP`. For extreme values of `p` (e.g. `INT_MIN` or `INT_MAX`), the previous implementation performed the modulo operation directly on `int`, which can invoke undefined behavior on overflow and produce a result outside the valid `[0, len)` range.

The fix widens the intermediate calculation to `int64_t` before taking the modulo, then adjusts for negative results and narrows back to `int` only once the value is confirmed to be in range.

### Changes

- `modules/core/src/copy.cpp`: use 64-bit intermediate arithmetic in the `BORDER_WRAP` branch of `borderInterpolate()` to avoid overflow.
- `modules/core/test/test_misc.cpp`: add `Core_BorderInterpolate.wrap_no_overflow_29232`, a regression test that exercises `BORDER_WRAP` with `INT_MIN` and `INT_MAX` and asserts the result stays within `[0, len)`.

Fixes #29232

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test for the patch (added in test_misc.cpp); no performance test needed as this is a bug fix with negligible performance impact.
- [x] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
