### PR TITLE
Fix minimal opencv_world configuration without imgcodecs 🤖🤖🤖

### DIFF
--- a/modules/world/CMakeLists.txt
+++ b/modules/world/CMakeLists.txt
@@ -95,9 +95,11 @@ if (WITH_QT AND QT_VERSION_MAJOR GREATER 5)
   qt_disable_unicode_defines(${the_module})
 endif()
 
-if(BUILD_opencv_imgcodecs AND OPENCV_MODULE_opencv_imgcodecs_IS_PART_OF_WORLD)
+if(COMMAND ocv_imgcodecs_configure_target AND
+    BUILD_opencv_imgcodecs AND OPENCV_MODULE_opencv_imgcodecs_IS_PART_OF_WORLD)
   ocv_imgcodecs_configure_target()
 endif()
-if(BUILD_opencv_highgui AND OPENCV_MODULE_opencv_highgui_IS_PART_OF_WORLD)
+if(COMMAND ocv_highgui_configure_target AND
+    BUILD_opencv_highgui AND OPENCV_MODULE_opencv_highgui_IS_PART_OF_WORLD)
   ocv_highgui_configure_target()
 endif()


### PR DESCRIPTION
Fixes #29778.

Guard the imgcodecs and highgui world configuration hooks with CMake COMMAND checks. This allows minimal opencv_world configurations that exclude those optional modules while preserving the hooks when their commands are available.

Validation:
- Configured with BUILD_LIST=core,imgproc and BUILD_opencv_world=ON
- Built the opencv_world target successfully (423/423)
- git diff --check

### Pull Request Readiness Checklist

- [x] I agree to contribute to the project under Apache 2 License.
- [x] To the best of my knowledge, the proposed patch is not based on code under GPL or another license incompatible with OpenCV.
- [x] The PR is proposed to the proper branch.
- [x] There is a reference to the original bug report and related work.
- [x] An accuracy/performance test and opencv_extra data are not applicable to this CMake configuration fix.
- [x] Documentation and sample changes are not applicable.