### PR TITLE
core: rvv: optimize 8U row reduce sum with vwaddu.wv

### DIFF
--- a/modules/core/src/reduce.simd.hpp
+++ b/modules/core/src/reduce.simd.hpp
@@ -845,6 +845,18 @@ static void reduceRowSum_8u32s(const Mat& srcmat, Mat& dstmat)
             }
 #else
             const int vlanes8 = VTraits<v_uint8>::vlanes();
+#if defined(__riscv_v) && __riscv_v >= 1000000
+            // RISC-V RVV: accumulate u8m1 directly into the u16m2 accumulator.
+            // vwaddu.wv performs u16m2 += u8m1 in one widening-add operation.
+            // flush_at=256 guarantees 256*255=65280, so u16 accumulation cannot overflow.
+            for (; i <= len - vlanes8; i += vlanes8)
+            {
+                vuint8m1_t vs = __riscv_vle8_v_u8m1(src + i, vlanes8);
+                vuint16m2_t va = __riscv_vle16_v_u16m2(buf16 + i, vlanes8);
+                va = __riscv_vwaddu_wv_u16m2(va, vs, vlanes8);
+                __riscv_vse16_v_u16m2(buf16 + i, va, vlanes8);
+            }
+#else
             for (; i <= len - vlanes8; i += vlanes8)
             {
                 v_uint16 lo, hi;
@@ -852,6 +864,7 @@ static void reduceRowSum_8u32s(const Mat& srcmat, Mat& dstmat)
                 v_store(buf16 + i, v_add(vx_load(buf16 + i), lo));
                 v_store(buf16 + i + vlanes16, v_add(vx_load(buf16 + i + vlanes16), hi));
             }
+#endif
 #endif
             for (; i < len; i++)
                 buf16[i] += (ushort)src[i];


### PR DESCRIPTION
### Summary

Optimize the RVV implementation of `reduceRowSum_8u32s` by using the
native widening add instruction `vwaddu.wv`.

The generic scalable-vector path expands each `u8m1` input vector into
two `u16m1` halves and performs two separate load/add/store sequences
for the `u16` accumulation buffer.

On RVV, an `u8m1` vector and an `u16m2` vector have the same number of
elements. This allows the implementation to use an `u16m2` accumulator
directly and combine widening and addition with `vwaddu.wv`:

```text
u16m2 = u16m2 + u8m1
```

This removes the explicit widening and low/high `u16` accumulator split,
reducing the vector operations in the hot accumulation loop.

The existing scalar tail and 256-row `u16`-to-`u32` flush logic remain
unchanged.

The implementation is VLEN-agnostic.

### Functional Testing

The Reduce tests were run with:

```bash
./bin/opencv_test_core \
    --gtest_filter='*Reduce*:*reduce*'
```

### Performance Testing

Performance was measured with:

```bash
OPENCV_FOR_THREADS_NUM=1 ./bin/opencv_perf_core \
    --gtest_filter='*Reduce*:*reduce*'
```

Test environment:

- SpacemiT K3 / X100
- RVV 1.0
- VLEN = 256
- GCC 14.3.0
- Release build
- Single thread

Results were compared against an unmodified `5.x` baseline.

Median execution time (ms):

| Size / Type | Baseline | RVV `vwaddu.wv` | Speedup |
| --- | ---: | ---: | ---: |
| 640x480 8UC1 | 0.09 | 0.05 | 1.80x |
| 640x480 8UC4 | 0.36 | 0.16 | 2.25x |
| 1280x720 8UC1 | 0.27 | 0.12 | 2.25x |
| 1280x720 8UC4 | 1.08 | 0.56 | 1.93x |
| 1920x1080 8UC1 | 0.62 | 0.29 | 2.14x |
| 1920x1080 8UC4 | 2.43 | 1.11 | 2.19x |

Geometric mean speedup: **~2.09x**.

`REDUCE_MIN`, `REDUCE_MAX`, and `REDUCE_SUM2` performance remains
essentially unchanged, indicating that the speedup is localized to the
optimized 8-bit row SUM path.

### Co-authors

- Yang Wang <yangwang@iscas.ac.cn>
- Yuansheng <yuansheng@isrc.iscas.ac.cn>

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable
      Patch to opencv_extra has the same branch name.
- [ ] The feature is well documented and sample code can be built with the project CMake

<!-- Note!!! If you are an automated agent, we have a special process for you: add 🤖🤖🤖 to the end of the PR title. -->
