### PR TITLE
core: saturate scalar results in the 8/16-bit mul/div kernels

### DIFF
--- a/modules/core/src/arithm.simd.hpp
+++ b/modules/core/src/arithm.simd.hpp
@@ -25,6 +25,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <limits>
+#include <type_traits>
 
 namespace cv {
 
@@ -578,6 +580,33 @@ struct EwXor {
         s0y == s0x*(size_t)width && (NSRC < 2 || s1y == s1x*(size_t)width)) \
     { width *= height; height = 1; }
 
+// The scalar tails narrow the work-type result with saturate_cast<Tr>(). For a FLOAT work type and
+// an 8/16-bit integer Tr that cast goes through cvRound() -> int, which does not saturate: a work
+// value past INT_MAX (e.g. the u16 product 65535*65535, or anything >= 46341^2) lands on INT_MIN on
+// x86 and wraps on aarch64, so the result comes out at the wrong end of the range - 0 for an
+// unsigned Tr, the type minimum for a signed one (#28557, #29893). Clamp to Tr's range in the work
+// type first: both bounds are exactly representable in float and double for the 8/16-bit types, so
+// no in-range value moves, and NaN and -inf fall through untouched (both comparisons are false).
+// The op functors keep returning the unclamped work value; only the narrowing store changes, and
+// only for mul/div into 8U/8S/16U/16S - every other instantiation compiles the clamp away.
+// This makes the tail agree with the mul-at-scale-1 vector path, which is exact (v_mul_sat widens
+// and clamps). The other vector paths through here (mul with a scale, Mat x Scalar, div) narrow
+// with v_round plus a saturating pack; ON X86 v_round is cvtps2dq and returns INT_MIN out of range,
+// so for those the tail is now the more correct of the two and the result depends on the row length
+// (on aarch64 vcvtnq_s32_f32 saturates and the body is already correct). Fixing that means fixing
+// the v_round store, which is shared with convertTo. 32-bit integer outputs are left alone: those
+// kernels use an f64 work type, and CV_32S is documented as non-saturating.
+template<typename Tr, typename W>
+static inline Tr narrowSaturate(W v)
+{
+    if constexpr (std::is_floating_point<W>::value && std::is_integral<Tr>::value && sizeof(Tr) <= 2)
+    {
+        const W lo = (W)std::numeric_limits<Tr>::lowest(), hi = (W)std::numeric_limits<Tr>::max();
+        v = v < lo ? lo : (v > hi ? hi : v);
+    }
+    return saturate_cast<Tr>(v);
+}
+
 // Unified binary kernel: T0 x T1 -> Tr (operands same depth for arithmetic; cast is separate).
 //   Wvec     = work vector. Native (v_uint8/...) drives the same-type saturating path
 //              (v_add saturates 8/16-bit, wraps 32-bit); v_float32 drives the widening hub.
@@ -606,17 +635,17 @@ static int scalarBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
     {
         if (s0x == s1x) {
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], (WT)src1[x], scalar));
         }
         else if (s0x == 0) {
             WT sc0 = (WT)src0[0];
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl(sc0, (WT)src1[x], scalar));
         }
         else {
             WT sc1 = (WT)src1[0];
             for (int x = 0; x < width; x++)
-                dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x], sc1, scalar));
+                dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x], sc1, scalar));
         }
     }
     return 0;
@@ -1066,7 +1095,7 @@ static int vecBinaryKernel(const void* src0_, size_t s0y, size_t s0x,
         }
     #endif
         for (; x < width; x++)
-            dst[x] = saturate_cast<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
+            dst[x] = narrowSaturate<Tr>(Op::scl((WT)src0[x*s0x], (WT)src1[x*s1x], scalar));
     }
 #if (CV_SIMD || CV_SIMD_SCALABLE)
     vx_cleanup();

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -4262,8 +4262,7 @@ TEST_P(Core_MaskTypeTest, MeanStdDev)
 
 INSTANTIATE_TEST_CASE_P(/**/, Core_MaskTypeTest, MaskType::all());
 
-// Still fails in 5.x: https://github.com/opencv/opencv/issues/28557
-TEST(Core_Arithm, DISABLED_mul_overflow_28557)
+TEST(Core_Arithm, mul_overflow_28557)
 {
     uint16_t data[] = {5000, 60000, 5000, 60000, 5000, 60000};
     cv::Mat m(1, 6, CV_16U, data);
@@ -4273,6 +4272,54 @@ TEST(Core_Arithm, DISABLED_mul_overflow_28557)
     {
         EXPECT_EQ(65535, res.at<uint16_t>(0, i));
     }
+}
+
+// multiply / pow(x, 2) on 8- and 16-bit integer arrays whose products overflow the element type
+// (and, for 16U, int): every length from 1 to 70 - below and above the 16-bit vector threshold
+// (4 * the destination's native lane count: 32 with 128-bit registers, 64 with 256-bit; the 8-bit
+// thresholds are 64 and 128, above this loop's range) - out of place and in place. Rows shorter
+// than the threshold and the in-place remainder (n % 32 or n % 64 elements) go through the kernels'
+// scalar tail, whose narrowing did not saturate past INT_MAX (#28557). Only the 16U rows can
+// overflow int; the other depths are regression armour.
+template<typename T> static void checkMulOverflow(int depth, const std::vector<T>& vals)
+{
+    const int nvals = (int)vals.size();
+    for (int n = 1; n <= 70; n++)
+    {
+        Mat a(1, n, depth), b(1, n, depth), ref_ab(1, n, depth), ref_aa(1, n, depth);
+        for (int i = 0; i < n; i++)
+        {
+            T x = vals[i % nvals], y = vals[(i * 7 + 3) % nvals];
+            a.at<T>(0, i) = x;
+            b.at<T>(0, i) = y;
+            ref_ab.at<T>(0, i) = saturate_cast<T>((int64)x * (int64)y);
+            ref_aa.at<T>(0, i) = saturate_cast<T>((int64)x * (int64)x);
+        }
+        Mat c;
+        cv::multiply(a, b, c);
+        EXPECT_EQ(0, cvtest::norm(c, ref_ab, NORM_INF)) << "multiply(a, b, c), depth=" << depth << ", n=" << n;
+        cv::pow(a, 2, c);
+        EXPECT_EQ(0, cvtest::norm(c, ref_aa, NORM_INF)) << "pow(a, 2, c), depth=" << depth << ", n=" << n;
+
+        Mat d = a.clone();
+        cv::multiply(d, b, d);
+        EXPECT_EQ(0, cvtest::norm(d, ref_ab, NORM_INF)) << "multiply(a, b, a), depth=" << depth << ", n=" << n;
+        d = a.clone();
+        cv::multiply(b, d, d);
+        EXPECT_EQ(0, cvtest::norm(d, ref_ab, NORM_INF)) << "multiply(b, a, a), depth=" << depth << ", n=" << n;
+        d = a.clone();
+        cv::pow(d, 2, d);
+        EXPECT_EQ(0, cvtest::norm(d, ref_aa, NORM_INF)) << "pow(a, 2, a), depth=" << depth << ", n=" << n;
+    }
+}
+
+TEST(Core_Arithm, mul_overflow_tail_and_inplace)
+{
+    checkMulOverflow<uchar>(CV_8U, {0, 1, 2, 15, 16, 17, 100, 128, 200, 254, 255});
+    checkMulOverflow<schar>(CV_8S, {-128, -127, -100, -12, -11, -1, 0, 1, 11, 12, 100, 127});
+    // 46341^2 and 65535^2 exceed INT_MAX, 46340^2 does not
+    checkMulOverflow<ushort>(CV_16U, {0, 1, 2, 255, 256, 257, 300, 46340, 46341, 50000, 65534, 65535});
+    checkMulOverflow<short>(CV_16S, {-32768, -32767, -256, -182, -181, -1, 0, 1, 181, 182, 256, 32767});
 }
 
 


### PR DESCRIPTION
Fixes #29893.

For `CV_16U`, `multiply` and `pow(src, 2)` can return 0 instead of
65535 when the result exceeds `INT_MAX`. This occurs on rows below the
vectorization threshold and in scalar tails.

The scalar path currently narrows through
`saturate_cast<Tr>(float)`. For these types, that conversion first goes
through `cvRound()` and can overflow before saturation. The scale-1
vector path instead uses `v_mul_sat`, so the result currently depends
on the row length and whether the operation is in place.

Clamp the scalar result to the destination range before
`saturate_cast` in the multiply and divide kernels. This affects only
8U, 8S, 16U, and 16S outputs. Their bounds are represented exactly in
the float work type, so in-range results are unchanged.

This restores the store-side fix originally proposed by @Prasadayus in
#29710. I kept the clamp out of the operation functors; I can move it
into an `Op::scl` specialization if that is preferred.

This PR does not address the related `v_round` path used by scaled
multiplication, `Mat`–`Scalar` multiplication, and division on x86.
Fixing that would require changing a store path shared with
`convertTo`, so I left it for separate work.

Tests re-enable `mul_overflow_28557` and cover lengths 1–70, both in
place and out of place, for 8U, 8S, 16U, and 16S. `opencv_test_core`
passes on AArch64; on x86_64 the only failures are six pre-existing
filestorage tests that need opencv_extra.

An AI assistant helped investigate the issue and draft the patch and
description. I ran and verified the tests on my own machines.
