### PR TITLE
cmake: alias ZLIB::ZLIB to the zlib built from source

### DIFF
--- a/cmake/OpenCVFindLibsGrfmt.cmake
+++ b/cmake/OpenCVFindLibsGrfmt.cmake
@@ -57,6 +57,10 @@ else()
   endif()
 endif()
 
+if(TARGET ${ZLIB_LIBRARY} AND NOT TARGET ZLIB::ZLIB)
+  add_library(ZLIB::ZLIB ALIAS ${ZLIB_LIBRARY})
+endif()
+
 # --- libavif (optional) ---
 
 if(WITH_AVIF)


### PR DESCRIPTION
With `-DOPENCV_FORCE_3RDPARTY_BUILD=ON` on Linux the build stops with `No rule to make target 'zlib', needed by 'lib/libopencv_imgcodecs.so.5.1.0'`.

zlib is built from source in that configuration and `ZLIB_LIBRARY` is cached as the plain target name `zlib`. The system OpenEXR package config then calls `find_dependency(ZLIB)`, `FindZLIB` accepts the cached value as an already found library, and the resulting `ZLIB::ZLIB` imported target gets `IMPORTED_LOCATION` `zlib`, which is not a file. Linking OpenEXR into imgcodecs drags that in as a link dependency and make has no rule for it. 4.x is not affected, since it also builds OpenEXR from source under the same option.

Making `ZLIB::ZLIB` an alias of the in-tree zlib target keeps `FindZLIB` from creating the broken imported target, and OpenEXR links the zlib that was actually built.

Fixes #29888

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
