### PR TITLE
ts: make --perf_min_samples effective for TEST_CYCLE_N perf tests

### DIFF
--- a/modules/ts/src/ts_perf.cpp
+++ b/modules/ts/src/ts_perf.cpp
@@ -39,6 +39,10 @@ static double       param_max_outliers;
 static double       param_max_deviation;
 static unsigned int param_min_samples;
 static unsigned int param_force_samples;
+// Whether the user passed the option explicitly. A value requested on the command line
+// must win over both the built-in default and the per-test declare.iterations() value.
+static bool         param_min_samples_specified = false;
+static bool         param_force_samples_specified = false;
 static double       param_time_limit;
 static bool         param_write_sanity;
 static bool         param_verify_sanity;
@@ -952,6 +956,27 @@ void InstumentData::printTree()
 *                                   ::perf::TestBase
 \*****************************************************************************************/
 
+// cv::CommandLineParser::has() can't be used to tell an explicitly passed option from its
+// default value, so scan the raw arguments the same way the parser does.
+static bool isCmdLineArgSpecified(int argc, const char* const argv[], const char* name)
+{
+    for (int i = 1; i < argc; i++)
+    {
+        if (argv[i] == NULL)
+            continue;
+        std::string s(argv[i]);
+        if (s.length() < 2 || s[0] != '-')
+            continue;
+        bool hasDoubleDash = s.length() > 2 && s[1] == '-';
+        std::string key = s.substr(hasDoubleDash ? 2 : 1);
+        size_t equalsPos = key.find('=');
+        if (equalsPos != std::string::npos)
+            key = key.substr(0, equalsPos);
+        if (key == name)
+            return true;
+    }
+    return false;
+}
 
 void TestBase::Init(int argc, const char* const argv[])
 {
@@ -1043,6 +1068,21 @@ void TestBase::Init(const std::vector<std::string> & availableImpls,
     param_seed          = args.get<unsigned int>("perf_seed");
     param_time_limit    = std::max(0., args.get<double>("perf_time_limit"));
     param_force_samples = args.get<unsigned int>("perf_force_samples");
+
+    param_min_samples_specified   = isCmdLineArgSpecified(argc, argv, "perf_min_samples");
+    param_force_samples_specified = isCmdLineArgSpecified(argc, argv, "perf_force_samples");
+
+    // perf_min_samples is a floor and perf_force_samples a ceiling, so a requested minimum
+    // above the maximum is contradictory. Resolve it in favour of the explicitly passed
+    // option; otherwise an explicit --perf_min_samples would be silently truncated by the
+    // default --perf_force_samples value.
+    if (param_force_samples != 0 && param_force_samples < param_min_samples)
+    {
+        if (param_min_samples_specified && !param_force_samples_specified)
+            param_force_samples = param_min_samples;
+        else
+            param_min_samples = param_force_samples;
+    }
     param_write_sanity  = args.get<bool>("perf_write_sanity");
     param_verify_sanity = args.get<bool>("perf_verify_sanity");
 
@@ -1984,9 +2024,15 @@ void TestBase::RunPerfTestBody()
 \*****************************************************************************************/
 TestBase::_declareHelper& TestBase::_declareHelper::iterations(unsigned int n)
 {
-    test->times.clear();
-    test->times.reserve(n);
     test->nIters = std::min(n, TestBase::iterationsLimitDefault);
+    // A minimum requested on the command line outranks the number of iterations hardcoded
+    // in the test, otherwise --perf_min_samples has no effect at all on tests using
+    // TEST_CYCLE_N()/declare.iterations() (the loop in next() stops at nIters).
+    if (param_min_samples_specified)
+        test->nIters = std::max(test->nIters, param_min_samples);
+
+    test->times.clear();
+    test->times.reserve(test->nIters);
     test->currentIter = (unsigned int)-1;
     test->metrics.clear();
     return *this;


### PR DESCRIPTION
Fixes #29887

### Problem

`--perf_min_samples` is silently ignored by every test that declares a fixed
iteration count. `TEST_CYCLE_N(n)` calls `declare.iterations(n)`, which set

```cpp
test->nIters = std::min(n, TestBase::iterationsLimitDefault);
```

and the sample loop in `next()` (`PERF_STRATEGY_SIMPLE`) checks the ceiling
*before* the floor, so it can never reach `minIters`:

```cpp
if (currentIter >= nIters) { has_next = false; break; }   // the test's own count wins
if (currentIter < minIters) { has_next = true;  break; }  // unreachable
```

`--perf_force_samples` behaves correctly as a maximum, but a maximum can only
lower the count, so there was no way to raise it — hence `samples=10` for all
8 cases in the report (`perf_variational_refinement.cpp` uses `TEST_CYCLE_N(10)`).

The reproducer in the issue mentions a gtest filter, but the filter is
incidental: the trigger is `TEST_CYCLE_N()` / `declare.iterations()`.

There is a second, independent truncation: an explicitly requested minimum was
also clamped by the *default* `perf_force_samples` ceiling of 100, so
`--perf_min_samples=300` capped plain `TEST_CYCLE()` tests at 100 samples.

### Fix

`modules/ts/src/ts_perf.cpp` only, +49/-2:

1. Record whether each option was passed explicitly. `CommandLineParser::has()`
   cannot be used for this — it only reports that the (defaulted) value is
   non-empty — so the raw arguments are scanned the same way the parser does,
   accepting both `-key=` and `--key=`.
2. In `Init()`, reconcile a floor that exceeds the ceiling in favour of whichever
   option was passed explicitly.
3. In `declare.iterations(n)`, apply an explicitly requested minimum on top of
   the count declared by the test.

`--perf_force_samples` is kept as a strict ceiling and `--perf_min_samples` as
the way to raise the count, which is what `run.py --check` relies on (it passes
`--perf_min_samples=1 --perf_force_samples=1`). Happy to make an explicit
`--perf_force_samples=N` pin the count exactly instead, if that reads better.

### Verification

Built `opencv_perf_video` + `opencv_perf_core`, ran the matrix, reverted the
patch, rebuilt, re-ran. Sample counts, before → after:

| options | `TEST_CYCLE_N(10)` | plain `TEST_CYCLE()` |
| --- | --- | --- |
| *(none)* | 10 → 10 | 100 → 100 |
| `--perf_force_samples=1000 --perf_min_samples=1000` | **10 → 1000** | — |
| `--perf_min_samples=1000` | **10 → 1000** | — |
| `--perf_min_samples=50` | **10 → 50** | — |
| `--perf_min_samples=300` | — | **100 → 300** |
| `-perf_min_samples=200` (single dash) | **10 → 200** | — |
| `--perf_min_samples=1 --perf_force_samples=1` (`run.py --check`) | 1 → 1 | 1 → 1 |
| `--perf_force_samples=1` | 1 → 1 | 1 → 1 |
| `--perf_min_samples=1000 --perf_force_samples=1` | 1 → 1 | — |

The reproducer from the issue now gives `samples=1000  mean=5.80  median=5.76
(6079 ms)` instead of `samples=10 (61 ms)`.

Defaults are unchanged, and tests that ask for few iterations deliberately —
e.g. `declare.iterations(1)` in `modules/calib/perf/perf_calibratecamera.cpp` —
still run that many unless `--perf_min_samples` is given.

Compiles warning-free under the module's flag set (`-W -Wall -Wshadow
-Wmissing-declarations -Wsuggest-override -Wundef -Wuninitialized ...`),
GCC 16.1 / MinGW-w64 UCRT64, Release. Only that toolchain was available locally;
no MSVC/clang check.

### Notes

- `modules/ts` is an `INTERNAL` module linked statically, so there is no public
  API or ABI change.
- The issue notes the bug reproduces on 4.x as well. 4.x carries byte-identical
  code here and the patch applies cleanly to it (`git apply --check` passes with
  a -9 line offset), so please say if you would rather have this based on 4.x and
  merged forward.
- No regression test: `modules/ts` has no test directory, and the framework
  cannot readily assert on its own sample counts. Suggestions welcome.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
