### PR TITLE
Disabled perf test for IntelligentScissors as it's too long.

### DIFF
--- a/modules/imgproc/perf/perf_intelligent_scissors.cpp
+++ b/modules/imgproc/perf/perf_intelligent_scissors.cpp
@@ -8,7 +8,7 @@ namespace opencv_test { namespace {
 
 typedef perf::TestBaseWithParam<int> TestIntelligentScissorsMB;
 
-PERF_TEST_P(TestIntelligentScissorsMB, buildMap, testing::Values( IMREAD_GRAYSCALE, IMREAD_COLOR ))
+PERF_TEST_P(TestIntelligentScissorsMB, DISABLED_buildMap, testing::Values( IMREAD_GRAYSCALE, IMREAD_COLOR ))
 {
     const int flags = GetParam();
 


### PR DESCRIPTION
### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [ ] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [ ] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake
