### PR TITLE
video: reuse the polynomial expansion between Farneback calls 🤖🤖🤖

### DIFF
--- a/modules/video/include/opencv2/video/tracking.hpp
+++ b/modules/video/include/opencv2/video/tracking.hpp
@@ -231,6 +231,10 @@ The function finds an optical flow for each prev pixel using the @cite Farneback
     opencv_source_code/samples/cpp/fback.cpp
 -   (Python) An example using the optical flow algorithm described by Gunnar Farneback can be
     found at opencv_source_code/samples/python/opt_flow.py
+
+@note This function creates a FarnebackOpticalFlow instance per call. To process a video, keep
+one instance from FarnebackOpticalFlow::create() and call its calc() per frame pair instead: it
+reuses the previous frame's polynomial expansion, for the same result at a lower cost.
  */
 CV_EXPORTS_W void calcOpticalFlowFarneback( InputArray prev, InputArray next, InputOutputArray flow,
                                             double pyr_scale, int levels, int winsize,
@@ -649,6 +653,22 @@ public:
 
 
 /** @brief Class computing a dense optical flow using the Gunnar Farneback's algorithm.
+
+Reuse one instance across the frames of a video: calc() keeps the polynomial expansion of its
+second image and reuses it when the next call is handed that image first, saving of the order
+of a tenth of a call. Reuse needs that image equal pixel for pixel to the one kept, with
+pyrScale, polyN, polySigma and the pyramid depth unchanged. A hit replays the same arithmetic,
+so the flow matches a fresh instance bit for bit, unless setUseOptimized() or
+ipp::setUseIPP() changed in between what that arithmetic is.
+
+It keeps about 28 bytes per pixel of 8-bit input at the default pyrScale, twice that while a
+call builds the replacement, and collectGarbage() releases it. calcOpticalFlowFarneback() keeps
+nothing, nor does the OpenCL implementation that a UMat flow argument selects when polyN is 5
+or 7.
+
+@note calc() may be called on one instance from several threads: whether a call finds the
+kept expansion is a race, what it returns is not. The setters are not synchronized with it,
+so retune an instance between calls rather than during one.
  */
 class CV_EXPORTS_W FarnebackOpticalFlow : public DenseOpticalFlow
 {

--- a/modules/video/perf/perf_optflowfarneback.cpp
+++ b/modules/video/perf/perf_optflowfarneback.cpp
@@ -1,0 +1,88 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "perf_precomp.hpp"
+
+namespace opencv_test { namespace {
+
+// One iteration walks a short sequence, which is how dense flow is normally used, so the
+// one cold call at the head of a sequence dilutes the saving a little.
+//
+// sharedInstance keeps one object across the sequence and so reuses; sharedInstanceNoReuse
+// is the same object with collectGarbage() before every calc(), which drops the held
+// expansion and nothing else on this path, so the gap between the two is the saving by
+// itself; calcOpticalFlowFarneback is how most callers reach this code and creates an
+// instance per pair, differing in its allocation as well.
+
+const int SEQUENCE_LENGTH = 10;
+
+// create()'s defaults, passed to the free function too, so every arm does the same work.
+const double PYR_SCALE = 0.5;
+const int NUM_LEVELS = 5;
+const int WIN_SIZE = 13;
+const int NUM_ITERS = 10;
+const int POLY_N = 5;
+const double POLY_SIGMA = 1.1;
+
+static std::vector<Mat> makeSequence(Size size)
+{
+    Mat base(size.height * 2, size.width * 2, CV_8U);
+    RNG(0x5eed).fill(base, RNG::UNIFORM, 0, 256);
+    GaussianBlur(base, base, Size(9, 9), 3, 3);
+
+    std::vector<Mat> frames;
+    for( int i = 0; i < SEQUENCE_LENGTH; i++ )
+    {
+        Mat shift = (Mat_<double>(2, 3) << 1, 0, 1.7 * i, 0, 1, -1.1 * i);
+        Mat warped;
+        warpAffine(base, warped, shift, base.size(), INTER_LINEAR);
+        frames.push_back(warped(Rect(size.width / 2, size.height / 2,
+                                     size.width, size.height)).clone());
+    }
+    return frames;
+}
+
+typedef tuple<Size, std::string> FarnebackParams;
+typedef TestBaseWithParam<FarnebackParams> DenseOpticalFlow_Farneback;
+
+// Two sizes: an iteration is a whole sequence, so six cases already take about a minute at
+// 20 samples, and the saving is a ratio that does not need a third size.
+PERF_TEST_P(DenseOpticalFlow_Farneback, perf,
+            Combine(Values(szQVGA, szVGA),
+                    Values("calcOpticalFlowFarneback", "sharedInstance",
+                           "sharedInstanceNoReuse")))
+{
+    const Size size = get<0>(GetParam());
+    const std::string mode = get<1>(GetParam());
+    const bool shared = mode != "calcOpticalFlowFarneback";
+    const bool dropExpansion = mode == "sharedInstanceNoReuse";
+
+    const std::vector<Mat> frames = makeSequence(size);
+    Mat flow;
+
+    // Built once, since what is measured is where the expansion comes from rather than the
+    // allocation. Every cycle still starts cold: the frame held from the end of the last
+    // one is not frames[0].
+    Ptr<FarnebackOpticalFlow> instance = FarnebackOpticalFlow::create(
+        NUM_LEVELS, PYR_SCALE, false, WIN_SIZE, NUM_ITERS, POLY_N, POLY_SIGMA, 0);
+
+    TEST_CYCLE()
+    {
+        for( int i = 0; i + 1 < SEQUENCE_LENGTH; i++ )
+        {
+            if( !shared )
+            {
+                calcOpticalFlowFarneback(frames[i], frames[i + 1], flow, PYR_SCALE, NUM_LEVELS,
+                                         WIN_SIZE, NUM_ITERS, POLY_N, POLY_SIGMA, 0);
+                continue;
+            }
+            if( dropExpansion )
+                instance->collectGarbage();
+            instance->calc(frames[i], frames[i + 1], flow);
+        }
+    }
+
+    SANITY_CHECK_NOTHING();
+}
+
+}} // namespace

--- a/modules/video/src/optflowgf.cpp
+++ b/modules/video/src/optflowgf.cpp
@@ -582,13 +582,37 @@ namespace cv
 {
 namespace
 {
+
+// Exact comparison of the pixels, row by row so a non-continuous ROI is handled.
+//
+// This is the only thing tying a kept expansion to the image it was computed from.  A
+// digest is wrong whenever it collides; a check on size, type or data pointer is wrong
+// on ordinary input, since callers refill or alternate frame buffers.  Either way an
+// image is handed a stranger's expansion and the flow is quietly wrong, never an error.
+static bool sameImageContent(const Mat& a, const Mat& b)
+{
+    if( a.empty() || b.empty() || a.dims != 2 || b.dims != 2 ||
+        a.size() != b.size() || a.type() != b.type() )
+        return false;
+
+    const size_t rowBytes = (size_t)a.cols * a.elemSize();
+    for( int y = 0; y < a.rows; y++ )
+    {
+        if( memcmp(a.ptr(y), b.ptr(y), rowBytes) != 0 )
+            return false;
+    }
+    return true;
+}
+
 class FarnebackOpticalFlowImpl : public FarnebackOpticalFlow
 {
 public:
     FarnebackOpticalFlowImpl(int numLevels=5, double pyrScale=0.5, bool fastPyramids=false, int winSize=13,
-                             int numIters=10, int polyN=5, double polySigma=1.1, int flags=0) :
+                             int numIters=10, int polyN=5, double polySigma=1.1, int flags=0,
+                             bool cacheExpansion=true) :
         numLevels_(numLevels), pyrScale_(pyrScale), fastPyramids_(fastPyramids), winSize_(winSize),
-        numIters_(numIters), polyN_(polyN), polySigma_(polySigma), flags_(flags)
+        numIters_(numIters), polyN_(polyN), polySigma_(polySigma), flags_(flags),
+        cacheExpansion_(cacheExpansion)
     {
     }
 
@@ -629,6 +653,48 @@ private:
     int polyN_;
     double polySigma_;
     int flags_;
+
+    // Whether calc() keeps the expansion of its second image for the next call.  Only an
+    // instance that outlives a call can hit it, so calcOpticalFlowFarneback(), which
+    // builds one per call, turns it off rather than pay the copy.
+    const bool cacheExpansion_;
+
+    // Polynomial expansion of the second image of the previous calc(), one entry per
+    // pyramid level.  Walking a video, frame k arrives as the second image and then as the
+    // first image of the next call, so half the expansion work per call is a repeat.
+    //
+    // The key is complete: level k is built from the image alone at size*pyrScale^k, so an
+    // equal frame and an equal pyrScale pin every level's geometry and R.size() pins the
+    // depth reached after min_size truncation.  winSize_, numIters_ and flags_ steer the
+    // update step, not the expansion; fastPyramids_ is read only by the OpenCL path.
+    struct PolyExpCache
+    {
+        PolyExpCache() : pyrScale(0), polySigma(0), polyN(0) {}
+
+        void release()
+        {
+            frame.release();
+            R.clear();
+        }
+
+        Mat frame;           // the image the expansion belongs to, deep-copied
+        std::vector<Mat> R;  // its expansion, indexed by pyramid level
+        double pyrScale;
+        double polySigma;
+        int polyN;
+    };
+    PolyExpCache expCache_;
+
+    // The expansion is the only state a call on this path leaves behind; the rest are
+    // locals.  Snapshotting under this lock and publishing under it again keeps concurrent
+    // calls on one instance independent: each may miss, none reads a half-replaced cache.
+    Mutex expCacheMutex_;
+
+    void releaseExpansion()
+    {
+        AutoLock lock(expCacheMutex_);
+        expCache_.release();
+    }
 
 #ifdef HAVE_OPENCL
     bool operator ()(const UMat &frame0, const UMat &frame1, UMat &flowx, UMat &flowy)
@@ -797,6 +863,7 @@ private:
     }
     virtual void collectGarbage() CV_OVERRIDE {
         releaseMemory();
+        releaseExpansion();
     }
     void releaseMemory()
     {
@@ -1091,7 +1158,7 @@ private:
         return true;
     }
 #else // HAVE_OPENCL
-    virtual void collectGarbage() CV_OVERRIDE {}
+    virtual void collectGarbage() CV_OVERRIDE { releaseExpansion(); }
 #endif
 };
 
@@ -1109,11 +1176,18 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
 
     int i, k;
     double scale;
+
+    // Read once: a setter running against a call would otherwise be able to label the
+    // cache with parameters other than the ones its expansion was built from.
+    const double pyrScale = pyrScale_;
+    const int polyN = polyN_;
+    const double polySigma = polySigma_;
+
     Mat prevFlow, flow, fimg;
     int levels = numLevels_;
 
     CV_Assert( prev0.size() == next0.size() && prev0.channels() == next0.channels() &&
-               prev0.channels() == 1 && pyrScale_ < 1 );
+               prev0.channels() == 1 && pyrScale < 1 );
 
     // If flag is set, check for integrity; if not set, allocate memory space
     if( flags_ & OPTFLOW_USE_INITIAL_FLOW )
@@ -1126,17 +1200,49 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
 
     for( k = 0, scale = 1; k < levels; k++ )
     {
-        scale *= pyrScale_;
+        scale *= pyrScale;
         if( prev0.cols*scale < min_size || prev0.rows*scale < min_size )
             break;
     }
 
     levels = k;
 
+    PolyExpCache cached;
+    if( cacheExpansion_ )
+    {
+        // By value: the planes are read-only and reference counted, so this keeps them
+        // alive whatever a concurrent call publishes.
+        AutoLock lock(expCacheMutex_);
+        cached = expCache_;
+    }
+
+    const bool reuseExpansion =
+        cacheExpansion_ && cached.R.size() == (size_t)(levels + 1) &&
+        cached.pyrScale == pyrScale && cached.polySigma == polySigma &&
+        cached.polyN == polyN &&
+        // Last because it is the dearest, and the only term tying the kept expansion to
+        // this image rather than to the way it was built.  Read sameImageContent()
+        // before making it cheaper.
+        sameImageContent(cached.frame, prev0);
+
+    Mat retained;
+    PolyExpCache newCache;
+    if( cacheExpansion_ )
+    {
+        newCache.R.resize(levels + 1);
+        newCache.pyrScale = pyrScale;
+        newCache.polySigma = polySigma;
+        newCache.polyN = polyN;
+        // Expanded from this copy, so the bytes a later call compares are the bytes that
+        // were expanded.
+        next0.copyTo(retained);
+        img[1] = &retained;
+    }
+
     for( k = levels; k >= 0; k-- )
     {
         for( i = 0, scale = 1; i < k; i++ )
-            scale *= pyrScale_;
+            scale *= pyrScale;
 
         double sigma = (1./scale-1)*0.5;
         int smooth_sz = cvRound(sigma*5)|1;
@@ -1163,16 +1269,27 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
         else
         {
             resize( prevFlow, flow, Size(width, height), 0, 0, INTER_LINEAR );
-            flow *= 1./pyrScale_;
+            flow *= 1./pyrScale;
         }
 
         Mat R[2], I, M;
         for( i = 0; i < 2; i++ )
         {
+            if( i == 0 && reuseExpansion )
+            {
+                // The update step walks these planes by row pointer, so check the shape
+                // before trusting one.
+                CV_Assert( cached.R[k].size() == Size(width, height) &&
+                           cached.R[k].type() == CV_32FC(5) );
+                R[0] = cached.R[k];  // shared, not copied: consumers take const Mat&
+                continue;
+            }
             img[i]->convertTo(fimg, CV_32F);
             GaussianBlur(fimg, fimg, Size(smooth_sz, smooth_sz), sigma, sigma);
             resize( fimg, I, Size(width, height), INTER_LINEAR );
-            FarnebackPolyExp( I, R[i], polyN_, polySigma_ );
+            FarnebackPolyExp( I, R[i], polyN, polySigma );
+            if( i == 1 && cacheExpansion_ )
+                newCache.R[k] = R[1];
         }
 
         FarnebackUpdateMatrices( R[0], R[1], flow, M, 0, flow.rows );
@@ -1187,6 +1304,20 @@ void FarnebackOpticalFlowImpl::calc(InputArray _prev0, InputArray _next0,
 
         prevFlow = flow;
     }
+
+    if( cacheExpansion_ )
+    {
+        // Published last, so a throw above leaves the previous cache in place rather than
+        // a half-filled one.  Swapped rather than assigned so the replaced planes are
+        // freed outside the lock.
+        newCache.frame = retained;
+        AutoLock lock(expCacheMutex_);
+        expCache_.R.swap(newCache.R);
+        std::swap(expCache_.frame, newCache.frame);
+        expCache_.pyrScale = newCache.pyrScale;
+        expCache_.polySigma = newCache.polySigma;
+        expCache_.polyN = newCache.polyN;
+    }
 }
 } // namespace
 } // namespace cv
@@ -1198,7 +1329,9 @@ void cv::calcOpticalFlowFarneback( InputArray _prev0, InputArray _next0,
     CV_INSTRUMENT_REGION();
 
     Ptr<cv::FarnebackOpticalFlow> optflow;
-    optflow = makePtr<FarnebackOpticalFlowImpl>(levels,pyr_scale,false,winsize,iterations,poly_n,poly_sigma,flags);
+    optflow = makePtr<FarnebackOpticalFlowImpl>(levels, pyr_scale, false, winsize, iterations,
+                                                poly_n, poly_sigma, flags,
+                                                /*cacheExpansion=*/false);
     optflow->calc(_prev0,_next0,_flow0);
 }
 
@@ -1207,5 +1340,6 @@ cv::Ptr<cv::FarnebackOpticalFlow> cv::FarnebackOpticalFlow::create(int numLevels
                                                                int numIters, int polyN, double polySigma, int flags)
 {
     return makePtr<FarnebackOpticalFlowImpl>(numLevels, pyrScale, fastPyramids, winSize,
-                                             numIters, polyN, polySigma, flags);
+                                             numIters, polyN, polySigma, flags,
+                                             /*cacheExpansion=*/true);
 }

--- a/modules/video/test/test_optflow_farneback.cpp
+++ b/modules/video/test/test_optflow_farneback.cpp
@@ -1,0 +1,619 @@
+// This file is part of OpenCV project.
+// It is subject to the license terms in the LICENSE file found in the top-level directory
+// of this distribution and at http://opencv.org/license.html.
+#include "test_precomp.hpp"
+
+#if !defined(OPENCV_DISABLE_THREAD_SUPPORT)
+#include <thread>
+#endif
+
+namespace opencv_test { namespace {
+
+// FarnebackOpticalFlow keeps the polynomial expansion of a call's second image and reuses
+// it on the next call, where in a video that image arrives as the first one. Every case
+// here asserts the same property: whatever the caller does in between, a reused instance
+// returns bit for bit what a fresh instance returns.
+//
+// Nothing counts cache hits, so a case that needs a hit asserts its premise instead --
+// that the buffer really was recycled, that the input really is strided, that two frames
+// really do differ.
+
+static void expectSameFlow(const Mat& fresh, const Mat& reused, const std::string& what,
+                           bool mayBeZero = false)
+{
+    ASSERT_EQ(fresh.size(), reused.size()) << what;
+    ASSERT_EQ(fresh.type(), reused.type()) << what;
+    ASSERT_FALSE(fresh.empty()) << what;
+    // An all-zero field would make the comparison below vacuous.
+    if( !mayBeZero )
+    {
+        ASSERT_GT(countNonZero(fresh.reshape(1) != 0.0f), 0)
+            << what << ": flow is entirely zero";
+    }
+
+    // Bytes, not ==: the claim is identical bits, and == calls +0.0f and -0.0f equal and
+    // a NaN unequal to itself.
+    int differingRows = 0;
+    const size_t rowBytes = (size_t)fresh.cols * fresh.elemSize();
+    for( int y = 0; y < fresh.rows; y++ )
+    {
+        if( memcmp(fresh.ptr(y), reused.ptr(y), rowBytes) != 0 )
+            differingRows++;
+    }
+    EXPECT_EQ(0, differingRows) << what << ": " << differingRows << " of " << fresh.rows
+                                << " flow rows differ";
+}
+
+// A translated texture, so the flow is a real field rather than the near-zero one a pair
+// of independent noise images produces.
+static std::vector<Mat> makeSequence(Size size, int count, int seed = 0x5eed)
+{
+    Mat base(size.height * 2, size.width * 2, CV_8U);
+    RNG(seed).fill(base, RNG::UNIFORM, 0, 256);
+    GaussianBlur(base, base, Size(9, 9), 3, 3);
+
+    std::vector<Mat> frames;
+    for( int i = 0; i < count; i++ )
+    {
+        Mat shift = (Mat_<double>(2, 3) << 1, 0, 1.7 * i, 0, 1, -1.1 * i);
+        Mat warped;
+        warpAffine(base, warped, shift, base.size(), INTER_LINEAR);
+        frames.push_back(warped(Rect(size.width / 2, size.height / 2,
+                                     size.width, size.height)).clone());
+    }
+    return frames;
+}
+
+typedef std::function<Ptr<FarnebackOpticalFlow>()> FlowFactory;
+
+// Cheaper than the defaults, so these tests can afford many calls.
+static Ptr<FarnebackOpticalFlow> makeFlow()
+{
+    Ptr<FarnebackOpticalFlow> algo = FarnebackOpticalFlow::create();
+    algo->setNumLevels(3);
+    algo->setWinSize(9);
+    algo->setNumIters(3);
+    return algo;
+}
+
+// Drives frame pairs through one reused instance and through a fresh instance per pair,
+// and requires the two to agree on every pair.
+static void checkPairs(const std::vector<std::pair<Mat, Mat> >& pairs,
+                       const FlowFactory& make,
+                       const std::string& what)
+{
+    ASSERT_FALSE(pairs.empty());
+
+    Ptr<FarnebackOpticalFlow> reused = make();
+    for( size_t i = 0; i < pairs.size(); i++ )
+    {
+        Mat flowFresh, flowReused;
+        make()->calc(pairs[i].first, pairs[i].second, flowFresh);
+        reused->calc(pairs[i].first, pairs[i].second, flowReused);
+        expectSameFlow(flowFresh, flowReused, what + ", pair " + std::to_string(i));
+    }
+}
+
+static std::vector<std::pair<Mat, Mat> > consecutivePairs(const std::vector<Mat>& frames)
+{
+    std::vector<std::pair<Mat, Mat> > pairs;
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+        pairs.push_back(std::make_pair(frames[i], frames[i + 1]));
+    return pairs;
+}
+
+typedef testing::TestWithParam<Size> DenseOpticalFlow_Farneback;
+
+// The case the reuse is for: consecutive pairs of one sequence, forwards and then
+// backwards, so every call after the first finds its first image already expanded.
+TEST_P(DenseOpticalFlow_Farneback, ReusedInstanceMatchesFreshOverSequence)
+{
+    std::vector<Mat> frames = makeSequence(GetParam(), 6);
+    checkPairs(consecutivePairs(frames), makeFlow, "forward sequence");
+    std::reverse(frames.begin(), frames.end());
+    checkPairs(consecutivePairs(frames), makeFlow, "reversed sequence");
+}
+
+// Two unrelated sources on one instance, as a caller multiplexing cameras would do.
+TEST_P(DenseOpticalFlow_Farneback, ReusedInstanceMatchesFreshWhenSourcesInterleave)
+{
+    const std::vector<Mat> a = makeSequence(GetParam(), 4, 0x11);
+    const std::vector<Mat> b = makeSequence(GetParam(), 4, 0x22);
+
+    std::vector<std::pair<Mat, Mat> > pairs;
+    for( size_t i = 0; i + 1 < a.size(); i++ )
+    {
+        pairs.push_back(std::make_pair(a[i], a[i + 1]));
+        pairs.push_back(std::make_pair(b[i], b[i + 1]));
+    }
+    checkPairs(pairs, makeFlow, "interleaved sources");
+}
+
+// Unrelated pairs agreeing on size, type and step and on nothing else, so weakening the
+// frame comparison to those makes this fail.
+TEST_P(DenseOpticalFlow_Farneback, ReusedInstanceMatchesFreshOnUnrelatedPairs)
+{
+    std::vector<std::pair<Mat, Mat> > pairs;
+    for( int i = 0; i < 4; i++ )
+    {
+        const std::vector<Mat> frames = makeSequence(GetParam(), 2, 0x100 + i * 7);
+        pairs.push_back(std::make_pair(frames[0], frames[1]));
+    }
+    checkPairs(pairs, makeFlow, "unrelated pairs");
+}
+
+// The ordinary in-place caller: one pair of Mats refilled per frame, so address, size and
+// step are constant and only the content moves.
+TEST_P(DenseOpticalFlow_Farneback, ReusedInstanceMatchesFreshWhenBuffersAreOverwritten)
+{
+    const Size size = GetParam();
+    const std::vector<Mat> frames = makeSequence(size, 6);
+
+    Mat prev(size, CV_8U), next(size, CV_8U);
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        // Shuffled, so no call is handed as its first image what the previous call was
+        // handed as its second: nothing here may be reused.
+        Mat leftBehind;
+        if( i > 0 )
+            next.copyTo(leftBehind);
+        frames[(i + 4) % frames.size()].copyTo(prev);
+        frames[i + 1].copyTo(next);
+        if( i > 0 )
+        {
+            ASSERT_GT(countNonZero(leftBehind != prev), 0)
+                << "pair " << i << ": the shuffle must not line up into a hit";
+        }
+
+        Mat flowFresh, flowReused;
+        makeFlow()->calc(prev, next, flowFresh);
+        reused->calc(prev, next, flowReused);
+        expectSameFlow(flowFresh, flowReused, "overwritten buffers, pair " + std::to_string(i));
+    }
+}
+
+// Two frame buffers swapping roles, so this call's first image sits in the buffer the
+// previous call was handed as its second, refilled in between. A key on the data pointer,
+// or a retained reference instead of a copy, matches here while the pixels do not.
+TEST_P(DenseOpticalFlow_Farneback, ReusedInstanceMatchesFreshWhenBuffersAlternate)
+{
+    const Size size = GetParam();
+    const std::vector<Mat> frames = makeSequence(size, 8);
+
+    Mat buf[2] = { Mat(size, CV_8U), Mat(size, CV_8U) };
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    const uchar* heldAddress = NULL;
+
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        Mat& first = buf[i % 2];
+        Mat& second = buf[(i + 1) % 2];
+
+        Mat heldContent;
+        if( i > 0 )
+            first.copyTo(heldContent);
+
+        // The stride of 3 keeps the two images of a call distinct, and this call's first
+        // image distinct from the previous call's second.
+        frames[i].copyTo(first);
+        frames[(i + 3) % frames.size()].copyTo(second);
+
+        // Without these the case could pass while testing nothing.
+        if( i > 0 )
+        {
+            ASSERT_EQ(heldAddress, first.data) << "pair " << i << ": buffers must alternate";
+            ASSERT_GT(countNonZero(heldContent != first), 0)
+                << "pair " << i << ": the alternating buffer must be refilled";
+        }
+        heldAddress = second.data;
+
+        Mat flowFresh, flowReused;
+        makeFlow()->calc(first, second, flowFresh);
+        reused->calc(first, second, flowReused);
+        expectSameFlow(flowFresh, flowReused, "alternating buffers, pair " + std::to_string(i));
+    }
+}
+
+INSTANTIATE_TEST_CASE_P(FullSet, DenseOpticalFlow_Farneback,
+                        testing::Values(szODD, szQVGA));
+
+// Pyramid geometries the parameterised sizes do not reach: a scale close to 1 goes deep,
+// and the last three sizes truncate a requested depth of 8 to one or two levels.
+TEST(DenseOpticalFlow_Farneback, PyramidDepthRangeKeepsResult)
+{
+    const struct { Size size; double pyrScale; int numLevels; } cases[] = {
+        { Size(320, 240), 0.8, 5 },
+        { Size(320, 240), 0.5, 5 },
+        { Size(200, 200), 0.9, 6 },
+        { Size(40, 34),   0.5, 8 },
+        { Size(70, 70),   0.5, 8 },
+        { Size(320, 61),  0.5, 8 },
+    };
+
+    for( size_t c = 0; c < sizeof(cases) / sizeof(cases[0]); c++ )
+    {
+        const double pyrScale = cases[c].pyrScale;
+        const int numLevels = cases[c].numLevels;
+        const FlowFactory make = [pyrScale, numLevels]()
+        {
+            Ptr<FarnebackOpticalFlow> algo = FarnebackOpticalFlow::create();
+            algo->setPyrScale(pyrScale);
+            algo->setNumLevels(numLevels);
+            algo->setWinSize(9);
+            algo->setNumIters(2);
+            return algo;
+        };
+
+        checkPairs(consecutivePairs(makeSequence(cases[c].size, 4)), make,
+                   format("%dx%d at pyrScale %.1f, numLevels %d",
+                          cases[c].size.width, cases[c].size.height, pyrScale, numLevels));
+    }
+}
+
+// calc() asserts one channel and equal sizes but not a depth, so wider images reach it.
+TEST(DenseOpticalFlow_Farneback, NonByteDepthKeepsResult)
+{
+    const int depths[] = { CV_16U, CV_32F };
+    const std::vector<Mat> frames8u = makeSequence(Size(96, 72), 5);
+
+    for( size_t d = 0; d < sizeof(depths) / sizeof(depths[0]); d++ )
+    {
+        std::vector<std::pair<Mat, Mat> > pairs;
+        for( size_t i = 0; i + 1 < frames8u.size(); i++ )
+        {
+            Mat a, b;
+            frames8u[i].convertTo(a, depths[d], 257.0);
+            frames8u[i + 1].convertTo(b, depths[d], 257.0);
+            pairs.push_back(std::make_pair(a, b));
+        }
+        checkPairs(pairs, makeFlow, format("depth %d", depths[d]));
+    }
+}
+
+// A 16-bit difference confined to the far end of every row. A row comparison sized from
+// the column count instead of the element size reads only the low half of each row, misses
+// the difference and hands these frames the wrong expansion.
+TEST(DenseOpticalFlow_Farneback, LateRowDifferenceIsDetected)
+{
+    const std::vector<Mat> frames = makeSequence(Size(96, 72), 3);
+
+    Mat first, held, other;
+    frames[0].convertTo(first, CV_16U, 257.0);
+    frames[1].convertTo(held, CV_16U, 257.0);
+    frames[2].convertTo(other, CV_16U, 257.0);
+
+    Mat altered = held.clone();
+    const Rect tail(held.cols / 2, 0, held.cols - held.cols / 2, held.rows);
+    other(tail).copyTo(altered(tail));
+    ASSERT_EQ(0, countNonZero(altered.colRange(0, held.cols / 2)
+                              != held.colRange(0, held.cols / 2)));
+    ASSERT_GT(countNonZero(altered != held), 0);
+
+    std::vector<std::pair<Mat, Mat> > pairs;
+    pairs.push_back(std::make_pair(first, held));
+    pairs.push_back(std::make_pair(altered, other));
+    checkPairs(pairs, makeFlow, "late row difference");
+}
+
+// Strided input: a whole sequence of ROIs into larger frames, and then the same pixels
+// arriving continuous on one call and strided on the next, which is still a hit.
+TEST(DenseOpticalFlow_Farneback, StridedInputKeepsResult)
+{
+    const Size size(96, 72);
+    const std::vector<Mat> frames = makeSequence(Size(size.width + 19, size.height + 13), 4);
+    const Rect roi(6, 4, size.width, size.height);
+
+    std::vector<std::pair<Mat, Mat> > pairs;
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        Mat a = frames[i](roi), b = frames[i + 1](roi);
+        ASSERT_FALSE(a.isContinuous());
+        pairs.push_back(std::make_pair(a, b));
+    }
+    checkPairs(pairs, makeFlow, "strided sequence");
+
+    const Mat firstStrided = frames[0](roi);
+    const Mat heldStrided = frames[1](roi);
+    const Mat nextStrided = frames[2](roi);
+    const Mat heldContinuous = heldStrided.clone();
+    ASSERT_TRUE(heldContinuous.isContinuous());
+
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    Mat flowFresh, flowReused;
+
+    makeFlow()->calc(firstStrided, heldContinuous, flowFresh);
+    reused->calc(firstStrided, heldContinuous, flowReused);
+    expectSameFlow(flowFresh, flowReused, "continuity change, first call");
+
+    makeFlow()->calc(heldStrided, nextStrided, flowFresh);
+    reused->calc(heldStrided, nextStrided, flowReused);
+    expectSameFlow(flowFresh, flowReused, "continuity change, second call");
+}
+
+// One image against itself, which answers zero and both finds and leaves an expansion of
+// that image.
+TEST(DenseOpticalFlow_Farneback, SelfPairKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(96, 72), 3);
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+
+    const std::pair<Mat, Mat> pairs[] = {
+        std::make_pair(frames[0], frames[1]),
+        std::make_pair(frames[1], frames[1]),
+        std::make_pair(frames[1], frames[2]),
+        std::make_pair(frames[2], frames[2]),
+    };
+
+    for( size_t i = 0; i < sizeof(pairs) / sizeof(pairs[0]); i++ )
+    {
+        Mat flowFresh, flowReused;
+        makeFlow()->calc(pairs[i].first, pairs[i].second, flowFresh);
+        reused->calc(pairs[i].first, pairs[i].second, flowReused);
+        const bool selfPair = pairs[i].first.data == pairs[i].second.data;
+        expectSameFlow(flowFresh, flowReused, "self pair, pair " + std::to_string(i), selfPair);
+    }
+}
+
+// The depth a call arrives at, changed with a warm cache: at 320x240 numLevels 1 keeps two
+// sets of planes and numLevels 3 asks for three, so the second call indexes past what the
+// first kept. Only the length of the held vector notices.
+TEST(DenseOpticalFlow_Farneback, EffectiveDepthChangeBetweenCallsKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(320, 240), 3);
+
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    reused->setNumLevels(1);
+    Ptr<FarnebackOpticalFlow> shallow = makeFlow();
+    shallow->setNumLevels(1);
+
+    Mat flowFresh, flowReused;
+    shallow->calc(frames[0], frames[1], flowFresh);
+    reused->calc(frames[0], frames[1], flowReused);
+    expectSameFlow(flowFresh, flowReused, "one level, first pair");
+
+    reused->setNumLevels(3);
+    Ptr<FarnebackOpticalFlow> deep = makeFlow();
+    deep->calc(frames[1], frames[2], flowFresh);
+    reused->calc(frames[1], frames[2], flowReused);
+    expectSameFlow(flowFresh, flowReused, "three levels after one level");
+
+    // The depth does move the answer, so a call served by the shallower expansion could
+    // not have passed above.
+    Mat flowShallow;
+    shallow->calc(frames[1], frames[2], flowShallow);
+    ASSERT_GT(countNonZero(flowShallow.reshape(1) != flowFresh.reshape(1)), 0);
+}
+
+// pyrScale changed with a warm cache between two values that truncate to the same number
+// of levels, 0.5 and 0.45 at this size, so the length of the held vector cannot tell them
+// apart and pyrScale is the only term that can.
+TEST(DenseOpticalFlow_Farneback, PyrScaleChangeBetweenCallsKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(320, 240), 3);
+
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    Mat flowFresh, flowReused;
+    makeFlow()->calc(frames[0], frames[1], flowFresh);
+    reused->calc(frames[0], frames[1], flowReused);
+    expectSameFlow(flowFresh, flowReused, "pyrScale 0.5, first pair");
+
+    reused->setPyrScale(0.45);
+    Ptr<FarnebackOpticalFlow> rescaled = makeFlow();
+    rescaled->setPyrScale(0.45);
+    Mat flowRescaled;
+    rescaled->calc(frames[1], frames[2], flowRescaled);
+    reused->calc(frames[1], frames[2], flowReused);
+    expectSameFlow(flowRescaled, flowReused, "pyrScale 0.45 after 0.5");
+
+    makeFlow()->calc(frames[1], frames[2], flowFresh);
+    ASSERT_GT(countNonZero(flowRescaled.reshape(1) != flowFresh.reshape(1)), 0);
+}
+
+// A size change with a warm cache, both ways round: the held planes are sized for the
+// previous frame, so carrying them over would give the update step short rows to read.
+TEST(DenseOpticalFlow_Farneback, FrameSizeChangeBetweenCallsKeepsResult)
+{
+    const Size sizes[] = { Size(320, 240), Size(96, 72), Size(127, 61), Size(320, 240) };
+    const int count = (int)(sizeof(sizes) / sizeof(sizes[0]));
+
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    for( int i = 0; i < count; i++ )
+    {
+        // Three frames per size, so the second call at each size chains.
+        const std::vector<Mat> frames = makeSequence(sizes[i], 3);
+        for( size_t j = 0; j + 1 < frames.size(); j++ )
+        {
+            Mat flowFresh, flowReused;
+            makeFlow()->calc(frames[j], frames[j + 1], flowFresh);
+            reused->calc(frames[j], frames[j + 1], flowReused);
+            expectSameFlow(flowFresh, flowReused,
+                           format("size change to %dx%d, pair %d",
+                                  sizes[i].width, sizes[i].height, (int)j));
+        }
+    }
+}
+
+// poly_n and poly_sigma size the expansion kernel and the flags pick the update step.
+// calc() constrains none of them to the documented values, so the range it accepts has to
+// keep working; 160x120 gives a pyramid rather than a single level.
+TEST(DenseOpticalFlow_Farneback, ExpansionParameterRangeKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(160, 120), 4);
+    const int polyNs[] = { 5, 6, 7 };
+    const int flagValues[] = { 0, OPTFLOW_FARNEBACK_GAUSSIAN };
+
+    for( size_t n = 0; n < sizeof(polyNs) / sizeof(polyNs[0]); n++ )
+    {
+        for( size_t f = 0; f < sizeof(flagValues) / sizeof(flagValues[0]); f++ )
+        {
+            const int polyN = polyNs[n], flags = flagValues[f];
+            const double polySigma = polyN <= 5 ? 1.1 : 1.5;
+            const FlowFactory make = [polyN, polySigma, flags]()
+            {
+                Ptr<FarnebackOpticalFlow> algo = makeFlow();
+                algo->setPolyN(polyN);
+                algo->setPolySigma(polySigma);
+                algo->setFlags(flags);
+                return algo;
+            };
+
+            checkPairs(consecutivePairs(frames), make,
+                       format("poly_n %d, flags %d", polyN, flags));
+        }
+    }
+}
+
+// Every setter, changed one at a time between two chaining calls. Those that feed the
+// expansion have to invalidate what is held, the rest may keep it, and either way the
+// answer cannot move. polyN and polySigma get a row each as well as a row together: they
+// are the key terms that leave no trace in the shape or type of a held plane.
+TEST(DenseOpticalFlow_Farneback, ParameterChangeBetweenCallsKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(96, 72), 3);
+
+    typedef std::function<void(const Ptr<FarnebackOpticalFlow>&)> Tweak;
+    std::vector<std::pair<std::string, Tweak> > tweaks;
+    tweaks.push_back(std::make_pair("numLevels",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setNumLevels(2); }));
+    tweaks.push_back(std::make_pair("pyrScale",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setPyrScale(0.4); }));
+    tweaks.push_back(std::make_pair("polyN",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setPolyN(7); }));
+    tweaks.push_back(std::make_pair("polyN and polySigma",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setPolyN(7); f->setPolySigma(1.5); }));
+    tweaks.push_back(std::make_pair("polySigma",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setPolySigma(1.3); }));
+    tweaks.push_back(std::make_pair("winSize",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setWinSize(13); }));
+    tweaks.push_back(std::make_pair("numIters",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setNumIters(5); }));
+    tweaks.push_back(std::make_pair("flags",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setFlags(OPTFLOW_FARNEBACK_GAUSSIAN); }));
+    tweaks.push_back(std::make_pair("fastPyramids",
+        [](const Ptr<FarnebackOpticalFlow>& f) { f->setFastPyramids(true); }));
+
+    for( size_t t = 0; t < tweaks.size(); t++ )
+    {
+        Ptr<FarnebackOpticalFlow> reused = makeFlow();
+        Mat ignored;
+        reused->calc(frames[0], frames[1], ignored);
+        tweaks[t].second(reused);
+
+        Ptr<FarnebackOpticalFlow> fresh = makeFlow();
+        tweaks[t].second(fresh);
+
+        Mat flowFresh, flowReused;
+        fresh->calc(frames[1], frames[2], flowFresh);
+        reused->calc(frames[1], frames[2], flowReused);
+        expectSameFlow(flowFresh, flowReused, "after changing " + tweaks[t].first);
+    }
+}
+
+// OPTFLOW_USE_INITIAL_FLOW feeds each call the previous flow field, so both instances have
+// to be fed the same one to stay comparable.
+TEST(DenseOpticalFlow_Farneback, InitialFlowSequenceKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(szQVGA, 5);
+
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+    reused->setFlags(OPTFLOW_USE_INITIAL_FLOW);
+
+    Mat carried = Mat::zeros(frames[0].size(), CV_32FC2);
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        Mat flowFresh = carried.clone(), flowReused = carried.clone();
+
+        Ptr<FarnebackOpticalFlow> fresh = makeFlow();
+        fresh->setFlags(OPTFLOW_USE_INITIAL_FLOW);
+        fresh->calc(frames[i], frames[i + 1], flowFresh);
+        reused->calc(frames[i], frames[i + 1], flowReused);
+
+        expectSameFlow(flowFresh, flowReused, "initial flow, pair " + std::to_string(i));
+        carried = flowFresh;
+    }
+}
+
+// collectGarbage() drops whatever is held; the next call must still be right.
+TEST(DenseOpticalFlow_Farneback, CollectGarbageBetweenCallsKeepsResult)
+{
+    const std::vector<Mat> frames = makeSequence(Size(96, 72), 5);
+    Ptr<FarnebackOpticalFlow> reused = makeFlow();
+
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        Mat flowFresh, flowReused;
+        makeFlow()->calc(frames[i], frames[i + 1], flowFresh);
+        reused->calc(frames[i], frames[i + 1], flowReused);
+        expectSameFlow(flowFresh, flowReused, "after collectGarbage, pair " + std::to_string(i));
+        if( i % 2 == 0 )
+            reused->collectGarbage();
+    }
+}
+
+#if !defined(OPENCV_DISABLE_THREAD_SUPPORT)
+
+// Several threads driving one instance, each over its own sequence. Whether a thread finds
+// the held expansion is a race; what it gets back is not. The small size keeps calls short
+// and publishes frequent, the larger one has a pyramid deep enough for a torn snapshot to
+// have levels to be torn between.
+static void runConcurrentCalls(Size size, int threads, int pairs)
+{
+    std::vector<std::vector<Mat> > frames(threads);
+    std::vector<std::vector<Mat> > expected(threads);
+    for( int t = 0; t < threads; t++ )
+    {
+        frames[t] = makeSequence(size, pairs + 1, 0x900 + t * 13);
+        for( int i = 0; i < pairs; i++ )
+        {
+            Mat flow;
+            makeFlow()->calc(frames[t][i], frames[t][i + 1], flow);
+            expected[t].push_back(flow);
+        }
+    }
+
+    Ptr<FarnebackOpticalFlow> shared = makeFlow();
+    std::vector<std::vector<Mat> > actual(threads);
+    std::vector<std::thread> workers;
+    for( int t = 0; t < threads; t++ )
+    {
+        actual[t].resize(pairs);
+        workers.push_back(std::thread([&, t]()
+        {
+            for( int i = 0; i < pairs; i++ )
+                shared->calc(frames[t][i], frames[t][i + 1], actual[t][i]);
+        }));
+    }
+    for( size_t t = 0; t < workers.size(); t++ )
+        workers[t].join();
+
+    for( int t = 0; t < threads; t++ )
+        for( int i = 0; i < pairs; i++ )
+            expectSameFlow(expected[t][i], actual[t][i],
+                           format("%dx%d, concurrent thread %d, pair %d",
+                                  size.width, size.height, t, i));
+}
+
+TEST(DenseOpticalFlow_Farneback, ConcurrentCallsOnOneInstanceKeepResult)
+{
+    runConcurrentCalls(Size(64, 48), 12, 20);
+    runConcurrentCalls(Size(160, 120), 8, 12);
+}
+
+#endif
+
+// The free function creates an instance per call and keeps nothing.
+TEST(DenseOpticalFlow_Farneback, FreeFunctionMatchesFreshInstance)
+{
+    const std::vector<Mat> frames = makeSequence(Size(96, 72), 4);
+    for( size_t i = 0; i + 1 < frames.size(); i++ )
+    {
+        Mat flowFunc, flowInstance;
+        calcOpticalFlowFarneback(frames[i], frames[i + 1], flowFunc, 0.5, 3, 9, 3, 5, 1.1, 0);
+        makeFlow()->calc(frames[i], frames[i + 1], flowInstance);
+        expectSameFlow(flowInstance, flowFunc, "free function, pair " + std::to_string(i));
+    }
+}
+
+}} // namespace


### PR DESCRIPTION
### Motivation

`FarnebackOpticalFlow::calc()` expands both of its input images into polynomials on every call. Walking a video, frame *k* is the second image of one call and the first image of the next, so one of the two expansions per call repeats one the same instance did a moment earlier. The expansion of an image depends on the image alone plus `pyrScale`, `polyN` and `polySigma`, so it can be kept and used again. There was no CPU accuracy or performance test for Farneback in the module, so this adds both.

### Measurements

The perf test added here, `opencv_perf_video --gtest_filter='*DenseOpticalFlow_Farneback*'`

| frame size | before | after | saved |
| --- | --- | --- | --- |
| 320x240 | 23.54 ms | 21.43 ms | 9.0% |
| 640x480 | 100.85 ms | 93.16 ms | 7.6% |
| 1280x720 | 327.20 ms | 286.09 ms | 12.6% |

```
DenseOpticalFlow_Farneback_perf.perf/0 (320x240, "calcOpticalFlowFarneback")  median=222.38 ms  stddev 2.9%
DenseOpticalFlow_Farneback_perf.perf/1 (320x240, "sharedInstance")            median=197.77 ms  stddev 2.9%
DenseOpticalFlow_Farneback_perf.perf/2 (320x240, "sharedInstanceNoReuse")     median=224.49 ms  stddev 4.7%
DenseOpticalFlow_Farneback_perf.perf/3 (640x480, "calcOpticalFlowFarneback")  median=923.00 ms  stddev 1.3%
DenseOpticalFlow_Farneback_perf.perf/4 (640x480, "sharedInstance")            median=837.39 ms  stddev 2.0%
DenseOpticalFlow_Farneback_perf.perf/5 (640x480, "sharedInstanceNoReuse")     median=939.60 ms  stddev 1.7%
```

The first call of a sequence has nothing to reuse, so a longer video sees a little more than these 20-call (10 at 720p) runs show.

### What changed

In the `Mat` path of `calc()` in `modules/video/src/optflowgf.cpp`:

- A call keeps the polynomial expansion of its second image, one `CV_32FC(5)` plane per pyramid level, plus a deep copy of that image.
- The next call reuses it for its first image when that image compares equal pixel for pixel to the copy, `pyrScale`, `polyN` and `polySigma` are unchanged and the number of kept levels matches. Otherwise it expands as before.
- The second image is expanded *from* the retained copy, so the bytes a later call compares are the bytes that were expanded. The planes are shared rather than copied: all three consumers take `const Mat&`.
- The cache is snapshotted by value under a `cv::Mutex` and the replacement published under it again after the pyramid loop, so a throw leaves the previous cache intact.
- `collectGarbage()`, already `CV_WRAP`ped on `DenseOpticalFlow` and documented as releasing inner buffers, releases it. No new public API.
- Whether anything is kept is a constructor argument on the private implementation class: `create()` passes true, `calcOpticalFlowFarneback()` passes false, since it builds an instance per call and would pay a frame copy for a cache nothing can read.
- `modules/video/include/opencv2/video/tracking.hpp` is comments only.

### Why the frame comparison is exact

The comparison is a row-by-row `memcmp` of the pixels, and it is the only thing tying a kept expansion to the image it was computed from. A digest (FNV-1a, Murmur, CRC) is wrong whenever it collides, and a collision raises nothing; a check on size, type, step or the address of the pixels is wrong on perfectly ordinary input, because callers refill one frame buffer per frame or alternate two, so equal dimensions and an equal address say nothing about the contents. Either way an image is handed a stranger's expansion and the flow is quietly wrong rather than an error. The address is also why the retained frame is a copy: comparing against the caller's own buffer would compare it with itself. One pass over an 8-bit frame against a pyramid of float convolutions is not a trade worth making, and the measurements above include it. `ReusedInstanceMatchesFreshOnUnrelatedPairs` (pairs equal in size, type and step and in nothing else) and `ReusedInstanceMatchesFreshWhenBuffersAlternate` (two buffers swapping roles, so the address always matches and the pixels never do) are the cases that fail if it is weakened; there is a mutation list at the end.

### Testing

Release, `BUILD_LIST=core,imgproc,video,ts`, gcc 13.3.0, Intel i7-13650HX, warning-free.

```
opencv_test_video --gtest_filter='*DenseOpticalFlow_Farneback*'   24 passed  (the new file)
opencv_test_video --gtest_filter='*Farneback*'                    48 passed  (+ 24 existing OpenCL cases)
opencv_test_video                                                 178 of 179, 33 skipped
opencv_perf_video --gtest_filter='*Farneback*' --perf_min_samples=20   6 passed
```

The one failure is `vittrack.accuracy_vittrack`, which says so itself: "to use vittrack, the tracking module needs to be built with opencv_dnn". `OPENCV_TEST_DATA_PATH` is required, or 24 OpenCL cases fail to load their input from `opencv_extra`.

Every case asserts that a reused instance returns *exactly* what a fresh instance returns, comparing the flow fields byte for byte rather than within a tolerance — bytes and not `==` on floats, since `==` calls `+0.0f` and `-0.0f` equal and a NaN unequal to itself — and refuses an all-zero field so the comparison cannot go vacuous. Nothing counts cache hits, and no counter was added to production code for the tests to read, so cases that need a hit assert their premise instead: that the buffer really was recycled, that the input really is strided, that two frames really do differ. Under temporary instrumentation the sequence cases hit on every call after the first and the unrelated-pairs case hits zero times. Test data is generated (a blurred random texture translated by a subpixel offset, in the spirit of `perf_disflow.cpp`), so there is no `opencv_extra` patch.

The 48 accuracy cases also pass at each of five `OPENCV_CPU_DISABLE` settings down to the SSE3 baseline, which is expected since no SIMD or dispatch code is touched.

Each guard was checked by breaking it and watching the right case fail, out of the 24:

| mutation | fails |
| --- | --- |
| comparison weakened to size, type and step | 10 |
| retain the caller's `Mat` instead of a copy of it | 2 (`...WhenBuffersAlternate`) |
| row length from the column count, not `elemSize()` | 1 (`LateRowDifferenceIsDetected`) |
| `polyN` dropped from the key | 1 (`ParameterChange...`) |
| `pyrScale` dropped from the key | 1 (`PyrScaleChange...`) |
| kept-level count replaced by "not empty" | 1 (`EffectiveDepthChange...`) |
| the mutex removed | `ConcurrentCalls...`, 6 runs in 10 |

A digest would fail only on a collision, which no test can be made to provoke; that asymmetry is the argument for an exact comparison. In the other direction, keying on the address *while* the copy stays never matches, so it does not corrupt a result — it silently stops reusing.


### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
      No bug report: this came out of profiling a Farneback pipeline, not a reported defect.
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Accuracy and performance tests are in this PR. No `opencv_extra` patch: the test data is generated.
- [x] The feature is well documented and sample code can be built with the project CMake
      Documented on `FarnebackOpticalFlow` and on `calcOpticalFlowFarneback()`. No sample is added or changed; the reuse needs no API, so there is nothing new to demonstrate.