### PR TITLE
imgproc: add remap3D

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -2213,6 +2213,35 @@ CV_EXPORTS_W void remap( InputArray src, OutputArray dst,
                          const Scalar& borderValue = Scalar(),
                          AlgorithmHint hint = cv::ALGO_HINT_DEFAULT);
 
+/** @brief Resamples a volume using a dense map of source coordinates.
+
+For each destination voxel `(z, y, x)`, map contains the absolute source coordinate
+`(x_src, y_src, z_src)`. Both src and map are three-dimensional Mat objects with
+spatial dimensions ordered as `(depth, height, width)`; channels are interleaved
+within each voxel, not represented by a fourth Mat dimension.
+
+#INTER_LINEAR performs trilinear interpolation using the eight neighboring voxels
+and the floating-point fractional coordinates (without interpolation-table quantization).
+#INTER_NEAREST rounds each coordinate to the nearest integer, with halfway values
+rounded toward positive infinity. #BORDER_CONSTANT substitutes borderValue for each
+out-of-bounds neighbor; #BORDER_REPLICATE clamps coordinates to the volume boundary.
+Destination storage must not overlap the source or the map.
+
+@param src Nonempty 3D volume of depth CV_8U or CV_32F, with one to four channels.
+@param dst Output volume with the spatial dimensions of map and the type of src.
+@param map Nonempty 3D CV_32FC3 map containing finite `(x, y, z)` coordinates.
+@param interpolation Either #INTER_NEAREST or #INTER_LINEAR.
+@param borderMode Either #BORDER_CONSTANT or #BORDER_REPLICATE.
+@param borderValue Per-channel constant border value, converted to the source type.
+
+@note In Python, use `cv.Mat(volume, wrap_channels=False)` for a `(D, H, W)`
+single-channel volume, `cv.Mat(volume, wrap_channels=True)` for a `(D, H, W, C)`
+volume, and `cv.Mat(map, wrap_channels=True)` for the `(D, H, W, 3)` map.
+*/
+CV_EXPORTS_W void remap3D(InputArray src, OutputArray dst, InputArray map,
+                         int interpolation, int borderMode = BORDER_CONSTANT,
+                         const Scalar& borderValue = Scalar());
+
 /** @brief Converts image transformation maps from one representation to another.
 
 The function converts a pair of maps for remap from one representation to another. The following

--- a/modules/imgproc/perf/perf_remap3d.cpp
+++ b/modules/imgproc/perf/perf_remap3d.cpp
@@ -1,0 +1,26 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "perf_precomp.hpp"
+
+namespace opencv_test {
+
+typedef TestBaseWithParam<tuple<int, MatType, int> > Remap3DPerf;
+
+PERF_TEST_P(Remap3DPerf, volume, Combine(Values(32, 64),
+            Values(CV_8UC1, CV_32FC1, CV_32FC3), Values(INTER_NEAREST, INTER_LINEAR)))
+{
+    const int side = get<0>(GetParam()), type = get<1>(GetParam());
+    const int interpolation = get<2>(GetParam()), size[] = {side, side, side};
+    Mat src(3, size, type), dst(3, size, type), map(3, size, CV_32FC3);
+    for (int z = 0; z < side; ++z)
+        for (int y = 0; y < side; ++y)
+            for (int x = 0; x < side; ++x)
+                map.at<Vec3f>(z, y, x) = Vec3f(x + 0.3f, y - 0.2f, z + 0.1f * (x % 7));
+    declare.in(src, WARMUP_RNG).in(map).out(dst);
+    TEST_CYCLE() cv::remap3D(src, dst, map, interpolation, BORDER_REPLICATE);
+    SANITY_CHECK_NOTHING();
+}
+
+} // namespace opencv_test

--- a/modules/imgproc/src/remap3d.cpp
+++ b/modules/imgproc/src/remap3d.cpp
@@ -1,0 +1,125 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "precomp.hpp"
+#include <cmath>
+
+namespace cv {
+namespace {
+
+template<typename T> class Remap3DInvoker : public ParallelLoopBody
+{
+public:
+    Remap3DInvoker(const Mat& src, Mat& dst, const Mat& map, int interpolation,
+                   int borderMode, const Scalar& borderValue)
+        : src_(src), dst_(dst), map_(map), interpolation_(interpolation), borderMode_(borderMode)
+    {
+        for (int c = 0; c < 4; ++c)
+            border_[c] = saturate_cast<T>(borderValue[c]);
+    }
+
+    void operator()(const Range& range) const CV_OVERRIDE
+    {
+        const int cn = src_.channels();
+        const int bounds[] = {src_.size[2], src_.size[1], src_.size[0]};
+        for (int row = range.start; row < range.end; ++row)
+        {
+            const int z = row / dst_.size[1], y = row % dst_.size[1];
+            const Vec3f* mapRow = map_.ptr<Vec3f>(z, y);
+            T* out = dst_.ptr<T>(z, y);
+            for (int x = 0; x < dst_.size[2]; ++x, out += cn)
+            {
+                double p[3];
+                bool outside = false;
+                for (int axis = 0; axis < 3; ++axis)
+                {
+                    p[axis] = mapRow[x][axis];
+                    CV_Assert(std::isfinite(p[axis]));
+                    if (borderMode_ == BORDER_REPLICATE)
+                        p[axis] = std::max(0.0, std::min(p[axis], double(bounds[axis] - 1)));
+                    if (interpolation_ == INTER_NEAREST)
+                        p[axis] = std::floor(p[axis] + 0.5);
+                    // Check in floating point before converting potentially huge coordinates.
+                    outside |= p[axis] <= -1.0 || p[axis] >= bounds[axis];
+                }
+                if (outside)
+                {
+                    for (int c = 0; c < cn; ++c)
+                        out[c] = border_[c];
+                    continue;
+                }
+                if (interpolation_ == INTER_NEAREST)
+                {
+                    const T* in = src_.ptr<T>(int(p[2]), int(p[1])) + size_t(p[0]) * cn;
+                    for (int c = 0; c < cn; ++c)
+                        out[c] = in[c];
+                    continue;
+                }
+
+                int index[3][2];
+                double weight[3][2];
+                for (int axis = 0; axis < 3; ++axis)
+                {
+                    const int base = int(std::floor(p[axis]));
+                    weight[axis][1] = p[axis] - base;
+                    weight[axis][0] = 1.0 - weight[axis][1];
+                    for (int i = 0; i < 2; ++i)
+                        index[axis][i] = borderMode_ == BORDER_REPLICATE
+                            ? std::min(base + i, bounds[axis] - 1) : base + i;
+                }
+                double value[4] = {};
+                for (int dz = 0; dz < 2; ++dz)
+                    for (int dy = 0; dy < 2; ++dy)
+                        for (int dx = 0; dx < 2; ++dx)
+                        {
+                            const double w = weight[0][dx] * weight[1][dy] * weight[2][dz];
+                            if (w == 0.0)
+                                continue;
+                            const int sx = index[0][dx], sy = index[1][dy], sz = index[2][dz];
+                            const bool valid = (unsigned)sx < (unsigned)bounds[0] &&
+                                               (unsigned)sy < (unsigned)bounds[1] &&
+                                               (unsigned)sz < (unsigned)bounds[2];
+                            const T* in = valid ? src_.ptr<T>(sz, sy) + size_t(sx) * cn : border_;
+                            for (int c = 0; c < cn; ++c)
+                                value[c] += w * in[c];
+                        }
+                for (int c = 0; c < cn; ++c)
+                    out[c] = saturate_cast<T>(value[c]);
+            }
+        }
+    }
+
+private:
+    const Mat& src_;
+    Mat& dst_;
+    const Mat& map_;
+    int interpolation_, borderMode_;
+    T border_[4];
+};
+
+} // namespace
+
+void remap3D(InputArray _src, OutputArray _dst, InputArray _map,
+             int interpolation, int borderMode, const Scalar& borderValue)
+{
+    CV_INSTRUMENT_REGION();
+    const Mat src = _src.getMat(), map = _map.getMat();
+    CV_Assert(!src.empty() && src.dims == 3);
+    CV_Assert((src.depth() == CV_8U || src.depth() == CV_32F) && src.channels() <= 4);
+    CV_Assert(!map.empty() && map.dims == 3 && map.type() == CV_32FC3);
+    CV_Assert(interpolation == INTER_NEAREST || interpolation == INTER_LINEAR);
+    CV_Assert(borderMode == BORDER_CONSTANT || borderMode == BORDER_REPLICATE);
+    CV_Assert(map.size[0] <= INT_MAX / map.size[1]);
+
+    _dst.create(map.size, src.type());
+    Mat dst = _dst.getMat();
+    CV_Assert(dst.datastart != src.datastart && dst.datastart != map.datastart);
+    const Range rows(0, map.size[0] * map.size[1]);
+    if (src.depth() == CV_8U)
+        parallel_for_(rows, Remap3DInvoker<uchar>(src, dst, map, interpolation, borderMode, borderValue));
+    else
+        parallel_for_(rows, Remap3DInvoker<float>(src, dst, map, interpolation, borderMode, borderValue));
+}
+
+} // namespace cv

--- a/modules/imgproc/test/test_remap3d.cpp
+++ b/modules/imgproc/test/test_remap3d.cpp
@@ -1,0 +1,165 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+
+#include "test_precomp.hpp"
+#include <limits>
+
+namespace opencv_test { namespace {
+
+TEST(Imgproc_Remap3D, linear_ramp_and_depth_displacement)
+{
+    const int size[] = {4, 5, 6}, outSize[] = {2, 3, 4};
+    Mat src(3, size, CV_32F), map(3, outSize, CV_32FC3), dst;
+    for (int z = 0; z < size[0]; ++z)
+        for (int y = 0; y < size[1]; ++y)
+            for (int x = 0; x < size[2]; ++x)
+                src.at<float>(z, y, x) = float(100 * z + 10 * y + x);
+    for (int z = 0; z < outSize[0]; ++z)
+        for (int y = 0; y < outSize[1]; ++y)
+            for (int x = 0; x < outSize[2]; ++x)
+                map.at<Vec3f>(z, y, x) = Vec3f(x + 0.23f, y + 0.37f, z + x * 0.19f);
+    cv::remap3D(src, dst, map, INTER_LINEAR);
+    ASSERT_EQ(3, dst.dims);
+    ASSERT_EQ(map.size, dst.size);
+    for (int z = 0; z < outSize[0]; ++z)
+        for (int y = 0; y < outSize[1]; ++y)
+            for (int x = 0; x < outSize[2]; ++x)
+            {
+                Vec3f p = map.at<Vec3f>(z, y, x);
+                EXPECT_NEAR(p[0] + 10 * p[1] + 100 * p[2], dst.at<float>(z, y, x), 5e-5);
+            }
+}
+
+typedef testing::TestWithParam<testing::tuple<int, int, int, int> > Remap3DTest;
+
+TEST_P(Remap3DTest, reference_and_strides)
+{
+    const int depth = testing::get<0>(GetParam()), cn = testing::get<1>(GetParam());
+    const int interpolation = testing::get<2>(GetParam()), border = testing::get<3>(GetParam());
+    const int type = CV_MAKETYPE(depth, cn), storageSize[] = {5, 6, 8};
+    const Range roi[] = {Range(1, 4), Range(1, 5), Range(1, 7)};
+    Mat storage(3, storageSize, type), mapStorage(3, storageSize, CV_32FC3);
+    Mat dstStorage(3, storageSize, type, Scalar::all(0));
+    Mat src = storage(roi), map = mapStorage(roi), dst = dstStorage(roi);
+    uchar* dstData = dst.data;
+    RNG rng(29768);
+    rng.fill(storage, RNG::UNIFORM, 0, 200);
+    for (int z = 0; z < map.size[0]; ++z)
+        for (int y = 0; y < map.size[1]; ++y)
+            for (int x = 0; x < map.size[2]; ++x)
+                map.at<Vec3f>(z, y, x) = Vec3f(rng.uniform(-2.f, 7.f),
+                                               rng.uniform(-2.f, 5.f), rng.uniform(-2.f, 4.f));
+    const Scalar borderValue(11, 23, 37, 49);
+    cv::remap3D(src, dst, map, interpolation, border, borderValue);
+    EXPECT_EQ(dstData, dst.data);
+    Mat source64, actual64;
+    src.convertTo(source64, CV_64F);
+    dst.convertTo(actual64, CV_64F);
+    // Independent reference: sum the separable tent kernels at the surrounding lattice points.
+    for (int z = 0; z < map.size[0]; ++z)
+        for (int y = 0; y < map.size[1]; ++y)
+            for (int x = 0; x < map.size[2]; ++x)
+            {
+                const Vec3f p = map.at<Vec3f>(z, y, x);
+                const int ix = cvFloor(p[0] + (interpolation == INTER_NEAREST ? 0.5 : 0.0));
+                const int iy = cvFloor(p[1] + (interpolation == INTER_NEAREST ? 0.5 : 0.0));
+                const int iz = cvFloor(p[2] + (interpolation == INTER_NEAREST ? 0.5 : 0.0));
+                for (int c = 0; c < cn; ++c)
+                {
+                    double expected = 0;
+                    const int n = interpolation == INTER_NEAREST ? 1 : 2;
+                    for (int k = iz; k < iz + n; ++k)
+                        for (int j = iy; j < iy + n; ++j)
+                            for (int i = ix; i < ix + n; ++i)
+                            {
+                                double w = n == 1 ? 1.0 : (1.0 - std::abs(p[0] - double(i))) *
+                                    (1.0 - std::abs(p[1] - double(j))) * (1.0 - std::abs(p[2] - double(k)));
+                                int sx = cv::borderInterpolate(i, src.size[2], border);
+                                int sy = cv::borderInterpolate(j, src.size[1], border);
+                                int sz = cv::borderInterpolate(k, src.size[0], border);
+                                double v = sx < 0 || sy < 0 || sz < 0 ? borderValue[c] :
+                                    source64.ptr<double>(sz, sy)[sx * cn + c];
+                                expected += w * v;
+                            }
+                    if (depth == CV_8U)
+                        expected = saturate_cast<uchar>(expected);
+                    EXPECT_NEAR(expected, actual64.ptr<double>(z, y)[x * cn + c], depth == CV_8U ? 0 : 2e-5);
+                }
+            }
+}
+
+INSTANTIATE_TEST_CASE_P(Imgproc, Remap3DTest, testing::Combine(
+    testing::Values(CV_8U, CV_32F), testing::Values(1, 2, 3, 4),
+    testing::Values(INTER_NEAREST, INTER_LINEAR), testing::Values(BORDER_CONSTANT, BORDER_REPLICATE)));
+
+TEST(Imgproc_Remap3D, singleton_borders_and_extreme_coordinates)
+{
+    const int size[] = {1, 1, 1}, mapSize[] = {1, 1, 5};
+    Mat src(3, size, CV_32F, Scalar(80)), map(3, mapSize, CV_32FC3), dst;
+    map.at<Vec3f>(0, 0, 0) = Vec3f(0, 0, 0);
+    map.at<Vec3f>(0, 0, 1) = Vec3f(-0.5f, -0.5f, -0.5f);
+    map.at<Vec3f>(0, 0, 2) = Vec3f(0.5f, 0.5f, 0.5f);
+    map.at<Vec3f>(0, 0, 3) = Vec3f(std::numeric_limits<float>::max(), 0, 0);
+    map.at<Vec3f>(0, 0, 4) = Vec3f(0, -std::numeric_limits<float>::max(), 0);
+    cv::remap3D(src, dst, map, INTER_LINEAR, BORDER_CONSTANT, Scalar(8));
+    const float expected[] = {80, 17, 17, 8, 8};
+    for (int i = 0; i < 5; ++i)
+        EXPECT_EQ(expected[i], dst.at<float>(0, 0, i));
+    cv::remap3D(src, dst, map, INTER_NEAREST, BORDER_CONSTANT, Scalar(8));
+    const float nearest[] = {80, 80, 8, 8, 8};
+    for (int i = 0; i < 5; ++i)
+        EXPECT_EQ(nearest[i], dst.at<float>(0, 0, i));
+    for (int interpolation = INTER_NEAREST; interpolation <= INTER_LINEAR; ++interpolation)
+    {
+        cv::remap3D(src, dst, map, interpolation, BORDER_REPLICATE);
+        for (int i = 0; i < 5; ++i)
+            EXPECT_EQ(80, dst.at<float>(0, 0, i));
+    }
+}
+
+TEST(Imgproc_Remap3D, invalid_arguments)
+{
+    const int size[] = {2, 3, 4};
+    Mat src(3, size, CV_8U, Scalar(1)), map(3, size, CV_32FC3, Scalar(0)), dst;
+    EXPECT_THROW(cv::remap3D(Mat(), dst, map, INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(Mat(3, 4, CV_8U), dst, map, INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(Mat(3, size, CV_16U), dst, map, INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(Mat(3, size, CV_8UC(5)), dst, map, INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, Mat(), INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, Mat(3, 4, CV_32FC3), INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, Mat(3, size, CV_32FC2), INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, Mat(3, size, CV_64FC3), INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, map, INTER_CUBIC), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, dst, map, INTER_LINEAR, BORDER_REFLECT), cv::Exception);
+    EXPECT_THROW(cv::remap3D(src, src, map, INTER_LINEAR), cv::Exception);
+    EXPECT_THROW(cv::remap3D(Mat(3, size, CV_32FC3), map, map, INTER_LINEAR), cv::Exception);
+    map.at<Vec3f>(0, 0, 0)[0] = std::numeric_limits<float>::quiet_NaN();
+    EXPECT_THROW(cv::remap3D(src, dst, map, INTER_LINEAR), cv::Exception);
+    map.at<Vec3f>(0, 0, 0)[0] = std::numeric_limits<float>::infinity();
+    EXPECT_THROW(cv::remap3D(src, dst, map, INTER_NEAREST, BORDER_REPLICATE), cv::Exception);
+}
+
+TEST(Imgproc_Remap3D, constant_border_conversion)
+{
+    const int size[] = {1, 1, 1};
+    Mat src(3, size, CV_8UC3, Scalar(100, 100, 100));
+    Mat map(3, size, CV_32FC3, Scalar(-0.5, 0, 0)), dst;
+    cv::remap3D(src, dst, map, INTER_LINEAR, BORDER_CONSTANT, Scalar(-100, 400, 40));
+    const Vec3b result = dst.at<Vec3b>(0, 0, 0);
+    EXPECT_EQ(50, result[0]);
+    EXPECT_EQ(saturate_cast<uchar>(177.5), result[1]);
+    EXPECT_EQ(70, result[2]);
+}
+
+TEST(Imgproc_Remap3D, integer_coordinate_ignores_zero_weight_neighbors)
+{
+    const int size[] = {2, 2, 2}, mapSize[] = {1, 1, 1};
+    Mat src(3, size, CV_32F, Scalar(std::numeric_limits<float>::quiet_NaN()));
+    src.at<float>(0, 0, 0) = 42;
+    Mat map(3, mapSize, CV_32FC3, Scalar(0)), dst;
+    cv::remap3D(src, dst, map, INTER_LINEAR);
+    EXPECT_EQ(42, dst.at<float>(0, 0, 0));
+}
+
+}} // namespace

--- a/modules/python/test/test_remap3d.py
+++ b/modules/python/test/test_remap3d.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import cv2 as cv
+import numpy as np
+
+from tests_common import NewOpenCVTests
+
+
+class Remap3DTest(NewOpenCVTests):
+    def test_volume_and_label_map(self):
+        z, y, x = np.indices((3, 4, 5), dtype=np.float32)
+        volume = cv.Mat(100 * z + 10 * y + x, wrap_channels=False)
+        coordinates = cv.Mat(np.stack((x, y, z + 0.25), axis=-1), wrap_channels=True)
+        result = cv.remap3D(volume, coordinates, cv.INTER_LINEAR,
+                            borderMode=cv.BORDER_REPLICATE)
+        expected = 100 * np.minimum(z + 0.25, 2) + 10 * y + x
+        self.assertEqual(result.shape, volume.shape)
+        np.testing.assert_allclose(result, expected)
+
+        labels = cv.Mat(z.astype(np.uint8), wrap_channels=False)
+        result = cv.remap3D(labels, coordinates, cv.INTER_NEAREST,
+                            borderMode=cv.BORDER_REPLICATE)
+        np.testing.assert_array_equal(result, labels)
+
+    def test_multichannel_identity(self):
+        z, y, x = np.indices((2, 3, 4), dtype=np.float32)
+        coordinates = cv.Mat(np.stack((x, y, z), axis=-1), wrap_channels=True)
+        for dtype in (np.uint8, np.float32):
+            for channels in (2, 3, 4):
+                data = np.arange(2 * 3 * 4 * channels, dtype=dtype).reshape(2, 3, 4, channels)
+                volume = cv.Mat(data, wrap_channels=True)
+                for interpolation in (cv.INTER_NEAREST, cv.INTER_LINEAR):
+                    result = cv.remap3D(volume, coordinates, interpolation)
+                    np.testing.assert_array_equal(result, volume)
+
+
+if __name__ == '__main__':
+    NewOpenCVTests.bootstrap()


### PR DESCRIPTION
Fixes #29768

## Summary

This PR adds `cv::remap3D`, a CPU implementation for dense coordinate-map resampling of 3D volumetric data.

The existing `cv::remap` API operates on 2D images and cannot represent spatially varying displacement along the depth axis. `remap3D` extends the same general remapping concept to 3D volumes, allowing each destination voxel to map to an arbitrary `(x, y, z)` source coordinate.

This is useful for volumetric workloads such as CT, MRI, microscopy, 3D augmentation, deformable registration, and segmentation-mask transformation.

## API

```cpp
void cv::remap3D(
    InputArray src,
    OutputArray dst,
    InputArray map,
    int interpolation,
    int borderMode = BORDER_CONSTANT,
    const Scalar& borderValue = Scalar()
);
```

The initial implementation supports:

* 3D source volumes
* `CV_8U` and `CV_32F` source depths
* 1 to 4 channels
* `CV_32FC3` dense coordinate maps
* absolute `(x, y, z)` source coordinates
* `INTER_NEAREST`
* `INTER_LINEAR` using trilinear interpolation
* `BORDER_CONSTANT`
* `BORDER_REPLICATE`

The destination spatial dimensions are derived from the coordinate map.

## Implementation

The implementation:

* performs nearest-neighbor or trilinear sampling for each destination voxel;
* uses all eight neighboring voxels for trilinear interpolation;
* supports constant and replicated border handling;
* supports non-contiguous 3D `Mat` layouts;
* validates finite map coordinates and supported input types/modes;
* avoids integer conversion of potentially extreme coordinates before bounds checking;
* preserves existing destination storage when a compatible output is supplied;
* uses `parallel_for_` across depth/row ranges for CPU parallelism.

For `INTER_LINEAR`, interpolation is computed directly from the floating-point coordinates rather than using the quantized interpolation tables used by the existing 2D `remap`.

## Python support

The API is exported to the Python bindings.

Volumes can be represented using `cv.Mat` with explicit channel wrapping, for example:

```python
volume = cv.Mat(volume, wrap_channels=False)
map3d = cv.Mat(map3d, wrap_channels=True)

dst = cv.remap3D(
    volume,
    map3d,
    cv.INTER_LINEAR,
    cv.BORDER_REPLICATE
)
```

Multi-channel `(D, H, W, C)` volumes can be passed using `wrap_channels=True`.

## Tests

C++ accuracy tests cover:

* trilinear interpolation against an independent reference implementation;
* nearest-neighbor interpolation;
* `CV_8U` and `CV_32F`;
* 1, 2, 3, and 4 channels;
* `BORDER_CONSTANT` and `BORDER_REPLICATE`;
* non-contiguous/ROI-backed 3D matrices;
* singleton dimensions and boundary coordinates;
* very large positive and negative coordinates;
* constant-border type conversion;
* exact integer-coordinate interpolation;
* invalid dimensions, types, interpolation modes, and border modes;
* source/map aliasing;
* NaN and infinite map coordinates.

Python tests are also included to verify single-channel and multi-channel volumetric usage through the generated Python bindings.

## Performance tests

Performance coverage is included for:

* `32³` and `64³` volumes;
* `CV_8UC1`;
* `CV_32FC1`;
* `CV_32FC3`;
* nearest-neighbor interpolation;
* trilinear interpolation.

The implementation currently provides a CPU baseline and uses OpenCV's parallel execution infrastructure. Further SIMD/backend-specific optimizations can be added independently without changing the public API.

### Pull Request Readiness Checklist

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
* [x] The PR is proposed to the proper branch (`5.x`).
* [x] There is a reference to the original bug report and related work (`#29768`).
* [x] Accuracy and performance tests are included. No additional `opencv_extra` test data is required.
* [x] The public API and supported behavior are documented.
