### PR TITLE
core: handle zero-sized broadcast dimensions

### DIFF
--- a/modules/core/src/matrix_transform.cpp
+++ b/modules/core/src/matrix_transform.cpp
@@ -1320,6 +1320,8 @@ void broadcast(InputArray _src, InputArray _shape, OutputArray _dst) {
             #undef OPENCV_CORE_BROADCAST_LOOP
         }
     } else {
+        if (dst.total() == 0)
+            return;
         // initial copy (src to dst)
         std::vector<size_t> step_src{src.step.p, src.step.p + dims_src};
         if (step_src.size() < static_cast<size_t>(dims_shape)) {

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2833,12 +2833,12 @@ TEST(BroadcastTo, basic) {
     {
         std::vector<int> shape{1, 0};
         std::vector<int> data;
-        Mat src(static_cast<int>(shape.size()), shape.data(), CV_32FC1, data.data());
+        Mat zero_src(static_cast<int>(shape.size()), shape.data(), CV_32FC1, data.data());
 
         std::vector<int> target_shape{3, 0};
         Mat dst;
 
-        broadcast(src, target_shape, dst);
+        broadcast(zero_src, target_shape, dst);
 
         EXPECT_EQ(dst.dims, 2);
         EXPECT_EQ(dst.size[0], 3);

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2843,7 +2843,7 @@ TEST(BroadcastTo, basic) {
         EXPECT_EQ(dst.dims, 2);
         EXPECT_EQ(dst.size[0], 3);
         EXPECT_EQ(dst.size[1], 0);
-        EXPECT_EQ(dst.total(), 0);
+        EXPECT_EQ(dst.total(), 0u);
     }
 
 }

--- a/modules/core/test/test_arithm.cpp
+++ b/modules/core/test/test_arithm.cpp
@@ -2829,6 +2829,23 @@ TEST(BroadcastTo, basic) {
         broadcast(_src, shape, dst);
         fn_verify(ref, dst);
     }
+
+    {
+        std::vector<int> shape{1, 0};
+        std::vector<int> data;
+        Mat src(static_cast<int>(shape.size()), shape.data(), CV_32FC1, data.data());
+
+        std::vector<int> target_shape{3, 0};
+        Mat dst;
+
+        broadcast(src, target_shape, dst);
+
+        EXPECT_EQ(dst.dims, 2);
+        EXPECT_EQ(dst.size[0], 3);
+        EXPECT_EQ(dst.size[1], 0);
+        EXPECT_EQ(dst.total(), 0);
+    }
+
 }
 
 TEST(BroadcastTo, regression_dst_dp_zero_when_last_dim_is_one)


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [x] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->

Port the fix from #29878 to the 5.x branch.

This adds a guard for zero-sized destination matrices in
cv::broadcast() and a regression test covering broadcasting
from {1, 0} to {3, 0}.

The relevant BroadcastTo.* tests pass locally.

Related: #29878