### PR TITLE
imgcodecs: fix JPEG 2000 encoding of images smaller than 32 pixels 🤖🤖🤖

### DIFF
--- a/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
+++ b/modules/imgcodecs/src/grfmt_jpeg2000_openjpeg.cpp
@@ -323,7 +323,7 @@ opj_dparameters setupDecoderParameters()
     return parameters;
 }
 
-opj_cparameters setupEncoderParameters(const std::vector<int>& params)
+opj_cparameters setupEncoderParameters(const std::vector<int>& params, const Size& imgSize)
 {
     opj_cparameters parameters;
     opj_set_default_encoder_parameters(&parameters);
@@ -353,6 +353,16 @@ opj_cparameters setupEncoderParameters(const std::vector<int>& params)
     {
         parameters.tcp_rates[0] = 4;
     }
+    // OpenJPEG rejects a tile smaller than 2^(numresolution - 1) in either direction.
+    // Tiling is not enabled, so the single tile is the whole image and the default
+    // number of resolutions has to be lowered for images smaller than that.
+    const int minSide = std::min(imgSize.width, imgSize.height);
+    int numresolution = 1;
+    while (numresolution < parameters.numresolution && (1 << numresolution) <= minSide)
+    {
+        numresolution++;
+    }
+    parameters.numresolution = numresolution;
     return parameters;
 }
 
@@ -724,7 +734,7 @@ bool Jpeg2KOpjEncoder::write(const Mat& img, const std::vector<int>& params)
                  cv::format("OpenJPEG2000: image precision > 16 not supported. Got: %d", depth));
     }();
 
-    opj_cparameters parameters = setupEncoderParameters(params);
+    opj_cparameters parameters = setupEncoderParameters(params, img.size());
 
     std::vector<opj_image_cmptparm_t> compparams(channels);
     for (int i = 0; i < channels; i++) {

--- a/modules/imgcodecs/test/test_read_write.cpp
+++ b/modules/imgcodecs/test/test_read_write.cpp
@@ -322,6 +322,34 @@ TEST(Imgcodecs_SunRaster, imread_grayscale_roundtrip)
 }
 #endif
 
+#if !defined(HAVE_JASPER) && defined(HAVE_OPENJPEG)
+// Regression test: the OpenJPEG encoder kept opj_cparameters::numresolution at
+// the library default of 6. OpenJPEG rejects that unless every tile - the whole
+// image here, because no tiling is configured - is at least 2^(6-1) = 32 pixels
+// in both directions, so encoding any smaller image failed with "Number of
+// resolutions is too high in comparison to the size of tiles".
+TEST(Imgcodecs_Jpeg2000, encode_small_image)
+{
+    const Size sizes[] = { Size(1, 1), Size(8, 8), Size(31, 31), Size(64, 8), Size(8, 64), Size(32, 32) };
+    for (size_t i = 0; i < sizeof(sizes)/sizeof(sizes[0]); i++)
+    {
+        SCOPED_TRACE(cv::format("%dx%d", sizes[i].width, sizes[i].height));
+
+        Mat src(sizes[i], CV_8UC3, Scalar(40, 80, 120));
+
+        vector<uchar> buf;
+        ASSERT_TRUE(imencode(".jp2", src, buf)) << "imencode() failed for .jp2";
+        ASSERT_FALSE(buf.empty());
+
+        Mat dst = imdecode(buf, IMREAD_UNCHANGED);
+        ASSERT_FALSE(dst.empty());
+        EXPECT_EQ(src.size(), dst.size());
+        EXPECT_EQ(src.type(), dst.type());
+        EXPECT_EQ(0, cvtest::norm(src, dst, NORM_INF));
+    }
+}
+#endif
+
 TEST(Imgcodecs_Image, regression_9376)
 {
     String path = findDataFile("readwrite/regression_9376.bmp");


### PR DESCRIPTION
`imwrite()` and `imencode()` cannot write a JPEG 2000 file for any image narrower or shorter than 32 pixels. The call fails with

```
OpenJPEG2000: Number of resolutions is too high in comparison to the size of tiles
imencode(): can't encode data: OpenCV(4.15.0-dev) .../grfmt_jpeg2000_openjpeg.cpp:802:
error: (-213:The function/feature is not implemented) OpenJPEG2000: Can not start
compression in function 'cv::Jpeg2KOpjEncoder::write'
```

and returns `false`. Every other encoder in the module writes an 8x8 image without complaint, so this is a gap specific to the OpenJPEG path.

`setupEncoderParameters()` never touched `opj_cparameters::numresolution`, leaving it at the OpenJPEG default of 6. `opj_j2k_encoding_validation()` (`3rdparty/openjpeg/openjp2/j2k.c:8840-8851`) requires each tile to be at least `1 << (numresolutions - 1)` in both directions, and because OpenCV does not enable tiling the single tile is the whole image. The threshold is therefore exactly `2^5 = 32` px, which matches the observed boundary: a 32x32 image encodes, a 31x31 image does not.

This patch lowers `numresolution` to what the image size allows. It only ever lowers it, so an image that is at least 32x32 keeps the default of 6 and its encoded bytes are unchanged. No public API is changed and no new test data is needed.

### Validation

Built `opencv_test_imgcodecs` on Windows 10.0.26200 x64 with MSVC 19.51.36256 (Visual Studio 18), Release, `-DBUILD_LIST=core,imgproc,imgcodecs,ts -DCPU_DISPATCH=` (baseline SSE3), bundled OpenJPEG 2.5.3, on `4.x` at `0aa49a8e`.

The test is in the first commit and the fix in the second. Against unmodified `0aa49a8e` the new test fails on the very first size:

```
[ RUN      ] Imgcodecs_Jpeg2000.encode_small_image
[ERROR:0@0.034] global grfmt_jpeg2000_openjpeg.cpp:299 cv::`anonymous-namespace'::errorLogCallback OpenJPEG2000: Number of resolutions is too high in comparison to the size of tiles
modules\imgcodecs\test\test_read_write.cpp(341): error: Value of: imencode(".jp2", src, buf)
  Actual: false
Expected: true
imencode() failed for .jp2
Google Test trace:
modules\imgcodecs\test\test_read_write.cpp(336): 1x1
[  FAILED  ] Imgcodecs_Jpeg2000.encode_small_image (3 ms)
```

With the fix applied, all six sizes (1x1, 8x8, 31x31, 64x8, 8x64, 32x32) encode, decode back to the same size and type, and round-trip bit-exactly:

```
[ RUN      ] Imgcodecs_Jpeg2000.encode_small_image
[       OK ] Imgcodecs_Jpeg2000.encode_small_image (23 ms)
[  PASSED  ] 1 test.
```

The 64x8 and 8x64 cases cover the tile-height and tile-width conditions separately; 32x32 pins the boundary where the default is still used.

No other result in the module changed. `opencv_test_imgcodecs` with no filter:

| | tests run | passed | failed |
|---|---:|---:|---:|
| unmodified `0aa49a8e` | 757 | 231 | 526 |
| with this patch | 758 | 232 | 526 |

The patch adds exactly one test, it passes, and the failed count is identical. Those 526 failures are pre-existing on this machine and unrelated to this change: `opencv_extra` is not checked out here, so every test that calls `findDataFile()` fails. I did not run the suite against `opencv_extra` data, and I have not tested a JasPer or a non-x86 build.

As a direct check that images at or above the threshold are untouched, I encoded the same fixed inputs before and after the patch and compared the output sizes. They are byte-for-byte identical above the threshold, and only the previously-failing cases change:

```
                     before        after
 8x8   CV_8UC3       (failed)      250 bytes
 8x8   CV_16UC3      (failed)      249 bytes
32x32  CV_8UC3          755 bytes    755 bytes
32x32  CV_16UC3        1542 bytes   1542 bytes
64x64  CV_8UC3         2952 bytes   2952 bytes
129x129 CV_8UC3       11981 bytes  11981 bytes
129x129 CV_16UC3      24922 bytes  24922 bytes
```

`git diff --check` is clean. `5.x` carries the identical code and the identical defect; this is proposed to `4.x` per the branch policy, to be ported by the core team.

I did not find an existing issue for this, so the PR references none.

### Pull Request Readiness Checklist

See details at https://github.com/opencv/opencv/wiki/How_to_contribute#making-a-good-pull-request

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on a code under GPL or another license that is incompatible with OpenCV
- [x] The PR is proposed to the proper branch
- [ ] There is a reference to the original bug report and related work *(no existing report found)*
- [x] There is accuracy test, performance test and test data in opencv_extra repository, if applicable *(accuracy test added in the first commit; self-contained, no new test data)*
- [ ] The feature is well documented and sample code can be built with the project CMake *(not applicable: bug fix, no API or documented behaviour change)*
