### PR TITLE
Extend OpenCV imgproc performance tests

### DIFF
--- a/modules/imgproc/perf/perf_accumulate.cpp
+++ b/modules/imgproc/perf/perf_accumulate.cpp
@@ -39,7 +39,7 @@ typedef Size_MatType Accumulate;
 
 /////////////////////////////////// Accumulate ///////////////////////////////////
 
-PERF_TEST_P_ACCUMULATE(Accumulate, MAT_TYPES_ACCUMLATE,
+PERF_TEST_P_ACCUMULATE(Accumulate, MAT_TYPES_ACCUMLATE_C,
         PERF_ACCUMULATE_INIT(CV_32FC), accumulate(src1, dst))
 
 PERF_TEST_P_ACCUMULATE(AccumulateMask, MAT_TYPES_ACCUMLATE_C,
@@ -51,7 +51,7 @@ PERF_TEST_P_ACCUMULATE(AccumulateMask32FC4, CV_32FC4,
 PERF_TEST_P_ACCUMULATE(AccumulateMask8UC4To32FC4, CV_8UC4,
     PERF_ACCUMULATE_MASK_INIT(CV_32FC), accumulate(src1, dst, mask))
 
-PERF_TEST_P_ACCUMULATE(AccumulateDouble, MAT_TYPES_ACCUMLATE_D,
+PERF_TEST_P_ACCUMULATE(AccumulateDouble, MAT_TYPES_ACCUMLATE_D_C,
     PERF_ACCUMULATE_INIT(CV_64FC), accumulate(src1, dst))
 
 PERF_TEST_P_ACCUMULATE(AccumulateDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
@@ -59,13 +59,13 @@ PERF_TEST_P_ACCUMULATE(AccumulateDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
 
 ///////////////////////////// AccumulateSquare ///////////////////////////////////
 
-PERF_TEST_P_ACCUMULATE(Square, MAT_TYPES_ACCUMLATE,
+PERF_TEST_P_ACCUMULATE(Square, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_INIT(CV_32FC), accumulateSquare(src1, dst))
 
 PERF_TEST_P_ACCUMULATE(SquareMask, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_MASK_INIT(CV_32FC), accumulateSquare(src1, dst, mask))
 
-PERF_TEST_P_ACCUMULATE(SquareDouble, MAT_TYPES_ACCUMLATE_D,
+PERF_TEST_P_ACCUMULATE(SquareDouble, MAT_TYPES_ACCUMLATE_D_C,
     PERF_ACCUMULATE_INIT(CV_64FC), accumulateSquare(src1, dst))
 
 PERF_TEST_P_ACCUMULATE(SquareDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
@@ -83,13 +83,13 @@ PERF_TEST_P_ACCUMULATE(SquareDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
     Mat src2(srcSize, srcType);            \
     declare.in(src2);
 
-PERF_TEST_P_ACCUMULATE(Product, MAT_TYPES_ACCUMLATE,
+PERF_TEST_P_ACCUMULATE(Product, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_INIT_2(CV_32FC), accumulateProduct(src1, src2, dst))
 
 PERF_TEST_P_ACCUMULATE(ProductMask, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_MASK_INIT_2(CV_32FC), accumulateProduct(src1, src2, dst, mask))
 
-PERF_TEST_P_ACCUMULATE(ProductDouble, MAT_TYPES_ACCUMLATE_D,
+PERF_TEST_P_ACCUMULATE(ProductDouble, MAT_TYPES_ACCUMLATE_D_C,
     PERF_ACCUMULATE_INIT_2(CV_64FC), accumulateProduct(src1, src2, dst))
 
 PERF_TEST_P_ACCUMULATE(ProductDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
@@ -97,13 +97,13 @@ PERF_TEST_P_ACCUMULATE(ProductDoubleMask, MAT_TYPES_ACCUMLATE_D_C,
 
 ///////////////////////////// AccumulateWeighted ///////////////////////////////////
 
-PERF_TEST_P_ACCUMULATE(Weighted, MAT_TYPES_ACCUMLATE,
+PERF_TEST_P_ACCUMULATE(Weighted, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_INIT(CV_32FC), accumulateWeighted(src1, dst, 0.123))
 
 PERF_TEST_P_ACCUMULATE(WeightedMask, MAT_TYPES_ACCUMLATE_C,
     PERF_ACCUMULATE_MASK_INIT(CV_32FC), accumulateWeighted(src1, dst, 0.123, mask))
 
-PERF_TEST_P_ACCUMULATE(WeightedDouble, MAT_TYPES_ACCUMLATE_D,
+PERF_TEST_P_ACCUMULATE(WeightedDouble, MAT_TYPES_ACCUMLATE_D_C,
     PERF_ACCUMULATE_INIT(CV_64FC), accumulateWeighted(src1, dst, 0.123456))
 
 PERF_TEST_P_ACCUMULATE(WeightedDoubleMask, MAT_TYPES_ACCUMLATE_D_C,

--- a/modules/imgproc/perf/perf_bilateral.cpp
+++ b/modules/imgproc/perf/perf_bilateral.cpp
@@ -12,7 +12,7 @@ typedef TestBaseWithParam< tuple<Size, int, Mat_Type, double> > TestBilateralFil
 PERF_TEST_P( TestBilateralFilter, BilateralFilter,
              Combine(
                 Values( szVGA, sz1080p ), // image size
-                Values( 3, 5 ), // d
+                Values( 3, 5, 7, 21 ), // d
                 Mat_Type::all(), // image type
                 Values(1., 5.)
              )

--- a/modules/imgproc/perf/perf_blur.cpp
+++ b/modules/imgproc/perf/perf_blur.cpp
@@ -11,7 +11,7 @@ typedef perf::TestBaseWithParam<Size_MatType_kSize_t> Size_MatType_kSize;
 PERF_TEST_P(Size_MatType_kSize, medianBlur,
             testing::Combine(
                 testing::Values(szODD, szQVGA, szVGA, sz720p),
-                testing::Values(CV_8UC1, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1),
+                testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16UC3, CV_16UC4, CV_16SC1, CV_16SC3, CV_16SC4, CV_32FC1),
                 testing::Values(3, 5)
                 )
             )
@@ -52,7 +52,7 @@ typedef perf::TestBaseWithParam<Size_MatType_BorderType_ksize_t> Size_MatType_Bo
 PERF_TEST_P(Size_MatType_BorderType3x3, gaussianBlur3x3,
             testing::Combine(
                 testing::Values(szODD, szQVGA, szVGA, sz720p),
-                testing::Values(CV_8UC1, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1),
+                testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16UC3, CV_16SC1, CV_16SC3, CV_32FC1, CV_32FC3),
                 BorderType3x3::all()
                 )
             )
@@ -121,9 +121,9 @@ PERF_TEST_P(Size_MatType_BorderType, blur16x16,
 PERF_TEST_P(Size_MatType_BorderType_ksize, box,
             testing::Combine(
                 testing::Values(szODD, szQVGA, szVGA, sz720p),
-                testing::Values(CV_8UC1, CV_16SC1, CV_32SC1, CV_32FC1, CV_32FC3),
+                testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16UC3, CV_16UC4, CV_16SC1, CV_16SC3, CV_16SC4, CV_32SC1, CV_32FC1, CV_32FC3, CV_32FC4),
                 BorderType::all(),
-                testing::Values(3, 5)
+                testing::Values(3, 5, 7, 21)
                 )
             )
 {
@@ -199,7 +199,7 @@ PERF_TEST_P(Size_MatType_BorderType_ksize, box_inplace,
 PERF_TEST_P(Size_MatType_BorderType, gaussianBlur5x5,
             testing::Combine(
                 testing::Values(szODD, szQVGA, szVGA, sz720p),
-                testing::Values(CV_8UC1, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1),
+                testing::Values(CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16UC3, CV_16SC1, CV_16SC3, CV_32FC1, CV_32FC3),
                 BorderType::all()
                 )
             )

--- a/modules/imgproc/perf/perf_corners.cpp
+++ b/modules/imgproc/perf/perf_corners.cpp
@@ -14,7 +14,7 @@ PERF_TEST_P(Img_BlockSize_ApertureSize_k_BorderType, cornerHarris,
             testing::Combine(
                 testing::Values( "stitching/a1.png", "cv/shared/pic5.png"),
                 testing::Values( 3, 5 ),
-                testing::Values( 3, 5 ),
+                testing::Values( -1, 3, 5 ),          // -1 = Scharr aperture
                 testing::Values( 0.04, 0.1 ),
                 BorderType::all()
                 )
@@ -70,7 +70,7 @@ PERF_TEST_P(Img_BlockSize_ApertureSize_BorderType, cornerMinEigenVal,
             testing::Combine(
                 testing::Values( "stitching/a1.png", "cv/shared/pic5.png"),
                 testing::Values( 3, 5 ),
-                testing::Values( 3, 5 ),
+                testing::Values( -1, 3, 5 ),          // -1 = Scharr aperture
                 BorderType::all()
             )
           )

--- a/modules/imgproc/perf/perf_laplacian.cpp
+++ b/modules/imgproc/perf/perf_laplacian.cpp
@@ -6,7 +6,7 @@
 namespace opencv_test {
 
 CV_ENUM(BorderMode, BORDER_CONSTANT, BORDER_REPLICATE, BORDER_REFLECT_101)
-CV_ENUM(TargetDepth, CV_8U, CV_16S)
+CV_ENUM(TargetDepth, CV_8U, CV_16S, CV_32F)
 
 typedef tuple<Size, int, TargetDepth, BorderMode> LaplacianParams;
 typedef perf::TestBaseWithParam<LaplacianParams> Perf_Laplacian;
@@ -15,7 +15,7 @@ PERF_TEST_P(Perf_Laplacian, Laplacian,
             testing::Combine(
                 testing::Values(szVGA, sz720p, sz1080p),
                 testing::Values(1, 3, 5),                // ksize: 1, 3, 5
-                TargetDepth::all(),                      // CV_8U and CV_16S
+                TargetDepth::all(),                      // CV_8U, CV_16S and CV_32F
                 BorderMode::all()
             ))
 {
@@ -25,7 +25,7 @@ PERF_TEST_P(Perf_Laplacian, Laplacian,
     int borderMode = get<3>(GetParam());
 
     Mat src(sz, CV_8UC1);
-    Mat dst(sz, ddepth == CV_16S ? CV_16SC1 : CV_8UC1);
+    Mat dst(sz, ddepth == CV_16S ? CV_16SC1 : ddepth == CV_32F ? CV_32FC1 : CV_8UC1);
 
     declare.in(src, WARMUP_RNG).out(dst);
 

--- a/modules/imgproc/perf/perf_morph.cpp
+++ b/modules/imgproc/perf/perf_morph.cpp
@@ -5,7 +5,7 @@
 
 namespace opencv_test {
 
-#define TYPICAL_MAT_TYPES_MORPH  CV_8UC1, CV_8UC4
+#define TYPICAL_MAT_TYPES_MORPH  CV_8UC1, CV_8UC3, CV_8UC4, CV_16UC1, CV_16SC1, CV_32FC1, CV_32FC3, CV_32FC4
 #define TYPICAL_MATS_MORPH       testing::Combine(SZ_ALL_GA, testing::Values(TYPICAL_MAT_TYPES_MORPH))
 
 PERF_TEST_P(Size_MatType, erode, TYPICAL_MATS_MORPH)


### PR DESCRIPTION
Added more cases for performance tests. It's a part of a bigger PR https://github.com/opencv/opencv/pull/29631
execution time increased by ~9% per my measurements.
OpenCV Extra: https://github.com/opencv/opencv_extra/pull/1409
Duplication of #29901, but from a different fork.

Following was added:

| File | Test | Added |
|------|------|-------|
| `perf_accumulate.cpp` | `Accumulate`, `Square`, `Product`, `Weighted` (+`*Double`) | channel `C3` (via `_C`/`_D_C` type macros) |
| `perf_bilateral.cpp` | `BilateralFilter` | `d` sizes `7`, `21` |
| `perf_blur.cpp` | `medianBlur` | types `CV_8UC3`, `CV_16UC3/4`, `CV_16SC3/4` |
| `perf_blur.cpp` | `gaussianBlur3x3`, `gaussianBlur5x5` | types `CV_8UC3`, `CV_16UC3`, `CV_16SC3`, `CV_32FC3` |
| `perf_blur.cpp` | `box` | types `CV_8UC3/4`, `CV_16UC1/3/4`, `CV_16SC3/4`, `CV_32FC4`; ksizes `7`, `21` |
| `perf_corners.cpp` | `cornerHarris`, `cornerMinEigenVal` | apertureSize `-1` (Scharr) |
| `perf_laplacian.cpp` | `Laplacian` | target depth `CV_32F` (`TargetDepth` enum) |
| `perf_moments.cpp` | `Moments1` | depth `CV_8U` |
| `perf_morph.cpp` | `erode`, `dilate` (`TYPICAL_MAT_TYPES_MORPH`) | types `CV_8UC3`, `CV_16UC1`, `CV_16SC1`, `CV_32FC1/3/4` |

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
