### PR TITLE
imgproc: repair contour accuracy test inputs and references 🤖🤖🤖

### DIFF
--- a/modules/imgproc/test/test_contours_new.cpp
+++ b/modules/imgproc/test/test_contours_new.cpp
@@ -70,6 +70,40 @@ inline static void drawContours(Mat& img,
     }
 }
 
+#if CHECK_OLD
+static void checkLegacyContours(const Mat& image, const vector<vector<Point>>& contours,
+                                const vector<Vec4i>& hierarchy, int mode, int method)
+{
+    const bool exact = method == CHAIN_APPROX_NONE || method == CHAIN_APPROX_SIMPLE;
+    vector<vector<Point>> reference;
+    vector<Vec4i> referenceHierarchy;
+    // Legacy TC89 has known approximation differences (see #25663). Its unapproximated
+    // contours still provide a reference for the boundary points and hierarchy.
+    findContours_legacy(image, reference, referenceHierarchy, mode,
+                        exact ? method : CHAIN_APPROX_NONE);
+    ASSERT_EQ(reference.size(), contours.size());
+    for (size_t i = 0; i < contours.size(); ++i)
+    {
+        SCOPED_TRACE(format("contour = %zu", i));
+        if (exact)
+        {
+            EXPECT_MAT_NEAR(Mat(reference[i]), Mat(contours[i]), 0);
+        }
+        else
+        {
+            ASSERT_FALSE(contours[i].empty());
+            EXPECT_LE(contours[i].size(), reference[i].size());
+            for (const Point& point : contours[i])
+            {
+                EXPECT_TRUE(std::find(reference[i].begin(), reference[i].end(), point) != reference[i].end())
+                    << "Point " << point << " is not on the unapproximated boundary";
+            }
+        }
+    }
+    EXPECT_MAT_NEAR(Mat(referenceHierarchy), Mat(hierarchy), 0);
+}
+#endif
+
 //==================================================================================================
 
 // Test parameters - mode + method
@@ -476,16 +510,7 @@ TEST_P(Imgproc_FindContours_Modes2, new_accuracy)
         EXPECT_EQ(0., diff1);
     }
 #if CHECK_OLD
-    vector<vector<Point>> contours_o;
-    vector<Vec4i> hierarchy_o;
-    findContours(img, contours_o, hierarchy_o, mode, method);
-    ASSERT_EQ(contours_o.size(), contours.size());
-    for (size_t i = 0; i < contours_o.size(); ++i)
-    {
-        SCOPED_TRACE(format("contour = %zu", i));
-        EXPECT_MAT_NEAR(Mat(contours_o[i]), Mat(contours[i]), 0);
-    }
-    EXPECT_MAT_NEAR(Mat(hierarchy_o), Mat(hierarchy), 0);
+    checkLegacyContours(img, contours, hierarchy, mode, method);
 #endif
 }
 
@@ -499,6 +524,7 @@ TEST_P(Imgproc_FindContours_Modes2, approx)
 
     for (int c = 0; c < 4; ++c)
     {
+        SCOPED_TRACE(format("case = %d", c));
         if (c != 0)
         {
             // noise + filter + threshold
@@ -508,13 +534,12 @@ TEST_P(Imgproc_FindContours_Modes2, approx)
             Mat fimg;
             boxFilter(img, fimg, CV_8U, Size(5, 5));
 
-            Mat timg;
             const int level = 44 + c * 42;
             // 'level' goes through:
             // 86 - some black speckles on white
             // 128 - 50/50 black/white
             // 170 - some white speckles on black
-            cv::threshold(fimg, timg, level, 255, THRESH_BINARY);
+            cv::threshold(fimg, img, level, 255, THRESH_BINARY);
         }
         else
         {
@@ -526,26 +551,16 @@ TEST_P(Imgproc_FindContours_Modes2, approx)
             rectangle(img, center, center + cut, Scalar(0), FILLED);
         }
 
+        ASSERT_EQ(0, countNonZero((img != 0) & (img != 255)));
         vector<vector<Point>> contours;
         vector<Vec4i> hierarchy;
         findContours(img, contours, hierarchy, mode, method);
 
 #if CHECK_OLD
-        // NOTE: old and new function results might not match when approximation mode is TC89.
-        // Currently this test passes, but might fail for other random data.
-        // See https://github.com/opencv/opencv/issues/25663 for details.
-        vector<vector<Point>> contours_o;
-        vector<Vec4i> hierarchy_o;
-        findContours_legacy(img, contours_o, hierarchy_o, mode, method);
-        ASSERT_EQ(contours_o.size(), contours.size());
-        for (size_t i = 0; i < contours_o.size(); ++i)
-        {
-            SCOPED_TRACE(format("c = %d, contour = %zu", c, i));
-            EXPECT_MAT_NEAR(Mat(contours_o[i]), Mat(contours[i]), 0);
-        }
-        EXPECT_MAT_NEAR(Mat(hierarchy_o), Mat(hierarchy), 0);
-#endif
+        checkLegacyContours(img, contours, hierarchy, mode, method);
+#else
         // TODO: check something
+#endif
     }
 }
 


### PR DESCRIPTION
Two existing `Imgproc_FindContours_Modes2` tests were not exercising their intended inputs/references:

- `approx` thresholded the filtered noise into a discarded local `timg`, then passed the original grayscale noise to `findContours`. The threshold levels therefore did not define the tested masks.
- `new_accuracy` called the current `findContours` again inside `CHECK_OLD`, comparing it with itself instead of the legacy implementation.

Write the threshold result into the tested image and assert that the fixture contains only 0/255 pixels. Both tests now share an actual legacy reference check. NONE/SIMPLE retain exact point and hierarchy comparisons. For TC89, the known legacy approximation differences discussed in #25663 make exact vertex equality inappropriate: compare the contour count/hierarchy to legacy CHAIN_APPROX_NONE, require nonempty approximations with no more points, and check that each output vertex belongs to the corresponding unapproximated boundary. This checks boundary membership rather than full TC89 vertex selection.

The per-image trace identifies the circle or threshold case on failure. Production code is unchanged. This is independent of the ROI/offset fixes in #29914.

### Validation

Base: `bb9e3eff13f5404d0225c44b0b752c6624c863ef` (4.x).

- Original tests: 32/32 pass despite the discarded input and self-comparison.
- Directly repairing the two connections exposed 8 TC89_L1 comparison failures, consistent with #25663. The final reference check handles that known difference without requiring the current implementation to reproduce the legacy bug.
- Built the normal `opencv_test_imgproc` target from this worktree: **132/132 contour and TRUCO tests pass**.
- Final Modes2 tests pass with eight RNG seeds (0, 1, 42, 1337, 809564, 20260910, 123456789, 3237998081): **32 cases × 8 seeds = 256 successful executions**, not 256 distinct tests.
- In an isolated temporary test translation unit, restoring the discarded-threshold-result mistake makes **all 16 `approx` cases fail** at the new binary-input assertion. The submitted source contains no mutation.
- GCC 13.3.0, Release, SSE3, pthreads CPU build; IPP, OpenCL and additional CPU dispatch disabled. No full imgproc-suite, sanitizer, or cross-platform claim.
- `git diff --check` passes. No external test data required.

```sh
opencv_test_imgproc --gtest_filter='*Imgproc_FindContours*:*Imgproc_FindTRUContours*'
opencv_test_imgproc --gtest_filter='*Imgproc_FindContours_Modes2*' --test_seed=42
```

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
- [x] The PR is proposed to the proper branch (4.x test fixes; legacy implementation is still present there).
- [x] The concrete test defects and related legacy behavior (#25663) are described above.
- [x] Existing accuracy tests are repaired and verified; no new external test data is needed.
- [x] No production API or feature documentation changes are needed.

AI assistance: OpenAI Codex helped inspect the source, repair the tests, run the validation and mutation check, and prepare this PR.
