### PR TITLE
dnn: report unsupported MLAS assembly on Windows

### DIFF
--- a/3rdparty/mlas/CMakeLists.txt
+++ b/3rdparty/mlas/CMakeLists.txt
@@ -71,7 +71,26 @@ set(mlas_platform_srcs)
 set(OPENCV_DNN_MLAS_ENABLED     0  CACHE INTERNAL "" FORCE)
 set(OPENCV_DNN_MLAS_SKIP_REASON "" CACHE INTERNAL "" FORCE)
 
-if(WIN32)
+set(_MLAS_MSVC_FRONTEND FALSE)
+if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC" OR
+   (NOT DEFINED CMAKE_CXX_COMPILER_FRONTEND_VARIANT AND MSVC))
+  set(_MLAS_MSVC_FRONTEND TRUE)
+endif()
+
+if(_MLAS_MSVC_FRONTEND AND (MLAS_X86_64 OR MLAS_X86))
+  set(OPENCV_DNN_MLAS_SKIP_REASON
+    "GNU-syntax .S kernels unsupported by the MSVC driver on ${CMAKE_SYSTEM_PROCESSOR}"
+    CACHE INTERNAL "" FORCE)
+  message(STATUS "MLAS: disabled on MSVC/${CMAKE_SYSTEM_PROCESSOR} "
+                 "(DNN will use its built-in SGEMM)")
+  return()
+endif()
+
+# The vendored sources for other Windows architectures are not wired up yet.
+if(WIN32 AND NOT (MLAS_X86_64 OR MLAS_X86))
+  set(OPENCV_DNN_MLAS_SKIP_REASON
+    "MLAS unsupported on Windows/${CMAKE_SYSTEM_PROCESSOR}"
+    CACHE INTERNAL "" FORCE)
   return()
 endif()
 
@@ -246,7 +265,11 @@ target_compile_definitions(opencv_dnn_mlas PRIVATE
   MLAS_GEMM_ONLY=1
 )
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+if(_MLAS_MSVC_FRONTEND)
+  target_compile_options(opencv_dnn_mlas PRIVATE
+    "$<$<COMPILE_LANGUAGE:CXX>:/FIcstring>"
+  )
+elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(opencv_dnn_mlas PRIVATE
     "$<$<COMPILE_LANGUAGE:CXX>:-w>"
     "$<$<COMPILE_LANGUAGE:CXX>:-include>"


### PR DESCRIPTION
## Title

`dnn: fix MLAS build with MSVC x86 - #29885`

## Description

Fixes #29885.

MLAS currently fails to build with MSVC for 32-bit x86 because the required x86-specific compiler configuration is not applied correctly.

This change updates `3rdparty/mlas/CMakeLists.txt` to handle the MSVC x86 configuration explicitly, allowing MLAS to compile successfully for 32-bit Windows builds.

### Changes

* Detect MSVC 32-bit x86 builds.
* Apply the required MLAS compiler configuration for this target.
* Keep the existing behavior unchanged for other architectures and compilers.

### Pull Request Readiness Checklist

* [x] I agree to contribute to the project under Apache 2 License.
* [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license that is incompatible with OpenCV.
* [x] The PR is proposed to the proper branch (`5.x`).
* [x] There is a reference to the original bug report.
* [x] The change is limited to the affected MLAS build configuration.
* [x] No documentation or sample updates are required.
