### PR TITLE
python: avoid empty LD_LIBRARY_PATH/PATH entries on import

### DIFF
--- a/modules/python/package/cv2/__init__.py
+++ b/modules/python/package/cv2/__init__.py
@@ -20,6 +20,14 @@ except ImportError:
 # is_x64 = sys.maxsize > 2**32
 
 
+def _prepend_env_paths(env_key, paths, sep):
+    extra = [p for p in paths if p]
+    if not extra:
+        return
+    old = os.environ.get(env_key)
+    os.environ[env_key] = sep.join(extra) + ((sep + old) if old else '')
+
+
 def __load_extra_py_code_for_module(base, name, enable_debug_print=False):
     module_name = "{}.{}".format(__name__, name)
     export_module_name = "{}.{}".format(base, name)
@@ -140,11 +148,11 @@ def bootstrap():
                 except Exception as e:
                     if DEBUG: print('Failed os.add_dll_directory(): '+ str(e))
                     pass
-        os.environ['PATH'] = ';'.join(l_vars['BINARIES_PATHS']) + ';' + os.environ.get('PATH', '')
-        if DEBUG: print('OpenCV loader: PATH={}'.format(str(os.environ['PATH'])))
+        _prepend_env_paths('PATH', l_vars['BINARIES_PATHS'], ';')
+        if DEBUG: print('OpenCV loader: PATH={}'.format(str(os.environ.get('PATH'))))
     else:
         # amending of LD_LIBRARY_PATH works for sub-processes only
-        os.environ['LD_LIBRARY_PATH'] = ':'.join(l_vars['BINARIES_PATHS']) + ':' + os.environ.get('LD_LIBRARY_PATH', '')
+        _prepend_env_paths('LD_LIBRARY_PATH', l_vars['BINARIES_PATHS'], ':')
 
     if DEBUG: print("Relink everything from native cv2 module to cv2 package")
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch (5.x)
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
- [ ] The feature is well documented and sample code can be built with the project CMake

## Bug

`import cv2` builds `LD_LIBRARY_PATH` as `':'.join(BINARIES_PATHS) + ':' + os.environ.get('LD_LIBRARY_PATH', '')`. If the variable was unset, that trailing `:` is an empty search-path entry. On POSIX `ld.so(8)` treats an empty entry as the current working directory, so later subprocesses can load the wrong `libssl`/`libcrypto`.

Reported against the wheels as opencv/opencv-python#1268 (reporter: @superbigcup325). The generated loader in those wheels comes from this file.

Related but different: #28994 disables the mutation behind `OPENCV_SKIP_LD_LIBRARY_PATH` and still uses the same join, so the empty-entry bug remains when the skip flag is unset. This PR keeps the default prepend and only fixes the join (Windows `PATH` has the same pattern).

## Fix

`_prepend_env_paths` prepends non-empty dirs and inserts the separator only when an old value exists. Empty `BINARIES_PATHS` leaves the environment unchanged.

## How to verify

```python
# old join, env unset
':'.join(['/a/lib']) + ':' + ''   # '/a/lib:'  <- empty entry
# new
# '/a/lib'
```

I cannot run the Linux child-process crash on macOS. The join helper was unit-checked: unset -> no trailing sep; existing value still prepended with a sep.

## Risk

Low. Behavior is unchanged when `LD_LIBRARY_PATH`/`PATH` already has a value. Only the empty-old case stops growing a dangling separator.