### PR TITLE
Fix potential CPU bomb

### DIFF
--- a/modules/imgproc/src/warp_kernels.simd.hpp
+++ b/modules/imgproc/src/warp_kernels.simd.hpp
@@ -336,17 +336,22 @@ static inline int borderInterpolate_fast( int p, int len, int borderType )
         p = p < 0 ? 0 : len - 1;
     else if( borderType == BORDER_REFLECT || borderType == BORDER_REFLECT_101 )
     {
+        const int delta = borderType == BORDER_REFLECT_101;
         if( len == 1 )
             return 0;
-        int delta = borderType == BORDER_REFLECT_101;
-        do
-        {
-            if( p < 0 )
-                p = -p - 1 + delta;
-            else
-                p = len - 1 - (p - len) - delta;
-        }
-        while( (unsigned)p >= (unsigned)len );
+
+        // Fast path: single reflection without division for small deviations.
+        if( -len + delta <= p && p < 2 * len - delta )
+            return p < 0 ? -p - 1 + delta : 2 * len - 1 - delta - p;
+        // Bounded fallback: O(1) modulo for large |p|
+        const int64 period = 2LL * (len - delta);
+        int64 p64 = p;
+        p64 %= period;
+        if( p64 < 0 )
+            p64 += period;
+        if( p64 >= len )
+            p64 = period - p64 - 1 + delta;
+        p = (int)p64;
     }
     else if( borderType == BORDER_WRAP )
     {

--- a/modules/imgproc/test/test_imgwarp.cpp
+++ b/modules/imgproc/test/test_imgwarp.cpp
@@ -1253,5 +1253,15 @@ TEST(Imgproc_Warping, infinite_loop)
         << "cv::warpAffine hung in an infinite loop!";
 }
 
+TEST(Imgproc_Warping, interpolate_loop)
+{
+    // 1000x1000 destination image with out-of-bounds coordinates:
+    cv::Mat src(2, 2, CV_8UC1, cv::Scalar(42));
+    cv::Mat dst;
+    // A perspective or affine transform mapping pixels to large coordinates:
+    cv::Matx23d M(1, 0, 1e7, 0, 1, 1e7);
+    cv::warpAffine(src, dst, M, cv::Size(50, 50), cv::INTER_NEAREST, cv::BORDER_REFLECT_101);
+}
+
 }} // namespace
 /* End of file. */


### PR DESCRIPTION
The test went from 2.8s to 7ms

The main function is not updated as it will be once https://github.com/opencv/opencv/pull/29751 and https://github.com/opencv/opencv/pull/29898 are merged from 4.x to 5.x

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
