### PR TITLE
Slightly faster borderInterpolate

### DIFF
--- a/modules/core/src/copy.cpp
+++ b/modules/core/src/copy.cpp
@@ -922,6 +922,10 @@ int cv::borderInterpolate( int p, int len, int borderType )
         if( len == 1 )
             return 0;
 
+        // Fast path: single reflection without division for small deviations.
+        if( -len + delta <= p && p < 2 * len - delta )
+            return p < 0 ? -p - 1 + delta : 2 * len - 1 - delta - p;
+        // Bounded fallback: O(1) modulo for large |p|
         const int64 period = 2LL * (len - delta);
         int64 p64 = p;
         p64 %= period;


### PR DESCRIPTION
Branch prediction is faster than the division + int64. This will matter for OpenCV 5 with borderInterpolate_fast in imgproc/src/warp_kernels.simd.hpp that is a copy of that code.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
