### PR TITLE
stitching: cite DpSeamFinder reference 🤖🤖🤖

### DIFF
--- a/doc/opencv.bib
+++ b/doc/opencv.bib
@@ -27,6 +27,18 @@
   publisher = {IEEE Computer Society},
   address = {Washington, DC, USA},
 }
+@article{MillsD09,
+  author = {Mills, Alec and Dudek, Gregory},
+  title = {Image stitching with dynamic elements},
+  journal = {Image and Vision Computing},
+  year = {2009},
+  volume = {27},
+  number = {10},
+  pages = {1593--1602},
+  publisher = {Elsevier},
+  doi = {10.1016/j.imavis.2009.03.004},
+  url = {https://doi.org/10.1016/j.imavis.2009.03.004}
+}
 @article{Zhao23,
   author = {Zhao, Xiaoming and Wu, Xingming and Chen, Weihai and Chen, Peter C. Y. and Xu, Qingsong and Li, Zhengguo},
   title = {ALIKED: A Lighter Keypoint and Descriptor Extraction Network via Deformable Transformation},

--- a/modules/stitching/include/opencv2/stitching/detail/seam_finders.hpp
+++ b/modules/stitching/include/opencv2/stitching/detail/seam_finders.hpp
@@ -117,6 +117,8 @@ private:
 };
 
 
+/** @brief Dynamic programming-based seam estimator. See @cite MillsD09 for a related approach.
+ */
 class CV_EXPORTS_W DpSeamFinder : public SeamFinder
 {
 public:


### PR DESCRIPTION
Closes https://github.com/opencv/opencv/issues/20905

This PR adds a bibliography entry for Mills and Dudek's image-stitching paper and references it from the `DpSeamFinder` Doxygen documentation, matching the neighboring `GraphCutSeamFinder` citation style.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [x] The feature is well documented and sample code can be built with the project CMake
