### PR TITLE
imgproc: fix ROI isolation and offsets in fast findContours 🤖🤖🤖

### DIFF
--- a/modules/imgproc/src/contours_new.cpp
+++ b/modules/imgproc/src/contours_new.cpp
@@ -666,7 +666,7 @@ void cv::findContours(InputArray _image,
             else
             {
                 const Scalar shift(offset.x, offset.y);
-                const int n = (int)_contours.size().height;
+                const int n = (int)_contours.total();
                 for (int i = 0; i < n; i++)
                     _contours.getMat(i) += shift;
             }

--- a/modules/imgproc/src/contours_truco.cpp
+++ b/modules/imgproc/src/contours_truco.cpp
@@ -622,7 +622,7 @@ void findTRUContours(InputArray _src, OutputArrayOfArrays _contours, int minSize
 
     // Buffer handling
     cv::Mat padded;
-    cv::copyMakeBorder(src, padded, 1, 1, 1, 1, cv::BORDER_CONSTANT, 0);
+    cv::copyMakeBorder(src, padded, 1, 1, 1, 1, cv::BORDER_CONSTANT | cv::BORDER_ISOLATED, 0);
     if (binarize)
         cv::threshold(padded, padded, 0, 255, cv::THRESH_BINARY);
 

--- a/modules/imgproc/test/test_contours_new.cpp
+++ b/modules/imgproc/test/test_contours_new.cpp
@@ -549,7 +549,94 @@ TEST_P(Imgproc_FindContours_Modes2, approx)
     }
 }
 
-// TODO: offset test
+typedef testing::TestWithParam<tuple<int, int, Point, bool, bool>> Imgproc_FindContours_ROIOffset;
+
+TEST_P(Imgproc_FindContours_ROIOffset, border_and_hole)
+{
+    const int mode = get<0>(GetParam());
+    const int method = get<1>(GetParam());
+    const Point offset = get<2>(GetParam());
+    const bool withHierarchy = get<3>(GetParam());
+    const bool matOutput = get<4>(GetParam());
+
+    // Nonzero pixels outside the non-contiguous ROI must not extend its contours.
+    Mat parent(15, 19, CV_8UC1, Scalar(123));
+    Mat image = parent(Rect(4, 2, 11, 9));
+    image.setTo(Scalar(37));
+    image(Rect(3, 3, 5, 3)).setTo(Scalar(0));
+    const Mat original = parent.clone();
+    ASSERT_FALSE(image.isContinuous());
+
+    // Coordinates refer to foreground pixels, including around the hole.
+    vector<vector<Point>> expected = {{Point(0, 0), Point(0, 8), Point(10, 8), Point(10, 0)}};
+    if (mode != RETR_EXTERNAL)
+        expected.push_back({Point(2, 3), Point(3, 2), Point(7, 2), Point(8, 3),
+                            Point(8, 5), Point(7, 6), Point(3, 6), Point(2, 5)});
+    for (auto& contour : expected)
+    {
+        vector<Point> points;
+        for (size_t i = 0; i < contour.size(); ++i)
+        {
+            const Point start = contour[i];
+            points.push_back(start + offset);
+            if (method == CHAIN_APPROX_NONE)
+            {
+                const Point delta = contour[(i + 1) % contour.size()] - start;
+                const int length = std::max(std::abs(delta.x), std::abs(delta.y));
+                const Point step(delta.x / length, delta.y / length);
+                for (int j = 1; j < length; ++j)
+                    points.push_back(start + step * j + offset);
+            }
+        }
+        contour.swap(points);
+    }
+
+    vector<vector<Point>> contours;
+    vector<Vec4i> hierarchy;
+    const _OutputArray hierarchyOutput = withHierarchy ? _OutputArray(hierarchy) : _OutputArray();
+    if (matOutput)
+    {
+        vector<Mat> mats;
+        findContours(image, mats, hierarchyOutput, mode, method, offset);
+        contours.resize(mats.size());
+        for (size_t i = 0; i < mats.size(); ++i)
+            mats[i].copyTo(contours[i]);
+    }
+    else
+    {
+        findContours(image, contours, hierarchyOutput, mode, method, offset);
+    }
+
+    EXPECT_EQ(0., cvtest::norm(parent, original, NORM_INF));
+    ASSERT_EQ(expected.size(), contours.size());
+    if (withHierarchy)
+    {
+        EXPECT_EQ(contours.size(), hierarchy.size());
+    }
+
+    // The fast and general paths may choose different contour/start-point orders.
+    const auto pointLess = [](const Point& a, const Point& b) {
+        return a.y < b.y || (a.y == b.y && a.x < b.x);
+    };
+    const auto contourLess = [&](const vector<Point>& a, const vector<Point>& b) {
+        return std::lexicographical_compare(a.begin(), a.end(), b.begin(), b.end(), pointLess);
+    };
+    for (auto& contour : expected)
+        std::sort(contour.begin(), contour.end(), pointLess);
+    for (auto& contour : contours)
+        std::sort(contour.begin(), contour.end(), pointLess);
+    std::sort(expected.begin(), expected.end(), contourLess);
+    std::sort(contours.begin(), contours.end(), contourLess);
+    EXPECT_EQ(expected, contours);
+}
+
+INSTANTIATE_TEST_CASE_P(
+    ,
+    Imgproc_FindContours_ROIOffset,
+    testing::Combine(testing::Values(RETR_EXTERNAL, RETR_LIST, RETR_CCOMP, RETR_TREE),
+                     testing::Values(CHAIN_APPROX_NONE, CHAIN_APPROX_SIMPLE),
+                     testing::Values(Point(), Point(4, 2), Point(-7, -11)),
+                     testing::Bool(), testing::Bool()));
 
 // no RETR_FLOODFILL - no CV_32S input images
 INSTANTIATE_TEST_CASE_P(


### PR DESCRIPTION
The `RETR_LIST` fast path can drop the outer contour of a non-contiguous ROI when its parent has nonzero pixels outside the ROI. With `vector<Mat>` output and a nonzero offset, it also shifts only the first contour. Both behaviors differ from the general path used when hierarchy is requested.

This change isolates ROI padding in `findTRUContours` and uses `_contours.total()` when applying offsets to generic output containers. For `vector<Mat>`, `size()` is `(number of contours, 1)`, so the previous height-based loop visited only one contour.

The new parameterized test uses an 11×9 foreground ROI with a rectangular hole inside a nonzero parent. Its expected coordinates come from explicit polygons, with unit-step expansion for `CHAIN_APPROX_NONE`, rather than another call to `findContours`. It checks four retrieval modes, two approximation methods, zero/positive/negative offsets, hierarchy requested/omitted, and `vector<vector<Point>>`/`vector<Mat>` output: 96 combinations. It also checks that the parent image is unchanged. Point and contour ordering are intentionally excluded from this coordinate/ROI contract test.

Related: #21544 (boundary/coordinate coverage, not a complete resolution of that documentation request) and #28773 (fast-path introduction). No documentation issue is auto-closed.

### Reproduction

```cpp
cv::Mat parent(15, 19, CV_8UC1, cv::Scalar(123));
cv::Mat roi = parent(cv::Rect(4, 2, 11, 9));
roi.setTo(37);
roi(cv::Rect(3, 3, 5, 3)).setTo(0);
std::vector<std::vector<cv::Point>> contours;
std::vector<cv::Vec4i> hierarchy;
cv::findContours(roi, contours, hierarchy, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
// 2 contours before and after the fix.
cv::findContours(roi, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
// Before: 1 contour (outer boundary missing). After: 2.
std::vector<cv::Mat> mats;
cv::findContours(roi.clone(), mats, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE, cv::Point(4, 2));
// Before: outer contour bounding rect starts at (0, 0). After: (4, 2).
```

### Validation

Base: `bb9e3eff13f5404d0225c44b0b752c6624c863ef` (4.x).

- New tests with unchanged implementation: **84 passed, 12 failed**; all failures are `RETR_LIST` without hierarchy.
- ROI-isolation fix alone: four nonzero-offset `vector<Mat>` cases still fail.
- Both fixes: **228/228 passed** (96 new cases and 132 existing contour/TRUCO cases), no skipped or disabled cases.
- Built `opencv_test_imgproc` with GCC 13.3.0, Release, SSE3 CPU, pthreads. IPP, OpenCL, and additional CPU dispatch were disabled; this is not an entire imgproc-suite or cross-platform validation.
- `git diff --check` passed. Synthetic images only; no opencv_extra data required.

```sh
opencv_test_imgproc --gtest_filter='*Imgproc_FindContours*:*Imgproc_FindTRUContours*'
```

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (4.x bug fix).
- [x] There is a reference to the original report and related work, with a concrete reproducer above.
- [x] Accuracy/regression tests are included; external test data and performance tests are not needed for these fixes.
- [x] This restores existing API behavior; no new feature or sample requires documentation.

AI assistance: OpenAI Codex helped inspect the source, implement the changes and tests, run the validation, and prepare this PR.
