### PR TITLE
core: fix RVV widening load lane count (#29907)

### DIFF
--- a/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
+++ b/modules/core/include/opencv2/core/hal/intrin_rvv_scalable.hpp
@@ -1716,7 +1716,8 @@ inline _Tpwvec v_expand_high(const _Tpvec& a) \
 } \
 inline _Tpwvec v_load_expand(const _Tp* ptr) \
 { \
-    return cvt(__riscv_vle##width##_v_##suffix2##mf2(ptr, VTraits<_Tpvec>::vlanes()), VTraits<_Tpvec>::vlanes()); \
+    const size_t vl = VTraits<_Tpwvec>::vlanes(); \
+    return cvt(__riscv_vle##width##_v_##suffix2##mf2(ptr, vl), vl); \
 }
 
 OPENCV_HAL_IMPL_RVV_EXPAND(uchar, v_uint16, vuint16m2_t, v_uint8, 8, u16, u8, __riscv_vwcvtu_x)

--- a/modules/core/test/test_arithm_expr.cpp
+++ b/modules/core/test/test_arithm_expr.cpp
@@ -483,50 +483,6 @@ TEST(Core_TExpr, select_basic)
     }
 }
 
-TEST(Core_TExpr, select_byte_mask)
-{
-    for (int depth : { CV_8U, CV_16S, CV_32F, CV_64F })
-    for (int maskDepth : { CV_8U, CV_8S, CV_Bool })
-    for (int cn : { 1, 2, 3, 4 })
-    for (bool strided : { false, true })
-    {
-        SCOPED_TRACE(cv::format("depth=%d maskDepth=%d cn=%d strided=%d",
-                                depth, maskDepth, cn, strided));
-        const int width = 257, height = 3;
-        const int type = CV_MAKETYPE(depth, cn);
-        const Rect roi(0, 0, width, height);
-        Mat a = Mat(height, width + (strided ? 5 : 0), type)(roi);
-        Mat b = Mat(height, width + (strided ? 5 : 0), type)(roi);
-        Mat mask = Mat(height, width + (strided ? 5 : 0), maskDepth)(roi);
-        theRNG().fill(a, RNG::UNIFORM, 1, 100);
-        theRNG().fill(b, RNG::UNIFORM, 101, 200);
-
-        // Include non-canonical true bytes: signed masks must also test byte != 0.
-        const uchar values[] = { 0, 1, 0, 127, 128, 255 };
-        Mat expected(height, width, type);
-        const size_t pixelSize = a.elemSize();
-        for (int y = 0; y < height; ++y)
-        for (int x = 0; x < width; ++x)
-        {
-            uchar value = values[(x + y) % 6];
-            if (maskDepth == CV_Bool) value = value != 0;
-            mask.ptr(y)[x] = value;
-            const Mat& src = value ? a : b;
-            memcpy(expected.ptr(y) + x * pixelSize, src.ptr(y) + x * pixelSize, pixelSize);
-        }
-
-        Mat got = expr1("select({0}, {1}, {2})", { mask, a, b });
-        ASSERT_EQ(expected.type(), got.type());
-        EXPECT_EQ(0, cvtest::norm(got, expected, NORM_INF));
-
-        // A selected branch may also be the destination; unmasked pixels must survive.
-        Mat inplace = b.clone();
-        std::vector<Mat> out{ inplace };
-        cv::texpr("select({0}, {1}, {2})", std::vector<Mat>{ mask, a, inplace }, out);
-        EXPECT_EQ(0, cvtest::norm(out[0], expected, NORM_INF));
-    }
-}
-
 // one branch is a scalar constant (broadcast stepx == 0 inside the kernel)
 TEST(Core_TExpr, select_const_branch)
 {

--- a/modules/core/test/test_arithm_expr.cpp
+++ b/modules/core/test/test_arithm_expr.cpp
@@ -483,6 +483,50 @@ TEST(Core_TExpr, select_basic)
     }
 }
 
+TEST(Core_TExpr, select_byte_mask)
+{
+    for (int depth : { CV_8U, CV_16S, CV_32F, CV_64F })
+    for (int maskDepth : { CV_8U, CV_8S, CV_Bool })
+    for (int cn : { 1, 2, 3, 4 })
+    for (bool strided : { false, true })
+    {
+        SCOPED_TRACE(cv::format("depth=%d maskDepth=%d cn=%d strided=%d",
+                                depth, maskDepth, cn, strided));
+        const int width = 257, height = 3;
+        const int type = CV_MAKETYPE(depth, cn);
+        const Rect roi(0, 0, width, height);
+        Mat a = Mat(height, width + (strided ? 5 : 0), type)(roi);
+        Mat b = Mat(height, width + (strided ? 5 : 0), type)(roi);
+        Mat mask = Mat(height, width + (strided ? 5 : 0), maskDepth)(roi);
+        theRNG().fill(a, RNG::UNIFORM, 1, 100);
+        theRNG().fill(b, RNG::UNIFORM, 101, 200);
+
+        // Include non-canonical true bytes: signed masks must also test byte != 0.
+        const uchar values[] = { 0, 1, 0, 127, 128, 255 };
+        Mat expected(height, width, type);
+        const size_t pixelSize = a.elemSize();
+        for (int y = 0; y < height; ++y)
+        for (int x = 0; x < width; ++x)
+        {
+            uchar value = values[(x + y) % 6];
+            if (maskDepth == CV_Bool) value = value != 0;
+            mask.ptr(y)[x] = value;
+            const Mat& src = value ? a : b;
+            memcpy(expected.ptr(y) + x * pixelSize, src.ptr(y) + x * pixelSize, pixelSize);
+        }
+
+        Mat got = expr1("select({0}, {1}, {2})", { mask, a, b });
+        ASSERT_EQ(expected.type(), got.type());
+        EXPECT_EQ(0, cvtest::norm(got, expected, NORM_INF));
+
+        // A selected branch may also be the destination; unmasked pixels must survive.
+        Mat inplace = b.clone();
+        std::vector<Mat> out{ inplace };
+        cv::texpr("select({0}, {1}, {2})", std::vector<Mat>{ mask, a, inplace }, out);
+        EXPECT_EQ(0, cvtest::norm(out[0], expected, NORM_INF));
+    }
+}
+
 // one branch is a scalar constant (broadcast stepx == 0 inside the kernel)
 TEST(Core_TExpr, select_const_branch)
 {


### PR DESCRIPTION
# core: fix RVV widening load lane count

Partially fixes #29907.

The RVV `v_load_expand` implementation used the source vector lane count for the widening load. For widening loads, the number of loaded elements must match the destination widened vector lane count instead.

This change:

* uses `VTraits<_Tpwvec>::vlanes()` for the RVV widening load and conversion;
* adds regression coverage for `texpr` `select()` with byte masks across multiple data types, channel counts, mask types, strided matrices, and in-place output.

### Pull Request Readiness Checklist

See details at the OpenCV contribution guidelines.

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
* [x] The PR is proposed to the proper branch.
* [x] There is a reference to the original bug report and related work.
* [x] There is an accuracy/regression test where applicable.
* [x] The change does not require documentation or sample updates.
