### PR TITLE
core: validate KeyPoint::convert indexes

### DIFF
--- a/modules/core/src/types.cpp
+++ b/modules/core/src/types.cpp
@@ -79,12 +79,11 @@ void KeyPoint::convert(const std::vector<KeyPoint>& keypoints, std::vector<Point
         for( size_t i = 0; i < keypointIndexes.size(); i++ )
         {
             int idx = keypointIndexes[i];
-            if( idx >= 0 )
+            if( idx >= 0 && static_cast<size_t>(idx) < keypoints.size() )
                 points2f[i] = keypoints[idx].pt;
             else
             {
-                CV_Error( cv::Error::StsBadArg, "keypointIndexes has element < 0. TODO: process this case" );
-                //points2f[i] = Point2f(-1, -1);
+                CV_Error( cv::Error::StsBadArg, "keypointIndexes has element out of range" );
             }
         }
     }

--- a/modules/core/test/test_misc.cpp
+++ b/modules/core/test/test_misc.cpp
@@ -950,6 +950,58 @@ TEST(Core_Types, trivially_copyable_extra)
 }
 #endif
 
+TEST(Core_KeyPoint, convert_rejects_negative_index)
+{
+    const std::vector<KeyPoint> keypoints(1, KeyPoint(1, 2, 1));
+    const std::vector<int> indexes(1, -1);
+    std::vector<Point2f> points;
+
+    EXPECT_THROW(KeyPoint::convert(keypoints, points, indexes), cv::Exception);
+}
+
+TEST(Core_KeyPoint, convert_rejects_index_for_empty_input)
+{
+    const std::vector<KeyPoint> keypoints;
+    const std::vector<int> indexes(1, 0);
+    std::vector<Point2f> points;
+
+    EXPECT_THROW(KeyPoint::convert(keypoints, points, indexes), cv::Exception);
+}
+
+TEST(Core_KeyPoint, convert_rejects_out_of_range_indexes)
+{
+    const std::vector<KeyPoint> keypoints(1, KeyPoint(1, 2, 1));
+    std::vector<Point2f> points;
+
+    const int invalidIndexes[] = { 1, 100 };
+    for( size_t i = 0; i < sizeof(invalidIndexes) / sizeof(invalidIndexes[0]); i++ )
+    {
+        const std::vector<int> indexes(1, invalidIndexes[i]);
+        EXPECT_THROW(KeyPoint::convert(keypoints, points, indexes), cv::Exception);
+    }
+}
+
+TEST(Core_KeyPoint, convert_preserves_index_order_and_duplicates)
+{
+    const std::vector<KeyPoint> keypoints = {
+        KeyPoint(1, 2, 1), KeyPoint(3, 4, 1), KeyPoint(5, 6, 1)
+    };
+    const std::vector<int> indexes = { 2, 0, 2, 1 };
+    std::vector<Point2f> points;
+
+    KeyPoint::convert(keypoints, points, indexes);
+
+    const Point2f expected[] = { Point2f(5, 6), Point2f(1, 2), Point2f(5, 6), Point2f(3, 4) };
+    ASSERT_EQ(sizeof(expected) / sizeof(expected[0]), points.size());
+    for( size_t i = 0; i < points.size(); i++ )
+        EXPECT_EQ(expected[i], points[i]);
+
+    KeyPoint::convert(keypoints, points);
+    ASSERT_EQ(keypoints.size(), points.size());
+    for( size_t i = 0; i < points.size(); i++ )
+        EXPECT_EQ(keypoints[i].pt, points[i]);
+}
+
 template <typename T> class Rect_Test : public testing::Test {};
 
 TYPED_TEST_CASE_P(Rect_Test);


### PR DESCRIPTION
KeyPoint::convert() rejects negative keypointIndexes. It did not check that positive indexes are smaller than keypoints.size() before using them with std::vector::operator[]. Thus, invalid positive indexes could cause an out-of-bounds read and undefined behavior. This PR adds the missing upper-bound validation and regression tests for empty and out-of-range input. It preserves valid index ordering and duplicate indexes.

No public API or ABI is changed.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
