### PR TITLE
videoio(ffmpeg): report decoder errors during VideoCapture read

### DIFF
--- a/modules/videoio/src/cap_ffmpeg_impl.hpp
+++ b/modules/videoio/src/cap_ffmpeg_impl.hpp
@@ -1664,6 +1664,7 @@ bool CvCapture_FFMPEG::grabFrame()
     // get the next frame
     while (!valid)
     {
+        bool eof = false;
 
         _opencv_ffmpeg_av_packet_unref (&packet);
 
@@ -1686,6 +1687,7 @@ bool CvCapture_FFMPEG::grabFrame()
                 break;
 
             // flush cached frames from video decoder
+            eof = true;
             packet.data = NULL;
             packet.size = 0;
             packet.stream_index = video_stream;
@@ -1714,13 +1716,22 @@ bool CvCapture_FFMPEG::grabFrame()
 
         // Decode video frame
 #if USE_AV_SEND_FRAME_API
-        if (avcodec_send_packet(context, &packet) < 0) {
+        ret = avcodec_send_packet(context, &packet);
+        if (ret < 0) {
+            if (cur_decode_attempts == 0 && !eof && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)
+            {
+                CV_LOG_ERROR(NULL, "Failed to send packet for decoding: " << _opencv_ffmpeg_get_error_string(ret) << " (" << ret << ")");
+            }
             break;
         }
         ret = avcodec_receive_frame(context, picture);
 #else
         int got_picture = 0;
-        avcodec_decode_video2(context, picture, &got_picture, &packet);
+        const int decode_ret = avcodec_decode_video2(context, picture, &got_picture, &packet);
+        if (decode_ret < 0 && !eof && decode_ret != AVERROR(EAGAIN) && decode_ret != AVERROR_EOF && cur_decode_attempts == 0)
+        {
+            CV_LOG_ERROR(NULL, "Failed to decode video packet: " << _opencv_ffmpeg_get_error_string(decode_ret) << " (" << decode_ret << ")");
+        }
         ret = got_picture ? 0 : -1;
 #endif
         if (ret >= 0) {
@@ -1730,6 +1741,12 @@ bool CvCapture_FFMPEG::grabFrame()
         }
         else
         {
+#if USE_AV_SEND_FRAME_API
+            if (cur_decode_attempts == 0 && !eof && ret != AVERROR(EAGAIN) && ret != AVERROR_EOF)
+            {
+                CV_LOG_ERROR(NULL, "Failed to decode video frame: " << _opencv_ffmpeg_get_error_string(ret) << " (" << ret << ")");
+            }
+#endif
             if (++cur_decode_attempts > max_decode_attempts)
             {
                 CV_LOG_WARNING(NULL,

--- a/modules/videoio/test/test_ffmpeg.cpp
+++ b/modules/videoio/test/test_ffmpeg.cpp
@@ -861,6 +861,49 @@ TEST(videoio_ffmpeg, open_with_format_cv8uc3)
     EXPECT_EQ(frame.channels(), 3);
 }
 
+TEST(videoio_ffmpeg, first_frame_decode_failure_is_reported)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    const string video_file = findDataFile("video/sample_322x242_15frames.yuv420p.libaom-av1.mp4");
+    VideoCapture cap(video_file, CAP_FFMPEG);
+    if (!cap.isOpened())
+        throw SkipTestException("AV1 decoder is not available");
+    ASSERT_EQ(cap.get(CAP_PROP_FRAME_COUNT), 15);
+
+    testing::internal::CaptureStderr();
+    Mat frame;
+    const bool read_result = cap.read(frame);
+    const string stderr_output = testing::internal::GetCapturedStderr();
+    if (read_result)
+        throw SkipTestException("AV1 decoder is available");
+
+    EXPECT_TRUE(stderr_output.find("Failed to send packet for decoding") != string::npos ||
+                stderr_output.find("Failed to decode video frame") != string::npos);
+}
+
+TEST(videoio_ffmpeg, normal_end_of_stream_is_not_reported_as_decode_failure)
+{
+    if (!videoio_registry::hasBackend(CAP_FFMPEG))
+        throw SkipTestException("FFmpeg backend was not found");
+
+    VideoCapture cap(findDataFile("video/big_buck_bunny.mp4"), CAP_FFMPEG);
+    ASSERT_TRUE(cap.isOpened());
+
+    testing::internal::CaptureStderr();
+    Mat frame;
+    int frames_read = 0;
+    while (cap.read(frame))
+        ++frames_read;
+    const string stderr_output = testing::internal::GetCapturedStderr();
+
+    ASSERT_EQ(frames_read, 125);
+    EXPECT_EQ(stderr_output.find("Failed to send packet for decoding"), string::npos);
+    EXPECT_EQ(stderr_output.find("Failed to decode video frame"), string::npos);
+    EXPECT_EQ(stderr_output.find("Failed to decode video packet"), string::npos);
+}
+
 // related issue: https://github.com/opencv/opencv/issues/16821
 TEST(videoio_ffmpeg, DISABLED_open_from_web)
 {


### PR DESCRIPTION
When FFmpeg opens a stream with a decoder that cannot decode packets, VideoCapture::read() returns false without exposing the decoder error. Report real decoder failures from the FFmpeg send/receive paths while keeping EOF and retry control states quiet; existing public read and frame-count behavior remains unchanged.

Fixes #29722

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [ ] I agree to contribute to the project under Apache 2 License.
- [ ] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake