### PR TITLE
imgproc: document integer filter2D kernels 🤖🤖🤖

### DIFF
--- a/modules/imgproc/include/opencv2/imgproc.hpp
+++ b/modules/imgproc/include/opencv2/imgproc.hpp
@@ -1721,8 +1721,9 @@ larger) and the direct algorithm for small kernels.
 @param src input image.
 @param dst output image of the same size and the same number of channels as src.
 @param ddepth desired depth of the destination image, see @ref filter_depths "combinations"
-@param kernel convolution kernel (or rather a correlation kernel), a single-channel floating point
-matrix; if you want to apply different kernels to different channels, split the image into
+@param kernel convolution kernel (or rather a correlation kernel), a single-channel matrix with
+integer or floating-point elements. Integer kernels are converted internally to floating point.
+If you want to apply different kernels to different channels, split the image into
 separate color planes using split and process them individually.
 @param anchor anchor of the kernel that indicates the relative position of a filtered point within
 the kernel; the anchor should lie within the kernel; default value (-1,-1) means that the anchor

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2102,7 +2102,7 @@ TEST_P(Imgproc_Filter2D_IntegerKernel, accuracy)
     const int srcType = get<2>(GetParam());
     const int dstDepth = CV_MAT_DEPTH(srcType) == CV_64F ? CV_64F : CV_32F;
 
-    RNG rng(22243);
+    RNG& rng = theRNG();
     Mat src(47, 53, srcType);
     rng.fill(src, RNG::UNIFORM, 0, 16);
 

--- a/modules/imgproc/test/test_filter.cpp
+++ b/modules/imgproc/test/test_filter.cpp
@@ -2092,6 +2092,44 @@ INSTANTIATE_TEST_CASE_P(/**/, Imgproc_FilterSupportedFormats,
     )
 );
 
+typedef tuple<perf::MatDepth, int, perf::MatType> Filter2DIntegerKernelParams;
+typedef testing::TestWithParam<Filter2DIntegerKernelParams> Imgproc_Filter2D_IntegerKernel;
+
+TEST_P(Imgproc_Filter2D_IntegerKernel, accuracy)
+{
+    const int kernelDepth = get<0>(GetParam());
+    const int kernelSize = get<1>(GetParam());
+    const int srcType = get<2>(GetParam());
+    const int dstDepth = CV_MAT_DEPTH(srcType) == CV_64F ? CV_64F : CV_32F;
+
+    RNG rng(22243);
+    Mat src(47, 53, srcType);
+    rng.fill(src, RNG::UNIFORM, 0, 16);
+
+    Mat coefficients(kernelSize, kernelSize, CV_32S), kernel, referenceKernel;
+    const bool unsignedKernel = kernelDepth == CV_8U || kernelDepth == CV_16U;
+    rng.fill(coefficients, RNG::UNIFORM, unsignedKernel ? 0 : -4, 5);
+    coefficients.convertTo(kernel, kernelDepth);
+    coefficients.convertTo(referenceKernel, CV_64F);
+
+    Mat actual, expected;
+    cv::filter2D(src, actual, dstDepth, kernel, Point(-1, -1), 0, BORDER_REPLICATE);
+    cvtest::filter2D(src, expected, dstDepth, referenceKernel, Point(-1, -1), 0,
+                     BORDER_REPLICATE);
+
+    ASSERT_EQ(expected.type(), actual.type());
+    ASSERT_EQ(expected.size(), actual.size());
+    EXPECT_LE(cvtest::norm(actual, expected, NORM_INF), dstDepth == CV_64F ? 1e-9 : 1e-3);
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Imgproc_Filter2D_IntegerKernel,
+    testing::Combine(
+        testing::Values(CV_8U, CV_8S, CV_16U, CV_16S, CV_32S),
+        testing::Values(3, 13),
+        testing::Values(CV_8UC1, CV_32FC1, CV_32FC3, CV_64FC1)
+    )
+);
+
 TEST(Imgproc_Blur, borderTypes)
 {
     Size kernelSize(3, 3);


### PR DESCRIPTION
### Summary

`filter2D` accepts integer kernels, but its parameter documentation currently restricts kernels to floating-point matrices. Document the existing integer support and add parameterized accuracy coverage against `cvtest::filter2D`, the reference implementation.

The 40 cases cover five integer kernel depths (`CV_8U`, `CV_8S`, `CV_16U`, `CV_16S`, `CV_32S`), 3x3 and 13x13 kernels, and four source formats (`CV_8UC1`, `CV_32FC1`, `CV_32FC3`, `CV_64FC1`). Signed kernels include negative coefficients. Kernel depth, size, and source format are separate Google Test parameters.

Fixes #22243. Related work: #29607 was closed without merging. This follow-up accounts for its review requests about parameterized tests and avoids claiming a specific implementation path from a test name. No filtering implementation changes are included.

### Validation

Built `opencv_test_imgproc` from current 4.x (`bb9e3eff13`) on Linux with GCC 13.3.0, Release/SSE3. IPP, OpenCL, and additional CPU dispatch variants were disabled in this local build.

```
./bin/opencv_test_imgproc --gtest_filter='*Imgproc_Filter2D*:*Imgproc_FilterSupportedFormats*'
```

All 58 selected tests passed: 40 new cases and 18 existing filter accuracy/format/regression cases. `git diff --check` passed. This is targeted CPU validation, not a full imgproc suite or a GPU/backend validation claim. The tests use synthetic data and need no opencv_extra assets.

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
- [x] The PR is proposed to the proper branch: 4.x for a documentation correction applicable to both maintained branches.
- [x] There is a reference to the original bug report and related work.
- [x] Accuracy tests are included; no external test data or performance change is involved.
- [x] The parameter documentation is updated and the affected test target builds.

### AI assistance

OpenAI Codex assisted with the source/review audit, patch preparation, and local validation. The commit includes an Assisted-by trailer.
